### PR TITLE
fix(engine): reconcile transient `in-review` frontmatter to done (0.7.10)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "bauto",
       "source": "./src/automator/data/skills",
       "description": "Automation-mode skills driven by the bmad-auto orchestrator: interactive escalation resolution (bmad-auto-resolve) and deferred-work sweep triage (bmad-auto-sweep) — the inner dev primitive (which self-reviews and commits) is the upstream bmad-dev-auto skill",
-      "version": "0.7.9",
+      "version": "0.7.10",
       "author": {
         "name": "pinkyd"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to `bmad-auto` are documented here. The format is based on
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html). While the project is pre-1.0,
 breaking changes may land in a minor release.
 
+## [0.7.10] — 2026-06-29
+
+### Fixed
+
+- **Completed work left at the transient `in-review` frontmatter is no longer falsely deferred and
+  rolled back.** A `bmad-dev-auto` session that dies in its step-04 Finalize tail can leave the spec
+  frontmatter at the transient `in-review` marker while the `## Auto Run Result` prose already says
+  `Status: done` — the same stale-frontmatter gate bug as 0.7.8 with a different value. The 0.7.8
+  reconcile skipped `in-review` to protect the legacy `bmad-auto-dev` review-handoff, but that fork
+  is retired and `in-review` is now only ever a transient marker, so it is reconciled to `done`
+  before the gates run. Every deterministic gate still runs afterward, and a `followup_review_recommended: true`
+  spec still triggers the follow-up review pass. Closes a re-sweep loop that re-ran and discarded the
+  same completed bundles (~47M tokens/cycle).
+
 ## [0.7.9] — 2026-06-29
 
 ### Fixed

--- a/module.yaml
+++ b/module.yaml
@@ -1,7 +1,7 @@
 code: bauto
 name: BMAD Auto Skills
 description: "Automation-mode skills driven by the bmad-auto orchestrator: interactive escalation resolution (bmad-auto-resolve) and deferred-work sweep triage (bmad-auto-sweep) — the inner dev primitive (which self-reviews and commits) is the upstream bmad-dev-auto skill"
-module_version: 0.7.9
+module_version: 0.7.10
 default_selected: false
 module_greeting: >
   BMAD Auto installed — both the automation skills and the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bmad-auto"
-version = "0.7.9"
+version = "0.7.10"
 description = "Deterministic ralph-loop orchestrator for the BMAD implementation phase"
 readme = "README.md"
 license = "MIT"

