### PR TITLE
fix(win32): show UNKNOWN for live-but-unreadable engine instead of false INTERRUPTED

### DIFF
--- a/src/automator/process_host.py
+++ b/src/automator/process_host.py
@@ -79,16 +79,31 @@ class ProcessHost(ABC):
         platform that can't provide one) degrades to :meth:`is_alive` — today's
         bare-existence behavior, with the documented residual reuse risk. Kept
         distinct from :meth:`is_alive` so existence and ownership are never
-        conflated again."""
+        conflated again.
+
+        Destructive paths use this strict check; non-destructive TUI reads use
+        :meth:`liveness_of` to preserve an ``'unknown'`` state."""
         if pid <= 0:
             return False
         if identity is None:
             return self.is_alive(pid)
-        # identity(pid) != the recorded value whenever the pid is gone, reused, or
-        # merely unreadable (a permission glitch, or no psutil off-Linux) — every
-        # case reads False (not-ours). An unreadable identity on a live pid thus
-        # reads as dead: the documented residual, deliberately biased safe.
+        # Gone, reused, or unreadable all read not-ours here.
         return self.identity(pid) == identity
+
+    def liveness_of(self, pid: int, identity: float | None) -> str:
+        """Non-destructive tri-state read of *our* engine: ``'alive'`` |
+        ``'dead'`` | ``'unknown'``. A pid that still exists but whose identity is
+        unreadable reads ``'unknown'``, never ``'dead'``."""
+        if pid <= 0:
+            return "dead"
+        if identity is None:
+            return "alive" if self.is_alive(pid) else "dead"
+        current = self.identity(pid)
+        if current == identity:
+            return "alive"
+        if current is None and self.is_alive(pid):
+            return "unknown"
+        return "dead"
 
     def shell_quote(self, arg: str) -> str:
         """Quote ``arg`` for the shell that runs this host's hook commands, so the

--- a/src/automator/tui/app.py
+++ b/src/automator/tui/app.py
@@ -39,6 +39,10 @@ from .screens.settings_screen import SettingsScreen
 from .settings import PolicyDoc
 
 
+def _engine_possibly_live(run_dir: Path) -> bool:
+    return runs.read_pid(run_dir) is not None and data.liveness(run_dir) != "dead"
+
+
 class BmadAutoApp(App[None]):
     TITLE = "bmad-auto"
 
@@ -143,12 +147,14 @@ class BmadAutoApp(App[None]):
         except verify.GitError as e:
             self.notify(f"git check failed: {e}", severity="error")
             return
-        live = [r.run_id for r in data.discover_runs(self.project) if r.status == data.RUNNING]
+        live = [
+            r.run_id for r in data.discover_runs(self.project) if _engine_possibly_live(r.run_dir)
+        ]
         if live:
             self.push_screen(
                 ConfirmModal(
-                    "another run is live",
-                    f"running now: {', '.join(live)}\n"
+                    "another run may be live",
+                    f"live or unknown: {', '.join(live)}\n"
                     "launching another engine on the same project may conflict.",
                     confirm_label="launch anyway",
                 ),
@@ -283,7 +289,7 @@ class BmadAutoApp(App[None]):
         if state.finished:
             self.notify(f"run {run_id} already finished", severity="warning")
             return
-        engine_alive = data.liveness(run_dir) == "alive"
+        engine_alive = _engine_possibly_live(run_dir)
 
         def done(ok: bool | None) -> None:
             if not ok:
@@ -378,8 +384,8 @@ class BmadAutoApp(App[None]):
                 severity="warning",
             )
             return
-        if data.liveness(run_dir) == "alive":
-            self.notify(f"run {run_id} is live — stop it first", severity="warning")
+        if _engine_possibly_live(run_dir):
+            self.notify(f"run {run_id} may still be live — stop it first", severity="warning")
             return
         story = state.paused_story_key or "?"
 

--- a/src/automator/tui/app.py
+++ b/src/automator/tui/app.py
@@ -40,7 +40,13 @@ from .settings import PolicyDoc
 
 
 def _engine_possibly_live(run_dir: Path) -> bool:
-    return runs.read_pid(run_dir) is not None and data.liveness(run_dir) != "dead"
+    live = data.liveness(run_dir)
+    if live == "alive":  # provably live, pid-backed or via a legacy session
+        return True
+    # 'unknown' means possibly-live only for a pid-backed run (a win32 engine
+    # whose pid exists but is unreadable). A legacy pid-less run's 'unknown' just
+    # means no session was found — it must not flag every old finished run.
+    return live == "unknown" and runs.read_pid(run_dir) is not None
 
 
 class BmadAutoApp(App[None]):

--- a/src/automator/tui/app.py
+++ b/src/automator/tui/app.py
@@ -465,9 +465,16 @@ class BmadAutoApp(App[None]):
         if selected is None:
             return
         run_id, run_dir = selected
-        if data.liveness(run_dir) == "alive":
+        # 'unknown' (a live-but-unreadable pid) does not block cleanup — see the
+        # deliberate runs.engine_alive invariant — but the irreversible confirm
+        # must not imply the run is safely dead, so it says so.
+        live = data.liveness(run_dir)
+        if live == "alive":
             self.notify(f"run {run_id} is live — stop it first", severity="warning")
             return
+        warning = "this cannot be undone"
+        if live == "unknown":
+            warning = f"engine may still be live (unverifiable pid) — {warning}"
 
         def done(ok: bool | None) -> None:
             if ok:
@@ -478,7 +485,7 @@ class BmadAutoApp(App[None]):
                 "delete run",
                 f"permanently delete run {run_id}?",
                 confirm_label="delete",
-                warning="this cannot be undone",
+                warning=warning,
             ),
             done,
         )
@@ -498,7 +505,8 @@ class BmadAutoApp(App[None]):
         if selected is None:
             return
         run_id, run_dir = selected
-        if data.liveness(run_dir) == "alive":
+        live = data.liveness(run_dir)
+        if live == "alive":
             self.notify(f"run {run_id} is live — stop it first", severity="warning")
             return
 
@@ -511,6 +519,9 @@ class BmadAutoApp(App[None]):
                 "archive run",
                 f"archive run {run_id} to .automator/archive?",
                 confirm_label="archive",
+                warning=(
+                    "engine may still be live (unverifiable pid)" if live == "unknown" else None
+                ),
             ),
             done,
         )

--- a/src/automator/tui/data.py
+++ b/src/automator/tui/data.py
@@ -74,10 +74,8 @@ def liveness(run_dir: Path) -> str:
     if pid is None:
         return _session_liveness(run_dir.name)
     try:
-        # identity-aware: a reused pid (a stranger inheriting the number) reads as
-        # 'dead', not a false RUNNING. Legacy pid file (identity None) degrades to a
-        # bare existence probe.
-        return "alive" if get_process_host().alive_and_ours(pid, identity) else "dead"
+        # non-destructive identity-aware tri-state probe
+        return get_process_host().liveness_of(pid, identity)
     except Exception:
         # never falsely dead — an unexpected probe failure stays 'unknown'
         return "unknown"

--- a/src/automator/tui/screens/modals.py
+++ b/src/automator/tui/screens/modals.py
@@ -169,7 +169,7 @@ class ConfirmModal(BaseDialog):
 
 class ConfirmResumeModal(ConfirmModal):
     """Resume confirmation with pause details and a double-drive warning when
