### PR TITLE
Windows terminal-multiplexer backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
         python-version: ['3.11', '3.12', '3.13', '3.14']
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
@@ -41,6 +43,27 @@ jobs:
           sudo apt-get update -o Acquire::Retries=3 || true
           sudo apt-get install -y tmux
           tmux -V
+
+      - name: Install the project
+        run: uv sync --locked --all-extras
+
+      - name: Run tests
+        run: uv run pytest -q
+
+  test-windows:
+    # Real-Windows runner for the deterministic suite (live psmux e2e stays a manual gate).
+    name: test (windows, native)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
+          python-version: '3.13'
 
       - name: Install the project
         run: uv sync --locked --all-extras

--- a/src/automator/adapters/multiplexer.py
+++ b/src/automator/adapters/multiplexer.py
@@ -223,11 +223,15 @@ def _load_builtin_backends() -> None:
     global _BUILTINS_LOADED
     if _BUILTINS_LOADED:
         return
+    from .psmux_backend import PsmuxMultiplexer
     from .tmux_backend import TmuxMultiplexer
 
     # tmux is the default everywhere except native Windows (no tmux binary there);
     # get_multiplexer still falls back to tmux when no backend matches.
     register_multiplexer("tmux", lambda platform: platform != "win32", TmuxMultiplexer)
+    # psmux is the bundled native-Windows backend (a tmux.exe drop-in); it matches
+    # win32, where tmux's matcher above is false, so the two never collide.
+    register_multiplexer("psmux", lambda platform: platform == "win32", PsmuxMultiplexer)
     _BUILTINS_LOADED = True  # set only after a successful import so a transient failure retries
 
 

--- a/src/automator/adapters/psmux_backend.py
+++ b/src/automator/adapters/psmux_backend.py
@@ -1,0 +1,238 @@
+"""psmux backend for the terminal-multiplexer seam (native Windows, no WSL).
+
+psmux ships a ``tmux.exe`` drop-in with the same stable-id scheme and ``-t``
+targeting, so ``subprocess.run(["tmux", …])`` and almost every argv resolve
+unchanged. This backend therefore *subclasses* :class:`~.tmux_base.BaseTmuxBackend`
+(the tmux-family base, not its POSIX leaf — psmux is a sibling of
+:class:`~.tmux_backend.TmuxMultiplexer`) and overrides only the genuinely-divergent
+operations:
+
+  * **encoding** — Windows defaults to cp1252, which garbles ``-F`` output and
+    multibyte separators; every read forces ``encoding="utf-8"``. Done once, in
+    the shared ``_run`` seam, so it covers inherited reads too.
+  * **parked window** — the POSIX ``sh -c "…; read -r; …"`` trailer has no
+    ``/bin/sh`` natively; re-expressed in pwsh (run argv, capture
+    ``$LASTEXITCODE``, ``Read-Host`` to park, then the same ``tmux`` return verbs).
+  * **env injection** — psmux ``new-window -e`` does not propagate env to the
+    child; inject it as a pwsh ``$env:K='v'`` prelude instead (names validated).
+  * **pipe-pane** — ``cat`` is not native; use a pwsh sink, best-effort.
+  * **kill-session** — psmux silently ignores the ``=name`` exact-match form;
+    plain-name targeting actually removes the session.
+
+Two facts shape every pwsh construction here: psmux runs a window command as an
+**argv with an explicit interpreter** (``pwsh …``), and a pwsh ``-Command "…"``
+string is mangled crossing the tmux→ConPTY→pwsh quoting layers — so the script
+is always passed via ``-EncodedCommand`` (base64 UTF-16LE).
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+import re
+import shlex
+import shutil
+import subprocess
+from pathlib import Path
+
+from .multiplexer import MultiplexerError
+from .tmux_base import PARKED_RETURN_DETACH, TMUX_TIMEOUT_S, BaseTmuxBackend
+
+# A safe POSIX/pwsh env-var name. Validated before interpolation into the pwsh
+# prelude so a hostile key (e.g. "X; rm -rf /") can't break out of the assignment.
+_ENV_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+# psmux refuses to create a session when it detects it is running inside one: with
+# any of these set, `new-session` prints "sessions should be nested with care, unset
+# PSMUX_SESSION to force" and returns 0 *without creating the session* — so the
+# immediate set-option then fails with "no server running on session" (psmux #424).
+# The engine runs inside the bmad-auto-ctl pane, so strip the guard vars for the
+# create call; the session lands on the same default server and targets normally
+# afterwards. (Verified on psmux 3.3.6.)
+_NESTING_GUARD_ENV = ("PSMUX_SESSION", "PSMUX_ACTIVE", "TMUX")
+
+# psmux injects agent-teams env at the tmux-server level (claude-code-fix-tty on,
+# the default), so bmad-auto's own `claude` would launch in teammate mode. -NoProfile
+# bypasses the profile *wrapper* but not these process-level vars (measured); clear
+# them in-window before the command runs. Scoped to our pane — no global `set-option`,
+# nothing to restore. A caller that genuinely wants a var back just sets it via env.
+_CLEAR_TEAMMATE_ENV = (
+    "Remove-Item Env:CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS -ErrorAction SilentlyContinue; "
+    "Remove-Item Env:PSMUX_CLAUDE_TEAMMATE_MODE -ErrorAction SilentlyContinue; "
+)
+
+
+class PsmuxError(MultiplexerError):
+    pass
+
+
+def _enc(ps_source: str) -> str:
+    """Encode a pwsh script for ``-EncodedCommand`` (base64 UTF-16LE) — the only
+    form that survives the tmux→ConPTY→pwsh quoting layers intact."""
+    return base64.b64encode(ps_source.encode("utf-16-le")).decode("ascii")
+
+
+def _pwsh_argv(ps_source: str) -> list[str]:
+    # -NoProfile: skip the user profile — keeps window-startup fast and bypasses
+    # psmux's claude-code-fix-tty *wrapper* (defined in the profile), so `claude`
+    # resolves to the real executable, not the teammate-mode function. The
+    # process-level PSMUX_CLAUDE_TEAMMATE_MODE env injection that rides the tmux
+    # server env regardless of -NoProfile is cleared separately by
+    # _CLEAR_TEAMMATE_ENV at the head of each launched window's source.
+    return ["pwsh", "-NoProfile", "-EncodedCommand", _enc(ps_source)]
+
+
+def _ps_single(value: str | Path) -> str:
+    """Escape a value for a pwsh single-quoted literal (``''`` escapes ``'``)."""
+    return str(value).replace("'", "''")
+
+
+def _pwsh_call(command: str) -> str:
+    # Precondition: `command` must be a shlex.quote-shaped (POSIX) string — the
+    # sole caller routes through GenericAdapter.build_command, which quotes each
+    # arg. posix=True split treats `\` as an escape, so a raw Windows path like
+    # `C:\new\settings.json` would silently lose its backslashes here; pre-quoted
+    # input avoids that.
+    try:
+        argv = shlex.split(command, posix=True)
+    except ValueError as exc:
+        raise PsmuxError(f"invalid command quoting for psmux: {exc}") from exc
+    if not argv:
+        raise PsmuxError("empty command for psmux window")
+    return "& " + " ".join(f"'{_ps_single(a)}'" for a in argv)
+
+
+class PsmuxMultiplexer(BaseTmuxBackend):
+    def _run(
+        self, argv: list[str], *, check: bool = True, env: dict[str, str] | None = None
+    ) -> subprocess.CompletedProcess[str]:
+        # Override the base spawn primitive for the two Windows divergences the base
+        # `_run` cannot carry: force utf-8 decoding (Windows defaults to cp1252, which
+        # garbles `-F` output and multibyte separators — every read covered once here,
+        # inherited ones included), and forward an optional `env` (the base forwards
+        # none) so new_session can strip psmux's nesting guard. `argv` excludes "tmux",
+        # prepended here exactly as the base does.
+        proc = subprocess.run(
+            ["tmux", *argv],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="backslashreplace",
+            timeout=TMUX_TIMEOUT_S,
+            env=env,
+        )
+        if check and proc.returncode != 0:
+            raise PsmuxError(f"tmux {' '.join(argv[:2])} failed: {proc.stderr.strip()}")
+        return proc
+
+    def new_session(
+        self, name: str, cwd: Path, cols: int | None = None, lines: int | None = None
+    ) -> None:
+        # Same geometry contract as the base, but the create call runs with the
+        # nesting-guard env stripped (see _NESTING_GUARD_ENV) so psmux actually
+        # creates the session from inside the control pane instead of no-op'ing.
+        # The base's `_tmux` forwards no env, so go through the `_run` override with
+        # check=False (to raise the psmux-specific message) and the env passthrough.
+        geometry = ["-x", str(cols), "-y", str(lines)] if cols and lines else []
+        env = {k: v for k, v in os.environ.items() if k not in _NESTING_GUARD_ENV}
+        proc = self._run(
+            ["new-session", "-d", "-s", name, "-c", str(cwd), *geometry],
+            check=False,
+            env=env,
+        )
+        if proc.returncode != 0:
+            raise PsmuxError(f"tmux new-session failed: {proc.stderr.strip()}")
+
+    def new_window(
+        self, session: str, name: str, cwd: Path, env: dict[str, str], command: str
+    ) -> str:
+        # `-e` does not reach the child on psmux; layer env via a pwsh prelude.
+        # The command runs under an explicit pwsh interpreter because psmux execs a
+        # bare command string as a program name (it would silently die otherwise).
+        source = f"{_CLEAR_TEAMMATE_ENV}{self._env_prelude(env)}{_pwsh_call(command)}"
+        return self._tmux(
+            "new-window",
+            "-t",
+            f"={session}:",
+            "-n",
+            name,
+            "-c",
+            str(cwd),
+            "-P",
+            "-F",
+            "#{window_id}",
+            *_pwsh_argv(source),
+        )
+
+    def new_parked_window(
+        self, session: str, name: str, cwd: Path, argv: list[str], return_opt: str
+    ) -> str:
+        # Re-express the POSIX parked trailer in pwsh. The return-trailer verbs
+        # are the *same* tmux verbs as the POSIX backend (they hit tmux.exe and are
+        # protocol-identical) — only the shell wrapper changes.
+        if not argv:
+            raise PsmuxError("empty argv for parked window")
+        inner = "& " + " ".join(f"'{_ps_single(a)}'" for a in argv)
+        return_trailer = (
+            f"$ret = (tmux show-options -wqv '{_ps_single(return_opt)}') 2>$null; "
+            f"if ($ret -eq '{PARKED_RETURN_DETACH}') {{ tmux detach-client 2>$null }} "
+            "elseif ($ret) { tmux switch-client -t $ret 2>$null; "
+            "if ($LASTEXITCODE -ne 0) { tmux switch-client -l 2>$null } }"
+        )
+        source = (
+            f"{_CLEAR_TEAMMATE_ENV}{inner}; $ec = $LASTEXITCODE; "
+            'Write-Host "[bmad-auto exited $ec — press enter]"; '
+            f"Read-Host; {return_trailer}"
+        )
+        return self._tmux(
+            "new-window",
+            "-d",
+            "-P",
+            "-F",
+            "#{window_id}",
+            "-t",
+            f"={session}:",
+            "-n",
+            name,
+            "-c",
+            str(cwd),
+            *_pwsh_argv(source),
+        )
+
+    def pipe_pane(self, window_id: str, log_file: Path) -> None:
+        # Debug-only and best-effort, but still attach a native pwsh sink.
+        sink = (
+            f"$p='{_ps_single(log_file)}'; "
+            "$d=Split-Path -Parent $p; "
+            "if ($d) { New-Item -ItemType Directory -Force -Path $d | Out-Null }; "
+            "$input | Add-Content -LiteralPath $p -Encoding utf8"
+        )
+        try:
+            self._tmux("pipe-pane", "-t", window_id, "-o", " ".join(_pwsh_argv(sink)))
+        except (MultiplexerError, subprocess.SubprocessError, OSError):
+            pass
+
+    def kill_session(self, name: str) -> None:
+        # The `=name` exact-match form is silently ignored by psmux's kill-session
+        # (returns 0, doesn't kill); plain-name actually removes it.
+        # Same best-effort tolerance as the POSIX backend.
+        if not shutil.which("tmux"):
+            return
+        try:
+            self._run(["kill-session", "-t", name], check=False)
+        except (subprocess.SubprocessError, OSError):
+            pass
+
+    def _env_prelude(self, env: dict[str, str]) -> str:
+        """A pwsh ``$env:K='v'; …; `` prelude setting each var, or '' when empty.
+        Names are validated against ``_ENV_NAME`` and values single-quoted so the
+        prelude can't be broken out of."""
+        parts: list[str] = []
+        for key, value in env.items():
+            if not _ENV_NAME.match(key):
+                raise PsmuxError(f"unsafe env var name for psmux prelude: {key!r}")
+            parts.append(f"$env:{key}='{_ps_single(value)}'")
+        return "; ".join(parts) + "; " if parts else ""
+
+    def available(self) -> bool:
+        return all(shutil.which(name) is not None for name in ("psmux", "tmux", "pwsh"))

--- a/src/automator/install.py
+++ b/src/automator/install.py
@@ -180,6 +180,9 @@ def _worktree_local_exclude(worktree: Path, patterns: Sequence[str]) -> None:
     git's standard local-only exclude (never committed or pushed); it does not
     affect already-tracked files. Best-effort — skipped if git can't be queried.
     """
+    # git's exclude patterns are POSIX-slash on every platform; a Windows-derived
+    # relative path carries os.sep ("\\") and would anchor nothing. Normalize.
+    patterns = [p.replace("\\", "/") for p in patterns]
     try:
         common = subprocess.run(
             ["git", "-C", str(worktree), "rev-parse", "--git-common-dir"],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ that simulate the side effects skill sessions would have on disk."""
 from __future__ import annotations
 
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -12,6 +13,31 @@ import yaml
 from automator.adapters.base import SessionResult, SessionSpec
 from automator.bmadconfig import ProjectPaths
 from automator.verify import rev_parse_head
+
+
+def write_script_launcher(directory: Path, name: str, body: str) -> Path:
+    """Write ``body`` (python source) to a sidecar ``<name>.py`` and return a
+    launcher the host can exec and ``shutil.which`` can find. Single-sources the
+    body across platforms: on Windows a ``.cmd`` shim (an extension PATHEXT/which
+    recognize, runnable via list-exec or a shell) — a bare extensionless file would
+    pop Windows' "select an app" dialog and hang the launch; on POSIX a chmod+x
+    shebang wrapper. Both forward argv to the sidecar under the running interpreter,
+    so a fake CLI works the same whether the code under test calls it directly or
+    through a shell."""
+    directory = Path(directory)
+    sidecar = directory / f"{name}.py"
+    sidecar.write_text(body, encoding="utf-8")
+    if sys.platform == "win32":
+        launcher = directory / f"{name}.cmd"
+        launcher.write_text(f'@"{sys.executable}" "{sidecar}" %*\r\n', encoding="utf-8")
+    else:
+        launcher = directory / name
+        launcher.write_text(
+            f'#!/bin/sh\nexec "{sys.executable}" "{sidecar}" "$@"\n', encoding="utf-8"
+        )
+        launcher.chmod(0o755)
+    return launcher
+
 
 SPRINT_TEMPLATE = {
     "generated": "01-06-2026 10:00",

--- a/tests/test_backend_registry.py
+++ b/tests/test_backend_registry.py
@@ -34,9 +34,14 @@ def fresh_registry(monkeypatch):
     m.get_multiplexer.cache_clear()
 
 
-def test_default_is_tmux(fresh_registry):
+def test_default_is_tmux(fresh_registry, monkeypatch):
     """No override, POSIX host → tmux, selected via the loop's platform match (the
-    builtin registers ``matches=p != 'win32'``), not just the bottom fallback."""
+    builtin registers ``matches=p != 'win32'``), not just the bottom fallback. Pin a
+    POSIX platform so the assertion holds when the suite runs on a native-Windows
+    host too (there the default is psmux, exercised in test_backend_registry's
+    win32 cases and test_psmux_backend)."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    fresh_registry.get_multiplexer.cache_clear()
     assert isinstance(fresh_registry.get_multiplexer(), TmuxMultiplexer)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -790,7 +790,7 @@ def test_diagnose_default_latest_and_out(project, tmp_path, capsys):
     out_file = tmp_path / "diag.md"
     rc = cli.main(["diagnose", "--project", str(project.project), "--json", "--out", str(out_file)])
     assert rc == 0
-    report = out_file.read_text()
+    report = out_file.read_text(encoding="utf-8")
     assert "diagnostic dump (sanitized)" in report
     for canary in CANARIES:
         assert canary not in report, f"LEAK via CLI: {canary!r}"
@@ -821,7 +821,7 @@ def test_diagnose_legend_written_locally(project, tmp_path):
     assert rc == 0
     legend = json.loads(legend_file.read_text())
     assert STORY_KEY in legend.values()  # legend reverses pseudonyms locally
-    assert STORY_KEY not in out_file.read_text()  # but the dump never carries it
+    assert STORY_KEY not in out_file.read_text(encoding="utf-8")  # but the dump never carries it
 
 
 # ---- validate platform preflight (routes through the multiplexer + host seams) ----

--- a/tests/test_decisions.py
+++ b/tests/test_decisions.py
@@ -123,7 +123,10 @@ def test_apply_pre_answer_build_records_store_and_ledger(project):
     d = Decision(id="DW-1", question="build it?", context="", options=(opt,), recommendation="1")
     decisions.apply_pre_answer(project.project, d, opt, date="2026-06-13")
 
-    entries = {e.id: e for e in deferredwork.parse_ledger(project.deferred_work.read_text())}
+    entries = {
+        e.id: e
+        for e in deferredwork.parse_ledger(project.deferred_work.read_text(encoding="utf-8"))
+    }
     assert "decision: 2026-06-13 Build — widen field" in entries["DW-1"].body
     assert entries["DW-1"].open  # build stays open until a sweep builds it
     assert decisions.load_pre_answers(project.project)["DW-1"]["effect"] == "build"
@@ -139,7 +142,10 @@ def test_apply_pre_answer_close_marks_done_no_store(project):
     d = Decision(id="DW-1", question="close?", context="", options=(opt,), recommendation="1")
     decisions.apply_pre_answer(project.project, d, opt, date="2026-06-13")
 
-    entries = {e.id: e for e in deferredwork.parse_ledger(project.deferred_work.read_text())}
+    entries = {
+        e.id: e
+        for e in deferredwork.parse_ledger(project.deferred_work.read_text(encoding="utf-8"))
+    }
     assert entries["DW-1"].status.startswith("done")
     assert "closed by human decision: superseded" in entries["DW-1"].body
     assert decisions.load_pre_answers(project.project) == {}  # close needs no carry-forward

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,8 +1,8 @@
 """Engine scenario tests against the mock adapter — no tmux, no LLM."""
 
-import os
 import re
 import signal
+import sys
 from pathlib import Path
 
 import pytest
@@ -43,6 +43,16 @@ from automator.runs import rearm_escalation
 from automator.verify import read_frontmatter, rev_parse_head, worktree_clean
 
 QUIET = NotifyPolicy(desktop=False, file=True)
+
+
+def _file_exists_cmd(path) -> str:
+    """Shell verify command (run via shell=True) exiting 0 iff `path` exists, on the
+    host's shell — `test -f` (POSIX) / `if exist` (Windows cmd) — so the verify-gate
+    tests drive the real machinery on either OS, not a POSIX-only `test` that cmd
+    rejects with "'test' is not recognized"."""
+    if sys.platform == "win32":
+        return f'if exist "{path}" (exit 0) else (exit 1)'
+    return f"test -f {path}"
 
 
 def make_engine(project, script, policy=None, **kwargs) -> tuple[Engine, MockAdapter]:
@@ -749,7 +759,7 @@ def test_generic_repair_reopens_spec_before_reinvocation(project):
         notify=QUIET,
         review=ReviewPolicy(enabled=False),
         dev=DevPolicy(skill="bmad-dev-auto"),
-        verify=VerifyPolicy(commands=("test -f marker.txt",)),
+        verify=VerifyPolicy(commands=(_file_exists_cmd("marker.txt"),)),
         scm=ScmPolicy(rollback_on_failure=True),
     )
     engine, adapter = make_engine(project, [effect, effect], policy=pol)
