### PR TITLE
docs(templates): point bug reports at bmad-auto diagnose

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -119,8 +119,7 @@ body:
     attributes:
       label: Diagnostic dump (bmad-auto diagnose)
       description: |
-        Output of `bmad-auto diagnose --out diag.md` (add `--json` for a machine-readable block, or `--all` to cover every run). This is sanitized — identifiers are pseudonymized and the output is re-scanned by a fail-closed leak check before it's written — but **no scrubber is perfect**. Open the file and verify it contains no PII, secrets, or project-specific content before pasting/attaching. You can drag-and-drop the `diag.md` file here instead of pasting.
-      render: shell
+        Output of `bmad-auto diagnose --out diag.md` (add `--json` for a machine-readable block, or `--all` to cover every run). **Drag-and-drop the `diag.md` file here** (or paste its contents). It's sanitized — identifiers are pseudonymized and the output is re-scanned by a fail-closed leak check before it's written — but **no scrubber is perfect**: open the file and verify it contains no PII, secrets, or project-specific content before attaching.
 
   - type: checkboxes
     id: terms

--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -9,6 +9,8 @@ body:
       value: |
         Thanks for filing a bug report! Please fill out the information below to help us reproduce and fix the issue.
 
+        Running `bmad-auto diagnose --out diag.md` produces a **sanitized** dump (no code, specs, prompts, paths, or PII) that helps us debug — please attach it below. **Review it first** and confirm it contains nothing private.
+
   - type: textarea
     id: description
     attributes:
@@ -112,6 +114,14 @@ body:
       description: Copy and paste any relevant log output (journal, run directory, tmux session)
       render: shell
 
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Diagnostic dump (bmad-auto diagnose)
+      description: |
+        Output of `bmad-auto diagnose --out diag.md` (add `--json` for a machine-readable block, or `--all` to cover every run). This is sanitized — identifiers are pseudonymized and the output is re-scanned by a fail-closed leak check before it's written — but **no scrubber is perfect**. Open the file and verify it contains no PII, secrets, or project-specific content before pasting/attaching. You can drag-and-drop the `diag.md` file here instead of pasting.
+      render: shell
+
   - type: checkboxes
     id: terms
     attributes:
@@ -119,5 +129,7 @@ body:
       options:
         - label: I've searched for existing issues
           required: true
+        - label: If I attached a diagnose dump, I reviewed it and confirmed it contains no PII, secrets, or project-specific information
+          required: false
         - label: I'm using the latest version
           required: false

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -6,3 +6,6 @@ contact_links:
   - name: 💬 Discord Community
     url: https://discord.gg/gk8jAdXWmj
     about: Join for questions, discussion, and help before opening an issue
+  - name: 🛠 Troubleshooting — run `bmad-auto diagnose`
+    url: https://github.com/bmad-code-org/bmad-auto/blob/main/README.md#contributing
+    about: Before filing a bug, run `bmad-auto diagnose` and attach the sanitized dump — and verify it has no PII first


### PR DESCRIPTION
## What

Surface the new `bmad-auto diagnose` command in the GitHub issue templates so bug reporters attach the sanitized diagnostic dump maintainers use to triage.

## Why

`bmad-auto diagnose` emits a sanitized run/sweep dump (histograms, escalation counts, adapter/model, env, run-dir sizes) — exactly what we want when triaging a bug — but the bug-report form never mentioned it. The README already advises attaching it; this brings the guidance into the form itself, with a clear reminder to verify the output for PII before uploading (no automated sanitizer is perfect).

## How

- `bug-report.yaml`: intro note pointing to `bmad-auto diagnose --out diag.md`; a new shell-rendered **Diagnostic dump** textarea (kept alongside the existing log field, supports drag-drop); and a PII-verification confirmation checkbox. Disclaimer reinforced in three places.
- `config.yaml`: a "🛠 Troubleshooting" contact link on the template chooser pointing at the README, with the run-diagnose-then-verify-PII reminder.

Out of scope: PR template, documentation.yaml, feature-request.md (not troubleshooting paths).

## Testing

- Both templates parse as valid YAML.
- `trunk check` (prettier/yamllint/markdownlint) clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)