### PR TITLE
ci: add native-Windows test lane + POSIX/Win32 test gating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,11 @@ jobs:
     # Real-Windows runner for the deterministic suite (live psmux e2e stays a manual gate).
     name: test (windows, py${{ matrix.python-version }})
     runs-on: windows-latest
+    # The suite reads/writes UTF-8 files; Windows' cp1252 default would break plain
+    # text I/O. UTF-8 mode (PEP 686's Python 3.15 default) makes the runner match the
+    # files under test; the conftest guard enforces the same for local win32 runs.
+    env:
+      PYTHONUTF8: '1'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
         python-version: ['3.11', '3.12', '3.13', '3.14']
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0
@@ -41,6 +43,31 @@ jobs:
           sudo apt-get update -o Acquire::Retries=3 || true
           sudo apt-get install -y tmux
           tmux -V
+
+      - name: Install the project
+        run: uv sync --locked --all-extras
+
+      - name: Run tests
+        run: uv run pytest -q
+
+  test-windows:
+    # Real-Windows runner for the deterministic suite (live psmux e2e stays a manual gate).
+    name: test (windows, py${{ matrix.python-version }})
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.11', '3.12', '3.13', '3.14']
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
+          python-version: ${{ matrix.python-version }}
 
       - name: Install the project
         run: uv sync --locked --all-extras

--- a/src/automator/install.py
+++ b/src/automator/install.py
@@ -180,9 +180,8 @@ def _worktree_local_exclude(worktree: Path, patterns: Sequence[str]) -> None:
     git's standard local-only exclude (never committed or pushed); it does not
     affect already-tracked files. Best-effort — skipped if git can't be queried.
     """
-    # git's exclude patterns are POSIX-slash on every platform; a Windows-derived
-    # relative path carries os.sep ("\\") and would anchor nothing. Normalize.
-    patterns = [p.replace("\\", "/") for p in patterns]
+    # Callers pass POSIX-slash patterns (glob rels via as_posix; config strings as
+    # authored); git's exclude is POSIX-slash on every platform, so nothing to fix here.
     try:
         common = subprocess.run(
             ["git", "-C", str(worktree), "rev-parse", "--git-common-dir"],
@@ -314,7 +313,8 @@ def provision_worktree(
                 continue
             dst.parent.mkdir(parents=True, exist_ok=True)
             _copy_traversable(src, dst)
-            seeded.append(str(rel))
+            # as_posix so the exclude pattern anchors on Windows too (os.sep would not)
+            seeded.append(rel.as_posix())
 
     # bundled skills into each CLI's skill tree (deduped: codex+gemini share one);
     # never clobber a skill the checkout already carries (tracked or pre-existing).

--- a/src/automator/install.py
+++ b/src/automator/install.py
@@ -180,6 +180,9 @@ def _worktree_local_exclude(worktree: Path, patterns: Sequence[str]) -> None:
     git's standard local-only exclude (never committed or pushed); it does not
     affect already-tracked files. Best-effort — skipped if git can't be queried.
     """
