### PR TITLE
Release 0.7.8 — reconcile stale spec frontmatter status (no more false defers)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "bauto",
       "source": "./src/automator/data/skills",
       "description": "Automation-mode skills driven by the bmad-auto orchestrator: interactive escalation resolution (bmad-auto-resolve) and deferred-work sweep triage (bmad-auto-sweep) — the inner dev primitive (which self-reviews and commits) is the upstream bmad-dev-auto skill",
-      "version": "0.7.7",
+      "version": "0.7.8",
       "author": {
         "name": "pinkyd"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to `bmad-auto` are documented here. The format is based on
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html). While the project is pre-1.0,
 breaking changes may land in a minor release.
 
+## [0.7.8] — 2026-06-29
+
+### Fixed
+
+- **Completed `bmad-dev-auto` work is no longer falsely deferred when the skill leaves the spec
+  frontmatter `status` stale.** The skill can finalize a run in its `## Auto Run Result` prose
+  (`Status: done`) yet leave the YAML frontmatter at the template default `draft`; since every gate
+  reads frontmatter, the sprint/ledger sync no-op'd and the story or sweep bundle deferred — losing
+  tested work on rollback. The orchestrator now reconciles the frontmatter to the success status
+  from the terminal prose before the gates run (journaled `spec-status-reconciled`). It reconciles
+  only a `done` outcome from a non-terminal status, and every deterministic gate (worktree diff,
+  dw-ids, verify commands, ledger) still runs — so the bookkeeping is repaired without trusting prose
+  to pass a gate.
+
 ## [0.7.7] — 2026-06-28
 
 ### Fixed

--- a/module.yaml
+++ b/module.yaml
@@ -1,7 +1,7 @@
 code: bauto
 name: BMAD Auto Skills
 description: "Automation-mode skills driven by the bmad-auto orchestrator: interactive escalation resolution (bmad-auto-resolve) and deferred-work sweep triage (bmad-auto-sweep) — the inner dev primitive (which self-reviews and commits) is the upstream bmad-dev-auto skill"
-module_version: 0.7.7
+module_version: 0.7.8
 default_selected: false
 module_greeting: >
   BMAD Auto installed — both the automation skills and the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bmad-auto"
-version = "0.7.7"
+version = "0.7.8"
 description = "Deterministic ralph-loop orchestrator for the BMAD implementation phase"
 readme = "README.md"
 license = "MIT"

