### PR TITLE
ci: make tmux install resilient to third-party apt repo flakiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,16 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install tmux (for generic_tmux integration tests)
-        run: sudo apt-get update && sudo apt-get install -y tmux
+        run: |
+          # `apt-get update` can exit non-zero when an unrelated third-party
+          # repo baked into the runner image (e.g. dl.google.com/chrome) serves
+          # a stale index (Hash Sum mismatch). That must not fail our build —
+          # the Ubuntu archive lists still refresh, so tmux installs cleanly.
+          # `tmux -V` then asserts tmux is actually present, so a genuine
+          # install failure still fails the job loudly.
+          sudo apt-get update -o Acquire::Retries=3 || true
+          sudo apt-get install -y tmux
+          tmux -V
 
       - name: Install the project
         run: uv sync --locked --all-extras


### PR DESCRIPTION
## Problem

The recurring "flaky" CI failure (most recently the [#17 / 0.7.4 merge run](https://github.com/bmad-code-org/bmad-auto/actions/runs/28262065820), job `test (py3.12)`, exit 100) is **not** a flaky pytest test — it's the **Install tmux** step.

The step ran `sudo apt-get update && sudo apt-get install -y tmux` under a `-e` shell. The job log shows `apt-get update` failing with a **Hash Sum mismatch** on `https://dl.google.com/linux/chrome-stable/deb` — a third-party repo baked into the GitHub runner image, unrelated to this project (the CDN served a stale index mid-publish). The Ubuntu archive lists fetched fine; only Chrome's `Packages.gz` failed its hash check. Because `update` is chained with `&&`, that unrelated hiccup returned non-zero and killed the whole job. It's intermittent (other matrix legs passed in the same run), which is exactly why it keeps recurring.

## Fix

- `apt-get update ... || true` — unrelated third-party repo flakiness can no longer fail the build (the Ubuntu lists still refresh, so tmux installs cleanly).
- `tmux -V` — safety net: if the swallowed `update` error ever did prevent install, the job fails on a clear, on-topic line instead of silently skipping the ~27 `generic_tmux` integration tests.
- `Acquire::Retries=3` — cheap resilience for genuine transient blips on the Ubuntu archive.

tmux is **not** pre-installed on `ubuntu-24.04`, so dropping the step was rejected (it would silently drop integration-test coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the CI test setup to handle package installation more reliably.
  * The workflow now retries package index updates and continues safely when a temporary repository issue occurs.
  * Verification still ensures the required tool is actually installed before tests proceed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->