### PR TITLE
fix(process): identity-aware liveness and win32 console-ctrl safety

### DIFF
--- a/src/automator/engine.py
+++ b/src/automator/engine.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import shutil
 import signal
+import sys
 import traceback
 from dataclasses import dataclass
 from pathlib import Path
@@ -275,14 +276,28 @@ class Engine:
         if Engine._stop_signals_owner is not None:
             return
 
+        windows_ctrl_signals = {signal.SIGINT}
+        sigbreak = getattr(signal, "SIGBREAK", None)
+        if sigbreak is not None:
+            windows_ctrl_signals.add(sigbreak)
+
         def handler(signum, frame):  # noqa: ANN001 - stdlib signal signature
+            if sys.platform == "win32" and signum in windows_ctrl_signals:
+                try:
+                    self.journal.append("console-ctrl-ignored", signum=signum)
+                except Exception:  # noqa: BLE001  # best-effort signal-handler journal
+                    pass
+                return
             if self._stopping:
                 return  # already unwinding; don't re-raise during teardown
             self._stopping = True
             raise RunStopped()
 
         try:
-            for sig in (signal.SIGTERM, signal.SIGINT):
+            signals = [signal.SIGTERM, signal.SIGINT]
+            if sys.platform == "win32" and sigbreak is not None:
+                signals.append(sigbreak)
+            for sig in dict.fromkeys(signals):
                 self._prev_handlers[sig] = signal.signal(sig, handler)
         except ValueError:
             # not on the main thread — cannot install; degrade to no handler

--- a/src/automator/engine.py
+++ b/src/automator/engine.py
@@ -8,6 +8,7 @@ verify. All creative work happens inside disposable adapter sessions.
 
 from __future__ import annotations
 
+import contextlib
 import shutil
 import signal
 import sys
@@ -283,10 +284,9 @@ class Engine:
 
         def handler(signum, frame):  # noqa: ANN001 - stdlib signal signature
             if sys.platform == "win32" and signum in windows_ctrl_signals:
-                try:
+                # best-effort: a journal error must never escape a signal handler.
+                with contextlib.suppress(Exception):
                     self.journal.append("console-ctrl-ignored", signum=signum)
-                except Exception:  # noqa: BLE001  # best-effort signal-handler journal
-                    pass
                 return
             if self._stopping:
                 return  # already unwinding; don't re-raise during teardown

--- a/src/automator/process_host.py
+++ b/src/automator/process_host.py
@@ -84,8 +84,10 @@ class ProcessHost(ABC):
             return False
         if identity is None:
             return self.is_alive(pid)
-        # identity(pid) is None when the pid is gone and a different value when it
-        # was reused — either way it != the recorded identity, so this is False.
+        # identity(pid) != the recorded value whenever the pid is gone, reused, or
+        # merely unreadable (a permission glitch, or no psutil off-Linux) — every
+        # case reads False (not-ours). An unreadable identity on a live pid thus
+        # reads as dead: the documented residual, deliberately biased safe.
         return self.identity(pid) == identity
 
     def shell_quote(self, arg: str) -> str:

