### PR TITLE
release: 0.7.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "bauto",
       "source": "./src/automator/data/skills",
       "description": "Automation-mode skills driven by the bmad-auto orchestrator: interactive escalation resolution (bmad-auto-resolve) and deferred-work sweep triage (bmad-auto-sweep) — the inner dev primitive (which self-reviews and commits) is the upstream bmad-dev-auto skill",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "author": {
         "name": "pinkyd"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,10 @@ breaking changes may land in a minor release.
   lives inside the kept `.automator` dir, so a rollback's `git reset --hard` to baseline silently
   reverted operator edits — a freshly enabled `scm.rollback_on_failure` could disappear before it ever
   took effect — and a lone policy edit could register as attempt dirtiness, trapping the
-  manual-recovery loop. Rollback now always snapshots and restores `policy.toml`, and the dirty check
-  always excludes it, regardless of the preserve set.
+  manual-recovery loop. Rollback now restores `policy.toml` from its on-disk content unconditionally —
+  so a config change committed after the baseline on an otherwise-clean tree survives too, not only
+  one that rode a non-empty `git stash` snapshot — and the dirty check always excludes it, regardless
+  of the preserve set.
 
 - **Fixed a decision-toast notification race in the TUI test suite on Python 3.14.** Test-only; no
   runtime change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to `bmad-auto` are documented here. The format is based on
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html). While the project is pre-1.0,
 breaking changes may land in a minor release.
 
+## [0.7.2] — 2026-06-26
+
+### Fixed
+
+- **Worktree isolation no longer false-stalls a story that actually finished.** Under
+  `scm.isolation = worktree` the `bmad-dev-auto` session runs with its cwd set to the worktree and
+  leaves its terminal spec in the worktree's `_bmad-output/implementation-artifacts`, but the dev
+  adapter searched the main checkout's dir (resolved once at startup). The completed `status: done`
+  spec was never found, so the orchestrator misread the session as stalled, rolled the unit branch
+  back to baseline, and re-ran the same story. The adapter now resolves the spec directory from the
+  live session cwd; in-place runs and artifact dirs configured outside the project tree are
+  unaffected.
+
+- **An uncommitted `policy.toml` edit no longer vanishes on rollback.** `policy.toml` is tracked but
+  lives inside the kept `.automator` dir, so a rollback's `git reset --hard` to baseline silently
+  reverted operator edits — a freshly enabled `scm.rollback_on_failure` could disappear before it ever
+  took effect — and a lone policy edit could register as attempt dirtiness, trapping the
+  manual-recovery loop. Rollback now always snapshots and restores `policy.toml`, and the dirty check
+  always excludes it, regardless of the preserve set.
+
+- **Fixed a decision-toast notification race in the TUI test suite on Python 3.14.** Test-only; no
+  runtime change.
+
 ## [0.7.1] — 2026-06-25
 
 ### Fixed
@@ -629,6 +652,7 @@ enforced in CI.
   implementation phase, driven by a Python control loop with hook-based session transport and
   resumable on-disk run state.
 
+[0.7.2]: https://github.com/bmad-code-org/bmad-auto/releases/tag/v0.7.2
 [0.7.0]: https://github.com/bmad-code-org/bmad-auto/releases/tag/v0.7.0
 [0.6.4]: https://github.com/bmad-code-org/bmad-auto/releases/tag/v0.6.4
 [0.6.3]: https://github.com/bmad-code-org/bmad-auto/releases/tag/v0.6.3

--- a/module.yaml
+++ b/module.yaml
@@ -1,7 +1,7 @@
 code: bauto
 name: BMAD Auto Skills
 description: "Automation-mode skills driven by the bmad-auto orchestrator: interactive escalation resolution (bmad-auto-resolve) and deferred-work sweep triage (bmad-auto-sweep) — the inner dev primitive (which self-reviews and commits) is the upstream bmad-dev-auto skill"
-module_version: 0.7.1
+module_version: 0.7.2
 default_selected: false
 module_greeting: >
   BMAD Auto installed — both the automation skills and the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bmad-auto"
