### PR TITLE
test(tui): fix decision-toast notification race on py3.14

### DIFF
--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -859,7 +859,10 @@ async def test_decision_banner_shows_and_clears(project):
         header = str(screen.query_one("#runheader", RunHeader).content)
         assert "decision needed: DW-7" in header
         assert "press a to attach and answer" in header
-        assert any("reopen the cache work?" in m for m in notifications(app))
+        # the toast is posted via self.notify() onto textual's async message pump,
+        # so it lands in app._notifications a tick after _decision is set — wait
+        # for it rather than asserting synchronously (matches the other notify tests)
+        await until(pilot, lambda: any("reopen the cache work?" in m for m in notifications(app)))
 
         journal.append("decision-answered", dw_id="DW-7", key="a", effect="build")
         await until(pilot, lambda: screen.decision_pending is None)


### PR DESCRIPTION
## What

The post-merge CI run for #13 failed a single job — `test (py3.14)` — on `tests/test_tui_app.py::test_decision_banner_shows_and_clears`. 3.11–3.13 passed. The failure is a test-timing race, not a product bug.

## Root cause

The test waits for `screen.decision_pending`, then **synchronously** asserts the decision toast is in `app._notifications`:

```python
await until(pilot, lambda: screen.decision_pending is not None)
...
assert any("reopen the cache work?" in m for m in notifications(app))
```

But the toast is emitted with `self.notify()`, which **posts a message** onto textual's async pump. `decision_pending` (`_decision`) is set synchronously in `_apply`, while the notification only lands in `app._notifications` a tick later when the pump processes the `Notify` message. So the bare `assert` can run before the notification is observable. Under CI's parallel IO contention the py3.14 runner lost that race; the faster interpreters happened to win it.

## Fix

Wait for the toast via `until()` instead of asserting synchronously — the exact pattern every other notification test in this file already uses (e.g. `test_attach_without_tmux_notifies`). One line, test-only, no product change.

## Verification

Ran the full `tests/test_tui_app.py` module on both **py3.13** and **py3.14** (CI-matching `uv sync --locked --all-extras`): 39 passed on each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated an app interaction test to better handle delayed notification delivery.
  * Improved test reliability by waiting for the expected message to appear before asserting on it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->