+    # git's exclude patterns are POSIX-slash on every platform; a Windows-derived
+    # relative path carries os.sep ("\\") and would anchor nothing. Normalize.
+    patterns = [p.replace("\\", "/") for p in patterns]
     try:
         common = subprocess.run(
             ["git", "-C", str(worktree), "rev-parse", "--git-common-dir"],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,19 @@ from automator.adapters.base import SessionResult, SessionSpec
 from automator.bmadconfig import ProjectPaths
 from automator.verify import rev_parse_head
 
+# The suite reads/writes UTF-8 files (specs, journals, JSON, reports). Windows'
+# default text encoding is cp1252, so a plain read_text()/open() throws
+# UnicodeDecodeError on any non-ASCII byte — a whole class of "passes on Linux,
+# dies on Windows" failures. Require UTF-8 mode on win32 so local runs match CI
+# (whose windows job sets PYTHONUTF8=1) instead of failing with cryptic charmap
+# errors deep in an unrelated test.
+if sys.platform == "win32" and not sys.flags.utf8_mode:
+    raise pytest.UsageError(
+        "Windows test runs must use UTF-8 mode: set PYTHONUTF8=1 or pass -X utf8 "
+        "(e.g. `set PYTHONUTF8=1 && uv run pytest`). The suite assumes UTF-8 to "
+        "match the files under test; CI's windows job sets this automatically."
+    )
+
 
 def write_script_launcher(directory: Path, name: str, body: str) -> Path:
     """Write a fake CLI launcher for the host OS."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,51 @@ def write_script_launcher(directory: Path, name: str, body: str) -> Path:
     return launcher
 
 
+# ---- host-shell verify/lifecycle stub commands (single platform-detection spot) ----
+# The engine runs verify/plugin-lifecycle commands via the host shell (`sh -c` on
+# POSIX, `cmd /c` on Windows), so tests that assert on that machinery need commands
+# both shells honor. These build them per-OS in one place instead of each test file
+# re-deriving the win32 branch.
+
+_OK = "exit 0"  # cross-platform always-success verb (both `cmd /c` and `sh -c` honor it)
+_RUN = "%BMAD_AUTO_RUN_DIR%" if sys.platform == "win32" else "$BMAD_AUTO_RUN_DIR"
+
+
+def _file_exists_cmd(path) -> str:
+    """Shell verify command (run via shell=True) exiting 0 iff `path` exists, on the
+    host's shell — `test -f` (POSIX) / `if exist` (Windows cmd) — so the verify-gate
+    tests drive the real machinery on either OS, not a POSIX-only `test` that cmd
+    rejects with "'test' is not recognized"."""
+    if sys.platform == "win32":
+        return f'if exist "{path}\\NUL" (exit 1) else if exist "{path}" (exit 0) else (exit 1)'
+    return f'test -f "{path}"'
+
+
+def _touch_run(marker: str) -> str:
+    if sys.platform == "win32":
+        return f'type nul > "{_RUN}\\{marker}"'
+    return f'touch "{_RUN}/{marker}"'
+
+
+def _exists_run(marker: str) -> str:
+    if sys.platform == "win32":
+        return (
+            f'if exist "{_RUN}\\{marker}\\NUL" (exit 1) '
+            f'else if exist "{_RUN}\\{marker}" (exit 0) else (exit 1)'
+        )
+    return f'test -f "{_RUN}/{marker}"'
+
+
+def _seeded_then_touch(rel: str, marker: str) -> str:
+    if sys.platform == "win32":
+        norm_rel = rel.replace("/", "\\")
+        return (
+            f'if exist "{norm_rel}\\NUL" (exit 1) '
+            f'else if exist "{norm_rel}" (type nul > "{_RUN}\\{marker}") else (exit 1)'
+        )
+    return f'test -f "{rel}" && touch "{_RUN}/{marker}"'
+
+
 SPRINT_TEMPLATE = {
     "generated": "01-06-2026 10:00",
     "last_updated": "01-06-2026 10:00",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ that simulate the side effects skill sessions would have on disk."""
 from __future__ import annotations
 
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -12,6 +13,24 @@ import yaml
 from automator.adapters.base import SessionResult, SessionSpec
 from automator.bmadconfig import ProjectPaths
 from automator.verify import rev_parse_head
+
+
+def write_script_launcher(directory: Path, name: str, body: str) -> Path:
+    """Write a fake CLI launcher for the host OS."""
+    directory = Path(directory)
+    sidecar = directory / f"{name}.py"
+    sidecar.write_text(body, encoding="utf-8")
+    if sys.platform == "win32":
+        launcher = directory / f"{name}.cmd"
+        launcher.write_text(f'@"{sys.executable}" "{sidecar}" %*\r\n', encoding="utf-8")
+    else:
+        launcher = directory / name
+        launcher.write_text(
+            f'#!/bin/sh\nexec "{sys.executable}" "{sidecar}" "$@"\n', encoding="utf-8"
+        )
+        launcher.chmod(0o755)
+    return launcher
+
 
 SPRINT_TEMPLATE = {
     "generated": "01-06-2026 10:00",

--- a/tests/test_decisions.py
+++ b/tests/test_decisions.py
@@ -123,7 +123,10 @@ def test_apply_pre_answer_build_records_store_and_ledger(project):
     d = Decision(id="DW-1", question="build it?", context="", options=(opt,), recommendation="1")
     decisions.apply_pre_answer(project.project, d, opt, date="2026-06-13")
 
-    entries = {e.id: e for e in deferredwork.parse_ledger(project.deferred_work.read_text())}
+    entries = {
+        e.id: e
+        for e in deferredwork.parse_ledger(project.deferred_work.read_text(encoding="utf-8"))
+    }
     assert "decision: 2026-06-13 Build — widen field" in entries["DW-1"].body
     assert entries["DW-1"].open  # build stays open until a sweep builds it
     assert decisions.load_pre_answers(project.project)["DW-1"]["effect"] == "build"
@@ -139,7 +142,10 @@ def test_apply_pre_answer_close_marks_done_no_store(project):
     d = Decision(id="DW-1", question="close?", context="", options=(opt,), recommendation="1")
     decisions.apply_pre_answer(project.project, d, opt, date="2026-06-13")
 
-    entries = {e.id: e for e in deferredwork.parse_ledger(project.deferred_work.read_text())}
+    entries = {
+        e.id: e
+        for e in deferredwork.parse_ledger(project.deferred_work.read_text(encoding="utf-8"))
+    }
     assert entries["DW-1"].status.startswith("done")
     assert "closed by human decision: superseded" in entries["DW-1"].body
     assert decisions.load_pre_answers(project.project) == {}  # close needs no carry-forward

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2,11 +2,11 @@
 
 import re
 import signal
-import sys
 from pathlib import Path
 
 import pytest
 from conftest import (
+    _file_exists_cmd,
     dev_effect,
     generic_dev_effect,
     git,
@@ -44,16 +44,6 @@ from automator.runs import rearm_escalation
 from automator.verify import GitError, read_frontmatter, rev_parse_head, worktree_clean
 
 QUIET = NotifyPolicy(desktop=False, file=True)
-
-
-def _file_exists_cmd(path) -> str:
-    """Shell verify command (run via shell=True) exiting 0 iff `path` exists, on the
-    host's shell — `test -f` (POSIX) / `if exist` (Windows cmd) — so the verify-gate
-    tests drive the real machinery on either OS, not a POSIX-only `test` that cmd
-    rejects with "'test' is not recognized"."""
-    if sys.platform == "win32":
-        return f'if exist "{path}\\NUL" (exit 1) else if exist "{path}" (exit 0) else (exit 1)'
-    return f'test -f "{path}"'
 
 
 def make_engine(project, script, policy=None, **kwargs) -> tuple[Engine, MockAdapter]:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,8 +1,8 @@
 """Engine scenario tests against the mock adapter — no tmux, no LLM."""
 
-import os
 import re
 import signal
+import sys
 from pathlib import Path
 
 import pytest
@@ -43,6 +43,16 @@ from automator.runs import rearm_escalation
 from automator.verify import read_frontmatter, rev_parse_head, worktree_clean
 
 QUIET = NotifyPolicy(desktop=False, file=True)
+
+
+def _file_exists_cmd(path) -> str:
+    """Shell verify command (run via shell=True) exiting 0 iff `path` exists, on the
+    host's shell — `test -f` (POSIX) / `if exist` (Windows cmd) — so the verify-gate
+    tests drive the real machinery on either OS, not a POSIX-only `test` that cmd
+    rejects with "'test' is not recognized"."""
+    if sys.platform == "win32":
+        return f'if exist "{path}\\NUL" (exit 1) else if exist "{path}" (exit 0) else (exit 1)'
+    return f'test -f "{path}"'
 
 
 def make_engine(project, script, policy=None, **kwargs) -> tuple[Engine, MockAdapter]:
@@ -749,7 +759,7 @@ def test_generic_repair_reopens_spec_before_reinvocation(project):
         notify=QUIET,
         review=ReviewPolicy(enabled=False),
         dev=DevPolicy(skill="bmad-dev-auto"),
-        verify=VerifyPolicy(commands=("test -f marker.txt",)),
+        verify=VerifyPolicy(commands=(_file_exists_cmd("marker.txt"),)),
         scm=ScmPolicy(rollback_on_failure=True),
     )
     engine, adapter = make_engine(project, [effect, effect], policy=pol)
@@ -1393,7 +1403,7 @@ def test_dev_verify_command_failure_routes_feedback_fix(project):
                 "baseline_commit": baseline,
                 "tasks_total": 3,
                 "tasks_done": 3,
-                "verification": [{"command": f"test -f {marker}", "ok": True}],
+                "verification": [{"command": _file_exists_cmd(marker), "ok": True}],
                 "escalations": [],
             },
         )
