### PR TITLE
Fix sweep bundle ledger sync after review

### DIFF
--- a/src/automator/engine.py
+++ b/src/automator/engine.py
@@ -1587,7 +1587,17 @@ class Engine:
         # and routes to step-04 for a fresh independent review pass (BMAD-METHOD
         # #2508) — so the follow-up review is just another dev-skill run, no
         # separate review skill. task.spec_file is set by verify_dev on success.
-        return f"/bmad-dev-auto {task.spec_file}"
+        # The ledger instruction is the prevention side of the reclose in
+        # SweepEngine._verify_review: a review that rewrites deferred-work.md
+        # from a stale snapshot clobbers orchestrator-recorded closures. The
+        # ledger is append-only for sessions — new findings are fine, existing
+        # entries are orchestrator-owned.
+        return (
+            f"/bmad-dev-auto {task.spec_file} — If this review defers new "
+            f"findings, append them to the deferred-work ledger as NEW entries "
+            f"only; do NOT modify, re-open, or rewrite existing ledger entries — "
+            f"the orchestrator owns their status and resolution."
+        )
 
     def _render_commit_template(self, task: StoryTask) -> str | None:
         """The configured commit message template with {story_key}/{run_id}

--- a/src/automator/sweep.py
+++ b/src/automator/sweep.py
@@ -1014,7 +1014,11 @@ class SweepEngine(Engine):
         self._close_bundle_ledger_when_spec_status(task, str(spec_file), success_status)
 
     def _close_bundle_ledger_when_spec_status(
-        self, task: StoryTask, spec_file: str, success_status: str
+        self,
+        task: StoryTask,
+        spec_file: str,
+        success_status: str,
+        kind: str = "sweep-bundle-closed",
     ) -> None:
         spec_path = verify.resolve_spec_path(spec_file, self.workspace.paths)
         if not spec_path.is_file():
@@ -1025,7 +1029,7 @@ class SweepEngine(Engine):
         note = f"resolved by sweep bundle {task.story_key}"
         marked = [i for i in task.dw_ids if deferredwork.mark_done(ledger, i, self._today(), note)]
         if marked:
-            self.journal.append("sweep-bundle-closed", story_key=task.story_key, dw_ids=marked)
+            self.journal.append(kind, story_key=task.story_key, dw_ids=marked)
 
     def _verify_dev_artifacts(self, task: StoryTask, result_json: dict | None):
         return verify.verify_dev_bundle(
@@ -1037,9 +1041,12 @@ class SweepEngine(Engine):
         # orchestrator is the ledger writer. A follow-up review can rewrite the
         # ledger from its own snapshot and re-open entries that were already
         # closed after dev. Re-apply that idempotent closure immediately before
-        # verify_review_bundle requires those entries.
+        # verify_review_bundle requires those entries. The distinct journal kind
+        # makes "a review rewrote the ledger" greppable when diagnosing runs.
         if self._generic_dev() and task.spec_file:
-            self._close_bundle_ledger_when_spec_status(task, task.spec_file, "done")
+            self._close_bundle_ledger_when_spec_status(
+                task, task.spec_file, "done", kind="sweep-bundle-reclosed"
+            )
         return verify.verify_review_bundle(task, self.workspace.paths, self.policy)
 
     def _commit_message(self, task: StoryTask) -> str:

--- a/src/automator/sweep.py
+++ b/src/automator/sweep.py
@@ -1001,19 +1001,24 @@ class SweepEngine(Engine):
 
     def _post_dev_state_sync(self, task: StoryTask, result_json: dict | None) -> None:
         """Generic-path ledger single-writer for bundles. The decoupled
-        bmad-dev-auto skill does not touch the ledger, so the
-        orchestrator marks each dw id the bundle owns ``done`` once the bundle's
-        spec reached its success status — before verify_review_bundle checks the
-        ledger. Mirrors the story sprint sync; no-op on the legacy path."""
+        bmad-dev-auto skill does not touch the ledger, so the orchestrator marks
+        each dw id the bundle owns ``done`` once the bundle's spec reaches the
+        terminal status for the current stage. Mirrors the story sprint sync;
+        no-op on the legacy path."""
         if not self._generic_dev():
             return
         spec_file = (result_json or {}).get("spec_file")
         if not spec_file:
             return
-        spec_path = verify.resolve_spec_path(str(spec_file), self.workspace.paths)
+        success_status = "in-review" if self._dev_review_enabled() else "done"
+        self._close_bundle_ledger_when_spec_status(task, str(spec_file), success_status)
+
+    def _close_bundle_ledger_when_spec_status(
+        self, task: StoryTask, spec_file: str, success_status: str
+    ) -> None:
+        spec_path = verify.resolve_spec_path(spec_file, self.workspace.paths)
         if not spec_path.is_file():
             return