--- a/src/automator/process_host.py
+++ b/src/automator/process_host.py
@@ -69,6 +69,25 @@ class ProcessHost(ABC):
         the ``python3`` on PATH; a Windows host overrides it (no ``python3`` there)
         so hook registration never branches on ``sys.platform`` at the call site."""
 
+    def alive_and_ours(self, pid: int, identity: float | None) -> bool:
+        """Identity-aware liveness: True only when ``pid`` is alive **and** still the
+        same process whose ``identity`` we recorded. A reused pid (immediate on
+        Windows) fails the identity match and reads as gone — the reuse guard the
+        bare :meth:`is_alive` existence probe lacks.
+
+        ``identity is None`` (a legacy pid file with no persisted identity, or a
+        platform that can't provide one) degrades to :meth:`is_alive` — today's
+        bare-existence behavior, with the documented residual reuse risk. Kept
+        distinct from :meth:`is_alive` so existence and ownership are never
+        conflated again."""
+        if pid <= 0:
+            return False
+        if identity is None:
+            return self.is_alive(pid)
+        # identity(pid) is None when the pid is gone and a different value when it
+        # was reused — either way it != the recorded identity, so this is False.
+        return self.identity(pid) == identity
+
     def shell_quote(self, arg: str) -> str:
         """Quote ``arg`` for the shell that runs this host's hook commands, so the
         argument-quoting axis sits behind the same seam as ``hook_interpreter``. Not

--- a/src/automator/runs.py
+++ b/src/automator/runs.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import os
 import secrets
 import shutil
@@ -18,6 +19,7 @@ from .process_host import get_process_host
 RUNS_DIR = Path(".automator") / "runs"
 ARCHIVE_DIR = Path(".automator") / "archive"
 PID_FILE = "engine.pid"
+_INVALID_PID_IDENTITY = -1.0  # impossible process start/create time; forces "not ours"
 
 
 class StopRunError(Exception):
@@ -51,9 +53,15 @@ def latest_run_dir(project: Path) -> Path | None:
 
 
 def write_pid(run_dir: Path) -> None:
-    """Record the engine process pid. Never deleted: a stale pid that
-    ``pid_alive`` reports as gone is the signal that a run was interrupted."""
-    (run_dir / PID_FILE).write_text(str(os.getpid()), encoding="utf-8")
+    """Record the engine pid plus its identity, so a later liveness read can tell
+    our engine from a stranger that inherited a reused pid (immediate on Windows).
+    One whitespace-delimited line: ``"<pid>"`` (legacy) or ``"<pid> <identity>"``;
+    the identity token is omitted when the platform can't provide one. Never
+    deleted: a stale pid that reads as gone is the signal a run was interrupted."""
+    pid = os.getpid()
+    identity = get_process_host().identity(pid)
+    line = f"{pid} {identity}" if identity is not None else str(pid)
+    (run_dir / PID_FILE).write_text(line, encoding="utf-8")
 
 
 def session_name(run_id: str) -> str:
@@ -113,21 +121,49 @@ def resolve_run_dir(project: Path, ref: str) -> Path:
 
 
 def read_pid(run_dir: Path) -> int | None:
-    """The recorded engine pid, or None when missing/unparseable."""
+    """The recorded engine pid, or None when missing/unparseable. Reads the first
+    whitespace token, tolerating both the legacy pid-only file and the
+    ``"<pid> <identity>"`` form (see :func:`read_pid_identity`)."""
+    return read_pid_identity(run_dir)[0]
+
+
+def read_pid_identity(run_dir: Path) -> tuple[int | None, float | None]:
+    """The recorded engine pid and its persisted identity. ``(None, None)`` when the
+    file is missing or the pid is unparseable; identity ``None`` for a legacy
+    pid-only file (callers then degrade to a bare existence check). A malformed
+    second token is not legacy: it returns an impossible identity so reuse guards
+    fail closed. First token is the pid, an optional second token the identity float."""
     try:
-        return int((run_dir / PID_FILE).read_text(encoding="utf-8").strip())
-    except (OSError, ValueError):
-        return None
+        tokens = (run_dir / PID_FILE).read_text(encoding="utf-8").split()
+    except OSError:
+        return None, None
+    if not tokens:
+        return None, None
+    try:
+        pid = int(tokens[0])
+    except ValueError:
+        return None, None
+    identity: float | None = None
+    if len(tokens) > 1:
+        try:
+            parsed = float(tokens[1])
+        except ValueError:
+            parsed = _INVALID_PID_IDENTITY
+        # Only a true one-token legacy file degrades to bare existence. If an
+        # identity token is present but corrupt/non-finite, fail closed as not-ours.
+        identity = parsed if math.isfinite(parsed) else _INVALID_PID_IDENTITY
+    return pid, identity
 
 
 def engine_alive(run_dir: Path) -> bool:
-    """True only when a local engine pid is provably alive (mirrors
-    tui.data.liveness, minus the tmux fallback — callers here want a definite
-    'is something running' answer, and 'unknown' must not block stop/delete)."""
-    pid = read_pid(run_dir)
+    """True only when a local engine pid is provably alive **and still our engine**
+    (identity-checked, so a reused pid reads as dead). Mirrors tui.data.liveness
+    minus the tmux fallback — callers here want a definite 'is something running'
+    answer, and 'unknown' must not block stop/delete."""
+    pid, identity = read_pid_identity(run_dir)
     if pid is None:
         return False
-    return get_process_host().is_alive(pid)
+    return get_process_host().alive_and_ours(pid, identity)
 
 
 # ----------------------------------------------------------- stop / delete / archive
@@ -230,10 +266,12 @@ def stop_run(run_dir: Path) -> bool:
         return False
 
     host = get_process_host()
-    pid = read_pid(run_dir)
-    identity = None
+    pid, identity = read_pid_identity(run_dir)  # identity recorded at run start, not sampled now
+    if pid is not None and identity is not None and not host.alive_and_ours(pid, identity):
+        # the pid we recorded is already gone, or was reused by an unrelated
+        # process before stop_run ran — never signal a stranger; mark stopped below.
+        pid = None
     if pid is not None:
-        identity = host.identity(pid)  # recorded before signalling, for the reuse guard
         try:
             host.terminate(pid)
         except (ProcessLookupError, PermissionError, OSError):
@@ -247,8 +285,12 @@ def stop_run(run_dir: Path) -> bool:
         if host.is_alive(pid):
             # still wedged past the grace window — escalate to a force-kill, but
             # only if this is provably the same process we signalled (never SIGKILL
-            # a pid the kernel may have recycled to an unrelated process).
-            if identity is not None and host.identity(pid) == identity:
+            # a pid the kernel may have recycled to an unrelated process). For a
+            # legacy pid file (no persisted identity) fall back to a stop-time
+            # sample so a pre-upgrade run can still be force-killed — today's
+            # behavior, carrying the same late-sample reuse window it always had.
+            guard = identity if identity is not None else host.identity(pid)
+            if guard is not None and host.identity(pid) == guard:
                 try:
                     host.force_kill(pid)
                 except (ProcessLookupError, PermissionError, OSError):

--- a/src/automator/tui/data.py
+++ b/src/automator/tui/data.py
@@ -31,7 +31,7 @@ from ..gates import ATTENTION_FILE
 from ..journal import JOURNAL_FILE, LOGS_DIR, STATE_FILE, load_state
 from ..model import RunState
 from ..process_host import get_process_host
-from ..runs import PID_FILE, list_run_dirs, session_name
+from ..runs import list_run_dirs, read_pid_identity, session_name
 
 # Run statuses shown by the dashboard.
 RUNNING = "running"
@@ -70,12 +70,14 @@ def liveness(run_dir: Path) -> str:
     proves nothing: 'unknown', never falsely dead. Pid checks are local-only;
     runs on other hosts always come back 'unknown'.
     """
-    try:
-        pid = int((run_dir / PID_FILE).read_text(encoding="utf-8").strip())
-    except (OSError, ValueError):
+    pid, identity = read_pid_identity(run_dir)
+    if pid is None:
         return _session_liveness(run_dir.name)
     try:
-        return "alive" if get_process_host().is_alive(pid) else "dead"
+        # identity-aware: a reused pid (a stranger inheriting the number) reads as
+        # 'dead', not a false RUNNING. Legacy pid file (identity None) degrades to a
+        # bare existence probe.
+        return "alive" if get_process_host().alive_and_ours(pid, identity) else "dead"
     except Exception:
         # never falsely dead — an unexpected probe failure stays 'unknown'
         return "unknown"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -407,7 +407,9 @@ def test_run_honors_preassigned_run_id_and_writes_pid(project, monkeypatch):
     assert cli.main(["run", "--project", str(project.project), "--run-id", run_id]) == 0
     run_dir = project.project / ".automator" / "runs" / run_id
     assert json.loads((run_dir / "state.json").read_text())["run_id"] == run_id
-    assert (run_dir / "engine.pid").read_text() == str(os.getpid())
+    # engine.pid is "<pid>" or "<pid> <identity>" (identity persisted on platforms
+    # that provide one) — assert on the pid token, not the whole line.
+    assert (run_dir / "engine.pid").read_text().split()[0] == str(os.getpid())
 
 
 def test_run_aborts_when_base_skills_missing(project, monkeypatch, capsys):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1715,6 +1715,75 @@ def test_journal_log_position_covers_post_session_entries(project):
 # ----------------------------------------------------------- stop / SIGTERM
 
 
+@pytest.mark.parametrize(
+    ("signal_name", "fallback_signum"),
+    [("SIGINT", signal.SIGINT), ("SIGBREAK", 21)],
+)
+def test_windows_console_ctrl_signal_is_ignored(project, monkeypatch, signal_name, fallback_signum):
+    import automator.engine as engine_mod
+
+    signum = getattr(signal, signal_name, fallback_signum)
+    if signal_name == "SIGBREAK":
+        monkeypatch.setattr(signal, "SIGBREAK", signum, raising=False)
+
+    installed = {}
+    restored = {}
+    previous = {}
+
+    def fake_signal(sig, handler):
+        previous.setdefault(sig, object())
+        if callable(handler):
+            installed[sig] = handler
+        else:
+            restored[sig] = handler
+        return previous[sig]
+
+    monkeypatch.setattr(engine_mod.sys, "platform", "win32")
+    monkeypatch.setattr(signal, "signal", fake_signal)
+    monkeypatch.setattr(engine_mod, "kill_session", lambda rid: None)
+
+    engine, _ = make_engine(project, [])
+    monkeypatch.setattr(engine, "_loop", lambda: installed[signum](signum, None))
+
+    summary = engine.run()
+
+    assert summary is not None
+    assert load_state(engine.run_dir).stopped is False
+    assert "console-ctrl-ignored" in (engine.run_dir / "journal.jsonl").read_text()
+    assert restored[signal.SIGTERM] is previous[signal.SIGTERM]
+    assert restored[signal.SIGINT] is previous[signal.SIGINT]
+    assert restored[signum] is previous[signum]
+    assert Engine._stop_signals_owner is None
+
+
+def test_non_windows_sigint_still_stops_run(project, monkeypatch):
+    import automator.engine as engine_mod
+
+    installed = {}
+    previous = {}
+
+    def fake_signal(sig, handler):
+        previous.setdefault(sig, object())
+        if callable(handler):
+            installed[sig] = handler
+        return previous[sig]
+
+    killed = []
+    monkeypatch.setattr(engine_mod.sys, "platform", "linux")
+    monkeypatch.setattr(signal, "signal", fake_signal)
+    monkeypatch.setattr(engine_mod, "kill_session", lambda rid: killed.append(rid))
+
+    engine, _ = make_engine(project, [])
+    monkeypatch.setattr(engine, "_loop", lambda: installed[signal.SIGINT](signal.SIGINT, None))
+
+    engine.run()
+
+    assert load_state(engine.run_dir).stopped is True
+    assert killed == ["test-run"]
+    assert "run-stop" in (engine.run_dir / "journal.jsonl").read_text()
+    assert Engine._stop_signals_owner is None
+
+
 def test_run_stopped_via_real_signal(project, monkeypatch):
     """SIGTERM unwinds the loop as RunStopped: the run is marked stopped, the
     agent session is torn down, and the prior signal handlers are restored."""

--- a/tests/test_process_host.py
+++ b/tests/test_process_host.py
@@ -30,8 +30,22 @@ def host():
     return PosixProcessHost()
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="PosixProcessHost.is_alive uses os.kill(pid, 0); on Windows signal 0 is "
+    "CTRL_C_EVENT, so the probe sends a real Ctrl+C to this process's console and "
+    "aborts the run. Windows self-liveness is covered by the WindowsProcessHost test below.",
+)
 def test_is_alive_true_for_self(host):
     assert host.is_alive(os.getpid()) is True
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="WindowsProcessHost is the win32 host")
+def test_is_alive_true_for_self_windows():
+    # The Windows host probes liveness via psutil (no os.kill), so checking self is
+    # safe here — unlike the POSIX host's os.kill(pid, 0), which is CTRL_C on Windows.
+    pytest.importorskip("psutil")
+    assert WindowsProcessHost().is_alive(os.getpid()) is True
 
 
 def test_is_alive_rejects_non_positive(host, monkeypatch):
@@ -74,6 +88,27 @@ def test_identity_stable_and_present_for_self(host):
 def test_identity_none_for_non_positive(host):
     assert host.identity(0) is None
     assert host.identity(-1) is None
+
+
+def test_alive_and_ours_rejects_non_positive(host):
+    assert host.alive_and_ours(0, 1.0) is False
+    assert host.alive_and_ours(-1, None) is False
+
+
+def test_alive_and_ours_none_identity_degrades_to_is_alive(host, monkeypatch):
+    # A legacy pid file (no persisted identity) can only fall back to bare existence.
+    monkeypatch.setattr(host, "is_alive", lambda pid: pid == 4242)
+    assert host.alive_and_ours(4242, None) is True
+    assert host.alive_and_ours(9999, None) is False
+
+
+def test_alive_and_ours_matches_only_same_identity(host, monkeypatch):
+    # Same identity → our process; a different value (reused pid) or None (gone) → not.
+    monkeypatch.setattr(host, "identity", lambda pid: 123.0)
+    assert host.alive_and_ours(4242, 123.0) is True
+    assert host.alive_and_ours(4242, 999.0) is False  # reused
+    monkeypatch.setattr(host, "identity", lambda pid: None)
+    assert host.alive_and_ours(4242, 123.0) is False  # gone
 
 
 def test_default_host_matches_platform(monkeypatch):

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -3,6 +3,7 @@
 import os
 import re
 import subprocess
+import sys
 import tarfile
 
 import pytest
@@ -68,6 +69,15 @@ class _FakeHost:
     def identity(self, pid):
         return self._identity() if callable(self._identity) else self._identity
 
+    def alive_and_ours(self, pid, identity):
+        # Mirrors ProcessHost.alive_and_ours: pid<=0 short-circuits, identity None
+        # degrades to is_alive, else the recorded identity must still match.
+        if pid <= 0:
+            return False
+        if identity is None:
+            return self.is_alive(pid)
+        return self.identity(pid) == identity
+
 
 def test_list_run_dirs_sorted_and_filtered(tmp_path):
     _make_run(tmp_path, "20260611-120000-bbbb")
@@ -94,7 +104,14 @@ def test_new_run_id_format():
 
 def test_write_pid(tmp_path):
     runs.write_pid(tmp_path)
-    assert (tmp_path / "engine.pid").read_text() == str(os.getpid())
+    tokens = (tmp_path / "engine.pid").read_text().split()
+    assert tokens[0] == str(os.getpid())
+    # identity is persisted as an optional second token so a reused pid can later be
+    # told from our engine; Linux always provides one (via /proc starttime).
+    if sys.platform.startswith("linux"):
+        assert len(tokens) == 2 and float(tokens[1]) > 0
+    elif len(tokens) > 1:
+        assert float(tokens[1]) > 0
 
 
 def test_attach_argv_outside_tmux(monkeypatch):
@@ -173,6 +190,47 @@ def test_engine_alive(tmp_path):
     assert runs.engine_alive(run_dir) is False
 
 
+def test_read_pid_identity_forms(tmp_path):
+    run_dir = _make_run(tmp_path, "r1")
+    assert runs.read_pid_identity(run_dir) == (None, None)  # missing
+    (run_dir / "engine.pid").write_text("4242")  # legacy: pid only
+    assert runs.read_pid_identity(run_dir) == (4242, None)
+    (run_dir / "engine.pid").write_text("4242 678.5")  # pid + identity
+    assert runs.read_pid_identity(run_dir) == (4242, 678.5)
+    (run_dir / "engine.pid").write_text("not-a-pid 1.0")  # unparseable pid
+    assert runs.read_pid_identity(run_dir) == (None, None)
+
+
+@pytest.mark.parametrize("identity_token", ["garbage", "nan", "inf", "-inf"])
+def test_engine_alive_malformed_identity_fails_closed(tmp_path, monkeypatch, identity_token):
+    # Two tokens means "identity was intended"; if token 2 is corrupt, do not
+    # degrade to legacy bare-existence liveness and report a reused pid as alive.
+    run_dir = _make_run(tmp_path, "r1")
+    (run_dir / "engine.pid").write_text(f"4242 {identity_token}")
+    monkeypatch.setattr(runs, "get_process_host", lambda: _FakeHost(alive=True, identity=123.0))
+    assert runs.engine_alive(run_dir) is False
+
+
+def test_engine_alive_reused_pid_reads_dead(tmp_path, monkeypatch):
+    # A stranger inherited the recorded pid: identity no longer matches → dead.
+    run_dir = _make_run(tmp_path, "r1")
+    (run_dir / "engine.pid").write_text("4242 123.0")
+    monkeypatch.setattr(runs, "get_process_host", lambda: _FakeHost(alive=True, identity=999.0))
+    assert runs.engine_alive(run_dir) is False
+    monkeypatch.setattr(runs, "get_process_host", lambda: _FakeHost(alive=True, identity=123.0))
+    assert runs.engine_alive(run_dir) is True
+
+
+def test_engine_alive_legacy_pid_degrades_to_existence(tmp_path, monkeypatch):
+    # A legacy pid file (no identity token) can only fall back to bare existence.
+    run_dir = _make_run(tmp_path, "r1")
+    (run_dir / "engine.pid").write_text("4242")
+    monkeypatch.setattr(runs, "get_process_host", lambda: _FakeHost(alive=True))
+    assert runs.engine_alive(run_dir) is True
+    monkeypatch.setattr(runs, "get_process_host", lambda: _FakeHost(alive=False))
+    assert runs.engine_alive(run_dir) is False
+
+
 # ---------------------------------------------------------------- stop / delete
 
 
@@ -243,9 +301,27 @@ def test_stop_run_force_kills_wedged_engine(tmp_path, monkeypatch):
     monkeypatch.setattr(runs, "_STOP_WAIT_S", 0.05)
     monkeypatch.setattr(runs, "_STOP_POLL_S", 0.01)
     run_dir = _make_state_run(tmp_path, "r1")
-    (run_dir / "engine.pid").write_text("4242")
+    (run_dir / "engine.pid").write_text("4242 123.0")  # persisted identity
 
     host = _FakeHost(alive=True, identity=123.0)  # never exits, identity stable
+    monkeypatch.setattr(runs, "get_process_host", lambda: host)
+    assert runs.stop_run(run_dir) is True
+    assert host.force_killed == [4242]
+    assert load_state(run_dir).stopped is True
+
+
+def test_stop_run_force_kills_wedged_legacy_engine(tmp_path, monkeypatch):
+    """A legacy pid file (no persisted identity) can still force-kill a wedged
+    engine: the forced path falls back to a stop-time identity sample (today's
+    behavior) rather than refusing outright — no capability regression for
+    pre-upgrade runs."""
+    monkeypatch.setattr(runs, "kill_session", lambda _rid: None)
+    monkeypatch.setattr(runs, "_STOP_WAIT_S", 0.05)
+    monkeypatch.setattr(runs, "_STOP_POLL_S", 0.01)
+    run_dir = _make_state_run(tmp_path, "r1")
+    (run_dir / "engine.pid").write_text("4242")  # legacy: pid only, no identity token
+
+    host = _FakeHost(alive=True, identity=555.0)  # never exits, identity stable
     monkeypatch.setattr(runs, "get_process_host", lambda: host)
     assert runs.stop_run(run_dir) is True
     assert host.force_killed == [4242]
@@ -259,9 +335,11 @@ def test_stop_run_refuses_force_kill_on_identity_mismatch(tmp_path, monkeypatch)
     monkeypatch.setattr(runs, "_STOP_WAIT_S", 0.05)
     monkeypatch.setattr(runs, "_STOP_POLL_S", 0.01)
     run_dir = _make_state_run(tmp_path, "r1")
-    (run_dir / "engine.pid").write_text("4242")
+    (run_dir / "engine.pid").write_text("4242 123.0")  # persisted identity at run start
 
-    identities = iter([123.0, 999.0])  # recorded at stop-time, then changed
+    # matches the persisted identity at stop entry, then changes before the
+    # post-grace force-kill check (pid reused mid-grace).
+    identities = iter([123.0, 999.0])
     host = _FakeHost(alive=True, identity=lambda: next(identities))
     monkeypatch.setattr(runs, "get_process_host", lambda: host)
     with pytest.raises(runs.StopRunError):
@@ -283,6 +361,24 @@ def test_stop_run_refuses_force_kill_without_identity(tmp_path, monkeypatch):
     with pytest.raises(runs.StopRunError):
         runs.stop_run(run_dir)
     assert host.force_killed == []
+
+
+def test_stop_run_clean_stop_on_pre_stop_pid_reuse(tmp_path, monkeypatch):
+    """If the recorded pid was reused by an unrelated process before stop_run
+    ran, don't signal the stranger — fall back to a clean mark-stopped, with no
+    StopRunError and no terminate/force-kill."""
+    killed = []
+    monkeypatch.setattr(runs, "kill_session", lambda rid: killed.append(rid))
+    run_dir = _make_state_run(tmp_path, "r1")
+    (run_dir / "engine.pid").write_text("4242 123.0")  # recorded identity 123.0
+
+    host = _FakeHost(alive=True, identity=999.0)  # alive, but identity differs → reused
+    monkeypatch.setattr(runs, "get_process_host", lambda: host)
+    assert runs.stop_run(run_dir) is True
+    assert host.terminated == [] and host.force_killed == []  # stranger never signalled
+    assert load_state(run_dir).stopped is True
+    assert killed == ["r1"]
+    assert '"fallback": true' in (run_dir / "journal.jsonl").read_text()
 
 
 # ---------------------------------------------------------------- prune sessions

--- a/tests/test_tui_data.py
+++ b/tests/test_tui_data.py
@@ -224,6 +224,17 @@ def test_watcher_status_interrupted(tmp_path):
     assert watcher.liveness() == "dead"
 
 
+def test_watcher_status_reused_pid_reads_interrupted(tmp_path):
+    # A live pid whose recorded identity no longer matches (pid reuse — immediate on
+    # Windows) must read as dead/INTERRUPTED, not a false RUNNING. Uses our own pid
+    # with a bogus identity token; identity() re-read never matches 0.5.
+    run_dir = make_run(tmp_path, "20260611-100000-aaaa")
+    (run_dir / "engine.pid").write_text(f"{os.getpid()} 0.5")
+    watcher = data.RunWatcher(run_dir)
+    assert watcher.liveness() == "dead"
+    assert watcher.status() == data.INTERRUPTED
+
+
 def test_classify_crashed(tmp_path):
     # a recorded crash classifies as CRASHED (distinct from a generic INTERRUPTED),
     # checked before liveness so the dead pid does not override it.


### PR DESCRIPTION
## What

Make engine process-liveness **identity-aware** and harden **Windows signal handling**. Liveness now answers *"is the specific engine I launched still alive?"* — comparing a persisted process identity, not just a PID number — and on Windows the engine ignores stray console Ctrl+C during a run so it can't be killed mid-flight.

## Why

Liveness was computed as bare PID *existence* (`does this pid number exist?`). The OS recycles a dead process's PID — **immediately on Windows**, once the last handle closes — so a stranger inheriting the number read as a false *"alive"*. That single defect cascaded:

- `resume` refused to resume a genuinely-dead run,
- worktree reclaim was stranded,
- agent sessions leaked (never pruned),
- the TUI showed a dead run as **RUNNING** (crash hidden).

Separately, on native Windows a terminal/ConPTY Ctrl+C is a **console broadcast** (`GenerateConsoleCtrlEvent`) that can deliver `CTRL_C_EVENT` to the engine sharing that console and kill it mid-run.

## How

- **Persist identity, then compare it.** `write_pid` now records the process *identity* (POSIX `/proc` start-time / Windows psutil `create_time`) as a second token next to the pid; `read_pid_identity` reads both. A new `ProcessHost.alive_and_ours(pid, identity)` is a **distinct** identity-aware op — `is_alive` stays the raw existence primitive — and is routed through `engine_alive`, the TUI liveness column, and `stop_run`'s pre-terminate check, so a reused PID reads as **dead-and-gone**.
- **Fail closed, degrade safely.** A malformed/non-finite identity token *fails closed* (reads as not-ours); a genuine legacy pid-only file degrades to bare existence (today's behaviour, no crash). The forced-path stop keeps a stop-time identity fallback for legacy files so a wedged pre-upgrade run can still be force-killed — and it **never** force-kills on a `None`/mismatched identity.
- **Windows signal safety.** During a run the stop handler ignores console `SIGINT`/`SIGBREAK` on win32 (journaling the event) so a broadcast Ctrl+C can't kill the engine; `SIGTERM` and non-win32 `SIGINT` still stop cleanly. The deliberate stop path on Windows is `taskkill` via the process-host seam, not Ctrl+C.

## Process management: win32 vs POSIX

The change exists because process lifecycle differs in kind, not just in API, between the two platforms. Everything sits behind a `ProcessHost` seam (`PosixProcessHost` / `WindowsProcessHost`, selected by a platform registry) so the engine, `runs`, and the TUI never branch on `sys.platform` at the call site.

| Concern | POSIX (Linux/macOS/WSL) | Native Windows (win32) |
|---|---|---|
| **Liveness probe** | `os.kill(pid, 0)` — a harmless, read-only existence check | `os.kill(pid, 0)` is **destructive**: Python maps signal 0 to `CTRL_C_EVENT` and sends a real Ctrl+C to the target's console. Must use psutil (`pid_exists` / `Process.is_running`) instead |
| **PID reuse** | Kernel cycles the whole PID space (default `pid_max` 32768) before wrapping → reuse is delayed and rare | PID freed for **immediate** reuse once the last handle to the dead process closes → reuse is routine |
| **Process identity** | `/proc/<pid>/stat` field 22 (start-time in clock ticks) | psutil `Process.create_time()` |
| **Polite stop** | `SIGTERM` (catchable, the engine unwinds and marks itself stopped) | `taskkill /PID` (posts `WM_CLOSE`); `SIGTERM` generally does **not** run a Python handler — the process is ended via `TerminateProcess` |
| **Forced stop** | `SIGKILL` | `taskkill /F /T` (kills the process **tree**) |
| **Ctrl+C delivery** | `SIGINT` to the foreground process group | `GenerateConsoleCtrlEvent` broadcasts `CTRL_C`/`CTRL_BREAK` to **every** process attached to the console — a Ctrl+C meant for one pane can hit the engine |

Two consequences drive this PR directly:

1. **PID reuse is a routine hazard on Windows, a rare one on POSIX.** Bare existence liveness is "usually fine" on Linux but wrong often enough on Windows to break resume/reclaim/prune. Persisting and comparing identity makes the answer correct on both — a reused PID has a different `create_time`/start-time, so it reads as not-ours.
2. **`os.kill(pid, 0)` and console Ctrl+C are the same underlying Windows behaviour** (`GenerateConsoleCtrlEvent`). The liveness path avoids `os.kill` entirely on win32 (psutil), and the engine ignores console-ctrl during a run so an errant broadcast can't take it down.

## Testing

New/updated unit tests across `test_process_host.py`, `test_runs.py`, `test_tui_data.py`, `test_engine.py`, and `test_cli.py` cover: identity match vs. reuse (reused PID → dead / INTERRUPTED), legacy pid-file degradation, **malformed-identity fail-closed** (`garbage`/`nan`/`inf`), pre-stop PID reuse → clean stop (no stray SIGTERM, no error), the legacy force-kill fallback, and the win32 console-ctrl-ignore path (both platforms). The POSIX self-liveness test that calls `os.kill(pid, 0)` is **skipped on win32** (it would fire a real Ctrl+C and abort the runner) with a psutil-based `WindowsProcessHost` self-liveness test covering Windows.

Green on **Linux** (WSL — full touched-file suite passes; the full suite is green aside from two pre-existing, unrelated skill-sync failures) and on **native Windows** (targeted Windows-safe subset). Lint clean: ruff, black, isort, bandit.

## Follow-up

A native **Windows CI runner** (`windows-latest` job) plus **correct POSIX/Win32 test-skipping** — gating the POSIX-only tests that crash or fail on Windows (the `os.kill(pid, 0)` self-liveness probe, `true`-binary dead-PID helpers, `test -f` verify commands, and the real-signal self-terminate test) — so the whole suite runs green on Windows CI and continuously validates this PR's Windows behaviour. Kept out of this PR to keep it focused on the process-safety change; tracked as a separate follow-up.

Separate PR, on top of this one): the inverse, native-Windows counterpart of what this PR fixes. On win32 the identity-aware read can report a live pid as DEAD when its identity is merely unreadable rather than gone - `psutil.Process(pid).create_time()` raising ERROR_ACCESS_DENIED (cross-session / elevation mismatch), a failure mode the POSIX /proc start-time path doesn't have — surfacing a running engine as INTERRUPTED. It belongs to this same win32 process-safety line and will be handled on its own by biasing a non-destructive liveness read to unknown/alive on an unreadable-but-existing pid (the destructive stop path keeps failing safe); kept out of this PR because it builds directly on this read path and is a read-vs-stop bias design decision.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved run stop handling so reused process IDs are less likely to be mistaken for active runs.
  * Run status now better reflects interrupted or dead states when a recorded process no longer matches the original one.
  * Enhanced stop behavior on Windows console-control events to avoid unintended stop signals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->