### PR TITLE
fix(engine): preserve an attempt's commits before auto-rollback hard …

### DIFF
--- a/src/automator/engine.py
+++ b/src/automator/engine.py
@@ -800,50 +800,81 @@ class Engine:
         commits = verify.commits_above(self.workspace.root, baseline)
         if not commits:
             return
-        head = commits[0]
+        head = verify.rev_parse_head(self.workspace.root)  # the tip the recovery ref parks at
         # run_id can be an arbitrary user `--run-id`; keep the ref component git-safe
-        # so an exotic id can't fail `git branch` and turn a routine rollback into a
-        # false "couldn't preserve" pause.
-        slug = "".join(c if (c.isalnum() or c in "_-") else "-" for c in self.state.run_id)
-        ref = verify.preserve_commits(
-            self.workspace.root, baseline, f"attempt-preserve/{slug}-{head[:8]}", commits=commits
-        )
+        # and length-bounded so an exotic/overlong id can't blow the ref-name limit,
+        # fail `git branch`, and drop the recovery ref (which on a re-drive would then
+        # reset past the work anyway).
+        slug = "".join(c if (c.isalnum() or c in "_-") else "-" for c in self.state.run_id)[:64]
+        try:
+            ref = verify.preserve_commits(
+                self.workspace.root,
+                baseline,
+                f"attempt-preserve/{slug}-{head[:8]}",
+                commits=commits,
+            )
+        except verify.GitError:
+            ref = None  # branch creation failed — treat as a preservation failure
         if ref is None:
             # commits exist (just enumerated) but the ref did not take.
             self.journal.append("attempt-preserve-failed", story_key=task.story_key, head=head)
             if allow_pause:
-                self._pause_for_manual_recovery(task, baseline)  # raises RunPaused
+                # the commits at HEAD could not be parked — the notice must NOT tell
+                # the operator to blindly `reset --hard` (that would discard them).
+                self._pause_for_manual_recovery(task, baseline, preserve_failed=True)
             return  # re-drive: never pause — proceed to the (human-directed) reset
         self.journal.append(
             "attempt-commits-preserved", story_key=task.story_key, ref=ref, count=len(commits)
         )
 
