### PR TITLE
docs(changelog): drop dead 0.5.1 release link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -416,7 +416,6 @@ enforced in CI.
   resumable on-disk run state.
 
 [0.6.0]: https://github.com/bmad-code-org/bmad-auto/releases/tag/v0.6.0
-[0.5.1]: https://github.com/bmad-code-org/bmad-auto/releases/tag/v0.5.1
 [0.5.0]: https://github.com/bmad-code-org/bmad-auto/releases/tag/v0.5.0
 [0.4.4]: https://github.com/bmad-code-org/bmad-auto/releases/tag/v0.4.4
 [0.4.3]: https://github.com/bmad-code-org/bmad-auto/releases/tag/v0.4.3


### PR DESCRIPTION
Removes the `[0.5.1]:` link reference from CHANGELOG.md — the v0.5.1 release and tag were deleted (data-loss potential), so the link 404s. The historical `## [0.5.1]` section is kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)