-version = "0.7.1"
+version = "0.7.2"
 description = "Deterministic ralph-loop orchestrator for the BMAD implementation phase"
 readme = "README.md"
 license = "MIT"

--- a/src/automator/__init__.py
+++ b/src/automator/__init__.py
@@ -6,4 +6,4 @@ on disk: sprint-status.yaml (owned by the skills, read-only here),
 spec files, and the per-run directory under .automator/runs/.
 """
 
-__version__ = "0.7.1"
+__version__ = "0.7.2"

--- a/src/automator/adapters/generic.py
+++ b/src/automator/adapters/generic.py
@@ -22,6 +22,7 @@ import time
 from pathlib import Path
 
 from .. import devcontract, runs
+from ..bmadconfig import ProjectPaths
 from ..journal import LOGS_DIR
 from ..model import TokenUsage
 from ..policy import Policy
@@ -292,26 +293,39 @@ class GenericDevAdapter(GenericAdapter):
     ``policy.dev.skill == "bmad-dev-auto"`` (see ``cli._make_adapters``).
     """
 
-    def __init__(self, *args, impl_artifacts: Path, **kwargs):
+    def __init__(self, *args, paths: ProjectPaths, **kwargs):
         super().__init__(*args, **kwargs)
-        self.impl_artifacts = impl_artifacts
+        self.paths = paths
         # The generic skill never writes result.json, so the base "write the
         # result JSON file" nudge is meaningless — and actively misleading — for
         # it. A Stop without a terminal spec is a genuine stall.
         self._stop_nudges = 0
+
+    def _artifact_dirs(self, cwd: Path) -> list[Path]:
+        # In worktree isolation the skill runs with cwd set to the worktree and
+        # writes its terminal spec under the worktree's rebased implementation-
+        # artifacts dir, not the main checkout's. Resolve the search dir from the
+        # live session cwd (a no-op in place, where cwd == the project root, and
+        # for artifact dirs configured outside the project tree, which rebased()
+        # leaves put). Keep the configured dir as a defensive fallback.
+        primary = self.paths.rebased(cwd).implementation_artifacts
+        dirs = [primary]
+        if self.paths.implementation_artifacts != primary:
+            dirs.append(self.paths.implementation_artifacts)
+        return dirs
 
     def _result_json(self, handle: SessionHandle, spec: SessionSpec, *, wait: bool) -> dict | None:
         # Mirror the base _await_result poll: the skill's terminal spec may not be
         # flushed to disk the instant the Stop event fires, so briefly await it when
         # wait=True instead of reading once and mis-reporting a stall.
         deadline = time.monotonic() + RESULT_GRACE_S
+        search_dirs = self._artifact_dirs(spec.cwd)
         while True:
-            spec_path = devcontract.find_result_artifact(
-                self.impl_artifacts, since_ns=handle.launched_ns
-            )
-            if spec_path is not None:
-                story_key = spec.env.get("BMAD_AUTO_STORY_KEY") or None
-                return devcontract.synthesize_result(spec_path, story_key=story_key).result_json
+            for artifacts in search_dirs:
+                spec_path = devcontract.find_result_artifact(artifacts, since_ns=handle.launched_ns)
+                if spec_path is not None:
+                    story_key = spec.env.get("BMAD_AUTO_STORY_KEY") or None
+                    return devcontract.synthesize_result(spec_path, story_key=story_key).result_json
             if not wait or time.monotonic() >= deadline:
                 return None
             time.sleep(RESULT_POLL_S)