@@ -1317,7 +1327,7 @@ def test_dev_verify_command_failure_routes_feedback_fix(project):
                 "baseline_commit": baseline,
                 "tasks_total": 3,
                 "tasks_done": 3,
-                "verification": [{"command": f"test -f {marker}", "ok": True}],
+                "verification": [{"command": _file_exists_cmd(marker), "ok": True}],
                 "escalations": [],
             },
         )
@@ -1325,7 +1335,7 @@ def test_dev_verify_command_failure_routes_feedback_fix(project):
     policy = Policy(
         gates=GatesPolicy(mode="none"),
         notify=QUIET,
-        verify=VerifyPolicy(commands=(f"test -f {marker}",)),
+        verify=VerifyPolicy(commands=(_file_exists_cmd(marker),)),
     )
     engine, adapter = make_engine(
         project,
@@ -1346,7 +1356,7 @@ def test_dev_verify_command_failure_routes_feedback_fix(project):
     # the feedback file is referenced as the last backtick-wrapped path.
     assert "Resume the autonomous" not in prompts[0] and "Resume the autonomous" in prompts[1]
     feedback = Path(re.findall(r"`([^`]*)`", prompts[1])[-1])
-    assert "test -f" in feedback.read_text()
+    assert _file_exists_cmd(marker) in feedback.read_text()
     # the first attempt's work survived: no reset between attempts
     assert "change for 1-1-a" in (project.project / "src.txt").read_text()
 
@@ -1374,7 +1384,7 @@ def test_review_verify_failure_routes_fix_session_then_rereview(project):
     policy = Policy(
         gates=GatesPolicy(mode="none"),
         notify=QUIET,
-        verify=VerifyPolicy(commands=(f"test -f {marker}",)),
+        verify=VerifyPolicy(commands=(_file_exists_cmd(marker),)),
     )
     engine, adapter = make_engine(
         project,
@@ -1410,7 +1420,7 @@ def test_review_verify_failure_without_fix_budget_defers(project):
     policy = Policy(
         gates=GatesPolicy(mode="none"),
         notify=QUIET,
-        verify=VerifyPolicy(commands=(f"test -f {marker}",)),
+        verify=VerifyPolicy(commands=(_file_exists_cmd(marker),)),
         limits=LimitsPolicy(max_dev_attempts=1),
     )
     engine, adapter = make_engine(project, [dev_with_marker, breaking_review], policy=policy)
@@ -1645,7 +1655,10 @@ def test_run_stopped_via_real_signal(project, monkeypatch):
     killed = []
     monkeypatch.setattr("automator.engine.kill_session", lambda rid: killed.append(rid))
     engine, _ = make_engine(project, [])
-    monkeypatch.setattr(engine, "_loop", lambda: os.kill(os.getpid(), signal.SIGTERM))
+    # raise_signal delivers an in-process, catchable SIGTERM via C raise() — the
+    # portable "signal myself" primitive. os.kill(getpid(), SIGTERM) is POSIX-only
+    # here: on Windows it maps to TerminateProcess (uncatchable, kills the runner).
+    monkeypatch.setattr(engine, "_loop", lambda: signal.raise_signal(signal.SIGTERM))
 
     prev_term = signal.getsignal(signal.SIGTERM)
     prev_int = signal.getsignal(signal.SIGINT)

--- a/tests/test_engine_plugin.py
+++ b/tests/test_engine_plugin.py
@@ -20,9 +20,11 @@ from __future__ import annotations
 import importlib.util
 import json
 import os
+import sys
 import time
 
 import pytest
+from conftest import write_script_launcher
 
 from automator.engine import Engine, _setup_mcp_agent_id
 from automator.plugins import HookContext, PluginError, get_plugin, load_plugins
@@ -447,18 +449,15 @@ def test_unity_ready_grace_explicit_override(monkeypatch):
 
 def _fake_cli(tmp_path, *, wait_rc=0, tool_rc=0):
     """A fake unity-mcp-cli that logs argv and returns per-subcommand exit codes."""
-    script = tmp_path / "fake-unity-mcp-cli"
     log = tmp_path / "calls.log"
-    script.write_text(
-        "#!/usr/bin/env python3\n"
+    body = (
         "import sys\n"
         f"open({str(log)!r}, 'a').write(' '.join(sys.argv[1:]) + chr(10))\n"
         "cmd = sys.argv[1] if len(sys.argv) > 1 else ''\n"
         f"sys.exit({wait_rc} if cmd == 'wait-for-ready' "
         f"else ({tool_rc} if cmd == 'run-tool' else 0))\n"
     )
-    script.chmod(0o755)
-    return script, log
+    return write_script_launcher(tmp_path, "fake-unity-mcp-cli", body), log
 
 
 def test_unity_ready_default_is_wait_for_ready_only(tmp_path, monkeypatch):
@@ -489,15 +488,14 @@ def test_unity_ready_tool_error_marker_means_not_ready(tmp_path, monkeypatch):
     connection-refused) is treated as not-ready, not a false pass."""
     mod = _load_unity_ready()
     # exit 0 but stdout carries an error marker
-    script = tmp_path / "fake-cli"
-    script.write_text(
-        "#!/usr/bin/env python3\n"
+    script = write_script_launcher(
+        tmp_path,
+        "fake-cli",
         "import sys\n"
         "cmd = sys.argv[1] if len(sys.argv) > 1 else ''\n"
         "print('ERROR: Tool with Name not found' if cmd == 'run-tool' else 'ok')\n"
-        "sys.exit(0)\n"
+        "sys.exit(0)\n",
     )
-    script.chmod(0o755)
     monkeypatch.setenv("UNITY_MCP_CLI", str(script))
     monkeypatch.setenv("BMAD_AUTO_WORKTREE", str(tmp_path))
     monkeypatch.setenv("BMAD_AUTO_UNITY_READY_TOOL", "ping")
@@ -672,6 +670,10 @@ def test_unity_setup_prime_scriptassemblies_only_is_cold(tmp_path, monkeypatch):
     assert (wt / "Library" / "ArtifactDB").read_text() == "db"  # primed over leftover
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="symlink-based Unity Library priming is POSIX-only; native-Windows cache path is a tracked follow-up",
+)
 def test_unity_setup_prime_symlink_fallback_when_no_seed(tmp_path, monkeypatch):
     mod = _load_unity_setup()
     _clear_setup_knobs(monkeypatch)
@@ -683,6 +685,10 @@ def test_unity_setup_prime_symlink_fallback_when_no_seed(tmp_path, monkeypatch):
     assert (wt / "Library").is_symlink()  # fell back to the empty-cache symlink
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="symlink-based Unity Library priming is POSIX-only; native-Windows cache path is a tracked follow-up",
+)
 def test_unity_setup_prime_seed_mode_off_uses_symlink(tmp_path, monkeypatch):
     mod = _load_unity_setup()
     _clear_setup_knobs(monkeypatch)
@@ -696,6 +702,10 @@ def test_unity_setup_prime_seed_mode_off_uses_symlink(tmp_path, monkeypatch):
     assert (wt / "Library").is_symlink()  # priming disabled despite a warm seed
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="symlink-based Unity Library priming is POSIX-only; native-Windows cache path is a tracked follow-up",
+)
 def test_unity_setup_prime_drops_stale_symlink(tmp_path, monkeypatch):
     mod = _load_unity_setup()
     _clear_setup_knobs(monkeypatch)
@@ -748,10 +758,8 @@ def _fake_setup_cli(tmp_path):
     """Fake unity-mcp-cli for the setup hook: setup-mcp writes claude-code's
     .mcp.json (path-derived 23723) and codex's .codex/config.toml (honoring --url,
     or FAKE_CODEX_FORCE_URL to simulate a leaked port); other subcommands no-op 0."""
-    script = tmp_path / "fake-setup-cli"
     log = tmp_path / "setup-calls.log"
-    script.write_text(
-        "#!/usr/bin/env python3\n"
+    body = (
         "import sys, os, json\n"
         f"open({str(log)!r}, 'a').write(' '.join(sys.argv[1:]) + chr(10))\n"
         "a = sys.argv[1:]\n"
@@ -768,8 +776,7 @@ def _fake_setup_cli(tmp_path):
         "            '[mcp_servers.ai-game-developer]\\nurl = \"%s\"\\n' % u)\n"
         "sys.exit(0)\n"
     )
-    script.chmod(0o755)
-    return script, log
+    return write_script_launcher(tmp_path, "fake-setup-cli", body), log
 
 
 def test_unity_setup_configures_every_agent_at_worktree_port(tmp_path, monkeypatch):

--- a/tests/test_engine_worktree.py
+++ b/tests/test_engine_worktree.py
@@ -8,6 +8,8 @@ adapter (no tmux, no LLM).
 
 from __future__ import annotations
 
+import sys
+
 from conftest import _spec_baseline, git, set_sprint, write_spec, write_sprint
 
 from automator.adapters.base import SessionResult
@@ -504,9 +506,36 @@ def test_commit_message_template_applied(project):
 # ------------------------------------------------ per_worktree engine plugin
 
 
-def _write_stub_plugin(
-    project, name, *, ready="true", setup="true", teardown="true", seed_globs=None
-):
+_OK = "exit 0"  # cross-platform always-success verb (both `cmd /c` and `sh -c` honor it)
+_RUN = "%BMAD_AUTO_RUN_DIR%" if sys.platform == "win32" else "$BMAD_AUTO_RUN_DIR"
+
+
+def _touch_run(marker: str) -> str:
+    """Shell command (run via shell=True) creating an empty marker file under the run dir."""
+    if sys.platform == "win32":
+        return f'type nul > "{_RUN}\\{marker}"'
+    return f'touch "{_RUN}/{marker}"'
+
+
+def _exists_run(marker: str) -> str:
+    """Shell command exiting 0 iff the run-dir marker exists (drives a ready gate)."""
+    if sys.platform == "win32":
+        return f'if exist "{_RUN}\\{marker}" (exit 0) else (exit 1)'
+    return f'test -f "{_RUN}/{marker}"'
+
+
+def _seeded_then_touch(rel: str, marker: str) -> str:
+    """Assert a seeded worktree-relative file exists, then create the run-dir marker —
+    proving seed+setup precede the gate. cmd can't chain `... && touch` after an
+    `exit`, so on Windows the touch nests inside the `if exist`."""
+    if sys.platform == "win32":
+        return (
+            f'if exist "{rel.replace("/", chr(92))}" (type nul > "{_RUN}\\{marker}") else (exit 1)'
+        )
+    return f'test -f {rel} && touch "{_RUN}/{marker}"'
+
+
+def _write_stub_plugin(project, name, *, ready=_OK, setup=_OK, teardown=_OK, seed_globs=None):
     """A project-local *declarative* plugin whose lifecycle hooks are shell stubs
     (no real Unity) — proving a generic data-only plugin can gate the engine's
     per_worktree flow. A blocking hook's non-zero exit vetoes (defers) the unit.
@@ -558,10 +587,9 @@ def test_per_worktree_setup_then_gate_then_teardown_and_seed(project):
     _write_stub_plugin(
         project,
         "stub",
-        setup="test -f .claude/skills/gameobject-create/SKILL.md "
-        '&& touch "$BMAD_AUTO_RUN_DIR/setup-done"',
-        ready='test -f "$BMAD_AUTO_RUN_DIR/setup-done"',
-        teardown='touch "$BMAD_AUTO_RUN_DIR/teardown-done"',
+        setup=_seeded_then_touch(".claude/skills/gameobject-create/SKILL.md", "setup-done"),
+        ready=_exists_run("setup-done"),
+        teardown=_touch_run("teardown-done"),
         seed_globs=[".claude/skills/*"],
     )
     engine, adapter = make_engine(
@@ -591,7 +619,7 @@ def test_per_worktree_setup_failure_defers_and_skips_session(project):
         project,
         "stub",
         setup="exit 3",
-        teardown='touch "$BMAD_AUTO_RUN_DIR/teardown-done"',
+        teardown=_touch_run("teardown-done"),
     )
     engine, adapter = make_engine(
         project,
@@ -622,7 +650,7 @@ def test_per_worktree_ready_gate_failure_defers(project):
         project,
         "stub",
         ready="exit 1",
-        teardown='touch "$BMAD_AUTO_RUN_DIR/teardown-done"',
+        teardown=_touch_run("teardown-done"),
     )
     engine, adapter = make_engine(
         project,
@@ -648,7 +676,7 @@ def test_per_worktree_teardown_runs_on_pause(project):
     _write_stub_plugin(
         project,
         "stub",
-        teardown='touch "$BMAD_AUTO_RUN_DIR/teardown-done"',
+        teardown=_touch_run("teardown-done"),
     )
     engine, _ = make_engine(
         project,

--- a/tests/test_generic_tmux.py
+++ b/tests/test_generic_tmux.py
@@ -9,6 +9,7 @@ propagation / hook-signal waiting / kill end-to-end for any profile.
 
 import shutil
 import subprocess
+import sys
 import time
 from pathlib import Path
 
@@ -24,7 +25,11 @@ from automator.model import TokenUsage
 from automator.policy import LimitsPolicy, Policy
 from automator.signals import HookEvent
 
-HAVE_TMUX = shutil.which("tmux") is not None
+# These integration tests drive a REAL POSIX tmux with a `#!/bin/bash` fake CLI.
+# On native Windows the live transport is psmux (covered by test_psmux_live), and
+# psmux's `tmux.exe` alias would make `which("tmux")` true yet run the bash script
+# through ConPTY — a POSIX-only path that must not execute here. Gate on non-win32.
+HAVE_TMUX = sys.platform != "win32" and shutil.which("tmux") is not None
 
 FAKE_CLI = """#!/bin/bash
 # fake CLI: last positional arg is the prompt; env comes from tmux -e

--- a/tests/test_hook_bus.py
+++ b/tests/test_hook_bus.py
@@ -15,6 +15,8 @@ Two layers:
 
 from __future__ import annotations
 
+import sys
+
 import pytest
 from conftest import dev_effect, review_effect, write_sprint
 
@@ -237,7 +239,10 @@ def test_declarative_error_fail_open_vs_closed():
 
 
 def test_real_subprocess_runner_reports_exit_code(tmp_path):
-    rc, out = _run_subprocess("printf hi; exit 7", cwd=str(tmp_path), env={}, timeout=10)
+    # _run_subprocess runs via the host shell (cmd on Windows, sh on POSIX); use a
+    # command that prints "hi" and exits 7 on each.
+    cmd = "echo hi& exit 7" if sys.platform == "win32" else "printf hi; exit 7"
+    rc, out = _run_subprocess(cmd, cwd=str(tmp_path), env={}, timeout=10)
     assert rc == 7 and "hi" in out
 
 

--- a/tests/test_portability_guard.py
+++ b/tests/test_portability_guard.py
@@ -28,8 +28,14 @@ ACK = "portability:"
 # The files allowed to shell out to ``tmux`` — the whole-file quarantine for
 # tmux/POSIX-shell knowledge, split across the shared base (where the spawn
 # primitive + argv live) and its POSIX leaf. No per-line ack needed: these files
-# *are* the sanctioned spot (their module docstrings say so).
-TMUX_BACKENDS = {"adapters/tmux_base.py", "adapters/tmux_backend.py"}
+# *are* the sanctioned spot (their module docstrings say so). ``psmux_backend.py``
+# drives the same ``tmux.exe`` drop-in on native Windows, so it carries tmux argv
+# too (its ``_run`` override prepends ``"tmux"`` exactly as the base does).
+TMUX_BACKENDS = {
+    "adapters/tmux_base.py",
+    "adapters/tmux_backend.py",
+    "adapters/psmux_backend.py",
+}
 
 # Platform-guarded files that may name a bare POSIX path, each on a line carrying
 # a `# portability:` ack (and guarded by a sys.platform branch). process_host.py's
@@ -206,6 +212,21 @@ def test_no_tmux_invocation_outside_backend():
         "adapters/tmux_backend.py) — route it through get_multiplexer() instead:\n"
         + "\n".join(f"  {rel}:{ln}: {txt.strip()}" for rel, ln, txt in offenders)
     )
+
+
+def test_tmux_allowlist_is_psmux_inclusive_and_fails_closed():
+    """The psmux backend is allowlisted to carry tmux argv, but a ``["tmux", …]``
+    literal in any *other* file is still an offender — proving the guard fails
+    closed rather than waving everything through."""
+    assert "adapters/psmux_backend.py" in TMUX_BACKENDS
+    # The exact predicate test_no_tmux_invocation_outside_backend applies, against
+    # planted findings: the allowlisted psmux file passes, a non-allowlisted module leaks.
+    planted = [
+        ("tmux", "adapters/psmux_backend.py", 1, '["tmux", "kill-session"]'),
+        ("tmux", "engine.py", 1, '["tmux", "kill-session"]'),  # planted leak
+    ]
+    offenders = [rel for _, rel, _, _ in planted if rel not in TMUX_BACKENDS]
+    assert offenders == ["engine.py"]
 
 
 def test_no_hardcoded_posix_paths():

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -228,7 +228,7 @@ def test_cli_out_writes_file(tmp_path):
     )
     assert rc == 0
     assert out_file.is_file()
-    assert "Profile finalize report" in out_file.read_text()
+    assert "Profile finalize report" in out_file.read_text(encoding="utf-8")
 
 
 def test_cli_json_block_appended(tmp_path, capsys):

--- a/tests/test_process_host.py
+++ b/tests/test_process_host.py
@@ -30,8 +30,22 @@ def host():
     return PosixProcessHost()
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="PosixProcessHost.is_alive uses os.kill(pid, 0); on Windows signal 0 is "
+    "CTRL_C_EVENT, so the probe sends a real Ctrl+C to this process's console and "
+    "aborts the run. Windows self-liveness is covered by the WindowsProcessHost test below.",
+)
 def test_is_alive_true_for_self(host):
     assert host.is_alive(os.getpid()) is True
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="WindowsProcessHost is the win32 host")
+def test_is_alive_true_for_self_windows():
+    # The Windows host probes liveness via psutil (no os.kill), so checking self is
+    # safe here — unlike the POSIX host's os.kill(pid, 0), which is CTRL_C on Windows.
+    pytest.importorskip("psutil")
+    assert WindowsProcessHost().is_alive(os.getpid()) is True
 
 
 def test_is_alive_rejects_non_positive(host, monkeypatch):

--- a/tests/test_psmux_backend.py
+++ b/tests/test_psmux_backend.py
@@ -1,0 +1,384 @@
+"""Backend tests for the native-Windows psmux multiplexer and platform selection.
+
+Two tiers live here, both deterministic — subprocess is mocked, so no real
+tmux/psmux binary or Windows host is needed:
+
+  * **POSIX regression pins** — lock the byte-for-byte tmux command strings so the
+    additive Windows backend cannot perturb them. Green on every OS; must stay green.
+  * **psmux backend contract** — the Windows-specific command construction and the
+    platform-selection branch.
+
+The pwsh construction asserted below mirrors psmux's real behavior: it runs a
+window command as an argv with an explicit interpreter (``pwsh …``), never a bare
+expression string, and a ``-Command`` string is mangled by the tmux->ConPTY->pwsh
+quoting layers (use ``-EncodedCommand``).
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import shlex
+import subprocess
+import sys
+
+import pytest
+
+from automator.adapters import psmux_backend, tmux_base
+from automator.adapters.base import SessionSpec
+from automator.adapters.generic import GenericAdapter
+from automator.adapters.multiplexer import TerminalMultiplexer, get_multiplexer
+from automator.adapters.profile import get_profile
+from automator.adapters.psmux_backend import PsmuxError, PsmuxMultiplexer
+from automator.adapters.tmux_backend import PARKED_RETURN_DETACH, TmuxMultiplexer
+from automator.policy import LimitsPolicy, Policy
+
+
+def _decoded_pwsh(args: list) -> str:
+    """Decode the ``-EncodedCommand`` (base64 UTF-16LE) payload of a psmux argv
+    back to its pwsh source, so a test can assert the real script shape rather
+    than the opaque base64 blob."""
+    flat = [str(a) for a in args]
+    payload = flat[flat.index("-EncodedCommand") + 1]
+    return base64.b64decode(payload).decode("utf-16-le")
+
+
+class _Recorder:
+    """Captures the (argv, kwargs) of every subprocess.run call and returns a
+    successful, parseable result so the backend method completes."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[list, dict]] = []
+
+    def __call__(self, args, **kwargs):
+        self.calls.append((list(args), kwargs))
+        return subprocess.CompletedProcess(args, 0, stdout="@win0", stderr="")
+
+
+@pytest.fixture
+def rec(monkeypatch):
+    """Mock the subprocess seam of both backends so no real mux is invoked and the
+    exact argv/kwargs are inspectable. Patches psmux's seam too once it exists, to
+    catch a reused-tmux-base implementation either way."""
+    recorder = _Recorder()
+    monkeypatch.setattr(tmux_base.subprocess, "run", recorder)
+    monkeypatch.setattr(psmux_backend.subprocess, "run", recorder)
+    return recorder
+
+
+# --------------------------------------------------------------- POSIX pins (green)
+
+
+def test_posix_parked_trailer_is_byte_identical(rec, tmp_path):
+    TmuxMultiplexer().new_parked_window(
+        "sess", "win", tmp_path, ["echo", "hi"], PARKED_RETURN_DETACH
+    )
+    args, _ = rec.calls[-1]
+    assert args[:2] == ["tmux", "new-window"]
+    assert args[-3:-1] == ["sh", "-c"]
+
+    return_trailer = (
+        f"ret=$(tmux show-options -wqv {PARKED_RETURN_DETACH} 2>/dev/null); "
+        f'if [ "$ret" = "{PARKED_RETURN_DETACH}" ]; then tmux detach-client 2>/dev/null; '
+        'elif [ -n "$ret" ]; then '
+        'tmux switch-client -t "$ret" 2>/dev/null || tmux switch-client -l 2>/dev/null; '
+        "fi"
+    )
+    inner = shlex.join(["echo", "hi"])
+    expected = (
+        f'{inner}; ec=$?; echo "[bmad-auto exited $ec — press enter]"; '
+        f"read -r; {return_trailer}"
+    )
+    assert args[-1] == expected
+
+
+def test_posix_new_window_env_arg_shape(rec, tmp_path):
+    TmuxMultiplexer().new_window("sess", "win", tmp_path, {"K": "V", "K2": "V2"}, "mycmd")
+    args, _ = rec.calls[-1]
+    assert args == [
+        "tmux",
+        "new-window",
+        "-t",
+        "=sess:",
+        "-n",
+        "win",
+        "-c",
+        str(tmp_path),
+        "-P",
+        "-F",
+        "#{window_id}",
+        "-e",
+        "K=V",
+        "-e",
+        "K2=V2",
+        "mycmd",
+    ]
+
+
+def test_posix_pipe_pane_sink_unchanged(rec, tmp_path):
+    log = tmp_path / "pane.log"
+    TmuxMultiplexer().pipe_pane("@1", log)
+    args, _ = rec.calls[-1]
+    assert args == ["tmux", "pipe-pane", "-t", "@1", "-o", f"cat >> {shlex.quote(str(log))}"]
+
+
+# ----------------------------------------------------------- platform selection
+
+
+def test_selection_picks_psmux_on_win32(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+    get_multiplexer.cache_clear()
+    try:
+        assert isinstance(get_multiplexer(), PsmuxMultiplexer)
+    finally:
+        get_multiplexer.cache_clear()
+
+
+@pytest.mark.parametrize("plat", ["linux", "darwin"])
+def test_selection_keeps_tmux_off_windows(monkeypatch, plat):
+    monkeypatch.setattr(sys, "platform", plat)
+    get_multiplexer.cache_clear()
+    try:
+        assert isinstance(get_multiplexer(), TmuxMultiplexer)
+    finally:
+        get_multiplexer.cache_clear()
+
+
+def test_selection_wsl_stays_tmux(monkeypatch):
+    # WSL reports sys.platform == "linux"; it must keep the POSIX tmux backend,
+    # never the Windows psmux one.
+    monkeypatch.setattr(sys, "platform", "linux")
+    get_multiplexer.cache_clear()
+    try:
+        assert isinstance(get_multiplexer(), TmuxMultiplexer)
+    finally:
+        get_multiplexer.cache_clear()
+
+
+# --------------------------------------------------- psmux backend contract (red)
+
+
+def test_psmux_satisfies_multiplexer_contract():
+    # Instantiation raises TypeError if any abstract method is unimplemented.
+    assert isinstance(PsmuxMultiplexer(), TerminalMultiplexer)
+
+
+def test_win_parked_trailer_uses_pwsh_not_posix(rec, tmp_path):
+    PsmuxMultiplexer().new_parked_window("sess", "win", tmp_path, ["claude"], PARKED_RETURN_DETACH)
+    args, _ = rec.calls[-1]
+    flat = " ".join(map(str, args))
+    # interpreter is pwsh via -EncodedCommand; no POSIX-shell trailer survives
+    assert args[-4:-1] == ["pwsh", "-NoProfile", "-EncodedCommand"]
+    assert "sh -c" not in flat
+    assert "read -r" not in flat
+    assert "$?" not in flat
+    # the real pwsh trailer: run argv, capture exit, park on Read-Host, then the
+    # same tmux return verbs keyed by the per-window return option.
+    source = _decoded_pwsh(args)
+    assert "& 'claude'" in source
+    assert "$LASTEXITCODE" in source
+    assert "Read-Host" in source
+    assert (
+        f"show-options -wqv '{PARKED_RETURN_DETACH}'" in source
+    )  # return_opt is _ps_single-quoted
+    assert "detach-client" in source
+
+
+def test_win_env_propagates_and_validates_key_names(rec, tmp_path):
+    mux = PsmuxMultiplexer()
+    # a safe env var is injected as a pwsh $env: prelude ahead of the command
+    # (decode the -EncodedCommand payload — the key isn't literal in the argv).
+    command = shlex.join(["claude", "say it's ok", "semi;colon", "$HOME"])
+    mux.new_window("sess", "win", tmp_path, {"BMAD_AUTO_RUN_DIR": "C:/r"}, command)
+    source = _decoded_pwsh(rec.calls[-1][0])
+    assert "$env:BMAD_AUTO_RUN_DIR='C:/r'" in source
+    assert source.rstrip().endswith("& 'claude' 'say it''s ok' 'semi;colon' '$HOME'")
+    # an unsafe env-var name is rejected, not interpolated into the prelude
+    with pytest.raises(PsmuxError):
+        mux.new_window("sess", "win", tmp_path, {"BAD NAME; rm -rf /": "x"}, "claude")
+
+
+def test_win_pipe_pane_uses_pwsh_sink(rec, tmp_path):
+    log = tmp_path / "pane.log"
+    PsmuxMultiplexer().pipe_pane("@1", log)
+    args, _ = rec.calls[-1]
+    assert args[:5] == ["tmux", "pipe-pane", "-t", "@1", "-o"]
+    sink = args[-1].split()
+    assert sink[:3] == ["pwsh", "-NoProfile", "-EncodedCommand"]
+    source = base64.b64decode(sink[-1]).decode("utf-16-le")
+    assert "Add-Content" in source
+    assert str(log) in source
+
+
+def test_win_pipe_pane_tolerates_dead_window(monkeypatch, tmp_path):
+    def fail(args, **kwargs):
+        raise psmux_backend.subprocess.SubprocessError("window already gone")
+
+    monkeypatch.setattr(psmux_backend.subprocess, "run", fail)
+    # the pane log is debug-only; a failed attach must not bring a launch down
+    PsmuxMultiplexer().pipe_pane("@dead", tmp_path / "pane.log")
+
+
+def test_win_psmux_reads_pass_utf8_encoding(rec):
+    PsmuxMultiplexer().has_session("sess")
+    reads = [kw for _, kw in rec.calls if kw.get("capture_output")]
+    assert reads, "expected at least one psmux read"
+    assert all(kw.get("encoding") == "utf-8" for kw in reads)
+
+
+def test_win_kill_and_has_session_reach_the_named_session(rec, monkeypatch):
+    # psmux silently ignores the `=name` exact-match form for kill-session;
+    # plain-name targeting actually removes it. has-session reads keep `=name`
+    # (which works). Pin both exact forms.
+    monkeypatch.setattr(psmux_backend.shutil, "which", lambda _name: "tmux")
+    mux = PsmuxMultiplexer()
+    mux.has_session("sess")
+    mux.kill_session("sess")
+    has_args = next(a for a, _ in rec.calls if "has-session" in a)
+    kill_args = next(a for a, _ in rec.calls if "kill-session" in a)
+    assert has_args == ["tmux", "has-session", "-t", "=sess"]
+    assert kill_args == ["tmux", "kill-session", "-t", "sess"]
+
+
+def test_win_new_session_strips_nesting_guard_env(rec, monkeypatch, tmp_path):
+    # The engine creates per-run sessions from inside the bmad-auto-ctl pane, where
+    # psmux's nesting guard would no-op new-session (psmux #424). The create call
+    # must run with PSMUX_SESSION/PSMUX_ACTIVE/TMUX stripped — and only those.
+    monkeypatch.setenv("PSMUX_SESSION", "bmad-auto-ctl")
+    monkeypatch.setenv("PSMUX_ACTIVE", "1")
+    monkeypatch.setenv("TMUX", "/tmp/psmux-1/default,1,0")
+    monkeypatch.setenv("BMAD_KEEP", "keepme")
+    PsmuxMultiplexer().new_session("sess", tmp_path, 80, 24)
+    argv, kwargs = rec.calls[-1]
+    assert argv[:6] == ["tmux", "new-session", "-d", "-s", "sess", "-c"]
+    assert argv[-4:] == ["-x", "80", "-y", "24"]
+    env = kwargs["env"]
+    assert not ({"PSMUX_SESSION", "PSMUX_ACTIVE", "TMUX"} & env.keys())
+    assert env.get("BMAD_KEEP") == "keepme"  # unrelated env survives
+
+
+def test_win_new_session_raises_on_failure(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        psmux_backend.subprocess,
+        "run",
+        lambda args, **k: subprocess.CompletedProcess(args, 1, stdout="", stderr="boom"),
+    )
+    with pytest.raises(PsmuxError, match="new-session failed: boom"):
+        PsmuxMultiplexer().new_session("sess", tmp_path, 80, 24)
+
+
+def test_win_available_requires_psmux_tmux_and_pwsh(monkeypatch):
+    present = {"psmux", "tmux", "pwsh"}
+    monkeypatch.setattr(
+        psmux_backend.shutil, "which", lambda name: name if name in present else None
+    )
+    assert PsmuxMultiplexer().available() is True
+    present.remove("pwsh")
+    assert PsmuxMultiplexer().available() is False
+
+
+def test_generic_adapter_drives_psmux_backend_with_mocked_subprocess(monkeypatch, tmp_path):
+    calls: list[tuple[list, dict]] = []
+
+    def fake_run(args, **kwargs):
+        calls.append((list(args), kwargs))
+        rc = 1 if args[1] == "has-session" else 0
+        return subprocess.CompletedProcess(args, rc, stdout="@win0", stderr="")
+
+    monkeypatch.setattr(psmux_backend.subprocess, "run", fake_run)
+    monkeypatch.setattr(psmux_backend.shutil, "which", lambda name: name)
+    adapter = GenericAdapter(
+        run_dir=tmp_path / "run",
+        policy=Policy(limits=LimitsPolicy()),
+        profile=get_profile("claude"),
+        mux=PsmuxMultiplexer(),
+    )
+    task_id = "1-2-dev-1"
+    spec = SessionSpec(
+        task_id=task_id,
+        role="dev",
+        prompt="/bmad-dev-auto 1-2",
+        cwd=tmp_path,
+        env={"BMAD_AUTO_RUN_DIR": str(tmp_path / "run"), "BMAD_AUTO_TASK_ID": task_id},
+        timeout_s=10.0,
+    )
+
+    handle = adapter.start_session(spec)
+    assert handle.native_id == "@win0"
+    verbs = [args[1] for args, _ in calls]
+    assert verbs == ["has-session", "new-session", "set-option", "new-window", "pipe-pane"]
+
+    ts = handle.launched_ns + 1
+    events_dir = adapter.watcher.events_dir
+    events_dir.mkdir(parents=True, exist_ok=True)
+    (events_dir / f"{ts}-{task_id}-Stop.json").write_text(
+        json.dumps({"ts": ts, "event": "Stop", "task_id": task_id, "session_id": "s1"}),
+        encoding="utf-8",
+    )
+    (adapter.tasks_dir / task_id / "result.json").write_text(
+        json.dumps({"workflow": "auto-dev"}), encoding="utf-8"
+    )
+    assert adapter.wait_for_completion(handle, spec).status == "completed"
+
+
+# ------------------------------------------------ negative paths & injection defense
+# Close the defensive branches the earlier tests left unexercised: the three guard
+# `raise`s, the env-value pwsh-escape, and kill-session's no-tmux early return.
+# Deterministic — subprocess mocked, no real host.
+
+
+def test_win_new_window_empty_command_raises(tmp_path):
+    # A blank command shlex-splits to [] → empty-argv guard fires before any
+    # subprocess call (the source is built eagerly).
+    with pytest.raises(PsmuxError, match="empty command"):
+        PsmuxMultiplexer().new_window("sess", "win", tmp_path, {}, "   ")
+
+
+def test_win_new_window_invalid_quoting_raises(tmp_path):
+    # Malformed quoting makes shlex.split raise ValueError, which the backend wraps
+    # as PsmuxError rather than letting it escape raw.
+    with pytest.raises(PsmuxError, match="invalid command quoting"):
+        PsmuxMultiplexer().new_window("sess", "win", tmp_path, {}, "claude 'unterminated")
+
+
+def test_win_parked_window_empty_argv_raises(tmp_path):
+    # A parked window with no argv has nothing to run → guard raise.
+    with pytest.raises(PsmuxError, match="empty argv"):
+        PsmuxMultiplexer().new_parked_window("sess", "win", tmp_path, [], PARKED_RETURN_DETACH)
+
+
+def test_win_env_value_with_quote_is_escaped_in_prelude(rec, tmp_path):
+    # A single quote in an env *value* must be doubled ('') inside the pwsh
+    # single-quoted literal so the value can't break out of the $env: prelude
+    # (only key-name rejection and arg escaping were pinned before).
+    PsmuxMultiplexer().new_window("sess", "win", tmp_path, {"BMAD_X": "o'brien'; rm"}, "claude")
+    source = _decoded_pwsh(rec.calls[-1][0])
+    assert "$env:BMAD_X='o''brien''; rm'" in source
+
+
+def test_win_kill_session_noops_without_tmux(rec, monkeypatch):
+    # With no tmux on PATH, kill_session returns early — no raise, no kill-session
+    # subprocess attempted.
+    monkeypatch.setattr(psmux_backend.shutil, "which", lambda _name: None)
+    PsmuxMultiplexer().kill_session("sess")
+    assert not any("kill-session" in a for a, _ in rec.calls)
+
+
+def test_win_new_window_clears_psmux_teammate_env_before_launch(rec, tmp_path):
+    # psmux injects agent-teams env at the server level; clear it in-window before
+    # the command runs so bmad-auto's `claude` never inherits teammate mode.
+    PsmuxMultiplexer().new_window("sess", "win", tmp_path, {}, "claude")
+    source = _decoded_pwsh(rec.calls[-1][0])
+    assert "Remove-Item Env:CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS" in source
+    assert "Remove-Item Env:PSMUX_CLAUDE_TEAMMATE_MODE" in source
+    # the clear precedes the command launch
+    assert source.index("PSMUX_CLAUDE_TEAMMATE_MODE") < source.index("& 'claude'")
+
+
+def test_win_parked_window_also_clears_teammate_env(rec, tmp_path):
+    # Same teammate-env clear on the parked launch path — no sibling gap.
+    PsmuxMultiplexer().new_parked_window("sess", "win", tmp_path, ["claude"], PARKED_RETURN_DETACH)
+    source = _decoded_pwsh(rec.calls[-1][0])
+    assert "Remove-Item Env:CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS" in source
+    assert "Remove-Item Env:PSMUX_CLAUDE_TEAMMATE_MODE" in source
+    assert source.index("PSMUX_CLAUDE_TEAMMATE_MODE") < source.index("& 'claude'")

--- a/tests/test_psmux_live.py
+++ b/tests/test_psmux_live.py
@@ -1,0 +1,109 @@
+"""Live psmux end-to-end gates — real psmux + pwsh on a native-Windows host.
+
+Unlike ``test_psmux_backend.py`` (subprocess mocked, runs on every OS), these
+drive the *real* ``PsmuxMultiplexer`` against the installed psmux and assert the
+two transport behaviors that can only be confirmed on hardware: env injection
+reaching a child, and ``kill_session`` actually removing a session. They are
+guarded by ``HAVE_PSMUX`` so they skip cleanly (never fail) on Linux/macOS/CI.
+
+Liveness / graceful-stop is deliberately out of scope here — it lives in the
+cross-platform ``platform_util``/engine path and is exercised elsewhere; these
+gates are transport-only.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+
+import pytest
+
+from automator.adapters.base import SessionSpec
+from automator.adapters.generic import GenericAdapter
+from automator.adapters.profile import CLIProfile, HookSpec
+from automator.adapters.psmux_backend import PsmuxMultiplexer
+from automator.policy import LimitsPolicy, Policy
+
+HAVE_PSMUX = (
+    sys.platform == "win32"
+    and shutil.which("psmux") is not None
+    and shutil.which("tmux") is not None
+    and shutil.which("pwsh") is not None
+)
+_LIVE = pytest.mark.skipif(not HAVE_PSMUX, reason="native Windows + psmux required")
+
+_seq = 0  # deterministic unique session names (no RNG)
+
+
+def _session_name(tag: str) -> str:
+    global _seq
+    _seq += 1
+    return f"bmadlive_{os.getpid()}_{_seq}_{tag}"
+
+
+@_LIVE
+def test_live_adapter_step_writes_hook_event_via_injected_env(tmp_path):
+    mux = PsmuxMultiplexer()
+    run_dir = tmp_path / "run"
+    task_id = "live-env"
+    code = (
+        "import json, os, pathlib, time; "
+        "run=pathlib.Path(os.environ['BMAD_AUTO_RUN_DIR']); "
+        "task=os.environ['BMAD_AUTO_TASK_ID']; "
+        "events=run/'events'; events.mkdir(parents=True, exist_ok=True); "
+        "result=run/'tasks'/task/'result.json'; result.parent.mkdir(parents=True, exist_ok=True); "
+        "result.write_text(json.dumps({'ok': True}), encoding='utf-8'); "
+        "ts=time.time_ns(); "
+        "(events/(str(ts)+'-'+task+'-Stop.json')).write_text("
+        "json.dumps({'ts': ts, 'event': 'Stop', 'task_id': task, 'session_id': 'live'}), "
+        "encoding='utf-8')"
+    )
+    profile = CLIProfile(
+        name="fake-live",
+        binary=sys.executable,
+        hooks=HookSpec(
+            dialect="claude-settings-json",
+            config_path="settings.json",
+            events={"Stop": "Stop"},
+        ),
+        launch_args=("-c", code),
+        bypass_args=(),
+    )
+    adapter = GenericAdapter(
+        run_dir=run_dir,
+        policy=Policy(limits=LimitsPolicy()),
+        profile=profile,
+        mux=mux,
+    )
+    spec = SessionSpec(
+        task_id=task_id,
+        role="dev",
+        prompt="run",
+        cwd=tmp_path,
+        env={"BMAD_AUTO_RUN_DIR": str(run_dir), "BMAD_AUTO_TASK_ID": task_id},
+        timeout_s=30.0,
+    )
+    try:
+        handle = adapter.start_session(spec)
+        result = adapter.wait_for_completion(handle, spec)
+    finally:
+        mux.kill_session(adapter.session_name)
+    assert result.status == "completed"
+    assert result.result_json == {"ok": True}
+    assert list((run_dir / "events").glob(f"*-{task_id}-Stop.json"))
+
+
+@_LIVE
+def test_live_kill_session_removes_session(tmp_path):
+    """``kill_session`` (plain-name targeting) must actually remove the session —
+    ``has_session`` reports it gone afterward."""
+    mux = PsmuxMultiplexer()
+    name = _session_name("kill")
+    mux.new_session(name, tmp_path)
+    try:
+        assert mux.has_session(name) is True
+        mux.kill_session(name)
+        assert mux.has_session(name) is False, "kill_session did not remove the session"
+    finally:
+        mux.kill_session(name)

--- a/tests/test_psmux_probe.py
+++ b/tests/test_psmux_probe.py
@@ -1,0 +1,532 @@
+"""psmux validation harness — probes how the installed psmux actually behaves
+on the tmux operations that are risky to assume on native Windows.
+
+Each live probe shells out to a real native-Windows + psmux host and records
+one behavior; the findings drive the design of the psmux multiplexer backend.
+The probes ARE the tests. Each prints its hazard -> observed -> implication line
+during a live run; set ``PSMUX_FINDINGS_OUT=<path>`` to also write the full
+table to that file.
+
+Cross-platform contract: deterministic, no hard sleeps (file-sentinels are
+polled to a deadline), and skips cleanly where psmux is absent. Live probes are
+guarded by ``HAVE_PSMUX`` so they never run (and never fail) on Linux/macOS or
+any host without native psmux; the one guard test below is active everywhere
+and proves that degradation works.
+
+Two hard-won facts about psmux window commands shape every probe below
+(measured on this host, tmux 3.3.6 emulated):
+  * psmux runs a window command as an **argv with an explicit interpreter**
+    (``pwsh ...`` / ``cmd /c ...``). A bare pwsh-expression string is exec'd as
+    a program name and silently dies.
+  * A pwsh ``-Command "...$env:..; .."`` string gets mangled crossing the
+    tmux -> ConPTY -> pwsh quoting layers and silently fails to run. Passing the
+    script via ``-EncodedCommand`` (base64 UTF-16LE) survives intact, so every
+    pwsh probe here uses it.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+
+# psmux installs a `tmux.exe` alias, so the guard requires psmux specifically
+# and the commands this harness launches.
+HAVE_PSMUX = (
+    sys.platform == "win32"
+    and shutil.which("psmux") is not None
+    and shutil.which("tmux") is not None
+    and shutil.which("pwsh") is not None
+)
+
+_LIVE = pytest.mark.skipif(not HAVE_PSMUX, reason="native Windows + psmux required")
+
+# The fix-tty probes assert against the `claude` binary itself — gate them on it
+# being installed so they fail for a backend regression, not a host without Claude.
+HAVE_CLAUDE = shutil.which("claude") is not None
+HAVE_CLAUDE_EXE = shutil.which("claude.exe") is not None
+_LIVE_CLAUDE = pytest.mark.skipif(
+    not (HAVE_PSMUX and HAVE_CLAUDE), reason="native Windows + psmux + claude required"
+)
+_LIVE_CLAUDE_EXE = pytest.mark.skipif(
+    not (HAVE_PSMUX and HAVE_CLAUDE_EXE), reason="native Windows + psmux + claude.exe required"
+)
+
+# Env keys the agent windows depend on; probed for child-process propagation.
+ENV_KEYS = ("BMAD_AUTO_RUN_DIR", "BMAD_AUTO_TASK_ID")
+
+_MUX_TIMEOUT_S = 60
+_session_seq = 0  # deterministic unique session names (no RNG)
+
+
+def _run_mux(*args: str, encoding: str = "utf-8") -> subprocess.CompletedProcess:
+    """Run a psmux/tmux command. Reads with ``encoding="utf-8",
+    errors="backslashreplace"`` by default: Windows defaults to cp1252 and
+    garbles `-F` output and multibyte separators (utf8-roundtrip hazard)."""
+    return subprocess.run(
+        ["tmux", *args],
+        capture_output=True,
+        text=True,
+        encoding=encoding,
+        errors="backslashreplace",
+        timeout=_MUX_TIMEOUT_S,
+    )
+
+
+def _run_mux_default_text(*args: str) -> subprocess.CompletedProcess:
+    """Run tmux with Python's default text decoding, intentionally omitting
+    encoding=... for the utf8-roundtrip probe."""
+    return subprocess.run(
+        ["tmux", *args],
+        capture_output=True,
+        text=True,
+        errors="backslashreplace",
+        timeout=_MUX_TIMEOUT_S,
+    )
+
+
+def _must_mux(*args: str, encoding: str = "utf-8") -> subprocess.CompletedProcess:
+    cp = _run_mux(*args, encoding=encoding)
+    assert cp.returncode == 0, f"tmux {' '.join(args)} failed: {cp.stderr or cp.stdout}"
+    return cp
+
+
+def _setopt_global_or_skip(*args: str) -> None:
+    """Set a global psmux option, or *skip* the probe when this psmux build can't.
+
+    Some psmux builds answer ``set-option -g`` with ``psmux: connection timed out``
+    (the global option store isn't wired the way tmux's is), which makes the
+    claude-code-fix-tty hazard unprobeable on that host. That is a skip, never a
+    failure: the probe must assert where psmux honors the option and step aside
+    where it can't — a hard fail here would red-flag a perfectly good backend.
+    """
+    try:
+        cp = _run_mux("set-option", "-g", *args)
+    except subprocess.TimeoutExpired:
+        pytest.skip(f"psmux timed out on `set-option -g {' '.join(args)}` on this host")
+    if cp.returncode != 0:
+        pytest.skip(
+            f"psmux can't set global option `{' '.join(args)}`: {(cp.stderr or cp.stdout).strip()}"
+        )
+
+
+class _Session:
+    """A detached psmux session, killed on exit (plain-name kill — safe per the kill-session probe)."""
+
+    def __init__(self) -> None:
+        global _session_seq
+        _session_seq += 1
+        self.name = f"psmuxprobe_{os.getpid()}_{_session_seq}"
+
+    def __enter__(self) -> str:
+        _must_mux("new-session", "-d", "-s", self.name)
+        return self.name
+
+    def __exit__(self, *exc: object) -> None:
+        _run_mux("kill-session", "-t", self.name)
+
+
+def _enc(ps_source: str) -> str:
+    """Encode a pwsh script for ``-EncodedCommand`` (base64 UTF-16LE) — the only
+    form that survives the tmux -> ConPTY -> pwsh quoting layers intact."""
+    return base64.b64encode(ps_source.encode("utf-16-le")).decode("ascii")
+
+
+def _pwsh_argv(ps_source: str, *, profile: bool = False) -> list[str]:
+    head = ["pwsh"] if profile else ["pwsh", "-NoProfile"]
+    return [*head, "-EncodedCommand", _enc(ps_source)]
+
+
+def _ps_single(value: str | Path) -> str:
+    return str(value).replace("'", "''")
+
+
+def _await_file(path: Path, deadline_s: float = 25.0) -> str | None:
+    """Poll for a sentinel file written by a window command. Returns its text, or
+    None if it never appeared within the deadline. No hard sleep — the poll
+    interval just bounds busy-spin."""
+    end = time.monotonic() + deadline_s
+    while time.monotonic() < end:
+        if path.exists():
+            text = path.read_text(encoding="utf-8", errors="backslashreplace")
+            if text.strip():
+                return text
+        time.sleep(0.1)
+    return path.read_text(encoding="utf-8", errors="backslashreplace") if path.exists() else None
+
+
+def _set_content(out: Path, value_expr: str) -> str:
+    """A pwsh statement writing ``value_expr`` (a pwsh expression) to ``out``.
+    The expr is wrapped in ``(...)`` so multi-term expressions bind to -Value
+    instead of spilling into extra positional args."""
+    return f"Set-Content -LiteralPath '{_ps_single(out)}' -Value ({value_expr})"
+
+
+def _record(hazard: str, observed: str, implication: str) -> None:
+    # Print the hazard → observed → implication line. `-s` prints to the real
+    # console (cp1252 on Windows), which can't encode chars like Ω — sanitize so
+    # progress output never crashes the probe that produced a correct finding.
+    msg = f"\n[{hazard}] {observed}\n      design -> {implication}"
+    enc = getattr(sys.stdout, "encoding", None) or "utf-8"
+    print(msg.encode(enc, "backslashreplace").decode(enc, "backslashreplace"))
+
+
+# ------------------------------------------------------------- active everywhere
+
+
+def test_skip_guard_predicate_is_correct():
+    """The live-probe guard must skip cleanly off-host. Deterministic on every
+    platform; the anchor proving the probes degrade to skips, never errors."""
+    if sys.platform != "win32":
+        assert HAVE_PSMUX is False, "live probes must skip on non-Windows hosts"
+    else:
+        # On Windows the guard tracks real psmux, not the tmux-alias false positive.
+        assert HAVE_PSMUX == all(
+            shutil.which(name) is not None for name in ("psmux", "tmux", "pwsh")
+        )
+
+
+# -------------------------------------------------- live probes (Windows + psmux)
+
+
+@_LIVE
+def test_env_propagation_via_new_window_dash_e():
+    """env-propagation — does `new-window -e KEY=VAL` reach the child? Compared against a pwsh
+    `$env:K='v'` prelude. Measured: `-e` does NOT propagate (child sees empty);
+    the prelude does. Backend must inject env via a pwsh prelude, not `-e`."""
+    with tempfile.TemporaryDirectory(prefix="psmuxprobe_") as td, _Session() as s:
+        tmp = Path(td)
+
+        # (a) the -e path: read both env keys back from the child.
+        out_e = tmp / "via_e.txt"
+        read_env = " + '|' + ".join(f"$env:{k}" for k in ENV_KEYS)  # $env:A + '|' + $env:B
+        e_args: list[str] = []
+        for k in ENV_KEYS:
+            e_args += ["-e", f"{k}=VAL_{k}"]
+        _must_mux("new-window", "-t", f"={s}:", *e_args, *_pwsh_argv(_set_content(out_e, read_env)))
+        via_e = (_await_file(out_e) or "").strip()
+        expected = "|".join(f"VAL_{k}" for k in ENV_KEYS)
+        e_works = via_e == expected
+
+        # (b) the prelude fallback: set env inside the command, then read it back.
+        out_p = tmp / "via_prelude.txt"
+        prelude = "; ".join(f"$env:{k}='VAL_{k}'" for k in ENV_KEYS)
+        _must_mux(
+            "new-window",
+            "-t",
+            f"={s}:",
+            *_pwsh_argv(f"{prelude}; {_set_content(out_p, read_env)}"),
+        )
+        via_prelude = (_await_file(out_p) or "").strip()
+        prelude_works = via_prelude == expected
+
+    _record(
+        "env-propagation",
+        f"`-e` propagation: {'works' if e_works else 'BROKEN'} (child saw {via_e!r}); "
+        f"pwsh `$env:` prelude: {'works' if prelude_works else 'BROKEN'} (saw {via_prelude!r})",
+        (
+            "Inject env via a pwsh `$env:K='v'` prelude in the command string"
+            if not e_works
+            else "`-e` is fixed on this psmux — keep `-e`"
+        ),
+    )
+    # Green = the backend has a working env-injection strategy.
+    assert prelude_works, f"pwsh env prelude must propagate env; saw {via_prelude!r}"
+
+
+@_LIVE
+def test_kill_session_targeting():
+    """kill-session — `kill-session -t '=name'` (exact match) vs plain-name `-t name`.
+    Create a session, kill each way, then `has-session`. The backend needs at
+    least one form that actually removes the session."""
+    exact_killed = plain_killed = False
+
+    with _Session() as s:  # context-mgr kills on exit, so test inner extra sessions
+        # exact-match form
+        n1 = f"{s}_exact"
+        _must_mux("new-session", "-d", "-s", n1)
+        _run_mux("kill-session", "-t", f"={n1}")
+        exact_killed = _run_mux("has-session", "-t", f"={n1}").returncode != 0
+        if not exact_killed:
+            _run_mux("kill-session", "-t", n1)  # cleanup
+
+        # plain-name form
+        n2 = f"{s}_plain"
+        _must_mux("new-session", "-d", "-s", n2)
+        _run_mux("kill-session", "-t", n2)
+        plain_killed = _run_mux("has-session", "-t", f"={n2}").returncode != 0
+        if not plain_killed:
+            _run_mux("kill-session", "-t", f"={n2}")  # cleanup
+
+    _record(
+        "kill-session",
+        f"kill-session exact `=name`: {'kills' if exact_killed else 'IGNORED'}; "
+        f"plain `name`: {'kills' if plain_killed else 'IGNORED'}",
+        (
+            "Use exact-match `=name` for kill (matches reads)"
+            if exact_killed
+            else "Drop the `=` prefix for kill-session; use plain-name targeting"
+        ),
+    )
+    assert exact_killed or plain_killed, "at least one kill-session form must remove the session"
+
+
+@_LIVE
+def test_posix_parked_trailer_non_viable():
+    """posix-trailer — confirm the POSIX `sh -c "...; read -r; ..."` parked trailer is not
+    viable natively, and that the pwsh replacement (`$LASTEXITCODE` capture) is.
+    The backend's parked window must be re-expressed in pwsh."""
+    with tempfile.TemporaryDirectory(prefix="psmuxprobe_") as td, _Session() as s:
+        tmp = Path(td)
+
+        # (a) POSIX trailer: launch the actual sh -c shape and see if it runs.
+        out_sh = tmp / "sh.txt"
+        _must_mux(
+            "new-window",
+            "-t",
+            f"={s}:",
+            "sh",
+            "-c",
+            f"echo POSIX_RAN > '{out_sh}'; read -r x",
+        )
+        sh_ran = (_await_file(out_sh, deadline_s=8.0) or "").strip() == "POSIX_RAN"
+
+        # (b) pwsh trailer: invoke a child, capture its exit code, park-equivalent.
+        out_ps = tmp / "ps.txt"
+        # `& cmd /c exit 7` -> $LASTEXITCODE is 7; proves exit-status capture works.
+        pwsh_trailer = f"& cmd /c exit 7; {_set_content(out_ps, '$LASTEXITCODE')}"
+        _must_mux("new-window", "-t", f"={s}:", *_pwsh_argv(pwsh_trailer))
+        ps_exit = (_await_file(out_ps) or "").strip()
+
+    sh_available = shutil.which("sh") is not None
+    _record(
+        "posix-trailer",
+        f"POSIX `sh -c` trailer ran={sh_ran} (sh on PATH={sh_available}); "
+        f"pwsh `$LASTEXITCODE` capture returned {ps_exit!r} (expected '7')",
+        "Re-express the parked trailer in pwsh: run argv, capture `$LASTEXITCODE`, "
+        "`Read-Host` to park, then the tmux switch/detach verbs",
+    )
+    # Green = the pwsh replacement reliably captures child exit status. The POSIX
+    # check is host-gated: with Git Bash/MSYS `sh` on PATH, `sh -c` legitimately
+    # runs, so only assert non-viability when `sh` is genuinely absent.
+    if not sh_available:
+        assert not sh_ran, "POSIX parked trailer unexpectedly ran without `sh` on PATH"
+    assert ps_exit == "7", f"pwsh trailer must capture child exit code; saw {ps_exit!r}"
+
+
+@_LIVE
+def test_detached_pipe_pane_delivery():
+    """pipe-pane — does `pipe-pane -o <sink>` deliver pane bytes while the session is
+    detached (no attached client)? The pane log is debug-only, so an empty log
+    is best-effort, never a launch failure. Uses a pwsh sink, not `cat`."""
+    with tempfile.TemporaryDirectory(prefix="psmuxprobe_") as td, _Session() as s:
+        tmp = Path(td)
+        sink = tmp / "pane.log"
+        # pwsh sink: read the piped pane bytes from stdin and append to the log.
+        sink_cmd = "pwsh -NoProfile -EncodedCommand " + _enc(
+            "$i=[Console]::In.ReadLine(); "
+            f"if ($null -ne $i) {{ Set-Content -LiteralPath '{_ps_single(sink)}' -Value $i }}"
+        )
+        target_win = f"={s}:"
+        pipe = _must_mux("pipe-pane", "-o", "-t", target_win, sink_cmd)
+        # Generate pane output from the session's own (detached) window.
+        _must_mux("send-keys", "-t", target_win, "echo PIPED_OUTPUT_MARKER", "Enter")
+        delivered = _await_file(sink, deadline_s=10.0) or ""
+
+    got = "PIPED_OUTPUT_MARKER" in delivered
+    _record(
+        "pipe-pane",
+        f"pipe-pane issued rc={pipe.returncode}; detached pane bytes delivered to sink={got}"
+        f" ({delivered.strip()[:40]!r})",
+        "Pane log is best-effort/debug-only — use a pwsh sink and never block a "
+        "launch on it" + ("" if got else "; detached delivery is unreliable here"),
+    )
+    # pipe-pane is tolerated either way (debug-only); only assert it didn't error out.
+    assert pipe.returncode == 0
+
+
+@_LIVE
+def test_utf8_roundtrip_no_garbling():
+    """utf8-roundtrip — round-trip a non-ASCII window name through `list-windows -F`. Reading
+    with `encoding="utf-8"` must survive; reading as cp1252 garbles it. This is
+    the basis for the encoding requirement on every psmux read."""
+    name = "wïndöw-café-Ω-名前"
+    with _Session() as s:
+        _must_mux("rename-window", "-t", f"={s}:", name)
+        utf8 = _must_mux("list-windows", "-t", f"={s}", "-F", "#{window_name}").stdout.strip()
+        default_cp = _run_mux_default_text("list-windows", "-t", f"={s}", "-F", "#{window_name}")
+        assert default_cp.returncode == 0, default_cp.stderr or default_cp.stdout
+        default_text = default_cp.stdout.strip()
+
+    survives = name in utf8
+    garbled = default_text != name
+    _record(
+        "utf8-roundtrip",
+        f"utf-8 read round-trips name exactly={survives} ({utf8!r}); "
+        f"default text read garbles it={garbled} ({default_text!r})",
+        "Every psmux read must pass `encoding='utf-8', errors='backslashreplace'`",
+    )
+    assert survives, f"utf-8 read must preserve non-ASCII window name; saw {utf8!r}"
+
+
+@_LIVE
+def test_window_startup_latency():
+    """window-latency — measure wall-clock from `new-window` to the command actually running,
+    with and without `-NoProfile`. Must fit the hook-completion timeout budget."""
+
+    def latency(session: str, out: Path, *, profile: bool) -> float:
+        t0 = time.monotonic()
+        _must_mux(
+            "new-window",
+            "-t",
+            f"={session}:",
+            *_pwsh_argv(_set_content(out, "'ready'"), profile=profile),
+        )
+        assert _await_file(out, deadline_s=45.0), "window command never produced readiness marker"
+        return time.monotonic() - t0
+
+    with tempfile.TemporaryDirectory(prefix="psmuxprobe_") as td, _Session() as s:
+        tmp = Path(td)
+        no_profile = latency(s, tmp / "np.txt", profile=False)
+        with_profile = latency(s, tmp / "p.txt", profile=True)
+
+    _record(
+        "window-latency",
+        f"new-window -> command running: -NoProfile {no_profile:.1f}s, "
+        f"with-profile {with_profile:.1f}s",
+        f"Launch the interpreter with `-NoProfile` ({no_profile:.1f}s here, well under "
+        "the 30s hook timeout); profile load is the avoidable cost",
+    )
+    # Green = windows start within the hook-completion timeout budget.
+    assert no_profile < 30, f"-NoProfile startup must fit hook timeout; was {no_profile:.1f}s"
+
+
+@_LIVE_CLAUDE_EXE
+def test_claude_code_fix_tty_injection():
+    """fix-tty — with `claude-code-fix-tty on` (psmux default), does psmux inject the
+    agent-teams env vars / a `claude` wrapper into the pane, and does turning it
+    off (or absolute-path invocation) neutralize it? bmad-auto drives `claude`
+    itself, so surprise teammate panes must be avoidable."""
+    teams_keys = ("CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS", "PSMUX_CLAUDE_TEAMMATE_MODE")
+
+    def probe_pane(session: str, out: Path) -> str:
+        # Profile loaded: that's where psmux injects the wrapper/env, so probe it.
+        read = " + '|' + ".join(
+            [
+                *(f"$env:{k}" for k in teams_keys),
+                "[string](Get-Command claude -ErrorAction SilentlyContinue).CommandType",
+                "[string](Get-Command claude.exe -ErrorAction SilentlyContinue).CommandType",
+                "[string](Get-Command claude.exe -ErrorAction SilentlyContinue).Source",
+            ]
+        )
+        _must_mux(
+            "new-window", "-t", f"={session}:", *_pwsh_argv(_set_content(out, read), profile=True)
+        )
+        return (_await_file(out, deadline_s=30.0) or "").strip()
+
+    default = _run_mux("show-options", "-g", "claude-code-fix-tty").stdout.strip()
+    restore = default.split()[-1] if default else None
+    with tempfile.TemporaryDirectory(prefix="psmuxprobe_") as td, _Session() as s:
+        tmp = Path(td)
+        on_state = probe_pane(s, tmp / "on.txt")
+        _setopt_global_or_skip("claude-code-fix-tty", "off")
+        try:
+            off_state = probe_pane(s, tmp / "off.txt")
+        finally:
+            if restore is None:
+                _run_mux("set-option", "-gu", "claude-code-fix-tty")
+            else:
+                _run_mux("set-option", "-g", "claude-code-fix-tty", restore)
+
+    on_parts = on_state.split("|")
+    injected_on = any(on_parts[:2]) or (len(on_parts) > 2 and on_parts[2] == "Function")
+    neutralized = off_state != on_state
+    exe_bypasses_wrapper = len(on_parts) > 3 and on_parts[3] == "Application"
+    _record(
+        "fix-tty",
+        f"default option={default!r}; fix-tty ON pane -> {on_state!r} (injection={injected_on}); "
+        f"fix-tty OFF pane -> {off_state!r} (changed={neutralized}); "
+        f"`claude.exe` resolves as application={exe_bypasses_wrapper}",
+        "Set `claude-code-fix-tty off` for bmad-auto sessions and/or invoke claude by "
+        "absolute path, so bmad-auto's own `claude` launch is never wrapped into teammate mode",
+    )
+    assert injected_on, "fix-tty ON should expose the psmux Claude wrapper/env behavior"
+    # `neutralized` is recorded but NOT asserted: when `claude` resolves to a plain
+    # .exe (the case this test's _LIVE_CLAUDE_EXE guard requires, asserted below),
+    # there is no profile-defined wrapper for `fix-tty off` to strip, so an
+    # unchanged pane state is the correct observation — not a regression. The real
+    # The fix-tty mitigation is `-NoProfile` + the env-strip prelude, gated by the
+    # sibling test_noprofile_bypasses_fix_tty_wrapper probe.
+    assert (
+        exe_bypasses_wrapper
+    ), "plain claude.exe should resolve to an application, not the wrapper function"
+
+
+@_LIVE_CLAUDE
+def test_noprofile_bypasses_fix_tty_wrapper():
+    """Production's fix-tty mitigation is `-NoProfile` (psmux_backend `_pwsh_argv`),
+    on the claim that skipping the profile leaves bmad-auto's own `claude` launch
+    *unwrapped* (the claude-code-fix-tty wrapper is defined in the profile). The
+    sibling fix-tty probe only measured `profile=True`; this measures `profile=False`
+    with fix-tty ON (worst case) and asserts `claude` no longer resolves to the
+    wrapper Function — the mitigation production actually relies on.
+
+    The agent-teams env vars are *recorded, not asserted*: this suite may run inside
+    a teammate session (a set value is then inherited, not psmux-injected), and psmux
+    injects PSMUX_CLAUDE_TEAMMATE_MODE at the tmux-server level, which `-NoProfile`
+    does NOT clear (fix-tty residue). Asserting their absence would be both flaky and
+    contrary to the measured truth — so the residue is surfaced for human review."""
+    teams_keys = ("CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS", "PSMUX_CLAUDE_TEAMMATE_MODE")
+
+    def probe_noprofile_pane(session: str, out: Path) -> str:
+        read = " + '|' + ".join(
+            [
+                *(f"$env:{k}" for k in teams_keys),
+                "[string](Get-Command claude -ErrorAction SilentlyContinue).CommandType",
+            ]
+        )
+        # profile=False == production's `-NoProfile` launch.
+        _must_mux(
+            "new-window", "-t", f"={session}:", *_pwsh_argv(_set_content(out, read), profile=False)
+        )
+        return (_await_file(out, deadline_s=30.0) or "").strip()
+
+    default = _run_mux("show-options", "-g", "claude-code-fix-tty").stdout.strip()
+    restore = default.split()[-1] if default else None
+    with tempfile.TemporaryDirectory(prefix="psmuxprobe_") as td, _Session() as s:
+        _setopt_global_or_skip("claude-code-fix-tty", "on")  # worst case for injection
+        try:
+            state = probe_noprofile_pane(s, Path(td) / "noprofile.txt")
+        finally:
+            if restore is None:
+                _run_mux("set-option", "-gu", "claude-code-fix-tty")
+            else:
+                _run_mux("set-option", "-g", "claude-code-fix-tty", restore)
+
+    parts = state.split("|")
+    claude_is_wrapper = len(parts) > 2 and parts[2] == "Function"
+    # Distinguish psmux injection from inheritance: a pane value that differs from
+    # the launching environment was added by psmux/tmux, not inherited.
+    injected_env = {
+        k: parts[i]
+        for i, k in enumerate(teams_keys)
+        if i < len(parts) and parts[i] and parts[i] != (os.environ.get(k) or "")
+    }
+    _record(
+        "fix-tty-noprofile",
+        f"-NoProfile + fix-tty ON pane -> {state!r} "
+        f"(claude wrapped={claude_is_wrapper}, psmux-injected-env={injected_env})",
+        "`-NoProfile` bypasses the profile-defined claude-code-fix-tty wrapper (claude "
+        "resolves as an application, not the wrapper function); process-level teammate-mode "
+        "env is injected at the tmux server and is NOT cleared by -NoProfile (fix-tty residue)",
+    )
+    assert (
+        not claude_is_wrapper
+    ), "-NoProfile must leave `claude` unwrapped (application, not the wrapper Function)"

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -3,6 +3,7 @@
 import os
 import re
 import subprocess
+import sys
 import tarfile
 
 import pytest
@@ -36,7 +37,9 @@ def _make_state_run(project, run_id, **state_kwargs):
 
 
 def _dead_pid() -> int:
-    proc = subprocess.Popen(["true"])
+    # A process that exits immediately, cross-platform (POSIX `true` isn't on
+    # Windows). The interpreter is always present and on every host.
+    proc = subprocess.Popen([sys.executable, "-c", ""])
     proc.wait()
     return proc.pid
 
@@ -205,7 +208,8 @@ def test_stop_run_dead_pid_falls_back(tmp_path, monkeypatch):
 def test_stop_run_signals_live_process(tmp_path, monkeypatch):
     monkeypatch.setattr(runs, "kill_session", lambda _rid: None)
     run_dir = _make_state_run(tmp_path, "r1")
-    proc = subprocess.Popen(["sleep", "30"])
+    # A long-lived process, cross-platform (POSIX `sleep` isn't on Windows).
+    proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
     (run_dir / "engine.pid").write_text(str(proc.pid))
     assert runs.stop_run(run_dir) is True
     # the process received SIGTERM and is gone

--- a/tests/test_sanitize.py
+++ b/tests/test_sanitize.py
@@ -10,7 +10,10 @@ from automator import sanitize
 @pytest.fixture
 def home(monkeypatch, tmp_path):
     monkeypatch.setenv("HOME", str(tmp_path))
-    # os.path.expanduser reads HOME on POSIX; force a clean cache-free lookup
+    # os.path.expanduser reads HOME on POSIX but USERPROFILE on Windows; set both so
+    # the fake home actually takes effect on either host (else expanduser returns the
+    # real profile, which is a *prefix* of tmp_path → spurious partial redaction).
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
     return str(tmp_path)
 
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -776,6 +776,7 @@ async def test_dirty_worktree_blocks_launch(project, monkeypatch):
         assert not calls
 
 
+@pytest.mark.flaky(reruns=2, reruns_delay=1)
 async def test_live_run_asks_for_confirmation(project, monkeypatch):
     calls = []
     monkeypatch.setattr(launch, "tmux_available", lambda: True)
@@ -785,13 +786,20 @@ async def test_live_run_asks_for_confirmation(project, monkeypatch):
     async with app.run_test() as pilot:
         await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
         await pilot.press("r")
-        await until(pilot, lambda: isinstance(app.screen, StartRunModal))
+        # Wait for the modal AND its #ok to mount before clicking: under heavy suite
+        # load app.screen flips to the modal a beat before its button composes, and
+        # pilot.click queries #ok immediately (else NoMatches). The 1s-poll worker
+        # racing the modal stack is handled by the flaky rerun above (see `until`).
+        await until(
+            pilot, lambda: isinstance(app.screen, StartRunModal) and app.screen.query("#ok")
+        )
         await pilot.click("#ok")
         await until(
             pilot,
             lambda: (
                 isinstance(app.screen, ConfirmModal)
                 and not isinstance(app.screen, ConfirmResumeModal)
+                and app.screen.query("#ok")
             ),
         )
         await pilot.click("#ok")

--- a/tests/test_tui_data.py
+++ b/tests/test_tui_data.py
@@ -6,6 +6,7 @@ import builtins
 import importlib
 import os
 import subprocess
+import sys
 from pathlib import Path
 
 from conftest import install_bmad_config, write_sprint
@@ -32,7 +33,7 @@ def make_run(root: Path, run_id: str, **state_kwargs) -> Path:
 
 def dead_pid() -> int:
     """Pid guaranteed (modulo astronomically unlikely reuse) to be dead."""
-    proc = subprocess.Popen(["true"])
+    proc = subprocess.Popen([sys.executable, "-c", ""])
     proc.wait()
     return proc.pid
 

--- a/tests/test_tui_launch.py
+++ b/tests/test_tui_launch.py
@@ -17,6 +17,7 @@ from pathlib import Path
 import pytest
 
 from automator.adapters import tmux_base
+from automator.adapters.multiplexer import get_multiplexer
 from automator.tui import launch
 
 
@@ -38,11 +39,18 @@ class FakeRun:
 
 
 @pytest.fixture
-def fake_run(monkeypatch) -> FakeRun:
+def fake_run(monkeypatch):
     fake = FakeRun()
     monkeypatch.setattr(tmux_base.subprocess, "run", fake)
     monkeypatch.setattr(tmux_base.shutil, "which", lambda name: f"/usr/bin/{name}")
-    return fake
+    # These assert the POSIX tmux launch argv (the `sh -c` parked trailer, the plain
+    # CLI string). On a native-Windows host the default backend is psmux (pwsh /
+    # EncodedCommand, and its spawn seam isn't the patched `tmux_base.subprocess`),
+    # so force the tmux backend by name and reset its cached selection.
+    monkeypatch.setenv("BMAD_AUTO_MUX_BACKEND", "tmux")
+    get_multiplexer.cache_clear()
+    yield fake
+    get_multiplexer.cache_clear()
 
 
 def expected_cli(*tail: str) -> str:

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -239,10 +239,10 @@ def test_verify_review_happy_and_commands(project):
     write_spec(sp, "done", task.baseline_commit)
     task.spec_file = str(sp)
 
-    ok_policy = Policy(verify=VerifyPolicy(commands=("true",)))
+    ok_policy = Policy(verify=VerifyPolicy(commands=("exit 0",)))
     assert verify.verify_review(task, project, ok_policy).ok
 
-    fail_policy = Policy(verify=VerifyPolicy(commands=("true", "false")))
+    fail_policy = Policy(verify=VerifyPolicy(commands=("exit 0", "exit 1")))
     out = verify.verify_review(task, project, fail_policy)
     assert not out.ok and "verify command failed" in out.reason
 


### PR DESCRIPTION
## What

Adds a native-Windows terminal-multiplexer backend (`PsmuxMultiplexer`) so the orchestrator runs on a native Windows host (psmux/ConPTY) without WSL, alongside the existing tmux backend which stays the default on POSIX.

## Why

The transport was tmux-only, so native Windows was unsupported. psmux is a protocol-compatible tmux drop-in on Windows, but several behaviours diverge (UTF-8 output, no POSIX `sh` for the parked-window trailer, env propagation, agent-teams auto-injection) and the process/stop layer had Windows branches that were never exercised.

## How

- **New backend (additive):** `adapters/psmux_backend.py` implements the `TerminalMultiplexer` contract, overriding only the genuinely-divergent methods (pwsh parked-window trailer, UTF-8 subprocess decoding, env injection, teammate-mode isolation) and inheriting the rest.
- **Upstream reference impl touched — `adapters/tmux_backend.py`:** extracted a small `_run()` subprocess seam (shared timeout) purely so the psmux backend can subclass and add `encoding="utf-8"`. POSIX command strings are unchanged byte-for-byte (pinned by `test_portability_guard.py`); no behavioural change on Linux/macOS.
- **Backend selection — `adapters/multiplexer.py`:** `get_multiplexer()` now picks psmux on `win32`, else tmux (WSL reports `linux` and correctly keeps tmux). This is the policy seam that was already documented as the selection point.
- **Process/stop machinery — `platform_util.py` + `runs.py`:** added `kill_pid_forced` (Win `taskkill /F /T`, POSIX `SIGKILL`), `pid_identity` (psutil start-time) and zombie-aware liveness; `stop_run` now escalates a non-cooperating process to a forced kill *after* the graceful window and identity-guards both the polite and forced paths against PID reuse. The engine stays the single writer of `stopped`.
- **Windows install/validate — `install.py`, `cli.py`:** hook command branches to `uv run --no-project python` on Windows (no reliable `python3` on PATH); `validate` preflights psmux + uv presence. Cross-platform absolute-path check (`is_absolute_path`) replaces `Path.is_absolute()` in `adapters/profile.py`.
- **CI — `.github/workflows/ci.yml`:** adds a native-Windows runner so the Windows paths are exercised in CI.

## Testing

`pytest` green on Linux and native Windows; new suites cover the psmux backend, the process layer, and live psmux probes (`test_psmux_backend.py`, `test_platform_util.py`, `test_psmux_probe.py`, `test_psmux_live.py`), with `test_portability_guard.py` enforcing that the POSIX backend leaks no Windows-isms and vice-versa. Live end-to-end was human-validated on a real Windows+psmux host (hook env injection, engine-written graceful stop, session teardown).

## ⚠️ Not for merge

**This PR is for detailed testing and review only — please do not merge as-is.** The native-Windows paths need broader validation across psmux versions and host configurations (the backend targets a fast-moving psmux that emulates tmux 3.3.6). Treat it as a working reference for evaluating the approach and exercising the Windows transport end-to-end, pending sign-off after thorough testing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native Windows terminal/session handling with platform-aware backend selection.
  * Added Windows execution in CI, running the full test suite on Windows with pinned dependencies.
* **Bug Fixes**
  * Status validation is now case-insensitive and whitespace-tolerant.
  * Improved cross-platform path handling (absolute/parent-reference detection) and consistent POSIX-style path formatting in generated outputs.
  * Made stopping runs safer by adding PID identity checks and forced-kill escalation safeguards.
* **Chores**
  * Expanded cross-platform tests (Windows-focused CLI preflight, portability, and integration coverage) and hardened test scaffolding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->