-    the recorded engine pid is still alive."""
+    the recorded engine pid may still be live."""
 
     def __init__(self, run_id: str, state: RunState, engine_alive: bool):
         body = Text()
@@ -183,7 +183,7 @@ class ConfirmResumeModal(ConfirmModal):
         else:
             body.append("run is not paused — it looks interrupted", style="dim")
         warning = (
-            "engine.pid is still alive — resuming would double-drive this run"
+            "engine.pid may still be live — resuming could double-drive this run"
             if engine_alive
             else None
         )

--- a/tests/test_process_host.py
+++ b/tests/test_process_host.py
@@ -108,7 +108,27 @@ def test_alive_and_ours_matches_only_same_identity(host, monkeypatch):
     assert host.alive_and_ours(4242, 123.0) is True
     assert host.alive_and_ours(4242, 999.0) is False  # reused
     monkeypatch.setattr(host, "identity", lambda pid: None)
-    assert host.alive_and_ours(4242, 123.0) is False  # gone
+    assert host.alive_and_ours(4242, 123.0) is False  # gone or unreadable → not-ours
+
+
+def test_liveness_of_reads_alive_dead_and_unknown(host, monkeypatch):
+    monkeypatch.setattr(host, "identity", lambda pid: 123.0)
+    assert host.liveness_of(4242, 123.0) == "alive"  # identity matches → ours
+    assert host.liveness_of(4242, 999.0) == "dead"  # readable-but-different → reused
+
+    monkeypatch.setattr(host, "identity", lambda pid: None)
+    monkeypatch.setattr(host, "is_alive", lambda pid: True)
+    assert host.liveness_of(4242, 123.0) == "unknown"
+    monkeypatch.setattr(host, "is_alive", lambda pid: False)
+    assert host.liveness_of(4242, 123.0) == "dead"
+
+
+def test_liveness_of_legacy_identity_degrades_to_is_alive(host, monkeypatch):
+    # A legacy pid file (no persisted identity) can only fall back to bare existence.
+    monkeypatch.setattr(host, "is_alive", lambda pid: pid == 4242)
+    assert host.liveness_of(4242, None) == "alive"
+    assert host.liveness_of(9999, None) == "dead"
+    assert host.liveness_of(0, None) == "dead"
 
 
 def test_default_host_matches_platform(monkeypatch):

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -70,8 +70,8 @@ class _FakeHost:
         return self._identity() if callable(self._identity) else self._identity
 
     def alive_and_ours(self, pid, identity):