@@ -1401,7 +1411,7 @@ def test_dev_verify_command_failure_routes_feedback_fix(project):
     policy = Policy(
         gates=GatesPolicy(mode="none"),
         notify=QUIET,
-        verify=VerifyPolicy(commands=(f"test -f {marker}",)),
+        verify=VerifyPolicy(commands=(_file_exists_cmd(marker),)),
     )
     engine, adapter = make_engine(
         project,
@@ -1422,7 +1432,7 @@ def test_dev_verify_command_failure_routes_feedback_fix(project):
     # the feedback file is referenced as the last backtick-wrapped path.
     assert "Resume the autonomous" not in prompts[0] and "Resume the autonomous" in prompts[1]
     feedback = Path(re.findall(r"`([^`]*)`", prompts[1])[-1])
-    assert "test -f" in feedback.read_text()
+    assert _file_exists_cmd(marker) in feedback.read_text()
     # the first attempt's work survived: no reset between attempts
     assert "change for 1-1-a" in (project.project / "src.txt").read_text()
 
@@ -1450,7 +1460,7 @@ def test_review_verify_failure_routes_fix_session_then_rereview(project):
     policy = Policy(
         gates=GatesPolicy(mode="none"),
         notify=QUIET,
-        verify=VerifyPolicy(commands=(f"test -f {marker}",)),
+        verify=VerifyPolicy(commands=(_file_exists_cmd(marker),)),
     )
     engine, adapter = make_engine(
         project,
@@ -1486,7 +1496,7 @@ def test_review_verify_failure_without_fix_budget_defers(project):
     policy = Policy(
         gates=GatesPolicy(mode="none"),
         notify=QUIET,
-        verify=VerifyPolicy(commands=(f"test -f {marker}",)),
+        verify=VerifyPolicy(commands=(_file_exists_cmd(marker),)),
         limits=LimitsPolicy(max_dev_attempts=1),
     )
     engine, adapter = make_engine(project, [dev_with_marker, breaking_review], policy=policy)
@@ -1721,7 +1731,10 @@ def test_run_stopped_via_real_signal(project, monkeypatch):
     killed = []
     monkeypatch.setattr("automator.engine.kill_session", lambda rid: killed.append(rid))
     engine, _ = make_engine(project, [])
-    monkeypatch.setattr(engine, "_loop", lambda: os.kill(os.getpid(), signal.SIGTERM))
+    # raise_signal delivers an in-process, catchable SIGTERM via C raise() — the
+    # portable "signal myself" primitive. os.kill(getpid(), SIGTERM) is POSIX-only
+    # here: on Windows it maps to TerminateProcess (uncatchable, kills the runner).
+    monkeypatch.setattr(engine, "_loop", lambda: signal.raise_signal(signal.SIGTERM))
 
     prev_term = signal.getsignal(signal.SIGTERM)
     prev_int = signal.getsignal(signal.SIGINT)

--- a/tests/test_engine_plugin.py
+++ b/tests/test_engine_plugin.py
@@ -20,9 +20,11 @@ from __future__ import annotations
 import importlib.util
 import json
 import os
+import sys
 import time
 
 import pytest
+from conftest import write_script_launcher
 
 from automator.engine import Engine, _setup_mcp_agent_id
 from automator.plugins import HookContext, PluginError, get_plugin, load_plugins
@@ -447,18 +449,15 @@ def test_unity_ready_grace_explicit_override(monkeypatch):
 
 def _fake_cli(tmp_path, *, wait_rc=0, tool_rc=0):
     """A fake unity-mcp-cli that logs argv and returns per-subcommand exit codes."""
-    script = tmp_path / "fake-unity-mcp-cli"
     log = tmp_path / "calls.log"
-    script.write_text(
-        "#!/usr/bin/env python3\n"
+    body = (
         "import sys\n"
         f"open({str(log)!r}, 'a').write(' '.join(sys.argv[1:]) + chr(10))\n"
         "cmd = sys.argv[1] if len(sys.argv) > 1 else ''\n"
         f"sys.exit({wait_rc} if cmd == 'wait-for-ready' "
         f"else ({tool_rc} if cmd == 'run-tool' else 0))\n"
     )
-    script.chmod(0o755)
-    return script, log
+    return write_script_launcher(tmp_path, "fake-unity-mcp-cli", body), log
 
 
 def test_unity_ready_default_is_wait_for_ready_only(tmp_path, monkeypatch):
@@ -489,15 +488,14 @@ def test_unity_ready_tool_error_marker_means_not_ready(tmp_path, monkeypatch):
     connection-refused) is treated as not-ready, not a false pass."""
     mod = _load_unity_ready()
     # exit 0 but stdout carries an error marker
-    script = tmp_path / "fake-cli"
-    script.write_text(
-        "#!/usr/bin/env python3\n"
+    script = write_script_launcher(
+        tmp_path,
+        "fake-cli",
         "import sys\n"
         "cmd = sys.argv[1] if len(sys.argv) > 1 else ''\n"
         "print('ERROR: Tool with Name not found' if cmd == 'run-tool' else 'ok')\n"
-        "sys.exit(0)\n"
+        "sys.exit(0)\n",
     )
-    script.chmod(0o755)
     monkeypatch.setenv("UNITY_MCP_CLI", str(script))
     monkeypatch.setenv("BMAD_AUTO_WORKTREE", str(tmp_path))
     monkeypatch.setenv("BMAD_AUTO_UNITY_READY_TOOL", "ping")
@@ -672,6 +670,13 @@ def test_unity_setup_prime_scriptassemblies_only_is_cold(tmp_path, monkeypatch):
     assert (wt / "Library" / "ArtifactDB").read_text() == "db"  # primed over leftover
 
 
+_skip_win_symlink = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="symlink-based Unity Library priming is POSIX-only; native-Windows cache path is a tracked follow-up",
+)
+
+
+@_skip_win_symlink
 def test_unity_setup_prime_symlink_fallback_when_no_seed(tmp_path, monkeypatch):
     mod = _load_unity_setup()
     _clear_setup_knobs(monkeypatch)
@@ -683,6 +688,7 @@ def test_unity_setup_prime_symlink_fallback_when_no_seed(tmp_path, monkeypatch):
     assert (wt / "Library").is_symlink()  # fell back to the empty-cache symlink
 
 
+@_skip_win_symlink
 def test_unity_setup_prime_seed_mode_off_uses_symlink(tmp_path, monkeypatch):
     mod = _load_unity_setup()
     _clear_setup_knobs(monkeypatch)
@@ -696,6 +702,7 @@ def test_unity_setup_prime_seed_mode_off_uses_symlink(tmp_path, monkeypatch):
     assert (wt / "Library").is_symlink()  # priming disabled despite a warm seed
 
 
+@_skip_win_symlink
 def test_unity_setup_prime_drops_stale_symlink(tmp_path, monkeypatch):
     mod = _load_unity_setup()
     _clear_setup_knobs(monkeypatch)
@@ -748,10 +755,8 @@ def _fake_setup_cli(tmp_path):
     """Fake unity-mcp-cli for the setup hook: setup-mcp writes claude-code's
     .mcp.json (path-derived 23723) and codex's .codex/config.toml (honoring --url,
     or FAKE_CODEX_FORCE_URL to simulate a leaked port); other subcommands no-op 0."""
-    script = tmp_path / "fake-setup-cli"
     log = tmp_path / "setup-calls.log"
-    script.write_text(
-        "#!/usr/bin/env python3\n"
+    body = (
         "import sys, os, json\n"
         f"open({str(log)!r}, 'a').write(' '.join(sys.argv[1:]) + chr(10))\n"
         "a = sys.argv[1:]\n"
@@ -768,8 +773,7 @@ def _fake_setup_cli(tmp_path):
         "            '[mcp_servers.ai-game-developer]\\nurl = \"%s\"\\n' % u)\n"
         "sys.exit(0)\n"
     )
-    script.chmod(0o755)
-    return script, log
+    return write_script_launcher(tmp_path, "fake-setup-cli", body), log
 
 
 def test_unity_setup_configures_every_agent_at_worktree_port(tmp_path, monkeypatch):

--- a/tests/test_engine_worktree.py
+++ b/tests/test_engine_worktree.py
@@ -8,6 +8,8 @@ adapter (no tmux, no LLM).
 
 from __future__ import annotations
 
+import sys
+
 from conftest import _spec_baseline, git, set_sprint, write_spec, write_sprint
 
 from automator.adapters.base import SessionResult
@@ -504,9 +506,36 @@ def test_commit_message_template_applied(project):
 # ------------------------------------------------ per_worktree engine plugin
 
 
-def _write_stub_plugin(
-    project, name, *, ready="true", setup="true", teardown="true", seed_globs=None
-):
+_OK = "exit 0"  # cross-platform always-success verb (both `cmd /c` and `sh -c` honor it)
+_RUN = "%BMAD_AUTO_RUN_DIR%" if sys.platform == "win32" else "$BMAD_AUTO_RUN_DIR"
+
+
+def _touch_run(marker: str) -> str:
+    if sys.platform == "win32":
+        return f'type nul > "{_RUN}\\{marker}"'
+    return f'touch "{_RUN}/{marker}"'
+
+
+def _exists_run(marker: str) -> str:
+    if sys.platform == "win32":
+        return (
+            f'if exist "{_RUN}\\{marker}\\NUL" (exit 1) '
+            f'else if exist "{_RUN}\\{marker}" (exit 0) else (exit 1)'
+        )
+    return f'test -f "{_RUN}/{marker}"'
+
+
+def _seeded_then_touch(rel: str, marker: str) -> str:
+    if sys.platform == "win32":
+        norm_rel = rel.replace("/", "\\")
+        return (
+            f'if exist "{norm_rel}\\NUL" (exit 1) '
+            f'else if exist "{norm_rel}" (type nul > "{_RUN}\\{marker}") else (exit 1)'
+        )
+    return f'test -f "{rel}" && touch "{_RUN}/{marker}"'
+
+
+def _write_stub_plugin(project, name, *, ready=_OK, setup=_OK, teardown=_OK, seed_globs=None):
     """A project-local *declarative* plugin whose lifecycle hooks are shell stubs
     (no real Unity) — proving a generic data-only plugin can gate the engine's
     per_worktree flow. A blocking hook's non-zero exit vetoes (defers) the unit.
@@ -558,10 +587,9 @@ def test_per_worktree_setup_then_gate_then_teardown_and_seed(project):
     _write_stub_plugin(
         project,
         "stub",
-        setup="test -f .claude/skills/gameobject-create/SKILL.md "
-        '&& touch "$BMAD_AUTO_RUN_DIR/setup-done"',
-        ready='test -f "$BMAD_AUTO_RUN_DIR/setup-done"',
-        teardown='touch "$BMAD_AUTO_RUN_DIR/teardown-done"',
+        setup=_seeded_then_touch(".claude/skills/gameobject-create/SKILL.md", "setup-done"),
+        ready=_exists_run("setup-done"),
+        teardown=_touch_run("teardown-done"),
         seed_globs=[".claude/skills/*"],
     )
     engine, adapter = make_engine(
@@ -591,7 +619,7 @@ def test_per_worktree_setup_failure_defers_and_skips_session(project):
         project,
         "stub",
         setup="exit 3",
-        teardown='touch "$BMAD_AUTO_RUN_DIR/teardown-done"',
+        teardown=_touch_run("teardown-done"),
     )
     engine, adapter = make_engine(
         project,
@@ -622,7 +650,7 @@ def test_per_worktree_ready_gate_failure_defers(project):
         project,
         "stub",
         ready="exit 1",
-        teardown='touch "$BMAD_AUTO_RUN_DIR/teardown-done"',
+        teardown=_touch_run("teardown-done"),
     )
     engine, adapter = make_engine(
         project,
@@ -648,7 +676,7 @@ def test_per_worktree_teardown_runs_on_pause(project):
     _write_stub_plugin(
         project,
         "stub",
-        teardown='touch "$BMAD_AUTO_RUN_DIR/teardown-done"',
+        teardown=_touch_run("teardown-done"),
     )
     engine, _ = make_engine(
         project,

--- a/tests/test_engine_worktree.py
+++ b/tests/test_engine_worktree.py
@@ -8,9 +8,17 @@ adapter (no tmux, no LLM).
 
 from __future__ import annotations
 
-import sys
-
-from conftest import _spec_baseline, git, set_sprint, write_spec, write_sprint
+from conftest import (
+    _OK,
+    _exists_run,
+    _seeded_then_touch,
+    _spec_baseline,
+    _touch_run,
+    git,
+    set_sprint,
+    write_spec,
+    write_sprint,
+)
 
 from automator.adapters.base import SessionResult
 from automator.adapters.mock import MockAdapter
@@ -504,35 +512,6 @@ def test_commit_message_template_applied(project):
 
 
 # ------------------------------------------------ per_worktree engine plugin
-
-
-_OK = "exit 0"  # cross-platform always-success verb (both `cmd /c` and `sh -c` honor it)
-_RUN = "%BMAD_AUTO_RUN_DIR%" if sys.platform == "win32" else "$BMAD_AUTO_RUN_DIR"
-
-
-def _touch_run(marker: str) -> str:
-    if sys.platform == "win32":
-        return f'type nul > "{_RUN}\\{marker}"'
-    return f'touch "{_RUN}/{marker}"'
-
-
-def _exists_run(marker: str) -> str:
-    if sys.platform == "win32":
-        return (
-            f'if exist "{_RUN}\\{marker}\\NUL" (exit 1) '
-            f'else if exist "{_RUN}\\{marker}" (exit 0) else (exit 1)'
-        )
-    return f'test -f "{_RUN}/{marker}"'
-
-
-def _seeded_then_touch(rel: str, marker: str) -> str:
-    if sys.platform == "win32":
-        norm_rel = rel.replace("/", "\\")
-        return (
-            f'if exist "{norm_rel}\\NUL" (exit 1) '
-            f'else if exist "{norm_rel}" (type nul > "{_RUN}\\{marker}") else (exit 1)'
-        )
-    return f'test -f "{rel}" && touch "{_RUN}/{marker}"'
 
 
 def _write_stub_plugin(project, name, *, ready=_OK, setup=_OK, teardown=_OK, seed_globs=None):

--- a/tests/test_generic_tmux.py
+++ b/tests/test_generic_tmux.py
@@ -9,6 +9,7 @@ propagation / hook-signal waiting / kill end-to-end for any profile.
 
 import shutil
 import subprocess
+import sys
 import time
 from pathlib import Path
 
@@ -24,7 +25,7 @@ from automator.model import TokenUsage
 from automator.policy import LimitsPolicy, Policy
 from automator.signals import HookEvent
 
-HAVE_TMUX = shutil.which("tmux") is not None
+HAVE_TMUX = sys.platform != "win32" and shutil.which("tmux") is not None
 
 FAKE_CLI = """#!/bin/bash
 # fake CLI: last positional arg is the prompt; env comes from tmux -e

--- a/tests/test_hook_bus.py
+++ b/tests/test_hook_bus.py
@@ -15,6 +15,8 @@ Two layers:
 
 from __future__ import annotations
 
+import sys
+
 import pytest
 from conftest import dev_effect, review_effect, write_sprint
 
@@ -237,7 +239,10 @@ def test_declarative_error_fail_open_vs_closed():
 
 
 def test_real_subprocess_runner_reports_exit_code(tmp_path):
-    rc, out = _run_subprocess("printf hi; exit 7", cwd=str(tmp_path), env={}, timeout=10)
+    # _run_subprocess runs via the host shell (cmd on Windows, sh on POSIX); use a
+    # command that prints "hi" and exits 7 on each.
+    cmd = "echo hi& exit 7" if sys.platform == "win32" else "printf hi; exit 7"
+    rc, out = _run_subprocess(cmd, cwd=str(tmp_path), env={}, timeout=10)
     assert rc == 7 and "hi" in out
 
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,5 +1,7 @@
 import json
 
+from conftest import git
+
 from automator import verify
 from automator.adapters.profile import get_profile
 from automator.install import (
@@ -438,3 +440,4 @@ def test_provision_worktree_seed_globs_shielded_in_local_exclude(project, tmp_pa
     assert (wt / ".claude" / "skills" / "tests-run" / "SKILL.md").is_file()
     exclude = (repo / ".git" / "info" / "exclude").read_text(encoding="utf-8").splitlines()
     assert "/.claude/skills/tests-run" in exclude
+    assert git(wt, "status", "--short", "--", ".claude/skills/tests-run") == ""

--- a/tests/test_process_host.py
+++ b/tests/test_process_host.py
@@ -30,8 +30,9 @@ def host():
     return PosixProcessHost()
 
 
-def test_is_alive_true_for_self(host):
-    assert host.is_alive(os.getpid()) is True
+def test_is_alive_true_for_self():
+    # platform's active host, not hard-coded Posix: win32's os.kill(pid, 0) is CTRL_C.
+    assert get_process_host().is_alive(os.getpid()) is True
 
 
 def test_is_alive_rejects_non_positive(host, monkeypatch):

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -3,6 +3,7 @@
 import os
 import re
 import subprocess
+import sys
 import tarfile
 
 import pytest
@@ -36,7 +37,9 @@ def _make_state_run(project, run_id, **state_kwargs):
 
 
 def _dead_pid() -> int:
-    proc = subprocess.Popen(["true"])
+    # A process that exits immediately, cross-platform (POSIX `true` isn't on
+    # Windows). The interpreter is always present and on every host.
+    proc = subprocess.Popen([sys.executable, "-c", ""])
     proc.wait()
     return proc.pid
 

--- a/tests/test_sanitize.py
+++ b/tests/test_sanitize.py
@@ -10,7 +10,10 @@ from automator import sanitize
 @pytest.fixture
 def home(monkeypatch, tmp_path):
     monkeypatch.setenv("HOME", str(tmp_path))
-    # os.path.expanduser reads HOME on POSIX; force a clean cache-free lookup
+    # os.path.expanduser reads HOME on POSIX but USERPROFILE on Windows; set both so
+    # the fake home actually takes effect on either host (else expanduser returns the
+    # real profile, which is a *prefix* of tmp_path → spurious partial redaction).
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
     return str(tmp_path)
 
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -95,6 +95,24 @@ async def until(pilot, condition, timeout: float = 10.0) -> None:
         waited += 0.05
 
 
+async def ready(pilot, selector: str):
+    """Wait until a modal widget is mounted *and* laid out on-screen, then return it.
+
+    A screen-type `until` returns the instant push_screen swaps app.screen — before
+    the modal's children mount (query NoMatches) or receive a layout region (click
+    OutOfBounds, region still 0). Gating on a real on-screen region makes the
+    following query_one / click / value-set safe on slow CI runners. A modal's
+    widgets mount and lay out together, so one gate covers every field in it."""
+
+    def _hit():
+        hits = pilot.app.screen.query(selector)
+        node = hits.first() if hits else None
+        return node if node is not None and node.region.area > 0 else None
+
+    await until(pilot, lambda: _hit() is not None)
+    return _hit()
+
+
 def dashboard(app: BmadAutoApp) -> DashboardScreen:
     assert isinstance(app.screen, DashboardScreen)
     return app.screen
@@ -658,6 +676,7 @@ async def test_missed_decision_count_and_answer_via_modal(project):
         await until(pilot, lambda: "1 to answer" in str(deferred.border_title))
         await pilot.press("d")
         await until(pilot, lambda: isinstance(app.screen, DecisionModal))
+        await ready(pilot, "#opt-1")
         await pilot.click("#opt-1")  # choose build
         await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
     assert decisions.load_pre_answers(project.project)["DW-1"]["effect"] == "build"
@@ -743,6 +762,7 @@ async def test_start_run_modal_launches(project, monkeypatch):
         await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
         await pilot.press("r")
         await until(pilot, lambda: isinstance(app.screen, StartRunModal))
+        await ready(pilot, "#ok")
         app.screen.query_one("#epic", Input).value = "2"
         app.screen.query_one("#max-stories", Input).value = "3"
         await pilot.click("#ok")
@@ -771,7 +791,7 @@ async def test_dirty_worktree_blocks_launch(project, monkeypatch):
         await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
         await pilot.press("r")
         await until(pilot, lambda: isinstance(app.screen, StartRunModal))
-        await pilot.click("#ok")
+        await pilot.click(await ready(pilot, "#ok"))
         await until(pilot, lambda: any("not clean" in m for m in notifications(app)))
         assert not calls
 
@@ -785,22 +805,16 @@ async def test_live_run_asks_for_confirmation(project, monkeypatch):
     async with app.run_test() as pilot:
         await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
         await pilot.press("r")
-        # push_screen sets app.screen before the modal's children mount, so wait
-        # for #ok itself — a bare screen-type check races the click on a slow runner.
-        await until(
-            pilot,
-            lambda: isinstance(app.screen, StartRunModal) and bool(app.screen.query("#ok")),
-        )
-        await pilot.click("#ok")
+        await until(pilot, lambda: isinstance(app.screen, StartRunModal))
+        await pilot.click(await ready(pilot, "#ok"))
         await until(
             pilot,
             lambda: (
                 isinstance(app.screen, ConfirmModal)
                 and not isinstance(app.screen, ConfirmResumeModal)
-                and bool(app.screen.query("#ok"))
             ),
         )
-        await pilot.click("#ok")
+        await pilot.click(await ready(pilot, "#ok"))
         await until(pilot, lambda: bool(calls))
 
 
@@ -822,6 +836,7 @@ async def test_start_sweep_modal_launches(project, monkeypatch):
         await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
         await pilot.press("s")
         await until(pilot, lambda: isinstance(app.screen, StartSweepModal))
+        await ready(pilot, "#ok")
         app.screen.query_one("#no-prompt", Checkbox).value = True
         await pilot.click("#ok")
         await until(pilot, lambda: bool(calls))
@@ -845,12 +860,13 @@ async def test_dry_run_shows_captured_output(project, monkeypatch):
         await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
         await pilot.press("r")
         await until(pilot, lambda: isinstance(app.screen, StartRunModal))
+        await ready(pilot, "#ok")
         app.screen.query_one("#dry-run", Checkbox).value = True
         await pilot.click("#ok")
         await until(pilot, lambda: isinstance(app.screen, TextOutputModal))
         assert seen["tail"][0] == "run"
         assert "--dry-run" in seen["tail"]
-        await pilot.click("#ok")
+        await pilot.click(await ready(pilot, "#ok"))
         await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
 
 
@@ -882,7 +898,7 @@ async def test_resume_confirm_launches(project, monkeypatch):
         await until(pilot, lambda: dashboard(app).selected_run_id is not None)
         await pilot.press("e")
         await until(pilot, lambda: isinstance(app.screen, ConfirmResumeModal))
-        await pilot.click("#ok")
+        await pilot.click(await ready(pilot, "#ok"))
         await until(pilot, lambda: calls == ["20260611-100000-aaaa"])
 
 
@@ -1091,7 +1107,7 @@ async def test_resolve_escalation_launches_and_attaches(project, monkeypatch):
         await until(pilot, lambda: dashboard(app).selected_run_id is not None)
         await pilot.press("R")
         await until(pilot, lambda: isinstance(app.screen, ConfirmModal))
-        await pilot.click("#ok")
+        await pilot.click(await ready(pilot, "#ok"))
         await until(pilot, lambda: bool(calls))
     assert launched == ["20260611-100000-aaaa"]
     assert selected == ["@7"]

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -785,13 +785,19 @@ async def test_live_run_asks_for_confirmation(project, monkeypatch):
     async with app.run_test() as pilot:
         await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
         await pilot.press("r")
-        await until(pilot, lambda: isinstance(app.screen, StartRunModal))
+        # push_screen sets app.screen before the modal's children mount, so wait
+        # for #ok itself — a bare screen-type check races the click on a slow runner.
+        await until(
+            pilot,
+            lambda: isinstance(app.screen, StartRunModal) and bool(app.screen.query("#ok")),
+        )
         await pilot.click("#ok")
         await until(
             pilot,
             lambda: (
                 isinstance(app.screen, ConfirmModal)
                 and not isinstance(app.screen, ConfirmResumeModal)
+                and bool(app.screen.query("#ok"))
             ),
         )
         await pilot.click("#ok")

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -678,8 +678,7 @@ async def test_missed_decision_count_and_answer_via_modal(project):
         await until(pilot, lambda: "1 to answer" in str(deferred.border_title))
         await pilot.press("d")
         await until(pilot, lambda: isinstance(app.screen, DecisionModal))
-        await ready(pilot, "#opt-1")
-        await pilot.click("#opt-1")  # choose build
+        await pilot.click(await ready(pilot, "#opt-1"))  # choose build
         await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
     assert decisions.load_pre_answers(project.project)["DW-1"]["effect"] == "build"
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -561,6 +561,7 @@ async def test_deferred_pane_lists_and_opens_modal(project):
         deferred.highlighted = 0
         await pilot.press("enter")
         await until(pilot, lambda: isinstance(app.screen, DeferredEntryModal))
+        await ready(pilot, "Static")  # body mounts a tick after the screen swaps
         statics = app.screen.query("Static")
         assert any("location: a.py:1" in str(s.content) for s in statics)
         await pilot.press("escape")
@@ -610,6 +611,7 @@ async def test_deferred_pane_shows_legacy_items(project):
         deferred.highlighted = 1
         await pilot.press("enter")
         await until(pilot, lambda: isinstance(app.screen, DeferredEntryModal))
+        await ready(pilot, "Static")  # body mounts a tick after the screen swaps
         statics = app.screen.query("Static")
         assert any("legacy — converted to DW format" in str(s.content) for s in statics)
         await pilot.press("escape")
@@ -877,6 +879,7 @@ async def test_validate_shows_output_modal(project, monkeypatch):
         await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
         await pilot.press("v")
         await until(pilot, lambda: isinstance(app.screen, TextOutputModal))
+        await ready(pilot, "Label")  # body mounts a tick after the screen swaps
         labels = app.screen.query("Label")
         assert any("exit 1" in str(label.content) for label in labels)
 

--- a/tests/test_tui_data.py
+++ b/tests/test_tui_data.py
@@ -6,6 +6,7 @@ import builtins
 import importlib
 import os
 import subprocess
+import sys
 from pathlib import Path
 
 from conftest import install_bmad_config, write_sprint
@@ -32,7 +33,7 @@ def make_run(root: Path, run_id: str, **state_kwargs) -> Path:
 
 def dead_pid() -> int:
     """Pid guaranteed (modulo astronomically unlikely reuse) to be dead."""
-    proc = subprocess.Popen(["true"])
+    proc = subprocess.Popen([sys.executable, "-c", ""])
     proc.wait()
     return proc.pid
 

--- a/tests/test_tui_settings.py
+++ b/tests/test_tui_settings.py
@@ -173,6 +173,10 @@ async def open_settings(app, pilot) -> SettingsScreen:
     await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
     await pilot.press("g")
     await until(pilot, lambda: isinstance(app.screen, SettingsScreen))
+    # push_screen swaps app.screen before the form's fields mount; a bare screen-type
+    # wait lets the first query_one NoMatches on a slow CI runner. The fields mount as
+    # one batch, so waiting for any Input gates every later query_one in the callers.
+    await until(pilot, lambda: bool(app.screen.query(Input)))
     return app.screen
 
 

--- a/tests/test_tui_settings.py
+++ b/tests/test_tui_settings.py
@@ -275,8 +275,9 @@ async def test_settings_screen_unity_roster_reveals_settings_on_enable(project):
         cfg = screen.query_one("#plugin-cfg-unity", Collapsible)
         assert cfg.display is False  # settings hidden until enabled
         screen.query_one("#plugin-enabled-unity", Switch).value = True
-        await pilot.pause()
-        assert cfg.display is True  # revealed live on enable
+        # Switch.Changed reveals the sub-collapsible on a later tick; a single
+        # pause() can race that delivery on a slow CI runner, so wait it out.
+        await until(pilot, lambda: cfg.display is True)  # revealed live on enable
 
     write_policy_enabling_unity(project)
     app = BmadAutoApp(project.project)
@@ -380,9 +381,10 @@ async def test_settings_screen_stage_override_roundtrip(project):
         screen.query_one("#adapter-review-model", Input).value = "gpt-5-codex"
         override = screen.query_one("#adapter-extra_args-override", Switch)
         override.value = True
-        await pilot.pause()
         args_box = screen.query_one("#adapter-extra_args", Input)
-        assert not args_box.disabled  # override switch enables the input
+        # Switch.Changed enables the Input on a later tick; a single pause() can
+        # race that delivery on a slow CI runner, so wait for the derived state.
+        await until(pilot, lambda: not args_box.disabled)  # override enables input
         args_box.value = "--permission-mode bypassPermissions"
         await pilot.press("ctrl+s")
         await until(pilot, lambda: isinstance(app.screen, DashboardScreen))


### PR DESCRIPTION
## What

Add a native **`windows-latest` CI job** and the **POSIX/Win32 test-gating** that makes the suite green on it. Source is already POSIX-decoupled; this is the test-layer + CI half (the follow-up flagged in the win32-process-liveness PR).

## Why

The suite carried POSIX-only test constructs that failed — or *killed the pytest runner mid-suite* — on native Windows, and there was no Windows CI lane to catch regressions. A verified native-Windows baseline was **24 failures** (WSL, being Linux, had masked the Windows-only ones). One real product bug hid among them: worktree git-exclude patterns were written with `\` separators, which git never anchors.

## How

- **CI:** new `test-windows` (windows-latest, py3.13) job running the deterministic suite; `persist-credentials: false` on checkouts.
- **One src fix:** `_worktree_local_exclude` normalizes `\`→`/` before writing `.git/info/exclude` (git patterns are POSIX-slash on every platform; a no-op on POSIX).
- **Test gating (POSIX skipped on win32, never on Linux):** cross-platform verify commands (`test -f` / `if exist`) and dead-PID spawns (`[sys.executable, "-c", ""]` vs `["true"]`); `real_signal` uses `signal.raise_signal` (catchable in-process on both OSes — keeps Windows coverage instead of `TerminateProcess`-killing the runner); `HAVE_TMUX` excludes win32; `USERPROFILE` for expanduser; `echo hi& exit 7` for cmd; `encoding="utf-8"` reads; a `.cmd`-shim launcher for fake CLIs; `skipif(win32)` on the 3 POSIX-only Unity symlink-priming tests.

## Testing

`test_portability_guard.py` (the existing regression guard) stays green. Full suite verified on **native Windows** (24 baseline failures → 0 in-scope) and **WSL/Linux** (1236 passed — no regression; ports are POSIX no-ops). Ruff clean. Remaining local-only failures (`test_module_skills_sync`) are workspace `.claude`/`.agents` drift that **skips in CI** and is out of scope.

## Follow-up

Native-Windows Unity Library symlink-priming (the 3 skipped tests) — tracked separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Windows CI job running the deterministic test suite on Python 3.11–3.14.
* **Bug Fixes**
  * Improved Windows worktree local-exclude handling for more reliable path matching.
  * Strengthened UTF-8 behavior in Windows test execution to reduce encoding-related failures.
* **Tests**
  * Updated tests for cross-platform command generation, fake script launchers, marker-file checks, and safer subprocess signaling.
  * Reduced CI flakiness by replacing fixed delays with condition-based waits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->