--- a/src/automator/cli.py
+++ b/src/automator/cli.py
@@ -64,9 +64,10 @@ def _make_adapters(project: Path, run_dir: Path, policy) -> dict[str, CodingCLIA
     from .adapters.profile import ProfileError, get_profile
 
     # The dev skill (bmad-dev-auto) writes no result.json: its adapter
-    # synthesizes the result from the spec, and so needs the
-    # implementation-artifacts dir to find that spec.
-    impl_artifacts = bmadconfig.load_paths(project).implementation_artifacts
+    # synthesizes the result from the spec, and so needs the project paths to
+    # find that spec — rebasing onto the active worktree's implementation-
+    # artifacts dir under isolation, not just the main checkout's.
+    paths = bmadconfig.load_paths(project)
     # One shared terminal-multiplexer backend for every role's adapter.
     mux = get_multiplexer()
 
@@ -77,8 +78,8 @@ def _make_adapters(project: Path, run_dir: Path, policy) -> dict[str, CodingCLIA
         # Both the dev and review sessions are now bmad-dev-auto runs (the review
         # session re-invokes the dev skill on the done spec for a follow-up pass),
         # and the skill writes no result.json — its adapter synthesizes the result
-        # from the spec it leaves on disk, so it needs impl_artifacts to find that
-        # spec and cannot be shared with the triage role even on identical config.
+        # from the spec it leaves on disk, so it needs the project paths to find
+        # that spec and cannot be shared with the triage role even on identical config.
         synthesizes = role in ("dev", "review") and policy.dev.skill == "bmad-dev-auto"
         key = (cfg, synthesizes)
         if key not in by_cfg:
@@ -96,7 +97,7 @@ def _make_adapters(project: Path, run_dir: Path, policy) -> dict[str, CodingCLIA
                 mux=mux,
             )
             by_cfg[key] = (
-                GenericDevAdapter(**common, impl_artifacts=impl_artifacts)
+                GenericDevAdapter(**common, paths=paths)
                 if synthesizes
                 else GenericAdapter(**common)
             )

--- a/src/automator/data/skills/bmad-auto-setup/assets/module.yaml
+++ b/src/automator/data/skills/bmad-auto-setup/assets/module.yaml
@@ -1,7 +1,7 @@
 code: bauto
 name: BMAD Auto Skills
 description: "Automation-mode skills driven by the bmad-auto orchestrator: interactive escalation resolution (bmad-auto-resolve) and deferred-work sweep triage (bmad-auto-sweep) — the inner dev primitive (which self-reviews and commits) is the upstream bmad-dev-auto skill"
-module_version: 0.7.1
+module_version: 0.7.2
 default_selected: false
 module_greeting: >
   BMAD Auto installed — both the automation skills and the

--- a/src/automator/verify.py
+++ b/src/automator/verify.py
@@ -210,32 +210,43 @@ def safe_rollback(
     snapshot. Untracked artifacts need no special handling: the reset leaves them
     alone and the cleanup below skips `keep` dirs.
 
-    `policy.toml` (the operator's orchestration config) is *always* restored the
-    same way, regardless of `preserve`. It lives inside the kept `.automator`
-    dir but is *tracked*, so a plain `git reset --hard` would silently revert an
-    uncommitted edit — e.g. a freshly enabled `scm.rollback_on_failure`, which
-    would then be gone before it ever takes effect. `keep` only guards untracked
-    deletion, not tracked reverts, so policy.toml needs the snapshot/restore.
+    `policy.toml` (the operator's orchestration config) is *always* restored,
+    regardless of `preserve`. It lives inside the kept `.automator` dir but is
+    *tracked*, so a plain `git reset --hard` would silently revert it — an
+    uncommitted edit (e.g. a freshly enabled `scm.rollback_on_failure`, gone
+    before it ever takes effect) or a change committed after `baseline`. `keep`
+    only guards untracked deletion, not tracked reverts. We can't ride the stash
+    snapshot for it: `git stash create` emits an empty snapshot for a clean tree,
+    so a policy change living in a *commit* (with no other working-tree dirt)
+    would skip the restore and be lost. Instead we read policy.toml's on-disk
+    content before the reset and write it straight back after — independent of
+    the snapshot, covering both the uncommitted and committed cases.
     """
-    # policy.toml first: always preserved (see above); preserve dirs follow.
-    restore = (POLICY_FILE_REL, *preserve)
+    # policy.toml: capture on-disk content now, restore unconditionally below.
+    policy_path = repo / POLICY_FILE_REL
+    policy_content = policy_path.read_bytes() if policy_path.is_file() else None
+
     rc, out = _git(repo, "stash", "create")
     snapshot = out.strip() if rc == 0 else ""
     rc, out = _git(repo, "reset", "--hard", baseline)
     if rc != 0:
         raise GitError(f"git reset --hard {baseline} failed: {out}")
     if snapshot:
-        # Restore each path's pre-reset content from the snapshot tree. A path
-        # with no tracked content in the snapshot makes `git checkout` exit
-        # non-zero ("pathspec did not match") — benign (policy.toml not yet
-        # committed, or a preserve dir holding only untracked files). Any other
-        # failure means a protected path wasn't restored: raise instead of
-        # silently dropping the operator's policy edit or a resolved re-drive's
+        # Restore each preserve dir's pre-reset content from the snapshot tree. A
+        # path with no tracked content in the snapshot makes `git checkout` exit
+        # non-zero ("pathspec did not match") — benign (a preserve dir holding
+        # only untracked files). Any other failure means a protected path wasn't
+        # restored: raise instead of silently dropping a resolved re-drive's
         # corrected spec (which would regress the re-drive into a recovery loop).
-        for d in restore:
+        for d in preserve:
             rc, out = _git(repo, "checkout", snapshot, "--", d)
             if rc != 0 and "did not match" not in out:
                 raise GitError(f"git checkout {snapshot[:12]} -- {d} failed: {out}")
+    if policy_content is not None:
+        current = policy_path.read_bytes() if policy_path.is_file() else None
+        if current != policy_content:
+            policy_path.parent.mkdir(parents=True, exist_ok=True)
+            policy_path.write_bytes(policy_content)
     if baseline_untracked is None:
         return  # no snapshot to diff against: never delete untracked files
     created = untracked_files(repo) - set(baseline_untracked)

--- a/src/automator/verify.py
+++ b/src/automator/verify.py
@@ -147,18 +147,20 @@ def attempt_dirty(
     `exclude` is repo-relative posix dir prefixes (e.g. the BMAD artifact
     folders) whose changes are orchestrator-owned and never count as a dev
     attempt's dirtiness — they pair with `safe_rollback`'s `preserve`, so a
-    change confined to those folders reads as clean."""
-    if exclude:
-        rc, _ = _git(repo, "diff", "--quiet", baseline, "--", ".", *_exclude_specs(exclude))
-    else:
-        rc, _ = _git(repo, "diff", "--quiet", baseline, "--")
+    change confined to those folders reads as clean.
+
+    `policy.toml` (the operator's orchestration config) is *always* excluded: it
+    is never a dev attempt's change, `safe_rollback` always restores it, and a
+    lone policy edit must not read as dirtiness — otherwise the manual-recovery
+    loop could never terminate. Mirrors `worktree_clean`'s exclusion."""
+    exclude = (POLICY_FILE_REL, *exclude)
+    rc, _ = _git(repo, "diff", "--quiet", baseline, "--", ".", *_exclude_specs(exclude))
     if rc != 0:
         return True
     if baseline_untracked is None:
         return False
     created = untracked_files(repo) - set(baseline_untracked)
-    if exclude:
-        created = {p for p in created if not _path_under_any(p, exclude)}
+    created = {p for p in created if not _path_under_any(p, exclude)}
     return bool(created)
 
 
@@ -207,22 +209,30 @@ def safe_rollback(
     tree with `git stash create`, reset, then restore those paths from the
     snapshot. Untracked artifacts need no special handling: the reset leaves them
     alone and the cleanup below skips `keep` dirs.
+
+    `policy.toml` (the operator's orchestration config) is *always* restored the
+    same way, regardless of `preserve`. It lives inside the kept `.automator`
+    dir but is *tracked*, so a plain `git reset --hard` would silently revert an
+    uncommitted edit — e.g. a freshly enabled `scm.rollback_on_failure`, which
+    would then be gone before it ever takes effect. `keep` only guards untracked
+    deletion, not tracked reverts, so policy.toml needs the snapshot/restore.
     """
-    snapshot = ""
-    if preserve:
-        rc, out = _git(repo, "stash", "create")
-        if rc == 0:
-            snapshot = out.strip()
+    # policy.toml first: always preserved (see above); preserve dirs follow.
+    restore = (POLICY_FILE_REL, *preserve)
+    rc, out = _git(repo, "stash", "create")
+    snapshot = out.strip() if rc == 0 else ""
     rc, out = _git(repo, "reset", "--hard", baseline)
     if rc != 0:
         raise GitError(f"git reset --hard {baseline} failed: {out}")
-    if preserve and snapshot:
-        # Restore each artifact path's pre-reset content from the snapshot tree.
-        # A dir with no tracked files in the snapshot makes `git checkout` exit
-        # non-zero ("pathspec did not match") — that's benign. Any other failure
-        # means the corrected artifact wasn't restored: raise instead of silently
-        # losing it (which would regress the resolved re-drive into a recovery loop).
-        for d in preserve:
+    if snapshot:
+        # Restore each path's pre-reset content from the snapshot tree. A path
+        # with no tracked content in the snapshot makes `git checkout` exit
+        # non-zero ("pathspec did not match") — benign (policy.toml not yet
+        # committed, or a preserve dir holding only untracked files). Any other
+        # failure means a protected path wasn't restored: raise instead of
+        # silently dropping the operator's policy edit or a resolved re-drive's
+        # corrected spec (which would regress the re-drive into a recovery loop).
+        for d in restore:
             rc, out = _git(repo, "checkout", snapshot, "--", d)
             if rc != 0 and "did not match" not in out:
                 raise GitError(f"git checkout {snapshot[:12]} -- {d} failed: {out}")

--- a/tests/test_generic_tmux.py
+++ b/tests/test_generic_tmux.py
@@ -18,6 +18,7 @@ from automator.adapters import generic, tmux_backend
 from automator.adapters.base import SessionHandle, SessionResult, SessionSpec
 from automator.adapters.generic import GenericDevAdapter, GenericTmuxAdapter
 from automator.adapters.profile import get_profile
+from automator.bmadconfig import ProjectPaths
 from automator.model import TokenUsage
 from automator.policy import LimitsPolicy, Policy
 from automator.signals import HookEvent
@@ -163,11 +164,18 @@ def test_await_result_grace_expires_fast(tmp_path):
 def make_dev_adapter(tmp_path, profile_name="claude"):
     impl = tmp_path / "impl"
     impl.mkdir()
+    # project root == tmp_path so rebased(spec.cwd=tmp_path) is a no-op: these
+    # unit tests exercise _result_json in place, where cwd == the project root.
+    paths = ProjectPaths(
+        project=tmp_path,
+        implementation_artifacts=impl,
+        planning_artifacts=tmp_path / "plan",
+    )
     adapter = GenericDevAdapter(
         run_dir=tmp_path / "run",
         policy=Policy(limits=LimitsPolicy()),
         profile=get_profile(profile_name),
-        impl_artifacts=impl,
+        paths=paths,
     )
     return adapter, impl
 
@@ -226,6 +234,40 @@ def test_generic_dev_synthesizes_done_spec(tmp_path):
     assert rj["baseline_commit"] == "abc123"  # mapped from baseline_revision
     assert rj["story_key"] == "3-1"
     assert rj["escalations"] == []
+
+
+def test_generic_dev_finds_spec_in_worktree(tmp_path):
+    # Under worktree isolation the skill runs with cwd set to the worktree and
+    # leaves its terminal spec in the worktree's rebased implementation-artifacts
+    # dir, not the main checkout's. The adapter must search the cwd-rebased dir or
+    # it false-stalls a story that actually completed (and rolls it back).
+    impl = tmp_path / "_bmad-output" / "impl"
+    impl.mkdir(parents=True)  # configured main-repo dir, left empty
+    paths = ProjectPaths(
+        project=tmp_path,
+        implementation_artifacts=impl,
+        planning_artifacts=tmp_path / "_bmad-output" / "plan",
+    )
+    adapter = GenericDevAdapter(
+        run_dir=tmp_path / "run",
+        policy=Policy(limits=LimitsPolicy()),
+        profile=get_profile("claude"),
+        paths=paths,
+    )
+
+    wt = tmp_path / "wt"
+    wt_impl = wt / "_bmad-output" / "impl"
+    wt_impl.mkdir(parents=True)
+    (wt_impl / "spec-3-1-foo.md").write_text(
+        "---\nstatus: done\nbaseline_revision: abc123\n---\n\n"
+        "## Auto Run Result\n\nStatus: done\nImplemented the thing.\n"
+    )
+
+    rj = adapter._result_json(_dev_handle(), _dev_spec(wt), wait=False)
+    assert rj is not None and rj["status"] == "done"
+
+    # Genuinely cwd-driven: pointed at the main checkout (empty dir), nothing is found.
+    assert adapter._result_json(_dev_handle(), _dev_spec(tmp_path), wait=False) is None
 
 
 def test_generic_dev_blocked_spec_is_critical(tmp_path):

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -486,6 +486,24 @@ def test_safe_rollback_restores_policy_deleted_by_reset(project):
     assert pol.read_text() == "[scm]\nrollback_on_failure = true\n"  # survived the reset
 
 
+def test_safe_rollback_restores_committed_policy_on_clean_tree(project):
+    """policy.toml committed AFTER the baseline, with an otherwise-clean tree:
+    `git stash create` is empty, so the old stash-gated restore skipped it and
+    `git reset --hard` reverted the operator's config. It must still survive."""
+    repo = project.project
+    baseline = verify.rev_parse_head(repo)  # baseline predates policy.toml
+    pol = repo / ".automator" / "policy.toml"
+    pol.parent.mkdir(parents=True, exist_ok=True)
+    pol.write_text("[scm]\nrollback_on_failure = true\n")
+    git(repo, "add", "-f", str(pol))
+    git(repo, "commit", "-q", "-m", "add policy after baseline")
+    snap = sorted(verify.untracked_files(repo))
+    # NOTE: no other working-tree change — tree is clean -> empty stash snapshot
+
+    verify.safe_rollback(repo, baseline, baseline_untracked=snap, keep=(".automator",))
+    assert pol.read_text() == "[scm]\nrollback_on_failure = true\n"  # survived
+
+
 def test_attempt_dirty_ignores_lone_policy_edit(project):
     """A diff confined to policy.toml is operator config, not the attempt's
     dirtiness — so a stopped attempt whose only residue is a policy edit reads as

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -445,6 +445,65 @@ def test_safe_rollback_tolerates_empty_preserve_dir(project):
     assert (repo / "src.txt").read_text() == "original\n"  # source still reverted
 
 
+def test_safe_rollback_preserves_uncommitted_policy_edit(project):
+    """A hand-edited, tracked but *uncommitted* .automator/policy.toml (e.g. a
+    freshly enabled scm.rollback_on_failure) must survive the hard reset — it is
+    operator config, not the dev attempt's work. Regression: a `git reset --hard`
+    used to silently revert it, so the very setting that gates auto-rollback was
+    gone before it could fire."""
+    repo = project.project
+    pol = repo / ".automator" / "policy.toml"
+    pol.parent.mkdir(parents=True, exist_ok=True)
+    pol.write_text("[scm]\nrollback_on_failure = false\n")
+    git(repo, "add", "-f", str(pol))
+    git(repo, "commit", "-q", "-m", "track policy")
+    baseline = verify.rev_parse_head(repo)
+    snap = sorted(verify.untracked_files(repo))
+
+    pol.write_text("[scm]\nrollback_on_failure = true\n")  # operator enables it, uncommitted
+    (repo / "src.txt").write_text("dev attempt\n")  # a real dev-attempt change
+
+    verify.safe_rollback(repo, baseline, baseline_untracked=snap, keep=(".automator",))
+    assert (repo / "src.txt").read_text() == "original\n"  # attempt reverted
+    assert pol.read_text() == "[scm]\nrollback_on_failure = true\n"  # edit preserved
+
+
+def test_safe_rollback_restores_policy_deleted_by_reset(project):
+    """policy.toml added/committed *after* the baseline would be deleted by a
+    reset to that older baseline; it is still restored from the snapshot."""
+    repo = project.project
+    baseline = verify.rev_parse_head(repo)  # baseline predates policy.toml
+    pol = repo / ".automator" / "policy.toml"
+    pol.parent.mkdir(parents=True, exist_ok=True)
+    pol.write_text("[scm]\nrollback_on_failure = true\n")
+    git(repo, "add", "-f", str(pol))
+    git(repo, "commit", "-q", "-m", "add policy after baseline")
+    snap = sorted(verify.untracked_files(repo))
+    (repo / "src.txt").write_text("dev attempt\n")
+
+    verify.safe_rollback(repo, baseline, baseline_untracked=snap, keep=(".automator",))
+    assert (repo / "src.txt").read_text() == "original\n"
+    assert pol.read_text() == "[scm]\nrollback_on_failure = true\n"  # survived the reset
+
+
+def test_attempt_dirty_ignores_lone_policy_edit(project):
+    """A diff confined to policy.toml is operator config, not the attempt's
+    dirtiness — so a stopped attempt whose only residue is a policy edit reads as
+    clean and the manual-recovery loop can terminate."""
+    repo = project.project
+    pol = repo / ".automator" / "policy.toml"
+    pol.parent.mkdir(parents=True, exist_ok=True)
+    pol.write_text("[scm]\nrollback_on_failure = false\n")
+    git(repo, "add", "-f", str(pol))
+    git(repo, "commit", "-q", "-m", "track policy")
+    baseline = verify.rev_parse_head(repo)
+
+    pol.write_text("[scm]\nrollback_on_failure = true\n")  # lone policy edit
+    assert verify.attempt_dirty(repo, baseline, []) is False
+    (repo / "src.txt").write_text("real change\n")  # plus a real change
+    assert verify.attempt_dirty(repo, baseline, []) is True
+
+
 def test_worktree_clean_ignores_policy_file(project):
     # A tracked-but-modified .automator/policy.toml (rewritten by the TUI
     # settings editor) must not count as a dirty tree, or every settings edit

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -470,7 +470,9 @@ def test_safe_rollback_preserves_uncommitted_policy_edit(project):
 
 def test_safe_rollback_restores_policy_deleted_by_reset(project):
     """policy.toml added/committed *after* the baseline would be deleted by a
-    reset to that older baseline; it is still restored from the snapshot."""
+    reset to that older baseline; it is still restored from the pre-reset on-disk
+    capture (the dirty src.txt here keeps the stash snapshot non-empty — the
+    clean-tree, empty-snapshot path is covered by the test below)."""
     repo = project.project
     baseline = verify.rev_parse_head(repo)  # baseline predates policy.toml
     pol = repo / ".automator" / "policy.toml"

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "bmad-auto"
-version = "0.7.1"
+version = "0.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
## 0.7.2 — bug-fix release

### Fixed

- **Worktree isolation no longer false-stalls a story that actually finished.** Under `scm.isolation = worktree` the `bmad-dev-auto` session runs with its cwd set to the worktree and leaves its terminal spec in the worktree's `_bmad-output/implementation-artifacts`, but the dev adapter searched the main checkout's dir (resolved once at startup). The completed `status: done` spec was never found, so the orchestrator misread the session as stalled, rolled the unit branch back to baseline, and re-ran the same story. The adapter now resolves the spec directory from the live session cwd; in-place runs and out-of-tree artifact dirs are unaffected.
- **An uncommitted `policy.toml` edit no longer vanishes on rollback.** `policy.toml` is tracked but lives inside the kept `.automator` dir, so a rollback's `git reset --hard` to baseline silently reverted operator edits and a lone policy edit could register as attempt dirtiness, trapping the manual-recovery loop. Rollback now restores `policy.toml` from its on-disk content unconditionally — so an edit committed after the baseline on an otherwise-clean tree survives too, not only one that rode a non-empty `git stash` snapshot — and the dirty check always excludes it.
- **Fixed a decision-toast notification race in the TUI test suite on Python 3.14.** Test-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worktree-aware file discovery so specs are found correctly during isolated runs, avoiding false “stalled” detections.
  * Rollbacks now preserve configuration changes, preventing unexpected loss of `policy.toml` edits.
  * Dirtiness checks now ignore configuration-only changes, reducing false positives.
  * Fixed a test-suite notification race on Python 3.14.

* **Chores**
  * Bumped the release version to `0.7.2`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