-        # Mirrors ProcessHost.alive_and_ours: pid<=0 short-circuits, identity None
-        # degrades to is_alive, else the recorded identity must still match.
+        # Mirrors ProcessHost.alive_and_ours (strict): pid<=0 short-circuits, identity
+        # None degrades to is_alive, else the recorded identity must still match.
         if pid <= 0:
             return False
         if identity is None:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -822,6 +822,31 @@ async def test_unknown_pid_run_asks_for_confirmation(project, monkeypatch):
         assert not calls
 
 
+async def test_legacy_pidless_but_live_run_asks_for_confirmation(project, monkeypatch):
+    # A legacy run has no engine.pid but is provably alive via its mux session
+    # (liveness == "alive"). The launch guard must still catch it — the pid gate
+    # alone would skip a running engine and allow a conflicting launch.
+    calls = []
+    monkeypatch.setattr(launch, "tmux_available", lambda: True)
+    monkeypatch.setattr(launch, "start_run_detached", lambda *a, **kw: calls.append(a))
+    monkeypatch.setattr(data, "liveness", lambda run_dir: "alive")
+    make_run(project.project, "20260611-100000-aaaa")  # no engine.pid: legacy run
+    app = BmadAutoApp(project.project)
+    async with app.run_test() as pilot:
+        await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
+        await pilot.press("r")
+        await until(pilot, lambda: isinstance(app.screen, StartRunModal))
+        await pilot.click("#ok")
+        await until(
+            pilot,
+            lambda: (
+                isinstance(app.screen, ConfirmModal)
+                and not isinstance(app.screen, ConfirmResumeModal)
+            ),
+        )
+        assert not calls
+
+
 async def test_start_sweep_modal_launches(project, monkeypatch):
     calls = {}
     monkeypatch.setattr(launch, "tmux_available", lambda: True)

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -798,6 +798,30 @@ async def test_live_run_asks_for_confirmation(project, monkeypatch):
         await until(pilot, lambda: bool(calls))
 
 
