### PR TITLE
release/0.7.11 — commit review-passing work instead of rolling it back on review-budget exhaustion

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "bauto",
       "source": "./src/automator/data/skills",
       "description": "Automation-mode skills driven by the bmad-auto orchestrator: interactive escalation resolution (bmad-auto-resolve) and deferred-work sweep triage (bmad-auto-sweep) — the inner dev primitive (which self-reviews and commits) is the upstream bmad-dev-auto skill",
-      "version": "0.7.10",
+      "version": "0.7.11",
       "author": {
         "name": "pinkyd"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to `bmad-auto` are documented here. The format is based on
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html). While the project is pre-1.0,
 breaking changes may land in a minor release.
 
+## [0.7.11] — 2026-06-30
+
+### Fixed
+
+- **A finalized story the review just won't stop recommending a follow-up for is now committed, not
+  rolled back, when the review budget runs out.** Exhausting `limits.max_review_cycles` previously
+  always deferred + reverted — discarding completed, review-passing work (frontmatter `status: done`,
+  verify green) whose only "failure" was a never-clearing `followup_review_recommended`. The
+  orchestrator now commits that work and re-files the lingering recommendation as a fresh open
+  deferred-work entry; a story that itself came from such an entry is committed without re-filing, so
+  a second non-convergence reaches a human instead of looping across sweeps. Worktree-isolation runs
+  were unaffected — a deferred unit already keeps its worktree.
+
 ## [0.7.10] — 2026-06-29
 
 ### Fixed
@@ -824,6 +837,7 @@ enforced in CI.
   implementation phase, driven by a Python control loop with hook-based session transport and
   resumable on-disk run state.
 
+[0.7.11]: https://github.com/bmad-code-org/bmad-auto/releases/tag/v0.7.11
 [0.7.9]: https://github.com/bmad-code-org/bmad-auto/releases/tag/v0.7.9
 [0.7.7]: https://github.com/bmad-code-org/bmad-auto/releases/tag/v0.7.7
 [0.7.6]: https://github.com/bmad-code-org/bmad-auto/releases/tag/v0.7.6

--- a/module.yaml
+++ b/module.yaml
@@ -1,7 +1,7 @@
 code: bauto
 name: BMAD Auto Skills
 description: "Automation-mode skills driven by the bmad-auto orchestrator: interactive escalation resolution (bmad-auto-resolve) and deferred-work sweep triage (bmad-auto-sweep) — the inner dev primitive (which self-reviews and commits) is the upstream bmad-dev-auto skill"
-module_version: 0.7.10
+module_version: 0.7.11
 default_selected: false
 module_greeting: >
   BMAD Auto installed — both the automation skills and the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bmad-auto"
-version = "0.7.10"
+version = "0.7.11"
 description = "Deterministic ralph-loop orchestrator for the BMAD implementation phase"
 readme = "README.md"
 license = "MIT"