--- a/src/automator/__init__.py
+++ b/src/automator/__init__.py
@@ -6,4 +6,4 @@ on disk: sprint-status.yaml (owned by the skills, read-only here),
 spec files, and the per-run directory under .automator/runs/.
 """
 
-__version__ = "0.7.7"
+__version__ = "0.7.8"

--- a/src/automator/data/skills/bmad-auto-setup/assets/module.yaml
+++ b/src/automator/data/skills/bmad-auto-setup/assets/module.yaml
@@ -1,7 +1,7 @@
 code: bauto
 name: BMAD Auto Skills
 description: "Automation-mode skills driven by the bmad-auto orchestrator: interactive escalation resolution (bmad-auto-resolve) and deferred-work sweep triage (bmad-auto-sweep) — the inner dev primitive (which self-reviews and commits) is the upstream bmad-dev-auto skill"
-module_version: 0.7.7
+module_version: 0.7.8
 default_selected: false
 module_greeting: >
   BMAD Auto installed — both the automation skills and the

--- a/src/automator/devcontract.py
+++ b/src/automator/devcontract.py
@@ -43,6 +43,13 @@ STATUS_LINE_RE = re.compile(
 DONE = "done"
 BLOCKED = "blocked"
 
+# Frontmatter statuses a half-finalized generic spec may be reconciled FROM when
+# its prose terminal `## Auto Run Result` Status is `done`. Deliberately an
+# allowlist: anything else (already-terminal done/in-review, blocked, or an
+# unknown custom token) is left untouched, so reconciliation can never override a
+# status the skill set on purpose.
+RECONCILABLE_FROM = frozenset({"", "draft", "ready-for-dev", "in-progress"})
+
 # The leading `---\n …frontmatter… \n---` block, captured in three parts so the
 # body can be rewritten while the fences stay byte-identical.
 _FRONTMATTER_RE = re.compile(r"\A(---\r?\n)(.*?\r?\n)(---[ \t]*\r?\n)", re.DOTALL)

--- a/src/automator/devcontract.py
+++ b/src/automator/devcontract.py
@@ -238,7 +238,13 @@ def reset_spec_status(spec_path: Path, new_status: str) -> bool:
         pre = m.group("pre")
         if not pre.endswith((" ", "\t")):
             pre += " "
-        return f"{pre}{m.group('q')}{new_status}{m.group('q')}{m.group('rest')}"
+        # When the value was blank with a trailing inline comment, `rest` begins at
+        # the `#`; abutting the value (`status: done# c`) makes the `#` part of the
+        # scalar instead of a comment. Re-insert a separating space.
+        rest = m.group("rest")
+        if rest.startswith("#"):
+            rest = " " + rest
+        return f"{pre}{m.group('q')}{new_status}{m.group('q')}{rest}"
 
     if _FM_STATUS_RE.search(body):
         new_body = _FM_STATUS_RE.sub(_repl, body, count=1)

--- a/src/automator/devcontract.py
+++ b/src/automator/devcontract.py
@@ -233,7 +233,12 @@ def reset_spec_status(spec_path: Path, new_status: str) -> bool:
         if m.group("val") == new_status:
             return m.group(0)
         changed = True
-        return f"{m.group('pre')}{m.group('q')}{new_status}{m.group('q')}{m.group('rest')}"
+        # Guarantee `key: value` spacing: a bare `status:` (no trailing space)
+        # would otherwise fill to `status:done` — invalid YAML, the key is lost.
+        pre = m.group("pre")
+        if not pre.endswith((" ", "\t")):
+            pre += " "
+        return f"{pre}{m.group('q')}{new_status}{m.group('q')}{m.group('rest')}"
 
     if _FM_STATUS_RE.search(body):
         new_body = _FM_STATUS_RE.sub(_repl, body, count=1)

--- a/src/automator/devcontract.py
+++ b/src/automator/devcontract.py
@@ -47,16 +47,19 @@ BLOCKED = "blocked"
 # its prose terminal `## Auto Run Result` Status is `done`. Deliberately an
 # allowlist: anything else (already-terminal done/in-review, blocked, or an
 # unknown custom token) is left untouched, so reconciliation can never override a
-# status the skill set on purpose.
+# status the skill set on purpose. `""` covers a blank or missing frontmatter
+# `status:` — `reset_spec_status` fills/inserts the line in that case.
 RECONCILABLE_FROM = frozenset({"", "draft", "ready-for-dev", "in-progress"})
 
 # The leading `---\n …frontmatter… \n---` block, captured in three parts so the
 # body can be rewritten while the fences stay byte-identical.
 _FRONTMATTER_RE = re.compile(r"\A(---\r?\n)(.*?\r?\n)(---[ \t]*\r?\n)", re.DOTALL)
 # A frontmatter `status:` line, preserving indent, the `: ` gap, optional quotes,
-# and any trailing inline comment. Only the value token is rewritten.
+# and any trailing inline comment. Only the value token is rewritten. The value is
+# `*` (not `+`) so a present-but-empty status (`status:` / `status: ""`) is matched
+# and filled — a bmad-dev-auto template can leave it blank.
 _FM_STATUS_RE = re.compile(
-    r"^(?P<pre>[ \t]*status[ \t]*:[ \t]*)(?P<q>['\"]?)(?P<val>[A-Za-z-]+)(?P=q)(?P<rest>.*)$",
+    r"^(?P<pre>[ \t]*status[ \t]*:[ \t]*)(?P<q>['\"]?)(?P<val>[A-Za-z-]*)(?P=q)(?P<rest>.*)$",
     re.MULTILINE,
 )
 
@@ -213,9 +216,11 @@ def reset_spec_status(spec_path: Path, new_status: str) -> bool:
     the spec by flipping its status back to ``in-progress``. A minimal line edit
     (not a YAML round-trip): preserves quote style and any trailing inline comment,
     and touches ONLY the first frontmatter block — never a ``Status:`` line in the
-    prose body (e.g. the ``## Auto Run Result`` section). Returns True on a real
-    change, False when the spec has no frontmatter, no status line, or is already
-    at ``new_status``."""
+    prose body (e.g. the ``## Auto Run Result`` section). A present-but-empty status
+    is filled, and a frontmatter block with NO ``status:`` line at all gets one
+    inserted before the closing fence (the skill's template can leave it blank or
+    absent). Returns True on a real change, False when the spec has no frontmatter
+    block or is already at ``new_status``."""
     text = spec_path.read_text(encoding="utf-8")
     fm = _FRONTMATTER_RE.match(text)
     if not fm:
@@ -230,7 +235,15 @@ def reset_spec_status(spec_path: Path, new_status: str) -> bool:
         changed = True
         return f"{m.group('pre')}{m.group('q')}{new_status}{m.group('q')}{m.group('rest')}"
 
-    new_body = _FM_STATUS_RE.sub(_repl, body, count=1)
+    if _FM_STATUS_RE.search(body):
+        new_body = _FM_STATUS_RE.sub(_repl, body, count=1)
+    else:
+        # No status: line at all — insert one before the closing fence, matching
+        # the block's line ending. `body` always ends with a newline (captured by
+        # _FRONTMATTER_RE), so this lands on its own line.
+        nl = "\r\n" if body.endswith("\r\n") else "\n"
+        new_body = f"{body}status: {new_status}{nl}"
+        changed = True
     if not changed:
         return False
     spec_path.write_text(head + new_body + tail + text[fm.end() :], encoding="utf-8")

--- a/src/automator/engine.py
+++ b/src/automator/engine.py
@@ -1038,6 +1038,12 @@ class Engine:
             advance(task, Phase.DEV_VERIFY)
             outcome = None
             if result.status == "completed":
+                # bmad-dev-auto sometimes finalizes the spec in prose (## Auto Run
+                # Result: Status done) but leaves the frontmatter status at the
+                # template default. Repair it BEFORE any frontmatter reader runs —
+                # the sync below, verify_dev, and the review-verify gate all key
+                # off the on-disk frontmatter status.
+                self._reconcile_generic_terminal_status(task, result.result_json)
                 # generic-path single-writer for the bookkeeping the decoupled
                 # skill never touches (sprint-status for stories, the deferred-work
                 # ledger for sweep bundles), before verify reads that state.
@@ -1294,6 +1300,58 @@ class Engine:
         if self._generic_dev():
             return False
         return self.policy.review.enabled
+
+    def _reconcile_generic_terminal_status(self, task: StoryTask, result_json: dict | None) -> None:
+        """Repair a generic-skill spec the session finalized in prose but not in
+        frontmatter. ``bmad-dev-auto`` sometimes appends a terminal
+        ``## Auto Run Result`` (``Status: done``) yet leaves the frontmatter
+        ``status`` at the template default. The orchestrator reads ONLY
+        frontmatter, so without this the sprint/ledger sync no-ops and the verify
+        gate falsely defers completed, tested work.
+
+        When (and only when) the prose terminal Status is ``done`` AND the
+        frontmatter sits at a reconcilable non-terminal status, advance the
+        frontmatter to the success status the skill should have set. Never
+        reconciles ``blocked`` (it must still route to PAUSE) and never overrides
+        an already-terminal or unknown frontmatter status. Idempotent and
+        never-regress: every deterministic verify gate still runs afterward against
+        real on-disk/git state, so this repairs bookkeeping only — it cannot pass
+        uncompleted work. Runs ahead of ``_post_dev_state_sync`` so both the story
+        (sprint) and bundle (ledger) sync, then verify, read the reconciled spec."""
+        if not self._generic_dev():
+            return
+        spec_file = (result_json or {}).get("spec_file")
+        if not spec_file:
+            return
+        spec_path = verify.resolve_spec_path(str(spec_file), self.workspace.paths)
+        if not spec_path.is_file():
+            return
+        success_status = "in-review" if self._dev_review_enabled() else "done"
+        fm_status = verify.status_of(verify.read_frontmatter(spec_path))
+        if fm_status == success_status:
+            return  # already finalized — idempotent
+        if fm_status not in devcontract.RECONCILABLE_FROM:
+            return  # blocked / in-review / unknown: never override a deliberate status
+        arr = devcontract.parse_auto_run_result(spec_path.read_text(encoding="utf-8"))
+        if not arr.present or arr.status != devcontract.DONE:
+            return  # no terminal prose, or a blocked outcome: leave for the escalation path
+        if not devcontract.reset_spec_status(spec_path, success_status):
+            return
+        # Keep the in-place result_json the rest of _dev_phase reads consistent with
+        # the now-reconciled spec (the followup flag is only carried on a done exit).
+        if isinstance(result_json, dict):
+            result_json["status"] = success_status
+            if success_status == "done":
+                result_json["followup_review_recommended"] = bool(
+                    verify.read_frontmatter(spec_path).get("followup_review_recommended", False)
+                )
+        self.journal.append(
+            "spec-status-reconciled",
+            story_key=task.story_key,
+            spec=str(spec_path),
+            frm=fm_status,
+            to=success_status,
+        )
 
     def _post_dev_state_sync(self, task: StoryTask, result_json: dict | None) -> None:
         """Single-writer for the on-disk bookkeeping the generic skill never touches.

--- a/src/automator/engine.py
+++ b/src/automator/engine.py
@@ -1330,6 +1330,15 @@ class Engine:
         spec_path = verify.resolve_spec_path(str(spec_file), self.workspace.paths)
         if not spec_path.is_file():
             return
+        # Refuse to mutate a spec the session reported outside the orchestrator-owned
+        # roots — reconcile is the only write keyed off a session-supplied path.
+        if not verify.spec_within_roots(spec_path, self.workspace.paths):
+            self.journal.append(
+                "spec-reconcile-skipped-out-of-tree",
+                story_key=task.story_key,
+                spec=str(spec_path),
+            )
+            return
         success_status = "in-review" if self._dev_review_enabled() else "done"
         # A YAML-null status (bare `status:` / `status: null`) reads as the string
         # "none" through verify.status_of (str(None)), which would dodge the

--- a/src/automator/engine.py
+++ b/src/automator/engine.py
@@ -650,9 +650,13 @@ class Engine:
             self.workspace.paths.planning_artifacts,
         ):
             try:
-                out.append(protected.relative_to(self.workspace.root).as_posix())
+                rel = protected.relative_to(self.workspace.root).as_posix()
             except ValueError:
-                pass  # configured outside the repo; nothing to protect here
+                continue  # configured outside the repo; nothing to protect here
+            # "." (folder == repo root) as an exclude/keep prefix would cover the
+            # whole tree — drop it so a misconfig can't disable the dirty check.
+            if rel and rel != ".":
+                out.append(rel)
         return tuple(out)
 
     def _rollback_or_pause(self, task: StoryTask, *, cause: str = "stopped") -> None:
@@ -1327,7 +1331,13 @@ class Engine:
         if not spec_path.is_file():
             return
         success_status = "in-review" if self._dev_review_enabled() else "done"
-        fm_status = verify.status_of(verify.read_frontmatter(spec_path))
+        # A YAML-null status (bare `status:` / `status: null`) reads as the string
+        # "none" through verify.status_of (str(None)), which would dodge the
+        # RECONCILABLE_FROM allowlist; normalize it (and a missing key) to "" so the
+        # blank-status case reconciles. A literal `status: none` stays "none".
+        fm = verify.read_frontmatter(spec_path)
+        raw_status = fm.get("status")
+        fm_status = "" if raw_status is None else str(raw_status).strip().lower()
         if fm_status == success_status:
             return  # already finalized — idempotent
         if fm_status not in devcontract.RECONCILABLE_FROM:

--- a/src/automator/verify.py
+++ b/src/automator/verify.py
@@ -666,6 +666,23 @@ def artifact_relpaths(paths: ProjectPaths) -> tuple[str, ...]:
     return tuple(out)
 
 
+def spec_within_roots(spec_path: Path, paths: ProjectPaths) -> bool:
+    """True if ``spec_path`` is, or sits under, an orchestrator-owned root (the
+    project root or an artifact dir). A mutating repair (the frontmatter-status
+    reconcile) must refuse a session-reported ``spec_file`` that resolves outside
+    these roots, so a surprising path can never be silently rewritten. Artifact
+    dirs configured outside ``project`` are roots too, so a legitimately
+    out-of-project spec is still allowed."""
+    sp = spec_path.resolve()
+    roots = (
+        paths.project,
+        paths.output_folder,
+        paths.implementation_artifacts,
+        paths.planning_artifacts,
+    )
+    return any(sp == r.resolve() or sp.is_relative_to(r.resolve()) for r in roots)
+
+
 def resolve_spec_path(spec_file: str, paths: ProjectPaths) -> Path:
     p = Path(spec_file)
     if p.is_absolute():

--- a/src/automator/verify.py
+++ b/src/automator/verify.py
@@ -656,9 +656,13 @@ def artifact_relpaths(paths: ProjectPaths) -> tuple[str, ...]:
         paths.planning_artifacts,
     ):
         try:
-            out.append(folder.relative_to(paths.project).as_posix())
+            rel = folder.relative_to(paths.project).as_posix()
         except ValueError:
-            pass  # configured outside the project tree; nothing to exclude here
+            continue  # configured outside the project tree; nothing to exclude here
+        # A folder == project root yields ".", which as an exclude prefix would
+        # disable change detection for the whole tree — drop it.
+        if rel and rel != ".":
+            out.append(rel)
     return tuple(out)
 
 

--- a/src/automator/verify.py
+++ b/src/automator/verify.py
@@ -122,13 +122,21 @@ def same_commit(a: str, b: str) -> bool:
     return a.startswith(b) or b.startswith(a)
 
 
-def has_changes_since(repo: Path, baseline: str) -> bool:
-    """True if tracked changes since baseline OR untracked files exist."""
-    rc, _ = _git(repo, "diff", "--quiet", baseline, "--")
+def has_changes_since(repo: Path, baseline: str, exclude: tuple[str, ...] = ()) -> bool:
+    """True if tracked changes since baseline OR untracked files exist.
+
+    `exclude` is repo-relative posix dir prefixes whose changes don't count —
+    used by the dev/bundle proof-of-work gate to ignore the orchestrator-owned
+    BMAD artifact folders (see `artifact_relpaths`), so a session that only
+    rewrites its own spec (e.g. the frontmatter-status reconcile) under those
+    folders doesn't register as real implementation work. Mirrors
+    `attempt_dirty`'s exclusion. Default `()` keeps the unscoped behavior."""
+    rc, _ = _git(repo, "diff", "--quiet", baseline, "--", ".", *_exclude_specs(exclude))
     if rc != 0:
         return True