+async def test_unknown_pid_run_asks_for_confirmation(project, monkeypatch):
+    calls = []
+    monkeypatch.setattr(launch, "tmux_available", lambda: True)
+    monkeypatch.setattr(launch, "start_run_detached", lambda *a, **kw: calls.append(a))
+    monkeypatch.setattr(data, "liveness", lambda run_dir: "unknown")
+    run_dir = make_run(project.project, "20260611-100000-aaaa")
+    (run_dir / "engine.pid").write_text("4242 123.0", encoding="utf-8")
+    app = BmadAutoApp(project.project)
+    async with app.run_test() as pilot:
+        await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
+        await pilot.press("r")
+        await until(pilot, lambda: isinstance(app.screen, StartRunModal))
+        await pilot.click("#ok")
+        await until(
+            pilot,
+            lambda: (
+                isinstance(app.screen, ConfirmModal)
+                and not isinstance(app.screen, ConfirmResumeModal)
+            ),
+        )
+        assert "unknown" in app.screen._body.plain
+        assert not calls
+
+
 async def test_start_sweep_modal_launches(project, monkeypatch):
     calls = {}
     monkeypatch.setattr(launch, "tmux_available", lambda: True)
@@ -878,6 +902,25 @@ async def test_resume_confirm_launches(project, monkeypatch):
         await until(pilot, lambda: isinstance(app.screen, ConfirmResumeModal))
         await pilot.click("#ok")
         await until(pilot, lambda: calls == ["20260611-100000-aaaa"])
+
+
+async def test_resume_unknown_pid_warns(project, monkeypatch):
+    monkeypatch.setattr(launch, "tmux_available", lambda: True)
+    monkeypatch.setattr(data, "liveness", lambda run_dir: "unknown")
+    run_dir = make_run(
+        project.project,
+        "20260611-100000-aaaa",
+        paused_stage="DEV_VERIFY",
+        paused_reason="verify failed",
+    )
+    (run_dir / "engine.pid").write_text("4242 123.0", encoding="utf-8")
+    app = BmadAutoApp(project.project)
+    async with app.run_test() as pilot:
+        await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
+        await until(pilot, lambda: dashboard(app).selected_run_id is not None)
+        await pilot.press("e")
+        await until(pilot, lambda: isinstance(app.screen, ConfirmResumeModal))
+        assert "may still be live" in app.screen._warning
 
 
 async def test_resume_finished_run_refused(project, monkeypatch):
@@ -1092,6 +1135,27 @@ async def test_resolve_escalation_launches_and_attaches(project, monkeypatch):
     assert calls == [["tmux", "switch-client", "-t", "=bmad-auto-ctl"]]
     # resolve runs in the freshly launched ctl window (@7) — stamp it to return
     assert stamps == [("@7", "%9")]
+
+
+async def test_resolve_unknown_pid_refused(project, monkeypatch):
+    launched: list[str] = []
+    monkeypatch.setattr(launch, "tmux_available", lambda: True)
+    monkeypatch.setattr(data, "liveness", lambda run_dir: "unknown")
+    monkeypatch.setattr(launch, "start_resolve_detached", lambda proj, rid: launched.append(rid))
+    run_dir = make_run(
+        project.project,
+        "20260611-100000-aaaa",
+        paused_stage="escalation",
+        paused_reason="CRITICAL escalation",
+    )
+    (run_dir / "engine.pid").write_text("4242 123.0", encoding="utf-8")
+    app = BmadAutoApp(project.project)
+    async with app.run_test() as pilot:
+        await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
+        await until(pilot, lambda: dashboard(app).selected_run_id is not None)
+        await pilot.press("R")
+        await until(pilot, lambda: any("may still be live" in m for m in notifications(app)))
+    assert launched == []
 
 
 async def test_resolve_refused_when_not_escalation(project, monkeypatch):

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -948,6 +948,23 @@ async def test_resume_unknown_pid_warns(project, monkeypatch):
         assert "may still be live" in app.screen._warning
 
 