--- a/src/automator/__init__.py
+++ b/src/automator/__init__.py
@@ -6,4 +6,4 @@ on disk: sprint-status.yaml (owned by the skills, read-only here),
 spec files, and the per-run directory under .automator/runs/.
 """
 
-__version__ = "0.7.10"
+__version__ = "0.7.11"

--- a/src/automator/data/skills/bmad-auto-setup/assets/module.yaml
+++ b/src/automator/data/skills/bmad-auto-setup/assets/module.yaml
@@ -1,7 +1,7 @@
 code: bauto
 name: BMAD Auto Skills
 description: "Automation-mode skills driven by the bmad-auto orchestrator: interactive escalation resolution (bmad-auto-resolve) and deferred-work sweep triage (bmad-auto-sweep) — the inner dev primitive (which self-reviews and commits) is the upstream bmad-dev-auto skill"
-module_version: 0.7.10
+module_version: 0.7.11
 default_selected: false
 module_greeting: >
   BMAD Auto installed — both the automation skills and the

--- a/src/automator/deferredwork.py
+++ b/src/automator/deferredwork.py
@@ -117,6 +117,57 @@ def append_decision(path: Path, dw_id: str, date: str, label: str, detail: str) 
     return True
 
 
+DW_ID_RE = re.compile(r"\bDW-(\d+)\b")
+
+
+def next_seq(text: str) -> int:
+    """The next free DW sequence number — one past the highest DW-<n> anywhere
+    in the ledger (malformed entries included, so a number is never reused and
+    the sweep numbering check stays satisfied)."""
+    nums = [int(m.group(1)) for m in DW_ID_RE.finditer(text)]
+    return (max(nums) + 1) if nums else 1
+
+
+def append_entry(
+    path: Path,
+    *,
+    title: str,
+    origin: str,
+    source_spec: str,
+    reason: str,
+    status: str = "open",
+    severity: str | None = None,
+) -> str | None:
+    """Append a new canonical `### DW-<seq>` entry numbered past the highest
+    existing DW id, returning the new id (e.g. "DW-42").
+
+    Idempotent: returns None without writing when an open entry already carries
+    the same `origin:` marker and `source_spec:` — so re-running the same defer
+    (e.g. a second sweep of the same story) never duplicates the entry. Creates
+    the ledger (and parent dir) if it does not yet exist."""
+    text = path.read_text(encoding="utf-8") if path.is_file() else ""
+    for entry in parse_ledger(text):
+        if entry.open and f"origin: {origin}" in entry.body and source_spec in entry.body:
+            return None
+    dw_id = f"DW-{next_seq(text)}"
+    lines = [f"### {dw_id}: {title}", f"origin: {origin}", f"source_spec: `{source_spec}`"]
+    if severity:
+        lines.append(f"severity: {severity}")
+    lines.append(f"reason: {reason}")
+    lines.append(f"status: {status}")
+    block = "\n".join(lines) + "\n"
+    # exactly one blank line between the previous content and the new entry
+    if text == "" or text.endswith("\n\n"):
+        sep = ""
+    elif text.endswith("\n"):
+        sep = "\n"
+    else:
+        sep = "\n\n"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text + sep + block, encoding="utf-8")
+    return dw_id
+
+
 # ------------------------------------------------------------------- legacy
 #
 # Ledgers written before the DW format (older BMAD-method projects) are

--- a/src/automator/deferredwork.py
+++ b/src/automator/deferredwork.py
@@ -128,6 +128,15 @@ def next_seq(text: str) -> int:
     return (max(nums) + 1) if nums else 1
 
 
+def field_line_present(body: str, field: str, value: str) -> bool:
+    """True when `body` has a `field:` line whose value is exactly `value`,
+    matching the shapes append_entry writes (plain, or backtick-wrapped as for
+    `source_spec:`). Anchored per-line so an incidental substring elsewhere in
+    the body (e.g. inside `reason:`) never counts as a match."""
+    v = re.escape(value)
+    return re.search(rf"(?m)^{re.escape(field)}:[ \t]*`?{v}`?[ \t]*$", body) is not None
+
+
 def append_entry(
     path: Path,
     *,
@@ -147,7 +156,11 @@ def append_entry(
     the ledger (and parent dir) if it does not yet exist."""
     text = path.read_text(encoding="utf-8") if path.is_file() else ""
     for entry in parse_ledger(text):
-        if entry.open and f"origin: {origin}" in entry.body and source_spec in entry.body:
+        if (
+            entry.open
+            and field_line_present(entry.body, "origin", origin)
+            and field_line_present(entry.body, "source_spec", source_spec)
+        ):
             return None
     dw_id = f"DW-{next_seq(text)}"
     lines = [f"### {dw_id}: {title}", f"origin: {origin}", f"source_spec: `{source_spec}`"]

--- a/src/automator/engine.py
+++ b/src/automator/engine.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
 