-    rc, out = _git(repo, "ls-files", "--others", "--exclude-standard")
-    return rc == 0 and out != ""
+    created = untracked_files(repo)
+    created = {p for p in created if not _path_under_any(p, exclude)}
+    return bool(created)
 
 
 def attempt_dirty(
@@ -634,6 +642,26 @@ def set_frontmatter_status(path: Path, status: str) -> bool:
     return True
 
 
+def artifact_relpaths(paths: ProjectPaths) -> tuple[str, ...]:
+    """Repo-relative posix prefixes of the orchestrator-owned BMAD artifact
+    folders (the output root and the implementation/planning artifact dirs),
+    relative to ``paths.project``. Folders configured outside the project tree
+    are skipped — nothing to exclude there. The same set as
+    ``Engine._protected_relpaths``; the dev/bundle proof-of-work gate passes
+    these to ``has_changes_since`` so spec-only edits never count as real work."""
+    out: list[str] = []
+    for folder in (
+        paths.output_folder,
+        paths.implementation_artifacts,
+        paths.planning_artifacts,
+    ):
+        try:
+            out.append(folder.relative_to(paths.project).as_posix())
+        except ValueError:
+            pass  # configured outside the project tree; nothing to exclude here
+    return tuple(out)
+
+
 def resolve_spec_path(spec_file: str, paths: ProjectPaths) -> Path:
     p = Path(spec_file)
     if p.is_absolute():
@@ -691,7 +719,9 @@ def verify_dev(
 
     if task.baseline_commit:
         try:
-            if not has_changes_since(paths.project, task.baseline_commit):
+            if not has_changes_since(
+                paths.project, task.baseline_commit, exclude=artifact_relpaths(paths)
+            ):
                 return VerifyOutcome.retry("no changes in worktree since baseline commit")
         except GitError as e:
             return VerifyOutcome.escalate(str(e))
@@ -750,7 +780,9 @@ def verify_dev_bundle(
 
     if task.baseline_commit:
         try:
-            if not has_changes_since(paths.project, task.baseline_commit):
+            if not has_changes_since(
+                paths.project, task.baseline_commit, exclude=artifact_relpaths(paths)
+            ):
                 return VerifyOutcome.retry("no changes in worktree since baseline commit")
         except GitError as e:
             return VerifyOutcome.escalate(str(e))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,11 +85,18 @@ def set_sprint(paths: ProjectPaths, key: str, status: str) -> None:
     paths.sprint_status.write_text(yaml.safe_dump(doc, sort_keys=False))
 
 
-def write_spec(path: Path, status: str, baseline: str) -> None:
-    path.write_text(
+def write_spec(path: Path, status: str, baseline: str, *, prose_status: str | None = None) -> None:
+    body = (
         f"---\ntitle: 'test'\ntype: 'feature'\nstatus: '{status}'\n"
         f"baseline_commit: '{baseline}'\n---\n\n## Intent\n\ntest spec\n"
     )
+    if prose_status is not None:
+        # mirror bmad-dev-auto's terminal finalize: it appends a `## Auto Run
+        # Result` prose block (carrying a `Status:` line) but can leave the
+        # frontmatter `status` short of the success value — the exact draft-vs-done
+        # split that the orchestrator's reconcile repairs.
+        body += f"\n## Auto Run Result\n\n- Status: {prose_status}\n\nSummary: test.\n"
+    path.write_text(body)
 
 
 def spec_path(paths: ProjectPaths, story_key: str) -> Path:
@@ -102,6 +109,7 @@ def dev_effect(
     *,
     final_status: str = "done",
     followup_review: bool = True,
+    prose_status: str | None = None,
 ):
     """Simulate a successful bmad-dev-auto session: it self-finalizes the spec
     (no in-review handoff — always straight to ``done``) but never touches the
@@ -110,14 +118,17 @@ def dev_effect(
     status to exercise the dev-verify gating. ``followup_review`` mirrors the
     skill's `followup_review_recommended` signal (PR #2505) — defaults True so
     the review-flow tests still run the review under the default
-    ``review.trigger = "recommended"``; set False to exercise the skip path."""
+    ``review.trigger = "recommended"``; set False to exercise the skip path.
+    ``prose_status`` appends a terminal ``## Auto Run Result`` block with that
+    Status line — pair it with a non-terminal ``final_status`` to reproduce the
+    skill leaving frontmatter behind its prose (the reconcile path)."""
 
     def effect(spec: SessionSpec) -> SessionResult:
         baseline = rev_parse_head(paths.project)
         source = paths.project / "src.txt"
         source.write_text(source.read_text() + f"change for {story_key}\n")
         sp = spec_path(paths, story_key)
-        write_spec(sp, final_status, baseline)
+        write_spec(sp, final_status, baseline, prose_status=prose_status)
         # deliberately NO set_sprint: the dev skill does not write sprint-status
         return SessionResult(
             status="completed",
@@ -249,13 +260,17 @@ def bundle_dev_effect(
     dw_ids,
     mark_ledger: bool = False,
     followup_review: bool = True,
+    final_status: str = "done",
+    prose_status: str | None = None,
 ):
     """Simulate a bmad-dev-auto bundle dev session: edits code and self-finalizes
     the bundle spec to ``done`` (no in-review handoff). On the decoupled path the
     orchestrator owns the ledger, so by default the session does NOT touch it;
     ``mark_ledger=True`` is kept only for the legacy-marking path in older tests.
     ``followup_review`` mirrors `followup_review_recommended` — defaults True so
-    the bundle review runs under the default trigger = "recommended"."""
+    the bundle review runs under the default trigger = "recommended". ``final_status``
+    / ``prose_status`` mirror ``dev_effect``: pair a non-terminal ``final_status``
+    with ``prose_status="done"`` to reproduce the skill finalizing in prose only."""
 
     def effect(spec: SessionSpec) -> SessionResult:
         baseline = rev_parse_head(paths.project)
@@ -263,7 +278,7 @@ def bundle_dev_effect(
         source.write_text(source.read_text() + f"change for dw-{name}\n")
         sp = bundle_spec_path(paths, name)
         # mirror the skill: always self-finalize the bundle spec straight to done
-        write_spec(sp, "done", baseline)
+        write_spec(sp, final_status, baseline, prose_status=prose_status)
         if mark_ledger:
             mark_ledger_done(paths, dw_ids)
         return SessionResult(

--- a/tests/test_devcontract.py
+++ b/tests/test_devcontract.py
@@ -283,6 +283,24 @@ def test_reset_status_fills_bare_yaml_null(tmp_path):
     assert "- Status: done\n" in text  # prose untouched
 
 
+def test_reset_status_blank_value_keeps_inline_comment(tmp_path):
+    """A blank value with a trailing inline comment (`status: # tbd`, parsed as
+    YAML-null) is filled without merging the comment into the scalar: the result
+    must stay valid YAML re-parsing to the new status, comment preserved."""
+    from automator import verify
+
+    sp = tmp_path / "spec.md"
+    sp.write_text(
+        "---\ntitle: 'x'\nstatus: # intentionally blank\n---\n\nbody\n",
+        encoding="utf-8",
+    )
+    assert devcontract.reset_spec_status(sp, "done") is True
+    text = sp.read_text()
+    assert "status: done # intentionally blank\n" in text  # space kept before `#`
+    assert "done#" not in text  # never abut the value to the comment
+    assert verify.status_of(verify.read_frontmatter(sp)) == "done"  # re-parses cleanly
+
+
 def test_reset_status_inserts_missing_line(tmp_path):
     """A frontmatter block with NO `status:` line gets one inserted before the
     closing fence; existing keys survive and the prose body is untouched."""

--- a/tests/test_devcontract.py
+++ b/tests/test_devcontract.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+import pytest
+
 from automator import devcontract
 
 
@@ -228,3 +230,26 @@ def test_reset_status_no_frontmatter(tmp_path):
     sp.write_text("# just a heading\n\nstatus: done\n", encoding="utf-8")
     assert devcontract.reset_spec_status(sp, "in-progress") is False
     assert "status: done\n" in sp.read_text()  # body status not touched
+
+
+# ----------------------------------------------------------- RECONCILABLE_FROM
+
+
+def test_reconcilable_from_excludes_terminal_and_deliberate_statuses():
+    """The allowlist must contain only non-terminal statuses a half-finalized spec
+    can be reconciled FROM — never a status the skill set on purpose."""
+    assert devcontract.RECONCILABLE_FROM == frozenset({"", "draft", "ready-for-dev", "in-progress"})
+    for deliberate in ("done", "in-review", "blocked"):
+        assert deliberate not in devcontract.RECONCILABLE_FROM
+
+
+@pytest.mark.parametrize("frm", ["draft", "ready-for-dev", "in-progress"])
+def test_reset_status_from_each_reconcilable_value_to_done(tmp_path, frm):
+    """reset_spec_status advances every line-valued reconcilable frontmatter status
+    to done, rewriting only the frontmatter line. (The "" allowlist member has no
+    status token to rewrite, so it is covered by the engine-helper guard, not here.)"""
+    sp = _spec(tmp_path / "spec.md", status=frm, auto_run="done")
+    assert devcontract.reset_spec_status(sp, "done") is True
+    text = sp.read_text()
+    assert "status: 'done'\n" in text  # frontmatter advanced
+    assert "- Status: done\n" in text  # prose untouched

--- a/tests/test_devcontract.py
+++ b/tests/test_devcontract.py
@@ -246,10 +246,34 @@ def test_reconcilable_from_excludes_terminal_and_deliberate_statuses():
 @pytest.mark.parametrize("frm", ["draft", "ready-for-dev", "in-progress"])
 def test_reset_status_from_each_reconcilable_value_to_done(tmp_path, frm):
     """reset_spec_status advances every line-valued reconcilable frontmatter status
-    to done, rewriting only the frontmatter line. (The "" allowlist member has no
-    status token to rewrite, so it is covered by the engine-helper guard, not here.)"""
+    to done, rewriting only the frontmatter line."""
     sp = _spec(tmp_path / "spec.md", status=frm, auto_run="done")
     assert devcontract.reset_spec_status(sp, "done") is True
     text = sp.read_text()
     assert "status: 'done'\n" in text  # frontmatter advanced
     assert "- Status: done\n" in text  # prose untouched
+
+
+def test_reset_status_fills_empty_value(tmp_path):
+    """The "" allowlist member: a present-but-empty `status:` is filled in place,
+    leaving the prose Status line untouched."""
+    sp = _spec(tmp_path / "spec.md", status="", auto_run="done")
+    assert devcontract.reset_spec_status(sp, "done") is True
+    text = sp.read_text()
+    assert "status: 'done'\n" in text  # empty value filled
+    assert "- Status: done\n" in text  # prose untouched
+
+
+def test_reset_status_inserts_missing_line(tmp_path):
+    """A frontmatter block with NO `status:` line gets one inserted before the
+    closing fence; existing keys survive and the prose body is untouched."""
+    sp = tmp_path / "spec.md"
+    sp.write_text(
+        "---\ntitle: 'x'\nbaseline_revision: 'abc'\n---\n\n## Intent\n\nbody\n",
+        encoding="utf-8",
+    )
+    assert devcontract.reset_spec_status(sp, "done") is True
+    text = sp.read_text()
+    assert "status: done\n" in text  # inserted
+    assert "title: 'x'\n" in text and "baseline_revision: 'abc'\n" in text  # kept
+    assert "## Intent\n\nbody\n" in text  # body untouched

--- a/tests/test_devcontract.py
+++ b/tests/test_devcontract.py
@@ -264,6 +264,25 @@ def test_reset_status_fills_empty_value(tmp_path):
     assert "- Status: done\n" in text  # prose untouched
 
 
+def test_reset_status_fills_bare_yaml_null(tmp_path):
+    """A bare `status:` (YAML null, no trailing space) is filled to a VALID
+    `status: done` line — never `status:done`, which would drop the key on
+    re-parse. Re-reading the frontmatter must yield the new status."""
+    from automator import verify
+
+    sp = tmp_path / "spec.md"
+    sp.write_text(
+        "---\ntitle: 'x'\nstatus:\n---\n\n## Auto Run Result\n\n- Status: done\n",
+        encoding="utf-8",
+    )
+    assert devcontract.reset_spec_status(sp, "done") is True
+    text = sp.read_text()
+    assert "status: done\n" in text  # space preserved -> valid YAML
+    assert "status:done" not in text  # the corruption form is never written
+    assert verify.status_of(verify.read_frontmatter(sp)) == "done"  # re-parses cleanly
+    assert "- Status: done\n" in text  # prose untouched
+
+
 def test_reset_status_inserts_missing_line(tmp_path):
     """A frontmatter block with NO `status:` line gets one inserted before the
     closing fence; existing keys survive and the prose body is untouched."""

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -426,6 +426,37 @@ def test_generic_reconcile_advances_bare_null_frontmatter_status(project):
     assert len(recon) == 1 and recon[0]["frm"] == "" and recon[0]["to"] == "done"
 
 
+def test_generic_reconcile_skips_out_of_tree_spec(project, tmp_path):
+    """Reconcile refuses to mutate a spec the session reports outside the
+    orchestrator-owned roots: the file is left untouched and the skip is journaled,
+    so a surprising `spec_file` can never be silently rewritten."""
+    from automator.policy import DevPolicy, ReviewPolicy
+
+    outside = tmp_path / "outside" / "spec.md"
+    outside.parent.mkdir(parents=True)
+    original = "---\ntitle: 'x'\nstatus:\n---\n\n## Auto Run Result\n\n- Status: done\n"
+    outside.write_text(original, encoding="utf-8")
+
+    pol = Policy(
+        gates=GatesPolicy(mode="none"),
+        notify=QUIET,
+        review=ReviewPolicy(enabled=False),
+        dev=DevPolicy(skill="bmad-dev-auto"),
+        scm=ScmPolicy(rollback_on_failure=True),
+    )
+    engine, _ = make_engine(project, [generic_dev_effect(project, "1-1-a")], policy=pol)
+    task = StoryTask(story_key="1-1-a", epic=1)
+    engine._reconcile_generic_terminal_status(task, {"spec_file": str(outside)})
+
+    assert outside.read_text() == original  # never written
+    kinds = [e["kind"] for e in engine.journal.entries()]
+    skipped = [
+        e for e in engine.journal.entries() if e["kind"] == "spec-reconcile-skipped-out-of-tree"
+    ]
+    assert len(skipped) == 1 and skipped[0]["spec"] == str(outside)
+    assert "spec-status-reconciled" not in kinds  # no reconcile happened
+
+
 def test_generic_reconcile_idempotent_when_already_done(project):
     """When the skill DID advance the frontmatter to done, reconcile is a no-op:
     no second write, no `spec-status-reconciled` journal entry."""

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -340,6 +340,150 @@ def test_generic_dev_path_no_sprint_advance_when_spec_unfinalized(project):
     assert story_status(project.sprint_status, "1-1-a") == "ready-for-dev"
 
 
+def test_generic_reconcile_advances_stale_frontmatter_done(project):
+    """bmad-dev-auto finalized in prose (## Auto Run Result: Status done) but left
+    the frontmatter at the template default. The orchestrator reconciles the
+    frontmatter before the sprint sync + verify, so completed, tested work reaches
+    DONE instead of falsely deferring — and the repair is journaled loudly."""
+    from automator.policy import DevPolicy, ReviewPolicy
+    from automator.sprintstatus import story_status
+    from automator.verify import read_frontmatter, status_of
+
+    write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
+    pol = Policy(
+        gates=GatesPolicy(mode="none"),
+        notify=QUIET,
+        review=ReviewPolicy(enabled=False),
+        dev=DevPolicy(skill="bmad-dev-auto"),
+        scm=ScmPolicy(rollback_on_failure=True),
+    )
+    engine, _ = make_engine(
+        project,
+        [generic_dev_effect(project, "1-1-a", final_status="draft", prose_status="done")],
+        policy=pol,
+    )
+    summary = engine.run()
+
+    assert summary.done == 1 and summary.deferred == 0 and not summary.paused
+    assert engine.state.tasks["1-1-a"].phase == Phase.DONE
+    assert story_status(project.sprint_status, "1-1-a") == "done"
+    # the frontmatter on disk was repaired to the success status
+    assert status_of(read_frontmatter(spec_path(project, "1-1-a"))) == "done"
+    # and the repair is recorded loudly so the upstream skill quirk stays visible
+    recon = [e for e in engine.journal.entries() if e["kind"] == "spec-status-reconciled"]
+    assert len(recon) == 1
+    assert recon[0]["frm"] == "draft" and recon[0]["to"] == "done"
+
+
+def test_generic_reconcile_idempotent_when_already_done(project):
+    """When the skill DID advance the frontmatter to done, reconcile is a no-op:
+    no second write, no `spec-status-reconciled` journal entry."""
+    from automator.policy import DevPolicy, ReviewPolicy
+
+    write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
+    pol = Policy(
+        gates=GatesPolicy(mode="none"),
+        notify=QUIET,
+        review=ReviewPolicy(enabled=False),
+        dev=DevPolicy(skill="bmad-dev-auto"),
+        scm=ScmPolicy(rollback_on_failure=True),
+    )
+    engine, _ = make_engine(
+        project,
+        [generic_dev_effect(project, "1-1-a", final_status="done", prose_status="done")],
+        policy=pol,
+    )
+    summary = engine.run()
+
+    assert summary.done == 1
+    recon = [e for e in engine.journal.entries() if e["kind"] == "spec-status-reconciled"]
+    assert recon == []
+
+
+def test_generic_reconcile_skips_blocked_prose(project):
+    """A blocked outcome (prose Status: blocked) is NEVER reconciled: the
+    frontmatter stays non-terminal, no `spec-status-reconciled` is emitted, and the
+    story does not falsely pass (it defers via the unfinalized-spec gate)."""
+    from automator.policy import DevPolicy, LimitsPolicy, ReviewPolicy
+
+    write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
+    pol = Policy(
+        gates=GatesPolicy(mode="none"),
+        notify=QUIET,
+        review=ReviewPolicy(enabled=False),
+        dev=DevPolicy(skill="bmad-dev-auto"),
+        limits=LimitsPolicy(max_dev_attempts=1),
+        scm=ScmPolicy(rollback_on_failure=True),
+    )
+    engine, _ = make_engine(
+        project,
+        [generic_dev_effect(project, "1-1-a", final_status="draft", prose_status="blocked")],
+        policy=pol,
+    )
+    summary = engine.run()
+
+    assert summary.done == 0  # blocked prose never rides reconcile to a pass
+    # reconcile never fired (no journal entry); the unfinalized spec defers as before
+    recon = [e for e in engine.journal.entries() if e["kind"] == "spec-status-reconciled"]
+    assert recon == []
+
+
+def test_generic_reconcile_does_not_bypass_no_change_gate(project):
+    """Reconcile repairs a bookkeeping field, never the proof-of-work gate. A
+    session that finalizes in prose (Status: done) but produced NO real code change
+    is reconciled to done on disk yet still DEFERS — has_changes_since backstops it,
+    so empty work cannot ride the prose marker to PROCEED."""
+    from conftest import git
+
+    from automator.adapters.base import SessionResult
+    from automator.policy import DevPolicy, LimitsPolicy, ReviewPolicy
+    from automator.verify import rev_parse_head
+
+    # match real projects (#2522): the spec dir is gitignored, so the spec file
+    # itself is not a "change" — only real code edits count toward the diff gate.
+    gi = project.project / ".gitignore"
+    gi.write_text(gi.read_text() + "_bmad-output/\n")
+    git(project.project, "add", "-A")
+    git(project.project, "commit", "-q", "-m", "ignore artifacts")
+
+    write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
+
+    def effect(spec):
+        # finalize in prose only; touch NO source file
+        baseline = rev_parse_head(project.project)
+        sp = spec_path(project, "1-1-a")
+        write_spec(sp, "draft", baseline, prose_status="done")
+        return SessionResult(
+            status="completed",
+            result_json={
+                "workflow": "auto-dev",
+                "story_key": "1-1-a",
+                "spec_file": str(sp),
+                "baseline_commit": baseline,
+                "escalations": [],
+            },
+        )
+
+    pol = Policy(
+        gates=GatesPolicy(mode="none"),
+        notify=QUIET,
+        review=ReviewPolicy(enabled=False),
+        dev=DevPolicy(skill="bmad-dev-auto"),
+        limits=LimitsPolicy(max_dev_attempts=1),
+        scm=ScmPolicy(rollback_on_failure=True),
+    )
+    engine, _ = make_engine(project, [effect], policy=pol)
+    summary = engine.run()
+
+    assert summary.deferred == 1 and summary.done == 0
+    # reconcile DID fire (the spec was advanced to done; recorded before the
+    # deferral relocates the spec to the archive) ...
+    recon = [e for e in engine.journal.entries() if e["kind"] == "spec-status-reconciled"]
+    assert len(recon) == 1 and recon[0]["to"] == "done"
+    # ... but the deterministic diff gate still deferred the empty work
+    assert "no changes" in (engine.state.tasks["1-1-a"].defer_reason or "")
+
+
 def test_generic_repair_reopens_spec_before_reinvocation(project):
     """B6: bmad-dev-auto self-finalizes to `done`; its step-01 would route a done
     spec to "ingest as context, don't resume." So before a verify-failure repair

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -375,6 +375,57 @@ def test_generic_reconcile_advances_stale_frontmatter_done(project):
     assert recon[0]["frm"] == "draft" and recon[0]["to"] == "done"
 
 
+def test_generic_reconcile_advances_bare_null_frontmatter_status(project):
+    """The skill left a bare `status:` (YAML null) but finalized in prose with real
+    code. status_of would read that as "none"; the reconcile normalizes null to ""
+    so it still advances to done — and the filled line is valid YAML."""
+    from automator.adapters.base import SessionResult
+    from automator.policy import DevPolicy, ReviewPolicy
+    from automator.sprintstatus import story_status
+    from automator.verify import read_frontmatter, rev_parse_head, status_of
+
+    write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
+
+    def effect(spec):
+        baseline = rev_parse_head(project.project)
+        # a real source change so the proof-of-work gate passes
+        src = project.project / "src.txt"
+        src.write_text(src.read_text() + "real work\n")
+        # spec finalized in prose, but frontmatter left at a bare YAML-null status
+        sp = spec_path(project, "1-1-a")
+        sp.write_text(
+            f"---\ntitle: 'x'\nstatus:\nbaseline_revision: '{baseline}'\n---\n\n"
+            "## Intent\n\nx\n\n## Auto Run Result\n\n- Status: done\n",
+            encoding="utf-8",
+        )
+        return SessionResult(
+            status="completed",
+            result_json={
+                "workflow": "auto-dev",
+                "story_key": "1-1-a",
+                "spec_file": str(sp),
+                "baseline_commit": baseline,
+                "escalations": [],
+            },
+        )
+
+    pol = Policy(
+        gates=GatesPolicy(mode="none"),
+        notify=QUIET,
+        review=ReviewPolicy(enabled=False),
+        dev=DevPolicy(skill="bmad-dev-auto"),
+        scm=ScmPolicy(rollback_on_failure=True),
+    )
+    engine, _ = make_engine(project, [effect], policy=pol)
+    summary = engine.run()
+
+    assert summary.done == 1 and summary.deferred == 0 and not summary.paused
+    assert story_status(project.sprint_status, "1-1-a") == "done"
+    assert status_of(read_frontmatter(spec_path(project, "1-1-a"))) == "done"
+    recon = [e for e in engine.journal.entries() if e["kind"] == "spec-status-reconciled"]
+    assert len(recon) == 1 and recon[0]["frm"] == "" and recon[0]["to"] == "done"
+
+
 def test_generic_reconcile_idempotent_when_already_done(project):
     """When the skill DID advance the frontmatter to done, reconcile is a no-op:
     no second write, no `spec-status-reconciled` journal entry."""

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -433,19 +433,14 @@ def test_generic_reconcile_does_not_bypass_no_change_gate(project):
     session that finalizes in prose (Status: done) but produced NO real code change
     is reconciled to done on disk yet still DEFERS — has_changes_since backstops it,
     so empty work cannot ride the prose marker to PROCEED."""
-    from conftest import git
-
     from automator.adapters.base import SessionResult
     from automator.policy import DevPolicy, LimitsPolicy, ReviewPolicy
     from automator.verify import rev_parse_head
 
-    # match real projects (#2522): the spec dir is gitignored, so the spec file
-    # itself is not a "change" — only real code edits count toward the diff gate.
-    gi = project.project / ".gitignore"
-    gi.write_text(gi.read_text() + "_bmad-output/\n")
-    git(project.project, "add", "-A")
-    git(project.project, "commit", "-q", "-m", "ignore artifacts")
-
+    # Real projects do NOT gitignore the BMAD output tree (`bmad-auto init` only
+    # ignores .automator/runs|cache), so the spec file the skill writes is tracked.
+    # The proof-of-work gate excludes the orchestrator-owned artifact folders, so a
+    # spec-only edit — including the reconcile rewrite — still reads as "no changes".
     write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
 
     def effect(spec):

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -469,6 +469,55 @@ def test_generic_skill_bundle_orchestrator_closes_ledger(project):
     assert "sweep-bundle-closed" in kinds
 
 
+def test_generic_bundle_reconcile_closes_ledger_on_stale_frontmatter(project):
+    """Regression for the DW-159/160/162 false-defer: the bundle session finalized
+    in prose (## Auto Run Result: Status done) but left the bundle spec frontmatter
+    at the template default `draft`. The orchestrator reconciles the frontmatter
+    before the ledger sync, so the bundle CLOSES — its dw ids are marked done and
+    not stranded in failed_ids — instead of falsely deferring completed work."""
+    from automator.policy import DevPolicy
+
+    write_ledger(project, {"DW-1": "open", "DW-2": "open"})
+    plan = triage_result(
+        ["DW-1", "DW-2"],
+        bundles=[{"name": "fix-things", "dw_ids": ["DW-1", "DW-2"], "intent": "fix both"}],
+    )
+    pol = Policy(
+        gates=GatesPolicy(mode="none"),
+        notify=QUIET,
+        review=ReviewPolicy(enabled=False),
+        dev=DevPolicy(skill="bmad-dev-auto"),
+        scm=ScmPolicy(rollback_on_failure=True),
+    )
+    engine, _ = make_sweep(
+        project,
+        [
+            triage_effect(plan),
+            # the skill leaves frontmatter at draft but writes prose Status: done
+            bundle_dev_effect(
+                project,
+                "fix-things",
+                ["DW-1", "DW-2"],
+                mark_ledger=False,
+                final_status="draft",
+                prose_status="done",
+            ),
+        ],
+        policy=pol,
+    )
+    summary = engine.run()
+
+    assert not summary.paused
+    assert engine.state.tasks["dw-fix-things"].phase == Phase.DONE
+    entries = ledger_entries(project)
+    assert entries["DW-1"].status.startswith("done")
+    assert entries["DW-2"].status.startswith("done")
+    recon = [e for e in engine.journal.entries() if e["kind"] == "spec-status-reconciled"]
+    assert len(recon) == 1
+    assert recon[0]["frm"] == "draft" and recon[0]["to"] == "done"
+    assert "sweep-bundle-closed" in {e["kind"] for e in engine.journal.entries()}
+
+
 def test_triage_validation_failure_retries_with_feedback_then_escalates(project):
     write_ledger(project, {"DW-1": "open"})
     bad = triage_result(["DW-1"])  # DW-1 not triaged anywhere

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 from conftest import git, spec_path, write_spec, write_sprint
 
@@ -742,3 +744,14 @@ def test_has_changes_since_excludes_artifact_only_edit(project):
         )
         is True
     )
+
+
+def test_spec_within_roots(project, tmp_path):
+    """Specs under the project / artifact roots are writable; an out-of-tree
+    absolute path is refused (guards the reconcile mutation)."""
+    assert verify.spec_within_roots(project.implementation_artifacts / "spec-x.md", project)
+    assert verify.spec_within_roots(project.project / "anywhere.md", project)
+    assert verify.spec_within_roots(project.output_folder, project)  # the root itself
+    outside = tmp_path / "outside" / "spec.md"
+    assert verify.spec_within_roots(outside, project) is False
+    assert verify.spec_within_roots(Path("/etc/passwd"), project) is False

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1,3 +1,4 @@
+import dataclasses
 from pathlib import Path
 
 import pytest
@@ -716,8 +717,6 @@ def test_artifact_relpaths_returns_in_repo_folders(project):
 def test_artifact_relpaths_drops_dot_when_folder_is_project_root(project):
     """A folder configured == project root yields "."; it must be dropped so it
     can't become a whole-tree exclude that disables the proof-of-work gate."""
-    import dataclasses
-
     paths = dataclasses.replace(project, output_folder=project.project)
     rels = verify.artifact_relpaths(paths)
     assert "." not in rels and "" not in rels
@@ -728,6 +727,9 @@ def test_artifact_relpaths_drops_dot_when_folder_is_project_root(project):
 def test_has_changes_since_excludes_artifact_only_edit(project):
     """A change confined to the artifact folders is not proof of dev work."""
     baseline = verify.rev_parse_head(project.project)
+    # root-level _bmad-output edit (bundle/ledger) + nested impl-artifact edit:
+    # both must be excluded, proving artifact_relpaths covers output_folder too.
+    (project.output_folder / "ledger.json").write_text("bookkeeping\n")
     (project.implementation_artifacts / "spec-x.md").write_text("bookkeeping\n")
     assert verify.has_changes_since(project.project, baseline) is True  # unscoped
     assert (
@@ -752,6 +754,11 @@ def test_spec_within_roots(project, tmp_path):
     assert verify.spec_within_roots(project.implementation_artifacts / "spec-x.md", project)
     assert verify.spec_within_roots(project.project / "anywhere.md", project)
     assert verify.spec_within_roots(project.output_folder, project)  # the root itself
+    # an artifact root configured OUTSIDE project is still a valid root
+    external_impl = tmp_path / "external-artifacts"
+    external_impl.mkdir()
+    external = dataclasses.replace(project, implementation_artifacts=external_impl)
+    assert verify.spec_within_roots(external_impl / "spec-x.md", external)
     outside = tmp_path / "outside" / "spec.md"
     assert verify.spec_within_roots(outside, project) is False
     assert verify.spec_within_roots(Path("/etc/passwd"), project) is False

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -701,3 +701,44 @@ def test_read_frontmatter_tolerates_garbage(project):
     assert verify.read_frontmatter(p) == {}
     p.write_text("---\n: : :\nbroken yaml [\n---\nbody")
     assert verify.read_frontmatter(p) == {}
+
+
+def test_artifact_relpaths_returns_in_repo_folders(project):
+    """The orchestrator-owned artifact folders, repo-relative posix."""
+    rels = verify.artifact_relpaths(project)
+    assert "_bmad-output/implementation-artifacts" in rels
+    assert "_bmad-output/planning-artifacts" in rels
+    assert all(r and r != "." for r in rels)
+
+
+def test_artifact_relpaths_drops_dot_when_folder_is_project_root(project):
+    """A folder configured == project root yields "."; it must be dropped so it
+    can't become a whole-tree exclude that disables the proof-of-work gate."""
+    import dataclasses
+
+    paths = dataclasses.replace(project, output_folder=project.project)
+    rels = verify.artifact_relpaths(paths)
+    assert "." not in rels and "" not in rels
+    # the real sub-dirs are still excluded; only the root-collapsing "." is dropped
+    assert "_bmad-output/implementation-artifacts" in rels
+
+
+def test_has_changes_since_excludes_artifact_only_edit(project):
+    """A change confined to the artifact folders is not proof of dev work."""
+    baseline = verify.rev_parse_head(project.project)
+    (project.implementation_artifacts / "spec-x.md").write_text("bookkeeping\n")
+    assert verify.has_changes_since(project.project, baseline) is True  # unscoped
+    assert (
+        verify.has_changes_since(
+            project.project, baseline, exclude=verify.artifact_relpaths(project)
+        )
+        is False
+    )
+    # a real source edit still counts
+    (project.project / "src.txt").write_text("real\n")
+    assert (
+        verify.has_changes_since(
+            project.project, baseline, exclude=verify.artifact_relpaths(project)
+        )
+        is True
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "bmad-auto"
-version = "0.7.7"
+version = "0.7.8"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

Fixes completed `bmad-dev-auto` work being **falsely deferred** when the skill leaves the spec
frontmatter `status` behind its prose.

The decoupled `bmad-dev-auto` skill can finalize a run in its `## Auto Run Result` prose
(`Status: done`) yet leave the YAML frontmatter at the template default `draft`. Every orchestrator
gate reads frontmatter, so `_post_dev_state_sync` no-op'd (sprint/ledger never advanced) and the
story or sweep bundle deferred — and with `rollback_on_failure` on, the tested work was reverted and
lost. (Observed in the wild: a fully-implemented, 1442-test-green deferred-work bundle deferred with
`spec status is 'draft', expected 'done'`.)

## Fix (Approach: reconcile, not escalate)

`engine._reconcile_generic_terminal_status` runs in the shared `Engine._dev_phase` immediately
before `_post_dev_state_sync`, so it covers **both** the story (sprint) and sweep-bundle (ledger)
paths. When the terminal `## Auto Run Result` Status is `done` and the frontmatter is at a
non-terminal status (`devcontract.RECONCILABLE_FROM`: `""`/`draft`/`ready-for-dev`/`in-progress`),
it advances the frontmatter to the success status via `devcontract.reset_spec_status` and journals
`spec-status-reconciled`.

**This does not violate the "never trust prose for a gate" doctrine.** Reconcile repairs a
bookkeeping field only; every deterministic gate still runs afterward against real on-disk/git state:

- `has_changes_since(baseline)` — real worktree diff
- dw-id cross-check (bundles)
- the verify-command suite
- the on-disk ledger check (review-bundle)

So a spec that lied (no diff / wrong dw-ids / broken build) still fails its gate. `blocked` is never
reconciled (guard: prose must be `done`); an already-terminal or unknown frontmatter status is never
overridden (idempotent, never-regress).

The companion upstream skill fix is bmad-code-org/BMAD-METHOD#2536 (make the Finalize step write
frontmatter `status` explicitly); this orchestrator change is the durable backstop regardless of
skill version.

## Tests

- `test_devcontract.py` — `RECONCILABLE_FROM` guard + reset-from-each-reconcilable-value
- `test_engine.py` — advance / idempotent-when-already-done / skip-blocked-prose / does-not-bypass-the-no-change-gate (story path)
- `test_sweep.py` — the exact DW-bundle regression: stale-frontmatter bundle now closes the ledger

Full suite **1194 green**, `trunk check` clean. Version bumped `0.7.7 → 0.7.8` (sync_version), CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed completed work sometimes staying deferred when spec frontmatter status was stale, by reconciling frontmatter status from the terminal auto-run result.
  * Correctly handles empty/null frontmatter status, preserves inline comments/formatting on updates, and avoids reconciliation for blocked, already-final, unknown, missing, or out-of-tree specs.
  * Verification now ignores orchestrator-generated artifact directories when checking for meaningful changes.
* **Chores**
  * Bumped release/version metadata to **0.7.8** (including marketplace/module packaging).
* **Tests**
  * Expanded coverage for the reconciliation behavior, YAML edge cases, out-of-tree skips, and updated verification gating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->