+async def test_delete_unknown_pid_warns_but_does_not_block(project, monkeypatch):
+    # 'unknown' liveness (a live-but-unreadable pid) must not block cleanup — the
+    # deliberate runs.engine_alive invariant — but the irreversible delete confirm
+    # must warn the run may still be live rather than imply it is safely dead.
+    monkeypatch.setattr(data, "liveness", lambda run_dir: "unknown")
+    run_dir = make_run(project.project, "20260611-100000-aaaa")
+    (run_dir / "engine.pid").write_text("4242 123.0", encoding="utf-8")
+    app = BmadAutoApp(project.project)
+    async with app.run_test() as pilot:
+        await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
+        await until(pilot, lambda: dashboard(app).selected_run_id is not None)
+        await pilot.press("D")
+        await until(pilot, lambda: isinstance(app.screen, ConfirmModal))
+        assert "may still be live" in app.screen._warning  # not blocked, but flagged
+        assert "cannot be undone" in app.screen._warning
+
+
 async def test_resume_finished_run_refused(project, monkeypatch):
     monkeypatch.setattr(launch, "tmux_available", lambda: True)
     make_run(project.project, "20260611-100000-aaaa", finished=True)

--- a/tests/test_tui_data.py
+++ b/tests/test_tui_data.py
@@ -128,6 +128,20 @@ def test_discover_runs_classification(tmp_path):
     assert [i.status for i in data.discover_runs(tmp_path)] == [i.status for i in infos]
 
 
+def test_live_pid_with_unreadable_identity_is_unknown_not_interrupted(tmp_path, monkeypatch):
+    run_dir = make_run(tmp_path, "20260611-100000-aaaa")
+    (run_dir / "engine.pid").write_text("4242 123.0")
+
+    class Host:
+        def liveness_of(self, pid, identity):
+            return "unknown"
+
+    host = Host()
+    monkeypatch.setattr(data, "get_process_host", lambda: host)
+    assert data.liveness(run_dir) == "unknown"
+    assert data.discover_runs(tmp_path)[0].status == data.UNKNOWN
+
+
 def test_stopped_run_classifies_as_stopped_not_interrupted(tmp_path):
     # a deliberate stop leaves a dead pid; it must read STOPPED, not INTERRUPTED
     run_dir = make_run(tmp_path, "20260611-100000-aaaa", stopped=True)


### PR DESCRIPTION
## What

Adds a tri-state `ProcessHost.liveness_of` (`alive`/`dead`/`unknown`) and routes only the TUI run-status through it, so a running engine whose identity is unreadable on win32 shows **UNKNOWN** instead of a false **INTERRUPTED**.

## Why

On win32, `psutil.create_time()` raises `ERROR_ACCESS_DENIED` for a live process in another session / at a different elevation, so `identity()` returns `None`; the identity-aware liveness check then read a running engine as dead, weakening resume/delete guards.

Fixes #33

## How

- Added tri-state `ProcessHost.liveness_of` biased away from false-dead: an unreadable identity on a still-existing pid reads `unknown`, not `dead`.
- Kept the shared `alive_and_ours` strict/fail-safe so the destructive `stop_run` gate and `engine_alive` delete/archive/reclaim guards are unchanged — an unverifiable pid is never signalled and never blocks cleanup.
- Wired only `tui.data.liveness` to the tri-state, and made the launch-conflict / resume double-drive guards treat `unknown` as possibly-live (`_engine_possibly_live`: has a pid and liveness != `dead`).

## Testing

`pytest tests/test_process_host.py tests/test_tui_app.py tests/test_tui_data.py` — added cases for the unreadable-but-live pid (`unknown`), the strict destructive guards, and the TUI UNKNOWN status / possibly-live prompt paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more nuanced run liveness detection, including an “unknown” state when process status can’t be confirmed.
  * Improved launch, resume, and resolve safeguards to treat uncertain runs as potentially active and prompt for confirmation.
* **Bug Fixes**
  * Reduced false assumptions that a run is definitely dead when its identity can’t be read.
  * Updated warning messages to better reflect uncertainty and prevent accidental double-starts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->