-    def _pause_for_manual_recovery(self, task: StoryTask, baseline: str) -> None:
-        """OFF path for a stopped/abandoned in-place attempt: leave the tree
-        untouched, surface bold manual-recovery instructions, and pause the run.
-        Always raises RunPaused. A *resolved* escalation never reaches here —
-        `_rollback_or_pause` auto-recovers that human-initiated re-drive
+    def _pause_for_manual_recovery(
+        self, task: StoryTask, baseline: str, *, preserve_failed: bool = False
+    ) -> None:
+        """Leave the tree untouched, surface bold manual-recovery instructions, and
+        pause the run. Always raises RunPaused. Reached either (a, default) the OFF
+        path for a stopped/abandoned in-place attempt, or (b, ``preserve_failed``)
+        rollback is ON/resolved but the attempt's commits above baseline could not be
+        parked on a recovery ref, so an automatic ``reset --hard`` would silently
+        discard them — a distinct notice that names the at-risk commits and never
+        tells the operator to blindly reset. A *resolved* escalation never reaches
+        here — `_rollback_or_pause` auto-recovers that human-initiated re-drive
         regardless of `scm.rollback_on_failure`."""
         short = baseline[:12] or "<baseline_commit>"
-        why = (
-            f"Story **{task.story_key}**'s attempt was stopped and auto-rollback "
-            "is OFF, so the working tree was left exactly as-is for you to "
-            "inspect.\n"
-        )
-        notice = (
-            "**ACTION REQUIRED — manual rollback needed**\n"
-            f"{why}"
-            "To discard this attempt yourself:\n"
-            "  1. **BACK UP any untracked files you want to keep** — the reset "
-            "below deletes uncommitted work.\n"
-            f"  2. `git reset --hard {short}` then review/remove leftover "
-            "untracked files.\n"
-            "  3. **Restore the files you backed up in step 1.**\n"
-            f"Then run `bmad-auto resume {self.state.run_id}`. To let the "
-            "orchestrator do a safe automatic rollback next time, enable "
-            "`[scm] rollback_on_failure` (it discards the attempt's uncommitted "
-            "work but never deletes pre-existing untracked files)."
-        )
+        if preserve_failed:
+            notice = (
+                "**ACTION REQUIRED — commits could not be auto-preserved**\n"
+                f"Story **{task.story_key}**'s attempt committed work above its "
+                "baseline, but a recovery ref for those commits could not be created, "
+                "so the automatic rollback was refused rather than `reset --hard` "
+                "past (and discard) them. **Your commits are intact at the current "
+                "HEAD.**\n"
+                "  1. **Save them first** — e.g. `git branch my-rescue HEAD` (the "
+                f"commits are `{short}..HEAD`).\n"
+                "  2. Only once they are safe, discard the attempt if you want to: "
+                f"`git reset --hard {short}`, then review/remove leftover untracked "
+                "files.\n"
+                f"Then run `bmad-auto resume {self.state.run_id}`."
+            )
+        else:
+            why = (
+                f"Story **{task.story_key}**'s attempt was stopped and auto-rollback "
+                "is OFF, so the working tree was left exactly as-is for you to "
+                "inspect.\n"
+            )
+            notice = (
+                "**ACTION REQUIRED — manual rollback needed**\n"
+                f"{why}"
+                "To discard this attempt yourself:\n"
+                "  1. **BACK UP any untracked files you want to keep** — the reset "
+                "below deletes uncommitted work.\n"
+                f"  2. `git reset --hard {short}` then review/remove leftover "
+                "untracked files.\n"
+                "  3. **Restore the files you backed up in step 1.**\n"
+                f"Then run `bmad-auto resume {self.state.run_id}`. To let the "
+                "orchestrator do a safe automatic rollback next time, enable "
+                "`[scm] rollback_on_failure` (it discards the attempt's uncommitted "
+                "work but never deletes pre-existing untracked files)."
+            )
         self.journal.append("rollback-manual-required", story_key=task.story_key, baseline=baseline)
         gates.notify(
             self.policy,

--- a/src/automator/engine.py
+++ b/src/automator/engine.py
@@ -756,6 +756,10 @@ class Engine:
                 baseline=task.baseline_commit or "",
                 note="reverting tracked changes + run-created untracked files",
             )
+            # A re-drive (resolved / mid-re-drive) is contractually pause-free, so it
+            # preserves best-effort but never blocks; a plain rollback pauses rather
+            # than reset past work it could not park.
+            self._preserve_attempt_commits(task, allow_pause=not redrive)
             self._safe_reset(task, preserve=protected)
             return
         self._pause_for_manual_recovery(task, task.baseline_commit or "")
@@ -776,6 +780,42 @@ class Engine:
             baseline_untracked=task.baseline_untracked,
             keep=(".automator", *self._protected_relpaths()),
             preserve=preserve,
+        )
+
+    def _preserve_attempt_commits(self, task: StoryTask, *, allow_pause: bool) -> None:
+        """Before an auto-rollback's hard reset, park any commits the attempt made
+        above its baseline under a named recovery ref, so `reset --hard baseline`
+        can't silently orphan committed work (it survives `git gc` and is
+        recoverable by name, not just the reflog). No-op when the attempt added no
+        commits — an uncommitted-only revert is the intended, non-destructive case.
+
+        If commits exist but the ref cannot be created: with ``allow_pause`` (a
+        plain rollback) refuse to reset — pause for manual recovery rather than
+        destroy the work. On a re-drive (``allow_pause=False``) the caller's
+        contract forbids pausing, so journal the failure and let the reset proceed
+        (the re-drive is a human-directed discard of the failed attempt)."""
+        baseline = task.baseline_commit
+        if not baseline:
+            return
+        commits = verify.commits_above(self.workspace.root, baseline)
+        if not commits:
+            return
+        head = commits[0]
+        # run_id can be an arbitrary user `--run-id`; keep the ref component git-safe
+        # so an exotic id can't fail `git branch` and turn a routine rollback into a
+        # false "couldn't preserve" pause.
+        slug = "".join(c if (c.isalnum() or c in "_-") else "-" for c in self.state.run_id)
+        ref = verify.preserve_commits(
+            self.workspace.root, baseline, f"attempt-preserve/{slug}-{head[:8]}", commits=commits
+        )
+        if ref is None:
+            # commits exist (just enumerated) but the ref did not take.
+            self.journal.append("attempt-preserve-failed", story_key=task.story_key, head=head)
+            if allow_pause:
+                self._pause_for_manual_recovery(task, baseline)  # raises RunPaused
+            return  # re-drive: never pause — proceed to the (human-directed) reset
+        self.journal.append(
+            "attempt-commits-preserved", story_key=task.story_key, ref=ref, count=len(commits)
         )
 
     def _pause_for_manual_recovery(self, task: StoryTask, baseline: str) -> None:

--- a/src/automator/verify.py
+++ b/src/automator/verify.py
@@ -193,10 +193,12 @@ def untracked_files(repo: Path) -> set[str]:
 
 
 def commits_above(repo: Path, baseline: str) -> list[str]:
-    """Commit shas (newest first) reachable from HEAD but not from ``baseline`` —
-    the commits an attempt added on top of its pre-attempt baseline. Empty when
-    HEAD is at or behind baseline. Raises GitError on a git failure (a bad
-    baseline is a real error, never quietly "no commits")."""
+    """Commit shas reachable from HEAD but not from ``baseline`` — the commits an
+    attempt added on top of its pre-attempt baseline, in ``git rev-list`` order (do
+    not assume a strict newest-first / HEAD-first ordering across merges or clock
+    skew; callers that need the tip should read HEAD directly). Empty when HEAD is
+    at or behind baseline. Raises GitError on a git failure (a bad baseline is a
+    real error, never quietly "no commits")."""
     rc, out = _git(repo, "rev-list", f"{baseline}..HEAD")
     if rc != 0:
         raise GitError(f"git rev-list {baseline}..HEAD failed in {repo}: {out}")
@@ -216,13 +218,20 @@ def preserve_commits(
 
     ``commits`` lets a caller that already ran :func:`commits_above` pass the result
     in to skip a second ``git rev-list`` subprocess; ``None`` self-fetches (keeps the
-    helper standalone/testable)."""
+    helper standalone/testable).
+
+    ``None`` means *nothing to preserve* — never a failure. If commits exist but the
+    branch cannot be created this raises :class:`GitError` (consistent with the rest
+    of this module), so a caller can never mistake a preservation failure for a
+    harmless no-op and reset past committed work."""
     if commits is None:
         commits = commits_above(repo, baseline)
     if not commits:
         return None
-    rc, _ = _git(repo, "branch", "-f", ref_name, "HEAD")
-    return ref_name if rc == 0 else None
+    rc, out = _git(repo, "branch", "-f", ref_name, "HEAD")
+    if rc != 0:
+        raise GitError(f"git branch -f {ref_name} HEAD failed in {repo}: {out}")
+    return ref_name
 
 
 def safe_rollback(

--- a/src/automator/verify.py
+++ b/src/automator/verify.py
@@ -192,6 +192,39 @@ def untracked_files(repo: Path) -> set[str]:
     return {line.strip() for line in out.splitlines() if line.strip()}
 
 
+def commits_above(repo: Path, baseline: str) -> list[str]:
+    """Commit shas (newest first) reachable from HEAD but not from ``baseline`` —
+    the commits an attempt added on top of its pre-attempt baseline. Empty when
+    HEAD is at or behind baseline. Raises GitError on a git failure (a bad
+    baseline is a real error, never quietly "no commits")."""
+    rc, out = _git(repo, "rev-list", f"{baseline}..HEAD")
+    if rc != 0:
+        raise GitError(f"git rev-list {baseline}..HEAD failed in {repo}: {out}")
+    return [line for line in out.splitlines() if line]
+
+
+def preserve_commits(
+    repo: Path, baseline: str, ref_name: str, commits: list[str] | None = None
+) -> str | None:
+    """Park the commits an attempt made above ``baseline`` under a branch at HEAD
+    so a following ``git reset --hard baseline`` cannot orphan them — they survive
+    `git gc` and are recoverable by name, not just via the reflog. Returns
+    ``ref_name`` on success; ``None`` when there is nothing to preserve (HEAD at/
+    below baseline) or the branch could not be created (the caller must then refuse
+    to reset rather than silently destroy committed work). ``-f`` because a retry
+    within the same run may re-preserve the same head under the same name.
+
+    ``commits`` lets a caller that already ran :func:`commits_above` pass the result
+    in to skip a second ``git rev-list`` subprocess; ``None`` self-fetches (keeps the
+    helper standalone/testable)."""
+    if commits is None:
+        commits = commits_above(repo, baseline)
+    if not commits:
+        return None
+    rc, _ = _git(repo, "branch", "-f", ref_name, "HEAD")
+    return ref_name if rc == 0 else None
+
+
 def safe_rollback(
     repo: Path,
     baseline: str,

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -41,7 +41,7 @@ from automator.policy import (
     VerifyPolicy,
 )
 from automator.runs import rearm_escalation
-from automator.verify import read_frontmatter, rev_parse_head, worktree_clean
+from automator.verify import GitError, read_frontmatter, rev_parse_head, worktree_clean
 
 QUIET = NotifyPolicy(desktop=False, file=True)
 
@@ -1112,7 +1112,9 @@ def test_rollback_preserves_committed_attempt_work(project):
 
 def test_rollback_pauses_when_preserve_fails(project, monkeypatch):
     """Safety invariant: if the recovery ref can't be created while commits exist,