--- a/src/automator/__init__.py
+++ b/src/automator/__init__.py
@@ -6,4 +6,4 @@ on disk: sprint-status.yaml (owned by the skills, read-only here),
 spec files, and the per-run directory under .automator/runs/.
 """
 
-__version__ = "0.7.9"
+__version__ = "0.7.10"

--- a/src/automator/data/skills/bmad-auto-setup/assets/module.yaml
+++ b/src/automator/data/skills/bmad-auto-setup/assets/module.yaml
@@ -1,7 +1,7 @@
 code: bauto
 name: BMAD Auto Skills
 description: "Automation-mode skills driven by the bmad-auto orchestrator: interactive escalation resolution (bmad-auto-resolve) and deferred-work sweep triage (bmad-auto-sweep) — the inner dev primitive (which self-reviews and commits) is the upstream bmad-dev-auto skill"
-module_version: 0.7.9
+module_version: 0.7.10
 default_selected: false
 module_greeting: >
   BMAD Auto installed — both the automation skills and the

--- a/src/automator/devcontract.py
+++ b/src/automator/devcontract.py
@@ -45,11 +45,15 @@ BLOCKED = "blocked"
 
 # Frontmatter statuses a half-finalized generic spec may be reconciled FROM when
 # its prose terminal `## Auto Run Result` Status is `done`. Deliberately an
-# allowlist: anything else (already-terminal done/in-review, blocked, or an
-# unknown custom token) is left untouched, so reconciliation can never override a
-# status the skill set on purpose. `""` covers a blank or missing frontmatter
-# `status:` — `reset_spec_status` fills/inserts the line in that case.
-RECONCILABLE_FROM = frozenset({"", "draft", "ready-for-dev", "in-progress"})
+# allowlist: anything else (already-`done`, `blocked`, or an unknown custom token)
+# is left untouched, so reconciliation can never override a status the skill set on
+# purpose. `""` covers a blank or missing frontmatter `status:` — `reset_spec_status`
+# fills/inserts the line in that case. `in-review` is included because on the sole
+# (generic `bmad-dev-auto`) path it is only ever the transient marker step-04 sets at
+# its start; the skill self-finalizes to `done`. The legacy `bmad-auto-dev` fork that
+# used `in-review` as a deliberate review-handoff terminal is retired, so nothing
+# leaves `in-review` on purpose anymore.
+RECONCILABLE_FROM = frozenset({"", "draft", "ready-for-dev", "in-progress", "in-review"})
 
 # The leading `---\n …frontmatter… \n---` block, captured in three parts so the
 # body can be rewritten while the fences stay byte-identical.

--- a/src/automator/engine.py
+++ b/src/automator/engine.py
@@ -1371,9 +1371,11 @@ class Engine:
 
         When (and only when) the prose terminal Status is ``done`` AND the
         frontmatter sits at a reconcilable non-terminal status, advance the
-        frontmatter to the success status the skill should have set. Never
+        frontmatter to the success status the skill should have set. This includes
+        the transient ``in-review`` marker, which on the generic path is never a
+        deliberate terminal (the legacy review-handoff fork is retired). Never
         reconciles ``blocked`` (it must still route to PAUSE) and never overrides
-        an already-terminal or unknown frontmatter status. Idempotent and
+        an already-``done`` or unknown frontmatter status. Idempotent and
         never-regress: every deterministic verify gate still runs afterward against
         real on-disk/git state, so this repairs bookkeeping only — it cannot pass
         uncompleted work. Runs ahead of ``_post_dev_state_sync`` so both the story
@@ -1406,7 +1408,7 @@ class Engine:
         if fm_status == success_status:
             return  # already finalized — idempotent
         if fm_status not in devcontract.RECONCILABLE_FROM:
-            return  # blocked / in-review / unknown: never override a deliberate status
+            return  # blocked / unknown custom status: never override a deliberate one
         arr = devcontract.parse_auto_run_result(spec_path.read_text(encoding="utf-8"))
         if not arr.present or arr.status != devcontract.DONE:
             return  # no terminal prose, or a blocked outcome: leave for the escalation path

--- a/tests/test_devcontract.py
+++ b/tests/test_devcontract.py
@@ -235,15 +235,20 @@ def test_reset_status_no_frontmatter(tmp_path):
 # ----------------------------------------------------------- RECONCILABLE_FROM
 
 
-def test_reconcilable_from_excludes_terminal_and_deliberate_statuses():
-    """The allowlist must contain only non-terminal statuses a half-finalized spec
-    can be reconciled FROM — never a status the skill set on purpose."""
-    assert devcontract.RECONCILABLE_FROM == frozenset({"", "draft", "ready-for-dev", "in-progress"})
-    for deliberate in ("done", "in-review", "blocked"):
+def test_reconcilable_from_includes_in_review_excludes_terminal_statuses():
+    """The allowlist contains only statuses a half-finalized generic spec can be
+    reconciled FROM. `in-review` is included: on the sole generic `bmad-dev-auto`
+    path it is the transient marker step-04 sets at its start, not a deliberate
+    terminal (the legacy `bmad-auto-dev` review-handoff fork is retired). `done`
+    and `blocked` are never reconciled (idempotent / must route to PAUSE)."""
+    assert devcontract.RECONCILABLE_FROM == frozenset(
+        {"", "draft", "ready-for-dev", "in-progress", "in-review"}
+    )
+    for deliberate in ("done", "blocked"):
         assert deliberate not in devcontract.RECONCILABLE_FROM
 
 
-@pytest.mark.parametrize("frm", ["draft", "ready-for-dev", "in-progress"])
+@pytest.mark.parametrize("frm", ["draft", "ready-for-dev", "in-progress", "in-review"])
 def test_reset_status_from_each_reconcilable_value_to_done(tmp_path, frm):
     """reset_spec_status advances every line-valued reconcilable frontmatter status
     to done, rewriting only the frontmatter line."""

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -375,6 +375,151 @@ def test_generic_reconcile_advances_stale_frontmatter_done(project):
     assert recon[0]["frm"] == "draft" and recon[0]["to"] == "done"
 
 
+def test_generic_reconcile_advances_in_review_frontmatter_done(project):
+    """A session that dies in its step-04 Finalize tail leaves the frontmatter at
+    the transient `in-review` marker while the prose `## Auto Run Result` already
+    says done (the Lights-Out DW-153 symptom). On the sole generic path in-review is
+    never a deliberate terminal — the legacy review-handoff fork is retired — so the
+    orchestrator reconciles it to done before the gates, closing the false-defer +
+    rollback re-sweep loop instead of discarding completed, tested work."""
+    from automator.policy import DevPolicy, ReviewPolicy
+    from automator.sprintstatus import story_status
+    from automator.verify import read_frontmatter, status_of
+
+    write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
+    pol = Policy(
+        gates=GatesPolicy(mode="none"),
+        notify=QUIET,
+        review=ReviewPolicy(enabled=False),
+        dev=DevPolicy(skill="bmad-dev-auto"),
+        scm=ScmPolicy(rollback_on_failure=True),
+    )
+    engine, _ = make_engine(
+        project,
+        [generic_dev_effect(project, "1-1-a", final_status="in-review", prose_status="done")],
+        policy=pol,
+    )
+    summary = engine.run()
+
+    assert summary.done == 1 and summary.deferred == 0 and not summary.paused
+    assert engine.state.tasks["1-1-a"].phase == Phase.DONE
+    assert story_status(project.sprint_status, "1-1-a") == "done"
+    assert status_of(read_frontmatter(spec_path(project, "1-1-a"))) == "done"
+    recon = [e for e in engine.journal.entries() if e["kind"] == "spec-status-reconciled"]
+    assert len(recon) == 1
+    assert recon[0]["frm"] == "in-review" and recon[0]["to"] == "done"
+
+
+def test_generic_reconcile_in_review_preserves_followup_review_true(project):
+    """The follow-up review pass MUST still run when a reconciled-from-in-review
+    spec carries `followup_review_recommended: true` in its frontmatter. synth drops
+    the flag for a non-done spec, so the frontmatter is the only source — reconcile
+    re-reads it when advancing to done, so the recommended-trigger gate still sees it
+    and re-invokes bmad-dev-auto on the done spec."""
+    from automator.adapters.base import SessionResult
+    from automator.policy import DevPolicy, ReviewPolicy
+    from automator.verify import rev_parse_head
+
+    write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
+
+    def dev(spec):
+        baseline = rev_parse_head(project.project)
+        src = project.project / "src.txt"
+        src.write_text(src.read_text() + "real work\n")
+        sp = spec_path(project, "1-1-a")
+        # Finalize tail died: frontmatter stuck at the transient in-review marker,
+        # but the skill wrote the followup flag + terminal prose done first.
+        sp.write_text(
+            f"---\ntitle: 'x'\nstatus: 'in-review'\n"
+            f"followup_review_recommended: true\nbaseline_commit: '{baseline}'\n---\n\n"
+            "## Intent\n\nx\n\n## Auto Run Result\n\n- Status: done\n",
+            encoding="utf-8",
+        )
+        return SessionResult(
+            status="completed",
+            result_json={
+                "workflow": "auto-dev",
+                "story_key": "1-1-a",
+                "spec_file": str(sp),
+                "baseline_commit": baseline,
+                "escalations": [],
+            },
+        )
+
+    pol = Policy(
+        gates=GatesPolicy(mode="none"),
+        notify=QUIET,
+        review=ReviewPolicy(enabled=True, trigger="recommended"),
+        dev=DevPolicy(skill="bmad-dev-auto"),
+        scm=ScmPolicy(rollback_on_failure=True),
+    )
+    engine, adapter = make_engine(
+        project, [dev, review_effect(project, "1-1-a", clean=True)], policy=pol
+    )
+    summary = engine.run()
+
+    assert summary.done == 1 and not summary.paused
+    # reconcile advanced in-review → done AND re-attached the frontmatter flag, so
+    # the follow-up review pass ran (dev then review session)
+    assert [s.role for s in adapter.sessions] == ["dev", "review"]
+    kinds = {e["kind"] for e in engine.journal.entries()}
+    assert "review-not-recommended" not in kinds
+    recon = [e for e in engine.journal.entries() if e["kind"] == "spec-status-reconciled"]
+    assert len(recon) == 1 and recon[0]["frm"] == "in-review" and recon[0]["to"] == "done"
+
+
+def test_generic_reconcile_in_review_followup_false_skips_review(project):
+    """The mirror case (DW-153's actual shape): a reconciled-from-in-review spec
+    with `followup_review_recommended: false` in frontmatter skips the follow-up
+    review and commits with the dev session only."""
+    from automator.adapters.base import SessionResult
+    from automator.policy import DevPolicy, ReviewPolicy
+    from automator.verify import rev_parse_head
+
+    write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
+
+    def dev(spec):
+        baseline = rev_parse_head(project.project)
+        src = project.project / "src.txt"
+        src.write_text(src.read_text() + "real work\n")
+        sp = spec_path(project, "1-1-a")
+        sp.write_text(
+            f"---\ntitle: 'x'\nstatus: 'in-review'\n"
+            f"followup_review_recommended: false\nbaseline_commit: '{baseline}'\n---\n\n"
+            "## Intent\n\nx\n\n## Auto Run Result\n\n- Status: done\n",
+            encoding="utf-8",
+        )
+        return SessionResult(
+            status="completed",
+            result_json={
+                "workflow": "auto-dev",
+                "story_key": "1-1-a",
+                "spec_file": str(sp),
+                "baseline_commit": baseline,
+                "escalations": [],
+            },
+        )
+
+    pol = Policy(
+        gates=GatesPolicy(mode="none"),
+        notify=QUIET,
+        review=ReviewPolicy(enabled=True, trigger="recommended"),
+        dev=DevPolicy(skill="bmad-dev-auto"),
+        scm=ScmPolicy(rollback_on_failure=True),
+    )
+    # No review_effect scripted: the recommended-trigger gate must skip the review.
+    engine, adapter = make_engine(project, [dev], policy=pol)
+    summary = engine.run()
+
+    assert summary.done == 1 and summary.deferred == 0 and not summary.paused
+    assert engine.state.tasks["1-1-a"].followup_review_recommended is False
+    assert [s.role for s in adapter.sessions] == ["dev"]
+    kinds = {e["kind"] for e in engine.journal.entries()}
+    assert "review-not-recommended" in kinds
+    recon = [e for e in engine.journal.entries() if e["kind"] == "spec-status-reconciled"]
+    assert len(recon) == 1 and recon[0]["frm"] == "in-review" and recon[0]["to"] == "done"
+
+
 def test_generic_reconcile_advances_bare_null_frontmatter_status(project):
     """The skill left a bare `status:` (YAML null) but finalized in prose with real
     code. status_of would read that as "none"; the reconcile normalizes null to ""

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -518,6 +518,57 @@ def test_generic_bundle_reconcile_closes_ledger_on_stale_frontmatter(project):
     assert "sweep-bundle-closed" in {e["kind"] for e in engine.journal.entries()}
 
 
+def test_generic_bundle_reconcile_closes_ledger_on_in_review_frontmatter(project):
+    """The Lights-Out DW-153 symptom on the bundle path: the session finalized in
+    prose (## Auto Run Result: Status done) but left the bundle spec frontmatter at
+    the transient `in-review` marker. in-review is never a deliberate terminal on
+    the generic path (the legacy review-handoff fork is retired), so the
+    orchestrator reconciles it to done before the ledger sync — the bundle CLOSES
+    instead of false-deferring + rolling back into an endless re-sweep loop."""
+    from automator.policy import DevPolicy
+
+    write_ledger(project, {"DW-1": "open", "DW-2": "open"})
+    plan = triage_result(
+        ["DW-1", "DW-2"],
+        bundles=[{"name": "fix-things", "dw_ids": ["DW-1", "DW-2"], "intent": "fix both"}],
+    )
+    pol = Policy(
+        gates=GatesPolicy(mode="none"),
+        notify=QUIET,
+        review=ReviewPolicy(enabled=False),
+        dev=DevPolicy(skill="bmad-dev-auto"),
+        scm=ScmPolicy(rollback_on_failure=True),
+    )
+    engine, _ = make_sweep(
+        project,
+        [
+            triage_effect(plan),
+            # the skill leaves frontmatter at the transient in-review marker but
+            # writes prose Status: done
+            bundle_dev_effect(
+                project,
+                "fix-things",
+                ["DW-1", "DW-2"],
+                mark_ledger=False,
+                final_status="in-review",
+                prose_status="done",
+            ),
+        ],
+        policy=pol,
+    )
+    summary = engine.run()
+
+    assert not summary.paused
+    assert engine.state.tasks["dw-fix-things"].phase == Phase.DONE
+    entries = ledger_entries(project)
+    assert entries["DW-1"].status.startswith("done")
+    assert entries["DW-2"].status.startswith("done")
+    recon = [e for e in engine.journal.entries() if e["kind"] == "spec-status-reconciled"]
+    assert len(recon) == 1
+    assert recon[0]["frm"] == "in-review" and recon[0]["to"] == "done"
+    assert "sweep-bundle-closed" in {e["kind"] for e in engine.journal.entries()}
+
+
 def test_triage_validation_failure_retries_with_feedback_then_escalates(project):
     write_ledger(project, {"DW-1": "open"})
     bad = triage_result(["DW-1"])  # DW-1 not triaged anywhere

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "bmad-auto"
-version = "0.7.9"
+version = "0.7.10"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
## Problem

A `bmad-dev-auto` session that dies in its step-04 *Finalize* tail leaves the spec frontmatter at the transient `in-review` marker (set at the **start** of step-04) while the `## Auto Run Result` prose already says `Status: done`. This is the **same stale-frontmatter gate bug fixed in 0.7.8, with a different stale value**.

Since every gate reads only frontmatter, completed, tested work false-deferred → was **rolled back** → the open ledger entry got re-bundled on the next sweep → re-run and discarded again. Observed in `~/dev/Lights-Out`: a repeating sweep loop burning ~47M tokens/cycle (e.g. DW-153, whose spec showed frontmatter `in-review` + prose `Status: done` + 1432/1432 EditMode & 222/222 PlayMode green).

The 0.7.8 reconcile (`_reconcile_generic_terminal_status`) could not catch it because `in-review` was deliberately excluded from `devcontract.RECONCILABLE_FROM`.

## Fix

That exclusion only ever protected the **legacy `bmad-auto-dev` fork's** review-handoff, where `in-review` was a real terminal. That fork is retired; on the sole generic `bmad-dev-auto` path `_dev_review_enabled()` is always `False`, so the success status is always `done` and `in-review` is never a deliberate terminal.

- Add `"in-review"` to `devcontract.RECONCILABLE_FROM` (one token) + rationale comment.
- No logic change in `engine.py` (comment-only): the existing reconcile mutate-block already re-reads the frontmatter and re-attaches `result_json["followup_review_recommended"]` when advancing to `done`, so a **`followup_review_recommended: true` spec still triggers the follow-up review pass** (a second `bmad-dev-auto` run — there is no separate `bmad-auto-review` skill).
- The prose `Status: done` requirement and every deterministic gate (worktree diff, dw-ids, verify commands, ledger) are unchanged — reconcile repairs bookkeeping only, it cannot pass uncompleted work.

Scope is intentionally minimal: no prose-absent ("Mode B") handling, no adapter nudge.

## Tests

- `test_devcontract.py` — doctrine test updated to assert `in-review` ∈ allowlist (and `done`/`blocked` still excluded); `reset_spec_status` parametrize gains `in-review`.
- `test_engine.py` — `test_generic_reconcile_advances_in_review_frontmatter_done`, `_preserves_followup_review_true`, `_followup_false_skips_review`.
- `test_sweep.py` — `test_generic_bundle_reconcile_closes_ledger_on_in_review_frontmatter`.

Full suite **1226 passed**, `trunk check` clean. Version bumped 0.7.9 → 0.7.10 (`sync_version.py`) + CHANGELOG `[0.7.10]`.

## Recovery note

Rolled-back work left no code in the tree; the affected Lights-Out ledger entries stay **open** and will re-run + commit on the next post-fix sweep. No manual ledger edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved status reconciliation so items left in a transient `in-review` state can now progress to `done` correctly.
  * Preserved follow-up review behavior after reconciliation, including recommended reviews and related completion tracking.
  * Fixed sweep and bundle flows so open work is closed and ledger updates are applied as expected when `in-review` appears.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->