-        success_status = "in-review" if self._dev_review_enabled() else "done"
         if verify.status_of(verify.read_frontmatter(spec_path)) != success_status:
             return
         ledger = self.workspace.paths.deferred_work
@@ -1028,6 +1033,13 @@ class SweepEngine(Engine):
         )
 
     def _verify_review(self, task: StoryTask):
+        # Generic bundle dev sessions are told not to edit deferred-work.md; the
+        # orchestrator is the ledger writer. A follow-up review can rewrite the
+        # ledger from its own snapshot and re-open entries that were already
+        # closed after dev. Re-apply that idempotent closure immediately before
+        # verify_review_bundle requires those entries.
+        if self._generic_dev() and task.spec_file:
+            self._close_bundle_ledger_when_spec_status(task, task.spec_file, "done")
         return verify.verify_review_bundle(task, self.workspace.paths, self.policy)
 
     def _commit_message(self, task: StoryTask) -> str:

--- a/src/automator/verify.py
+++ b/src/automator/verify.py
@@ -808,10 +808,10 @@ def verify_dev_bundle(
 ) -> VerifyOutcome:
     """verify_dev for a deferred-work bundle: bundles have no sprint-status
     entry. The orchestrator owns the bundle→dw-id binding (``task.dw_ids``,
-    marked done by ``SweepEngine._post_dev_state_sync``); the generic
-    ``bmad-dev-auto`` primitive never authors dw ids. So the dw_ids cross-check
-    is enforced only when the session actually claims them — an empty/absent
-    claim is the normal generic path and passes."""
+    marked done by ``SweepEngine``'s ledger sync); the generic ``bmad-dev-auto``
+    primitive never authors dw ids. So the dw_ids cross-check is enforced only
+    when the session actually claims them — an empty/absent claim is the normal
+    generic path and passes."""
     rj = result_json or {}
     spec_file = rj.get("spec_file")
     if not spec_file:
@@ -923,8 +923,9 @@ def verify_review_bundle(task: StoryTask, paths: ProjectPaths, policy: Policy) -
     """verify_review for a deferred-work bundle: no sprint-status check, but
     every dw id the bundle owns must be marked done in the ledger on disk. The
     legacy --dw-bundle skill flips them; on the generic bmad-dev-auto path the
-    orchestrator flips them in _post_dev_state_sync. Either way this gate is why
-    we can trust it happened."""
+    orchestrator flips them after dev and, if review rewrites the ledger diff,
+    again immediately before this review gate. Either way this gate is why we
+    can trust it happened."""
     if not task.spec_file:
         return VerifyOutcome.retry("no spec file recorded for task")
     fm = read_frontmatter(Path(task.spec_file))

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -11,13 +11,14 @@ from conftest import (
     triage_effect,
     write_ledger,
     write_legacy_ledger,
+    write_spec,
 )
 
 from automator import deferredwork
 from automator.adapters.base import SessionResult
 from automator.adapters.mock import MockAdapter
 from automator.journal import Journal, load_state