-from . import devcontract, gates, verify
+from . import deferredwork, devcontract, gates, verify
 from .adapters.base import CodingCLIAdapter, SessionResult, SessionSpec
 from .bmadconfig import ProjectPaths
 from .escalation import (
@@ -1279,6 +1279,26 @@ class Engine:
             # fresh review pass on the newly-patched tree, bounded by max_review_cycles
 
         if not clean:
+            # Budget exhausted. Before discarding work, distinguish two modes:
+            #   (a) the tree is finalized + clean (spec/sprint done, verify green)
+            #       and the loop only failed to converge because the pass keeps
+            #       recommending an independent follow-up. That work is
+            #       committable — commit it and re-file the lingering follow-up as
+            #       a fresh deferred-work entry instead of rolling everything back
+            #       (the failure mode that silently threw away review-passing work).
+            #   (b) anything else (non-terminal status, verify failing): a genuine
+            #       failure → defer + roll back as before.
+            # _verify_review is the same authoritative gate the converged path uses
+            # (frontmatter status==done AND sprint==done AND verify commands pass),
+            # so this can never ship uncompleted work, and it is robust regardless
+            # of how the loop exited (e.g. a final-iteration RETRY). Only for the
+            # non-isolated path: in worktree isolation a defer already keeps the
+            # unit's worktree + patch (no work is lost), so there is nothing to
+            # rescue and committing into the main repo would be wrong.
+            if not self._isolated and self._verify_review(task).ok:
+                self._record_review_budget_followup(task)
+                self._commit(task)
+                return
             self._defer(
                 task, "review did not converge within budget (still recommending a follow-up pass)"
             )
@@ -1671,6 +1691,69 @@ class Engine:
             if ok:
                 return True
         return False
+
+    def _record_review_budget_followup(self, task: StoryTask) -> None:
+        """The review loop exhausted its budget on a *finalized, verify-green*
+        story that the pass kept recommending a follow-up for. The work is being
+        committed (not rolled back); preserve the lingering recommendation as a
+        new open deferred-work entry so a later, deliberate review can pick it up,
+        and notify the human. Called immediately before ``_commit`` so the ledger
+        edit is squashed into the same commit.
+
+        Re-review cap: if this story itself *originated* from such an entry (a
+        sweep bundle closing a ``review-budget-followup`` id), don't re-file again
+        — commit + notify only, so a second non-convergence reaches a human
+        instead of slowly looping across sweeps."""
+        cycles = self.policy.limits.max_review_cycles
+        spec = Path(task.spec_file).name if task.spec_file else task.story_key
+        ledger = self.workspace.paths.deferred_work
+        reason = (
+            f"Review budget ({cycles} cycles) was exhausted with the story finalized "
+            f"(status: done, verify green) while the review pass kept recommending an "
+            f"independent follow-up. The work was committed by bmad-auto run "
+            f"{self.state.run_id}; this entry preserves the lingering follow-up "
+            f"recommendation for a deliberate later review."
+        )
+        re_review = False
+        if task.dw_ids and ledger.is_file():
+            entries = {
+                e.id: e for e in deferredwork.parse_ledger(ledger.read_text(encoding="utf-8"))
+            }
+            re_review = any(
+                i in entries and "origin: review-budget-followup" in entries[i].body
+                for i in task.dw_ids
+            )
+        refiled: str | None = None
+        if not re_review:
+            refiled = deferredwork.append_entry(
+                ledger,
+                title=f"Follow-up review still recommended for {task.story_key} "
+                f"after the review budget was exhausted",
+                origin="review-budget-followup",
+                source_spec=spec,
+                reason=reason,
+                severity="low",
+            )
+        self.journal.append(
+            "review-budget-committed",
+            story_key=task.story_key,
+            cycles=cycles,
+            refiled=refiled,
+            re_review_capped=re_review,
+        )
+        note = reason
+        if re_review:
+            note = (
+                f"{reason} This story already came from a review-budget follow-up and "
+                f"still won't converge — a human should review whether the recommended "
+                f"follow-up is real before sweeping it again."
+            )
+        gates.notify(
+            self.policy,
+            self.run_dir,
+            f"review budget reached, work committed: {task.story_key}",
+            note,
+        )
 
     def _defer(self, task: StoryTask, reason: str) -> None:
         task.defer_reason = reason

--- a/src/automator/engine.py
+++ b/src/automator/engine.py
@@ -1204,8 +1204,13 @@ class Engine:
         if self._vetoed(self._emit("pre_review_phase", task), task):
             return
         clean = False
+        # Tracks whether the last *completed* review pass left the story finalized
+        # (status: done) while still recommending an independent follow-up — the
+        # only state the budget-exhaustion rescue below is allowed to commit.
+        refileable_followup = False
         while task.review_cycle < self.policy.limits.max_review_cycles:
             task.review_cycle += 1
+            refileable_followup = False  # only a completed pass this cycle can set it
             advance(task, Phase.REVIEW_RUNNING)
             self._save()
             result = self._run_session(
@@ -1247,6 +1252,7 @@ class Engine:
             status = str(rj.get("status", "")).strip()
             followup = bool(rj.get("followup_review_recommended", False))
             task.followup_review_recommended = followup  # latest pass wins
+            refileable_followup = status == "done" and followup
             self.journal.append(
                 "review-result",
                 story_key=task.story_key,
@@ -1280,23 +1286,26 @@ class Engine:
 
         if not clean:
             # Budget exhausted. Before discarding work, distinguish two modes:
-            #   (a) the tree is finalized + verify-green (spec/sprint done, verify
-            #       commands pass) and the loop only failed to converge because the
-            #       pass keeps recommending an independent follow-up (`clean` stays
-            #       False). That work is committable — commit it and re-file the
-            #       lingering follow-up as a fresh deferred-work entry instead of
-            #       rolling everything back (the failure mode that silently threw
-            #       away review-passing work).
-            #   (b) anything else (non-terminal status, verify failing): a genuine
-            #       failure → defer + roll back as before.
-            # _verify_review is the same authoritative gate the converged path uses
-            # (frontmatter status==done AND sprint==done AND verify commands pass),
-            # so this can never ship uncompleted work, and it is robust regardless
-            # of how the loop exited (e.g. a final-iteration RETRY). Only for the
-            # non-isolated path: in worktree isolation a defer already keeps the
+            #   (a) the last *completed* pass left the story finalized + verify-green
+            #       (status: done) but kept recommending an independent follow-up
+            #       (`refileable_followup`, `clean` stays False). That work is
+            #       committable — commit it and re-file the lingering follow-up as a
+            #       fresh deferred-work entry instead of rolling everything back (the
+            #       failure mode that silently threw away review-passing work).
+            #   (b) anything else (non-terminal status, no outstanding follow-up,
+            #       verify failing): a genuine failure → defer + roll back as before.
+            # A failed *final* review session never reaches here at all: with the
+            # budget spent, decide_review_session returns DEFER (not RETRY), so the
+            # loop above already deferred — a RETRY only ever loops again. The
+            # rescue therefore requires both `refileable_followup` (the last
+            # completed pass's own signal) AND _verify_review — the same authoritative
+            # gate the converged path uses (frontmatter status==done AND sprint==done
+            # AND verify commands pass) — so it can never ship uncompleted work, nor
+            # re-file a follow-up the last pass did not actually recommend. Only for
+            # the non-isolated path: in worktree isolation a defer already keeps the
             # unit's worktree + patch (no work is lost), so there is nothing to
             # rescue and committing into the main repo would be wrong.
-            if not self._isolated and self._verify_review(task).ok:
+            if refileable_followup and not self._isolated and self._verify_review(task).ok:
                 self._record_review_budget_followup(task)
                 self._commit(task)
                 return

--- a/src/automator/engine.py
+++ b/src/automator/engine.py
@@ -1280,12 +1280,13 @@ class Engine:
 
         if not clean:
             # Budget exhausted. Before discarding work, distinguish two modes:
-            #   (a) the tree is finalized + clean (spec/sprint done, verify green)
-            #       and the loop only failed to converge because the pass keeps
-            #       recommending an independent follow-up. That work is
-            #       committable — commit it and re-file the lingering follow-up as
-            #       a fresh deferred-work entry instead of rolling everything back
-            #       (the failure mode that silently threw away review-passing work).
+            #   (a) the tree is finalized + verify-green (spec/sprint done, verify
+            #       commands pass) and the loop only failed to converge because the
+            #       pass keeps recommending an independent follow-up (`clean` stays
+            #       False). That work is committable — commit it and re-file the
+            #       lingering follow-up as a fresh deferred-work entry instead of
+            #       rolling everything back (the failure mode that silently threw
+            #       away review-passing work).
             #   (b) anything else (non-terminal status, verify failing): a genuine
             #       failure → defer + roll back as before.
             # _verify_review is the same authoritative gate the converged path uses
@@ -1720,7 +1721,10 @@ class Engine:
                 e.id: e for e in deferredwork.parse_ledger(ledger.read_text(encoding="utf-8"))
             }
             re_review = any(
-                i in entries and "origin: review-budget-followup" in entries[i].body
+                i in entries
+                and deferredwork.field_line_present(
+                    entries[i].body, "origin", "review-budget-followup"
+                )
                 for i in task.dw_ids
             )
         refiled: str | None = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -153,20 +153,30 @@ def dev_effect(
 generic_dev_effect = dev_effect
 
 
-def review_effect(paths: ProjectPaths, story_key: str, clean: bool, patched: int = 0):
+def review_effect(
+    paths: ProjectPaths, story_key: str, clean: bool, patched: int = 0, finalized: bool = True
+):
     """Simulate a follow-up review pass — a bmad-dev-auto re-invocation on the
     done spec (BMAD-METHOD #2508). A review pass always finalizes the spec to
     ``done`` and re-sets `followup_review_recommended`; the orchestrator
     synthesizes the result the same way it does for a dev pass. ``clean=True``
     means the pass no longer recommends a follow-up (the loop converges);
     ``clean=False`` means it still does (the orchestrator loops). ``patched`` is
-    accepted for call-site compatibility and otherwise unused."""
+    accepted for call-site compatibility and otherwise unused.
+
+    ``finalized=False`` leaves the spec at a non-terminal ``in-progress`` status
+    (and does not advance the sprint), so when the review budget is exhausted the
+    post-loop ``_verify_review`` gate fails — the genuine-non-convergence path
+    that defers + rolls back, as opposed to a finalized story that merely keeps
+    recommending a follow-up (which the orchestrator now commits)."""
 
     def effect(spec: SessionSpec) -> SessionResult:
         sp = spec_path(paths, story_key)
         baseline = _spec_baseline(sp)
-        write_spec(sp, "done", baseline)
-        set_sprint(paths, story_key, "done")
+        status = "done" if finalized else "in-progress"
+        write_spec(sp, status, baseline)
+        if finalized:
+            set_sprint(paths, story_key, "done")
         return SessionResult(
             status="completed",
             result_json={
@@ -174,7 +184,7 @@ def review_effect(paths: ProjectPaths, story_key: str, clean: bool, patched: int
                 "story_key": story_key,
                 "spec_file": str(sp),
                 "baseline_commit": baseline,
-                "status": "done",
+                "status": status,
                 "followup_review_recommended": not clean,
                 "escalations": [],
             },

--- a/tests/test_deferredwork.py
+++ b/tests/test_deferredwork.py
@@ -4,9 +4,11 @@ from pathlib import Path
 
 from automator.deferredwork import (
     append_decision,
+    append_entry,
     field_severity,
     has_legacy,
     mark_done,
+    next_seq,
     open_ids,
     parse_ledger,
     parse_legacy,
@@ -380,3 +382,74 @@ def test_flat_appender_in_done_section_is_done():
     )
     (entry,) = parse_legacy(text)
     assert entry.done and entry.title == "Already handled upstream"
+
+
+# ------------------------------------------------------- append_entry / next_seq
+
+
+def test_next_seq_past_highest():
+    text = "### DW-3: a\nstatus: open\n\n### DW-7: b\nstatus: done 2026-01-01\n"
+    assert next_seq(text) == 8
+
+
+def test_next_seq_empty_starts_at_one():
+    assert next_seq("") == 1
+    assert next_seq("# Deferred Work\n") == 1
+
+
+def test_append_entry_numbers_and_writes(tmp_path):
+    p = tmp_path / "deferred-work.md"
+    p.write_text("# Deferred Work\n\n### DW-4: existing\norigin: test\nstatus: open\n")
+    new_id = append_entry(
+        p,
+        title="follow-up still recommended for dw-x",
+        origin="review-budget-followup",
+        source_spec="spec-foo.md",
+        reason="review budget exhausted, work committed",
+        severity="low",
+    )
+    assert new_id == "DW-5"
+    entries = {e.id: e for e in parse_ledger(p.read_text())}
+    assert "DW-5" in entries and entries["DW-5"].open
+    body = entries["DW-5"].body
+    assert "origin: review-budget-followup" in body
+    assert "source_spec: `spec-foo.md`" in body
+    assert "severity: low" in body
+    assert "follow-up still recommended for dw-x" in body
+
+
+def test_append_entry_idempotent_for_open_origin_and_spec(tmp_path):
+    p = tmp_path / "deferred-work.md"
+    p.write_text("# Deferred Work\n")
+    first = append_entry(
+        p, title="t", origin="review-budget-followup", source_spec="spec-foo.md", reason="r"
+    )
+    assert first == "DW-1"
+    again = append_entry(
+        p, title="t2", origin="review-budget-followup", source_spec="spec-foo.md", reason="r2"
+    )
+    assert again is None  # an open entry with the same origin+spec already exists
+    assert len(parse_ledger(p.read_text())) == 1
+    # a different source_spec is not blocked
+    other = append_entry(
+        p, title="t3", origin="review-budget-followup", source_spec="spec-bar.md", reason="r3"
+    )
+    assert other == "DW-2"
+
+
+def test_append_entry_not_blocked_when_prior_is_done(tmp_path):
+    p = tmp_path / "deferred-work.md"
+    p.write_text(
+        "### DW-1: t\norigin: review-budget-followup\n"
+        "source_spec: `spec-foo.md`\nstatus: done 2026-01-01\n"
+    )
+    new_id = append_entry(
+        p, title="t2", origin="review-budget-followup", source_spec="spec-foo.md", reason="r"
+    )
+    assert new_id == "DW-2"  # prior entry is done, not open → re-file allowed
+
+
+def test_append_entry_creates_missing_ledger(tmp_path):
+    p = tmp_path / "sub" / "deferred-work.md"
+    new_id = append_entry(p, title="t", origin="o", source_spec="s.md", reason="r")
+    assert new_id == "DW-1" and p.is_file()

--- a/tests/test_deferredwork.py
+++ b/tests/test_deferredwork.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from automator.deferredwork import (
     append_decision,
     append_entry,
+    field_line_present,
     field_severity,
     has_legacy,
     mark_done,
@@ -453,3 +454,34 @@ def test_append_entry_creates_missing_ledger(tmp_path):
     p = tmp_path / "sub" / "deferred-work.md"
     new_id = append_entry(p, title="t", origin="o", source_spec="s.md", reason="r")
     assert new_id == "DW-1" and p.is_file()
+
+
+def test_append_entry_idempotency_ignores_incidental_substring(tmp_path):
+    """An unrelated open entry that merely *mentions* the origin marker and the
+    spec filename in its `reason:` prose must not suppress a legitimately new
+    entry — dedup matches the canonical field lines, not raw body substrings."""
+    p = tmp_path / "deferred-work.md"
+    p.write_text(
+        "### DW-1: unrelated\norigin: code review\n"
+        "reason: see the origin: review-budget-followup note re spec-foo.md for context\n"
+        "status: open\n"
+    )
+    new_id = append_entry(
+        p, title="t", origin="review-budget-followup", source_spec="spec-foo.md", reason="r"
+    )
+    assert new_id == "DW-2"  # not suppressed by the incidental mentions
+
+
+def test_field_line_present_matches_field_not_substring():
+    body = (
+        "### DW-1: x\norigin: review-budget-followup\n"
+        "source_spec: `spec-foo.md`\nreason: mentions spec-foobar.md and review-budget-followup-x\n"
+        "status: open\n"
+    )
+    # exact field-line matches (plain and backtick-wrapped)
+    assert field_line_present(body, "origin", "review-budget-followup")
+    assert field_line_present(body, "source_spec", "spec-foo.md")
+    # a superstring value must not match the shorter field line
+    assert not field_line_present(body, "origin", "review-budget")
+    # a value that only appears incidentally inside `reason:` is not a field line
+    assert not field_line_present(body, "source_spec", "spec-foobar.md")

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -912,6 +912,13 @@ def test_budget_exhausted_unfinalized_defers(project):
     # repo rolled back for the next story
     assert (project.project / "src.txt").read_text() == "original\n"
     assert rev_parse_head(project.project) == task.baseline_commit
+    # the in-review spec is stashed out of artifacts into the run dir so a
+    # leftover can't confuse the next attempt — the work is kept for the human
+    from conftest import spec_path
+
+    assert not spec_path(project, "1-1-a").exists()
+    stashed = engine.run_dir / "deferred" / "1-1-a" / "spec-1-1-a.md"
+    assert stashed.is_file() and "status: 'in-progress'" in stashed.read_text()
 
 
 def test_defer_preserves_deferred_work_additions(project):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -858,12 +858,50 @@ def test_review_loop_converges_within_budget(project):
     assert engine.state.tasks["1-1-a"].review_cycle == 2
 
 
-def test_plateau_defer_when_review_never_clean(project):
+def test_budget_exhausted_finalized_work_commits(project):
+    """A finalized story (status: done, sprint done, verify green) whose review
+    pass keeps recommending an independent follow-up is COMMITTED when the review
+    budget is exhausted — not rolled back. The lingering recommendation is
+    re-filed as a fresh open deferred-work entry, and the run records the event."""
+    from automator import deferredwork
+
     write_sprint(project, {"1-1-a": "ready-for-dev"})
-    engine, adapter = make_engine(
+    engine, _ = make_engine(
         project,
         [dev_effect(project, "1-1-a")]
         + [review_effect(project, "1-1-a", clean=False, patched=1) for _ in range(3)],
+    )
+    summary = engine.run()
+
+    assert summary.done == 1 and summary.deferred == 0 and not summary.paused
+    task = engine.state.tasks["1-1-a"]
+    assert task.phase == Phase.DONE
+    assert task.review_cycle == 3
+    assert task.commit_sha and task.commit_sha != task.baseline_commit
+    # the finalized work is committed, not reverted
+    assert "change for 1-1-a" in (project.project / "src.txt").read_text()
+    kinds = [e["kind"] for e in engine.journal.entries()]
+    assert "review-budget-committed" in kinds and "story-deferred" not in kinds
+    # the lingering follow-up is preserved as a new open deferred-work entry
+    open_entries = [
+        e for e in deferredwork.parse_ledger(project.deferred_work.read_text()) if e.open
+    ]
+    assert any("origin: review-budget-followup" in e.body for e in open_entries)
+
+
+def test_budget_exhausted_unfinalized_defers(project):
+    """Genuine non-convergence: the review never finalizes the spec (status stays
+    in-progress, so the post-budget verify gate fails). Budget exhaustion defers
+    and rolls the tree back, exactly as before the commit-instead-of-rollback
+    safeguard."""
+    write_sprint(project, {"1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(
+        project,
+        [dev_effect(project, "1-1-a")]
+        + [
+            review_effect(project, "1-1-a", clean=False, patched=1, finalized=False)
+            for _ in range(3)
+        ],
     )
     summary = engine.run()
 
@@ -874,12 +912,6 @@ def test_plateau_defer_when_review_never_clean(project):
     # repo rolled back for the next story
     assert (project.project / "src.txt").read_text() == "original\n"
     assert rev_parse_head(project.project) == task.baseline_commit
-    # the dev-finalized spec is stashed into the run dir, not left in artifacts
-    from conftest import spec_path
-
-    assert not spec_path(project, "1-1-a").exists()
-    stashed = engine.run_dir / "deferred" / "1-1-a" / "spec-1-1-a.md"
-    assert stashed.is_file() and "status: 'done'" in stashed.read_text()
 
 
 def test_defer_preserves_deferred_work_additions(project):
@@ -896,7 +928,7 @@ def test_defer_preserves_deferred_work_additions(project):
     def reviewing_with_defer(spec):
         with project.deferred_work.open("a") as f:
             f.write("\n### DW-1: pre-existing flaky retry\n\nstatus: open\n")
-        return make_review(project, "1-1-a", clean=False, patched=1)(spec)
+        return make_review(project, "1-1-a", clean=False, patched=1, finalized=False)(spec)
 
     engine, _ = make_engine(
         project,
@@ -920,7 +952,10 @@ def test_rollback_off_pauses_with_manual_notice(project):
     engine, _ = make_engine(
         project,
         [dev_effect(project, "1-1-a")]
-        + [review_effect(project, "1-1-a", clean=False, patched=1) for _ in range(3)],
+        + [
+            review_effect(project, "1-1-a", clean=False, patched=1, finalized=False)
+            for _ in range(3)
+        ],
         policy=policy,
     )
     precious = project.project / "keep-me.txt"
@@ -952,7 +987,10 @@ def test_rollback_on_preserves_preexisting_untracked(project):
     engine, _ = make_engine(
         project,
         [dev_effect(project, "1-1-a")]
-        + [review_effect(project, "1-1-a", clean=False, patched=1) for _ in range(3)],
+        + [
+            review_effect(project, "1-1-a", clean=False, patched=1, finalized=False)
+            for _ in range(3)
+        ],
         policy=policy,
     )
     precious = project.project / "user-notes.txt"

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -921,6 +921,37 @@ def test_budget_exhausted_unfinalized_defers(project):
     assert stashed.is_file() and "status: 'in-progress'" in stashed.read_text()
 
 
+def test_budget_exhausted_failed_review_sessions_defer_not_commit(project):
+    """A *failed* final review session must never trigger the commit-instead-of-
+    rollback rescue. Dev finalizes the story (status: done, recommends a follow-up),
+    but every review session crashes/stalls. On the last cycle the budget is spent,
+    so decide_review_session returns DEFER (not RETRY) and the loop rolls the tree
+    back — it does not reach (or fire) the budget-exhaustion rescue commit. Locks in
+    the invariant that makes a 'final-iteration RETRY commits un-reviewed work' path
+    unreachable."""
+    write_sprint(project, {"1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(
+        project,
+        [
+            dev_effect(project, "1-1-a"),  # finalizes spec to done, recommends follow-up
+            SessionResult(status="crashed"),
+            SessionResult(status="stalled"),
+            SessionResult(status="crashed"),  # final cycle: budget spent -> DEFER
+        ],
+    )
+    summary = engine.run()
+
+    assert summary.deferred == 1 and summary.done == 0 and not summary.paused
+    task = engine.state.tasks["1-1-a"]
+    assert task.phase == Phase.DEFERRED
+    assert "review session" in task.defer_reason  # decide_review_session's DEFER reason
+    # rolled back, not committed — and the rescue commit never ran
+    assert (project.project / "src.txt").read_text() == "original\n"
+    assert rev_parse_head(project.project) == task.baseline_commit
+    kinds = [e["kind"] for e in engine.journal.entries()]
+    assert "story-deferred" in kinds and "review-budget-committed" not in kinds
+
+
 def test_defer_preserves_deferred_work_additions(project):
     """Review sessions append real knowledge to deferred-work.md; a plateau
     defer's git reset must not erase it."""

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -1496,3 +1496,69 @@ def test_mixed_ledger_migration_preserves_canonical_open_set(project):
     assert engine.state.tasks["sweep-migrate"].phase == Phase.DONE
     assert engine.state.tasks["sweep-triage"].phase == Phase.DONE
     assert ledger_entries(project)["DW-1"].open  # skipped, untouched
+
+
+# ------------------------------------------ review-budget commit-instead-of-rollback
+
+
+def test_sweep_bundle_budget_exhausted_commits_and_refiles(project):
+    """A bundle whose review keeps recommending a follow-up but is finalized
+    (spec done, owned dw ids closed, verify green) is COMMITTED when the review
+    budget is exhausted — not rolled back. The lingering follow-up is re-filed as
+    a fresh open deferred-work entry."""
+    write_ledger(project, {"DW-1": "open"})
+    plan = triage_result(
+        ["DW-1"],
+        bundles=[{"name": "fix-it", "dw_ids": ["DW-1"], "intent": "fix it"}],
+    )
+    engine, _ = make_sweep(
+        project,
+        [triage_effect(plan), bundle_dev_effect(project, "fix-it", ["DW-1"])]
+        + [bundle_review_effect(project, "fix-it", clean=False) for _ in range(3)],
+    )
+    summary = engine.run()
+
+    assert summary.deferred == 0 and not summary.paused
+    assert engine.state.tasks["dw-fix-it"].phase == Phase.DONE
+    entries = ledger_entries(project)
+    assert entries["DW-1"].status.startswith("done")  # the worked item closed
+    refiled = [e for e in entries.values() if e.open and "origin: review-budget-followup" in e.body]
+    assert len(refiled) == 1
+    kinds = {e["kind"] for e in engine.journal.entries()}
+    assert "review-budget-committed" in kinds and "story-deferred" not in kinds
+
+
+def test_sweep_bundle_budget_followup_not_refiled_twice(project):
+    """Re-review cap: when a bundle itself closes a `review-budget-followup` entry
+    and still won't converge, the work is committed but NOT re-filed again — a
+    second non-convergence should reach a human, not loop across sweeps."""
+    ledger = (
+        "# Deferred Work\n\n"
+        "### DW-1: follow-up still recommended for dw-prior\n"
+        "origin: review-budget-followup\nsource_spec: `spec-dw-fix-it.md`\n"
+        "severity: low\nreason: a prior budget exhaustion.\nstatus: open\n"
+    )
+    project.deferred_work.write_text(ledger, encoding="utf-8")
+    git(project.project, "add", "-A")
+    git(project.project, "commit", "-q", "-m", "ledger")
+    plan = triage_result(
+        ["DW-1"],
+        bundles=[{"name": "fix-it", "dw_ids": ["DW-1"], "intent": "fix it"}],
+    )
+    engine, _ = make_sweep(
+        project,
+        [triage_effect(plan), bundle_dev_effect(project, "fix-it", ["DW-1"])]
+        + [bundle_review_effect(project, "fix-it", clean=False) for _ in range(3)],
+    )
+    summary = engine.run()
+
+    assert summary.deferred == 0 and not summary.paused
+    assert engine.state.tasks["dw-fix-it"].phase == Phase.DONE
+    entries = ledger_entries(project)
+    assert entries["DW-1"].status.startswith("done")  # the worked entry still closes
+    open_followups = [
+        e for e in entries.values() if e.open and "origin: review-budget-followup" in e.body
+    ]
+    assert open_followups == []  # no second follow-up entry created
+    capped = [e for e in engine.journal.entries() if e["kind"] == "review-budget-committed"]
+    assert len(capped) == 1 and capped[0]["re_review_capped"] is True

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "bmad-auto"
-version = "0.7.10"
+version = "0.7.11"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
## 0.7.11 — review-budget commit-instead-of-rollback

### The bug

When the follow-up review loop hit `limits.max_review_cycles` while a story was **finalized** (frontmatter `status: done`, sprint/ledger done, verify green) and the only reason it never converged was a never-clearing `followup_review_recommended`, the orchestrator deferred + **rolled back** the work — discarding completed, review-passing changes. Observed in the wild on real Lights-Out runs (e.g. a story whose reviewer re-recommended a follow-up every cycle because each pass changed test semantics — structurally never converges within any finite budget).

This is distinct from the stale-frontmatter false-defer fixed in 0.7.8/0.7.10: here the frontmatter is *correct* (`status: done`) every cycle; the loop just never sees `followup == false`.

### The fix

At budget exhaustion in `Engine._review_and_commit`, if the tree is finalized and verify-green (gated on the **same** `_verify_review` the converged path uses, so it can never ship unverified work) and the run is non-isolated:

- **commit** the work instead of deferring + reverting, and
- re-file the lingering follow-up as a fresh open deferred-work entry (new `deferredwork.append_entry`, idempotent on open `origin`+`source_spec`).

Guards:
- **Re-review cap** — a story that itself originated from a `review-budget-followup` entry is committed *without* re-filing (journals `review-budget-committed` with `re_review_capped`), so a second non-convergence reaches a human instead of looping across sweeps.
- **Worktree-isolation exempt** — a deferred unit already keeps its worktree, so there's nothing to rescue and committing into the main repo would be wrong; that path still defers.

Genuine non-convergence (spec never reaches `done`, or verify red) still defers + rolls back exactly as before.

### Tests

- `tests/test_engine.py` — finalized-but-followup → commits + re-files; unfinalized → still defers + rolls back; repurposed the old plateau test.
- `tests/test_sweep.py` — bundle budget exhaustion commits + re-files; re-review cap commits without re-filing.
- `tests/test_deferredwork.py` — `append_entry`/`next_seq` numbering, idempotency, create-if-missing.
- Full suite: 1235 passed; `trunk check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when the review budget is exhausted: if review completes successfully, changes are now committed instead of rolled back.
  * When follow-up review is still recommended, the follow-up is re-filed as a new deferred-work item to avoid repeated non-convergence loops.
  * Prevented duplicate follow-up deferred-work entries on repeated re-reviews by capping re-filing when an open follow-up already exists.
* **Maintenance**
  * Released version **0.7.11** (marketplace/module/package version bumps).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->