-    the engine pauses for manual recovery rather than resetting past the work."""
+    the engine pauses for manual recovery rather than resetting past the work — and
+    the notice names the at-risk commits instead of the misleading rollback-OFF
+    'just reset --hard' wording."""
     policy = Policy(
         gates=GatesPolicy(mode="none"),
         notify=QUIET,
@@ -1127,12 +1129,19 @@ def test_rollback_pauses_when_preserve_fails(project, monkeypatch):
     git(repo, "add", "-A")
     git(repo, "commit", "-q", "-m", "attempt work")
     attempt_head = rev_parse_head(repo)
-    monkeypatch.setattr("automator.verify.preserve_commits", lambda *a, **k: None)
 
-    with pytest.raises(RunPaused):
+    def _fail(*a, **k):
+        raise GitError("simulated branch failure")
+
+    monkeypatch.setattr("automator.verify.preserve_commits", _fail)
+
+    with pytest.raises(RunPaused) as paused:
         engine._rollback_or_pause(task)
 
     assert rev_parse_head(repo) == attempt_head  # NOT reset — work left intact
+    reason = paused.value.reason.lower()
+    assert "commit" in reason  # notice names the at-risk committed work
+    assert "auto-rollback is off" not in reason  # never the misleading OFF wording (rollback is ON)
 
 
 def test_resolved_redrive_never_pauses_when_preserve_fails(project, monkeypatch):
@@ -1152,7 +1161,11 @@ def test_resolved_redrive_never_pauses_when_preserve_fails(project, monkeypatch)
     (repo / "impl.txt").write_text("failed attempt work\n")  # committed, outside artifacts
     git(repo, "add", "-A")
     git(repo, "commit", "-q", "-m", "failed attempt")
-    monkeypatch.setattr("automator.verify.preserve_commits", lambda *a, **k: None)
+
+    def _fail(*args, **kwargs):
+        raise GitError("simulated branch failure")
+
+    monkeypatch.setattr("automator.verify.preserve_commits", _fail)
 
     engine._rollback_or_pause(task, cause="resolved")  # must NOT raise RunPaused
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -9,6 +9,7 @@ import pytest
 from conftest import (
     dev_effect,
     generic_dev_effect,
+    git,
     review_effect,
     spec_path,
     write_spec,
@@ -1082,6 +1083,83 @@ def test_manual_recovery_wording_stopped(project):
     assert "failed" not in stopped.value.reason
     assert "manual rollback" in stopped.value.reason.lower()
     assert "attempt was stopped" in stopped.value.reason
+
+
+def test_rollback_preserves_committed_attempt_work(project):
+    """rollback_on_failure ON + an attempt that committed its work: the hard reset
+    parks those commits under a recovery ref instead of orphaning them."""
+    policy = Policy(
+        gates=GatesPolicy(mode="none"),
+        notify=QUIET,
+        scm=ScmPolicy(rollback_on_failure=True),
+    )
+    engine, _ = make_engine(project, [], policy=policy)
+    repo = project.project
+    task = StoryTask(story_key="1-1-a", epic=1)
+    task.baseline_commit = rev_parse_head(repo)
+    task.baseline_untracked = []
+    (repo / "impl.txt").write_text("committed implementation\n")  # attempt commits its work
+    git(repo, "add", "-A")
+    git(repo, "commit", "-q", "-m", "attempt work")
+    attempt_head = rev_parse_head(repo)
+
+    engine._rollback_or_pause(task)  # rollback ON: resets to baseline
+
+    assert rev_parse_head(repo) == task.baseline_commit  # reset happened
+    entry = next(e for e in engine.journal.entries() if e["kind"] == "attempt-commits-preserved")
+    assert git(repo, "rev-parse", entry["ref"]).strip() == attempt_head  # reachable by name
+
+
+def test_rollback_pauses_when_preserve_fails(project, monkeypatch):
+    """Safety invariant: if the recovery ref can't be created while commits exist,
+    the engine pauses for manual recovery rather than resetting past the work."""
+    policy = Policy(
+        gates=GatesPolicy(mode="none"),
+        notify=QUIET,
+        scm=ScmPolicy(rollback_on_failure=True),
+    )
+    engine, _ = make_engine(project, [], policy=policy)
+    repo = project.project
+    task = StoryTask(story_key="1-1-a", epic=1)
+    task.baseline_commit = rev_parse_head(repo)
+    task.baseline_untracked = []
+    (repo / "impl.txt").write_text("committed work\n")
+    git(repo, "add", "-A")
+    git(repo, "commit", "-q", "-m", "attempt work")
+    attempt_head = rev_parse_head(repo)
+    monkeypatch.setattr("automator.verify.preserve_commits", lambda *a, **k: None)
+
+    with pytest.raises(RunPaused):
+        engine._rollback_or_pause(task)
+
+    assert rev_parse_head(repo) == attempt_head  # NOT reset — work left intact
+
+
+def test_resolved_redrive_never_pauses_when_preserve_fails(project, monkeypatch):
+    """A resolved re-drive is contractually pause-free. Even if the recovery ref
+    can't be created for the attempt's commits, it journals the failure and lets
+    the reset proceed — unlike the general rollback path, which pauses."""
+    policy = Policy(
+        gates=GatesPolicy(mode="none"),
+        notify=QUIET,
+        scm=ScmPolicy(rollback_on_failure=False),  # OFF: only the resolved path resets here
+    )
+    engine, _ = make_engine(project, [], policy=policy)
+    repo = project.project
+    task = StoryTask(story_key="1-1-a", epic=1)
+    task.baseline_commit = rev_parse_head(repo)
+    task.baseline_untracked = []
+    (repo / "impl.txt").write_text("failed attempt work\n")  # committed, outside artifacts
+    git(repo, "add", "-A")
+    git(repo, "commit", "-q", "-m", "failed attempt")
+    monkeypatch.setattr("automator.verify.preserve_commits", lambda *a, **k: None)
+
+    engine._rollback_or_pause(task, cause="resolved")  # must NOT raise RunPaused
+
+    assert rev_parse_head(repo) == task.baseline_commit  # reset proceeded, not paused
+    kinds = [e["kind"] for e in engine.journal.entries()]
+    assert "attempt-preserve-failed" in kinds
+    assert "rollback-manual-required" not in kinds
 
 
 def test_rollback_or_pause_resolved_auto_recovers(project):

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -813,3 +813,16 @@ def test_preserve_commits_noop_without_commits(project):
     (repo / "dirty.txt").write_text("uncommitted\n")  # dirty but never committed
     assert verify.preserve_commits(repo, baseline, "attempt-preserve/run-none") is None
     assert git(repo, "branch", "--list", "attempt-preserve/run-none").strip() == ""
+
+
+def test_preserve_commits_raises_on_branch_failure(project):
+    """When commits exist but the branch cannot be created (here, an illegal ref
+    name), raise GitError — never return None, so a caller can't mistake a
+    preservation failure for a harmless no-op and reset past committed work."""
+    repo = project.project
+    baseline = verify.rev_parse_head(repo)
+    (repo / "impl.txt").write_text("committed\n")
+    git(repo, "add", "-A")
+    git(repo, "commit", "-q", "-m", "attempt work")
+    with pytest.raises(verify.GitError):
+        verify.preserve_commits(repo, baseline, "bad..ref")  # ".." is an illegal git ref name

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -762,3 +762,54 @@ def test_spec_within_roots(project, tmp_path):
     outside = tmp_path / "outside" / "spec.md"
     assert verify.spec_within_roots(outside, project) is False
     assert verify.spec_within_roots(Path("/etc/passwd"), project) is False
+
+
+def test_commits_above_empty_at_baseline(project):
+    """HEAD sitting at baseline has no attempt commits to preserve."""
+    repo = project.project
+    baseline = verify.rev_parse_head(repo)
+    assert verify.commits_above(repo, baseline) == []
+
+
+def test_commits_above_lists_attempt_commits_newest_first(project):
+    repo = project.project
+    baseline = verify.rev_parse_head(repo)
+    (repo / "impl.txt").write_text("work\n")
+    git(repo, "add", "-A")
+    git(repo, "commit", "-q", "-m", "attempt work")
+    head = verify.rev_parse_head(repo)
+    commits = verify.commits_above(repo, baseline)
+    assert commits == [head]
+
+
+def test_preserve_commits_survives_reset_and_gc(project):
+    """The parked ref keeps committed attempt work reachable through the exact
+    destructive sequence safe_rollback performs (reset --hard baseline) and a gc."""
+    repo = project.project
+    baseline = verify.rev_parse_head(repo)
+    (repo / "impl.txt").write_text("committed work\n")
+    git(repo, "add", "-A")
+    git(repo, "commit", "-q", "-m", "attempt work")
+    head = verify.rev_parse_head(repo)
+
+    ref = verify.preserve_commits(repo, baseline, "attempt-preserve/run-abc12345")
+    assert ref == "attempt-preserve/run-abc12345"
+
+    git(repo, "reset", "--hard", baseline)
+    git(repo, "gc", "--prune=now")
+
+    assert verify.rev_parse_head(repo) == baseline  # reset landed
+    assert git(repo, "rev-parse", ref).strip() == head  # work still reachable by name
+    assert (repo / "impl.txt").exists() is False  # gone from the working tree...
+    git(repo, "checkout", ref, "--", "impl.txt")  # ...but recoverable
+    assert (repo / "impl.txt").read_text() == "committed work\n"
+
+
+def test_preserve_commits_noop_without_commits(project):
+    """An uncommitted-only attempt (HEAD at baseline) creates no ref and returns
+    None — the caller then resets as before."""
+    repo = project.project
+    baseline = verify.rev_parse_head(repo)
+    (repo / "dirty.txt").write_text("uncommitted\n")  # dirty but never committed
+    assert verify.preserve_commits(repo, baseline, "attempt-preserve/run-none") is None
+    assert git(repo, "branch", "--list", "attempt-preserve/run-none").strip() == ""


### PR DESCRIPTION
## What

When an in-place attempt is auto-rolled-back, the engine now parks any commits the attempt made above its baseline under a named `attempt-preserve/<run_id>-<sha>` branch before running `git reset --hard <baseline>`, so committed work is always recoverable by name.

## Why

With `scm.rollback_on_failure` enabled (or on a resolved re-drive), a deferred or stopped attempt's committed work was discarded by the hard reset and recoverable only from git's reflog until garbage collection — a silent data-loss risk.

## How

- Add `verify.commits_above` / `verify.preserve_commits` (pure git mechanics): enumerate `baseline..HEAD` and, when non-empty, create a gc-safe recovery branch at HEAD.
- Wire `engine._preserve_attempt_commits` into the rollback path before the reset — a plain rollback that cannot create the ref pauses for manual recovery instead of destroying work, while a (contractually pause-free) re-drive journals the failure and proceeds.
- Sanitize `run_id` in the ref name; leave uncommitted-only attempts and the sweep ledger-recovery reset path untouched.

## Testing

New unit tests (`tests/test_verify.py`) and engine-path tests (`tests/test_engine.py`) cover preservation, ref survival through `reset --hard` + `git gc`, the pause-on-failure safety path, and the resolved-re-drive no-pause path.
Full `test_verify.py` + `test_engine.py` are green on both Linux (131 passed) and Windows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Rollbacks now better protect committed work by preserving attempt commits before resetting.
  * If commit preservation fails during a normal rollback, the system can pause for recovery instead of discarding work.
  * During re-drive recovery, rollback behavior is now more consistent and won’t pause unexpectedly.
  * Recovery information is now recorded more reliably, making rollback outcomes easier to trace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->