-from automator.model import Phase, RunState, TokenUsage
+from automator.model import Phase, RunState, StoryTask, TokenUsage
 from automator.policy import (
     GatesPolicy,
     LimitsPolicy,
@@ -467,6 +468,42 @@ def test_generic_skill_bundle_orchestrator_closes_ledger(project):
     assert "--dw-bundle" not in dev_prompt
     kinds = {e["kind"] for e in engine.journal.entries()}
     assert "sweep-bundle-closed" in kinds
+
+
+def test_generic_bundle_review_verify_recloses_ledger_after_review_rewrites_it(project):
+    """A follow-up review can rewrite deferred-work.md from its own snapshot and
+    re-open entries the orchestrator already closed after dev. The review gate
+    should re-apply the orchestrator-owned ledger closure before verification,
+    otherwise the sweep launches a spurious repair/dev pass for complete work."""
+    from automator.policy import DevPolicy
+
+    write_ledger(project, {"DW-1": "open", "DW-2": "open"})
+    baseline = git(project.project, "rev-parse", "HEAD")
+    spec = project.implementation_artifacts / "spec-dw-fix-things.md"
+    write_spec(spec, "done", baseline)
+    pol = Policy(
+        gates=GatesPolicy(mode="none"),
+        notify=QUIET,
+        review=ReviewPolicy(enabled=True, trigger="always"),
+        dev=DevPolicy(skill="bmad-dev-auto"),
+        scm=ScmPolicy(rollback_on_failure=True),
+    )
+    engine, _ = make_sweep(project, [], policy=pol)
+    task = StoryTask(
+        story_key="dw-fix-things",
+        epic=0,
+        dw_ids=["DW-1", "DW-2"],
+        spec_file=str(spec),
+    )
+
+    out = engine._verify_review(task)
+
+    assert out.ok
+    entries = ledger_entries(project)
+    assert entries["DW-1"].status.startswith("done")
+    assert entries["DW-2"].status.startswith("done")
+    assert "resolved by sweep bundle dw-fix-things" in entries["DW-1"].body
+    assert "sweep-bundle-closed" in {e["kind"] for e in engine.journal.entries()}
 
 
 def test_generic_bundle_reconcile_closes_ledger_on_stale_frontmatter(project):

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -20,6 +20,7 @@ from automator.adapters.mock import MockAdapter
 from automator.journal import Journal, load_state
 from automator.model import Phase, RunState, StoryTask, TokenUsage
 from automator.policy import (
+    DevPolicy,
     GatesPolicy,
     LimitsPolicy,
     NotifyPolicy,
@@ -431,8 +432,6 @@ def test_generic_skill_bundle_orchestrator_closes_ledger(project):
     """B4: on the generic bmad-dev-auto path the bundle session never edits the
     ledger; the orchestrator marks each owned dw id done (in _post_dev_state_sync)
     and verify_review_bundle confirms its own write. The invocation is freeform."""
-    from automator.policy import DevPolicy
-
     write_ledger(project, {"DW-1": "open", "DW-2": "open"})
     plan = triage_result(
         ["DW-1", "DW-2"],
@@ -475,8 +474,6 @@ def test_generic_bundle_review_verify_recloses_ledger_after_review_rewrites_it(p
     re-open entries the orchestrator already closed after dev. The review gate
     should re-apply the orchestrator-owned ledger closure before verification,
     otherwise the sweep launches a spurious repair/dev pass for complete work."""
-    from automator.policy import DevPolicy
-
     write_ledger(project, {"DW-1": "open", "DW-2": "open"})
     baseline = git(project.project, "rev-parse", "HEAD")
     spec = project.implementation_artifacts / "spec-dw-fix-things.md"
@@ -503,7 +500,7 @@ def test_generic_bundle_review_verify_recloses_ledger_after_review_rewrites_it(p
     assert entries["DW-1"].status.startswith("done")
     assert entries["DW-2"].status.startswith("done")
     assert "resolved by sweep bundle dw-fix-things" in entries["DW-1"].body
-    assert "sweep-bundle-closed" in {e["kind"] for e in engine.journal.entries()}
+    assert "sweep-bundle-reclosed" in {e["kind"] for e in engine.journal.entries()}
 
 
 def test_generic_bundle_reconcile_closes_ledger_on_stale_frontmatter(project):
@@ -512,8 +509,6 @@ def test_generic_bundle_reconcile_closes_ledger_on_stale_frontmatter(project):
     at the template default `draft`. The orchestrator reconciles the frontmatter
     before the ledger sync, so the bundle CLOSES — its dw ids are marked done and
     not stranded in failed_ids — instead of falsely deferring completed work."""
-    from automator.policy import DevPolicy
-
     write_ledger(project, {"DW-1": "open", "DW-2": "open"})
     plan = triage_result(
         ["DW-1", "DW-2"],
@@ -562,8 +557,6 @@ def test_generic_bundle_reconcile_closes_ledger_on_in_review_frontmatter(project
     the generic path (the legacy review-handoff fork is retired), so the
     orchestrator reconciles it to done before the ledger sync — the bundle CLOSES
     instead of false-deferring + rolling back into an endless re-sweep loop."""
-    from automator.policy import DevPolicy
-
     write_ledger(project, {"DW-1": "open", "DW-2": "open"})
     plan = triage_result(
         ["DW-1", "DW-2"],


### PR DESCRIPTION
## Summary
- Re-apply orchestrator-owned DW ledger closure immediately before bundle review verification.
- Factor the ledger closure into an idempotent helper shared by dev-time and review-time sync.
- Add a regression test for review re-opening already-closed bundle DW entries.

## Why
A review-enabled sweep can have bmad-dev-auto leave the bundle spec complete while the follow-up review rewrites deferred-work.md from a stale snapshot. The existing review verifier then sees open DW entries and sends completed work into a second dev/repair pass.

## Tests
- uv run pytest tests/test_sweep.py tests/test_verify.py
- uv run python -m py_compile src/automator/sweep.py src/automator/verify.py tests/test_sweep.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured deferred-work ledger entries are (re)closed to the expected “done” state immediately before review verification for generic development sessions with a spec file.
  * Updated review-session instructions to clearly direct how deferred-work entries should be appended without modifying existing ledger entries.
* **Tests**
  * Added a new scenario covering review verification rewriting deferred-work entries back to done and confirming the expected journal event.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->