### PR TITLE
fix(cli): surface unknown liveness in resolve/delete/archive (win32)

### DIFF
--- a/src/automator/cli.py
+++ b/src/automator/cli.py
@@ -600,8 +600,11 @@ def cmd_resolve(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 1
-    if runs.engine_alive(run_dir):
-        print(f"run {args.run_id} is still live — stop it first", file=sys.stderr)
+    # Not a cleanup path, so the "unknown must not block" invariant does not apply:
+    # an unverifiable-but-live pid must not be re-driven. Refuse on alive OR unknown.
+    if runs.engine_liveness(run_dir) != "dead":
+        # "may" not "is": the gate fires on unknown too, where liveness is unverifiable.
+        print(f"run {args.run_id} may still be live — stop it first", file=sys.stderr)
         return 1
     story_key = args.story or state.paused_story_key
     task = state.tasks.get(story_key) if story_key else None
@@ -815,6 +818,27 @@ def cmd_stop(args: argparse.Namespace) -> int:
     return 0
 
 
+def _stop_or_block_live_engine(run_dir: Path, run_id: str, force: bool) -> int | None:
+    """Shared delete/archive guard. One liveness sample drives both the warning and the
+    block, so a mid-check identity flip can't fire one without the other. An unverifiable
+    pid (``unknown``) warns but never blocks cleanup; only a provably-live engine blocks,
+    or is stopped first under ``force``. Returns an exit code to propagate, or None to
+    proceed with cleanup."""
+    live = runs.engine_liveness(run_dir)
+    if live == "unknown":
+        print(f"run {run_id}: engine may still be live (unverifiable pid)", file=sys.stderr)
+    if live == "alive":
+        if not force:
+            print(f"run {run_id} is still live — stop it first (or pass --force)", file=sys.stderr)
+            return 1
+        try:
+            runs.stop_run(run_dir)
+        except (runs.StopRunError, ProcessHostError) as e:
+            print(str(e), file=sys.stderr)
+            return 1
+    return None
+
+
 def cmd_delete(args: argparse.Namespace) -> int:
     project = _project(args)
     try:
@@ -823,18 +847,9 @@ def cmd_delete(args: argparse.Namespace) -> int:
         print(str(e), file=sys.stderr)
         return 1
     args.run_id = run_dir.name
-    if runs.engine_alive(run_dir):
-        if not args.force:
-            print(
-                f"run {args.run_id} is still live — stop it first (or pass --force)",
-                file=sys.stderr,
-            )
-            return 1
-        try:
-            runs.stop_run(run_dir)
-        except (runs.StopRunError, ProcessHostError) as e:
-            print(str(e), file=sys.stderr)
-            return 1
+    rc = _stop_or_block_live_engine(run_dir, args.run_id, args.force)
+    if rc is not None:
+        return rc
     runs.delete_run(run_dir)
     print(f"run {args.run_id} deleted")
     return 0
@@ -848,18 +863,9 @@ def cmd_archive(args: argparse.Namespace) -> int:
         print(str(e), file=sys.stderr)
         return 1
     args.run_id = run_dir.name
-    if runs.engine_alive(run_dir):
-        if not args.force:
-            print(
-                f"run {args.run_id} is still live — stop it first (or pass --force)",
-                file=sys.stderr,
-            )
-            return 1
-        try:
-            runs.stop_run(run_dir)
-        except (runs.StopRunError, ProcessHostError) as e:
-            print(str(e), file=sys.stderr)
-            return 1
+    rc = _stop_or_block_live_engine(run_dir, args.run_id, args.force)
+    if rc is not None:
+        return rc
     dest = runs.archive_run(project, run_dir)
     print(f"run {args.run_id} archived to {dest}")
     return 0

--- a/src/automator/cli.py
+++ b/src/automator/cli.py
@@ -928,7 +928,7 @@ def cmd_cleanup(args: argparse.Namespace) -> int:
         if live:
             print(f"leaving {len(live)} live session(s) untouched")
         return 0
-    killed = runs.prune_sessions(project)
+    killed, _ = runs.prune_sessions(project)
     windows = launch.prune_ctl_windows(project)
     print(f"removed {len(killed)} session(s), {len(windows)} ctl window(s)")
     if live:

--- a/src/automator/cli.py
+++ b/src/automator/cli.py
@@ -911,7 +911,11 @@ def cmd_cleanup(args: argparse.Namespace) -> int:
     from .tui import launch  # pure stdlib; no textual import
 
     project = _project(args)
-    prunable, live = runs.prunable_sessions(project)
+    prunable, live, unknown = runs.prunable_sessions(project)
+    for run_id in sorted(unknown):
+        # warn-only: unknown never blocks cleanup (same wording as delete/archive).
+        # Printed for --dry-run too — it describes state, not action.
+        print(f"run {run_id}: engine may still be live (unverifiable pid)", file=sys.stderr)
     if args.dry_run:
         windows = launch.prunable_ctl_windows(project)
         if not prunable and not windows:
@@ -990,6 +994,12 @@ def cmd_clean(args: argparse.Namespace) -> int:
     archived: list[str] = []
     deleted: list[str] = []
     for run_dir in reclaimable:
+        if runs.engine_liveness(run_dir) == "unknown":
+            # warn-only: unknown never blocks cleanup, but say so before removal
+            print(
+                f"run {run_dir.name}: engine may still be live (unverifiable pid)",
+                file=sys.stderr,
+            )
         # measure before mutating so the reclaim estimate holds for --dry-run too
         wt_dir = run_dir / "worktrees"
         wt_bytes = _dir_size(wt_dir) if wt_dir.is_dir() else 0

--- a/src/automator/cli.py
+++ b/src/automator/cli.py
@@ -571,6 +571,25 @@ def cmd_resume(args: argparse.Namespace) -> int:
     except runs.RunRefError as e:
         print(str(e), file=sys.stderr)
         return 1
+    args.run_id = run_dir.name  # normalize so messages show the full id
+    # Gate here, NOT in _resume_paused_run: that helper is also resolve's re-arm
+    # path, which is already gated at resolve entry. A provably-live engine blocks
+    # outright (the TUI warns in its confirm modal instead; the CLI has no confirm
+    # step). 'unknown' warns but proceeds: resume is the recovery path that
+    # rewrites engine.pid, so it must stay usable when liveness is unverifiable.
+    live = runs.engine_liveness(run_dir)
+    if live == "alive":
+        print(
+            f"run {args.run_id} is still live — resuming would double-drive it; stop it first",
+            file=sys.stderr,
+        )
+        return 1
+    if live == "unknown":
+        print(
+            f"run {args.run_id}: engine may still be live (unverifiable pid) — "
+            "resuming could double-drive this run",
+            file=sys.stderr,
+        )
     return _resume_paused_run(project, run_dir)
 
 
@@ -601,11 +620,28 @@ def cmd_resolve(args: argparse.Namespace) -> int:
         )
         return 1
     # Not a cleanup path, so the "unknown must not block" invariant does not apply:
-    # an unverifiable-but-live pid must not be re-driven. Refuse on alive OR unknown.
-    if runs.engine_liveness(run_dir) != "dead":
-        # "may" not "is": the gate fires on unknown too, where liveness is unverifiable.
-        print(f"run {args.run_id} may still be live — stop it first", file=sys.stderr)
+    # an unverifiable-but-live pid must not be re-driven. A provably-live engine
+    # always blocks (--force never bypasses it); unknown blocks unless the operator
+    # vouches with --force — `stop` cannot verify or clear an unverifiable pid, so
+    # without an escape hatch a squatted pid would lock resolve out forever.
+    live = runs.engine_liveness(run_dir)
+    if live == "alive":
+        print(f"run {args.run_id} is still live — stop it first", file=sys.stderr)
         return 1
+    if live == "unknown":
+        if not args.force:
+            print(
+                f"run {args.run_id}: engine may still be live (unverifiable pid) — "
+                "refusing to re-arm. Confirm the engine process is gone, then re-run "
+                "with --force (`stop` cannot verify or clear an unverifiable pid).",
+                file=sys.stderr,
+            )
+            return 1
+        print(
+            f"run {args.run_id}: engine may still be live (unverifiable pid) — "
+            "proceeding anyway (--force)",
+            file=sys.stderr,
+        )
     story_key = args.story or state.paused_story_key
     task = state.tasks.get(story_key) if story_key else None
     if story_key is None or task is None or task.phase != Phase.ESCALATED:
@@ -1256,6 +1292,12 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help="--resume: re-arm + resume without prompting; --no-resume: re-arm only "
         "(default: prompt to confirm, then resume)",
+    )
+    resolve_p.add_argument(
+        "--force",
+        action="store_true",
+        help="proceed when engine liveness is unverifiable (unknown); "
+        "a provably-live engine still blocks",
     )
 
     decisions_p = add(

--- a/src/automator/cli.py
+++ b/src/automator/cli.py
@@ -911,24 +911,26 @@ def cmd_cleanup(args: argparse.Namespace) -> int:
     from .tui import launch  # pure stdlib; no textual import
 
     project = _project(args)
-    prunable, live, unknown = runs.prunable_sessions(project)
+    # one partition sample drives the prune and every message below, so the
+    # warnings and live count always match what was actually killed/skipped
+    killed, live, unknown = runs.prune_sessions(project, dry_run=args.dry_run)
     for run_id in sorted(unknown):
         # warn-only: unknown never blocks cleanup (same wording as delete/archive).
-        # Printed for --dry-run too — it describes state, not action.
+        # Pruning kills the tmux session, never the engine pid, so the warning
+        # holds after the fact too.
         print(f"run {run_id}: engine may still be live (unverifiable pid)", file=sys.stderr)
     if args.dry_run:
         windows = launch.prunable_ctl_windows(project)
-        if not prunable and not windows:
+        if not killed and not windows:
             print("nothing to clean up")
         else:
-            for run_id in prunable:
+            for run_id in killed:
                 print(f"would kill session bmad-auto-{run_id}")
             for name in windows:
                 print(f"would close ctl window {name}")
         if live:
             print(f"leaving {len(live)} live session(s) untouched")
         return 0
-    killed, _ = runs.prune_sessions(project)
     windows = launch.prune_ctl_windows(project)
     print(f"removed {len(killed)} session(s), {len(windows)} ctl window(s)")
     if live:

--- a/src/automator/process_host.py
+++ b/src/automator/process_host.py
@@ -82,13 +82,11 @@ class ProcessHost(ABC):
         conflated again.
 
         Destructive paths use this strict check; non-destructive TUI reads use
-        :meth:`liveness_of` to preserve an ``'unknown'`` state."""
-        if pid <= 0:
-            return False
-        if identity is None:
-            return self.is_alive(pid)
-        # Gone, reused, or unreadable all read not-ours here.
-        return self.identity(pid) == identity
+        :meth:`liveness_of` to preserve an ``'unknown'`` state. Derived from
+        :meth:`liveness_of` — one decision table, two projections — so the binary
+        and tri-state probes can never drift: gone, reused, or unreadable
+        (``'unknown'``) all read not-ours here."""
+        return self.liveness_of(pid, identity) == "alive"
 
     def liveness_of(self, pid: int, identity: float | None) -> str:
         """Non-destructive tri-state read of *our* engine: ``'alive'`` |

--- a/src/automator/runs.py
+++ b/src/automator/runs.py
@@ -269,14 +269,17 @@ def prunable_sessions(project: Path) -> tuple[list[str], list[str], set[str]]:
     return prunable, live, unknown
 
 
-def prune_sessions(project: Path, *, dry_run: bool = False) -> list[str]:
+def prune_sessions(project: Path, *, dry_run: bool = False) -> tuple[list[str], set[str]]:
     """Kill every prunable bmad-auto-<id> session (see prunable_sessions);
-    returns the run ids that were (or, with dry_run, would be) killed."""
-    prunable, _, _ = prunable_sessions(project)
+    returns (killed, unknown): the run ids that were (or, with dry_run, would
+    be) killed, plus the subset whose engine liveness read 'unknown'. Both come
+    from the same partition sample, so a frontend warning built from `unknown`
+    always describes sessions that were actually pruned."""
+    prunable, _, unknown = prunable_sessions(project)
     if not dry_run:
         for run_id in prunable:
             kill_session(run_id)
-    return prunable
+    return prunable, unknown
 
 
 def stop_run(run_dir: Path) -> bool:

--- a/src/automator/runs.py
+++ b/src/automator/runs.py
@@ -269,17 +269,19 @@ def prunable_sessions(project: Path) -> tuple[list[str], list[str], set[str]]:
     return prunable, live, unknown
 
 
-def prune_sessions(project: Path, *, dry_run: bool = False) -> tuple[list[str], set[str]]:
+def prune_sessions(
+    project: Path, *, dry_run: bool = False
+) -> tuple[list[str], list[str], set[str]]:
     """Kill every prunable bmad-auto-<id> session (see prunable_sessions);
-    returns (killed, unknown): the run ids that were (or, with dry_run, would
-    be) killed, plus the subset whose engine liveness read 'unknown'. Both come
-    from the same partition sample, so a frontend warning built from `unknown`
-    always describes sessions that were actually pruned."""
-    prunable, _, unknown = prunable_sessions(project)
+    returns (killed, live, unknown): the run ids that were (or, with dry_run,
+    would be) killed, the live ids skipped, and the killed subset whose engine
+    liveness read 'unknown'. All three come from the same partition sample, so
+    frontend messaging built from them always describes the performed actions."""
+    prunable, live, unknown = prunable_sessions(project)
     if not dry_run:
         for run_id in prunable:
             kill_session(run_id)
-    return prunable, unknown
+    return prunable, live, unknown
 
 
 def stop_run(run_dir: Path) -> bool:

--- a/src/automator/runs.py
+++ b/src/automator/runs.py
@@ -166,6 +166,28 @@ def engine_alive(run_dir: Path) -> bool:
     return get_process_host().alive_and_ours(pid, identity)
 
 
+def engine_liveness(run_dir: Path) -> str:
+    """Tri-state read of the local engine: ``'alive'`` | ``'dead'`` | ``'unknown'``.
+    Wraps :meth:`ProcessHost.liveness_of` so a live-but-unreadable pid (win32
+    ``ERROR_ACCESS_DENIED``) reads ``'unknown'``, not a false ``'dead'``. No pid →
+    ``'dead'`` (the session fallback lives in the TUI layer)."""
+    pid, identity = read_pid_identity(run_dir)
+    if pid is None:
+        return "dead"
+    return probe_liveness(pid, identity)
+
+
+def probe_liveness(pid: int, identity: float | None) -> str:
+    """Tri-state probe of an already-read ``(pid, identity)`` — the shared body of
+    :func:`engine_liveness` and ``tui.data.liveness``, so both read the pid file once.
+    A probe failure degrades to ``'unknown'``, never a false ``'dead'``."""
+    host = get_process_host()  # ProcessHostError (misconfig) propagates, not masked as unknown
+    try:
+        return host.liveness_of(pid, identity)
+    except Exception:
+        return "unknown"
+
+
 # ----------------------------------------------------------- stop / delete / archive
 
 

--- a/src/automator/runs.py
+++ b/src/automator/runs.py
@@ -226,15 +226,18 @@ def session_project_tags() -> dict[str, str]:
     return get_multiplexer().session_options(PROJECT_OPTION)
 
 
-def prunable_sessions(project: Path) -> tuple[list[str], list[str]]:
-    """Partition the bmad-auto-<id> agent sessions into (prunable, live) run ids.
+def prunable_sessions(project: Path) -> tuple[list[str], list[str], set[str]]:
+    """Partition the bmad-auto-<id> agent sessions into (prunable, live) run ids,
+    plus the subset of prunable ids whose engine liveness read 'unknown'
+    (unverifiable pid). Unknown never blocks cleanup — those sessions stay
+    prunable — but frontends surface a warning for them.
 
     The control session (bmad-auto-ctl) is never a candidate. Pruning is scoped
     to `project` via the PROJECT_OPTION tag set at session creation:
 
     - tag == this project: ours — prunable unless a provably-alive engine pid is
       running (covers finished/stopped/crashed *and* orphans whose run dir was
-      deleted, since engine_alive is False with no pid).
+      deleted, since engine_liveness reads 'dead' with no pid).
     - tag is another project: skipped — never touched.
     - tag empty (pre-upgrade, untagged session): can't prove ownership, so fall
       back to the run dir — prunable only when the dir exists under this project
@@ -244,6 +247,7 @@ def prunable_sessions(project: Path) -> tuple[list[str], list[str]]:
     mine = project_tag(project)
     prunable: list[str] = []
     live: list[str] = []
+    unknown: set[str] = set()
     for name in tmux_sessions():
         if name == CTL_SESSION or not name.startswith(_SESSION_PREFIX):
             continue
@@ -255,17 +259,20 @@ def prunable_sessions(project: Path) -> tuple[list[str], list[str]]:
                 continue  # another project's session
         elif not is_run(run_dir):
             continue  # untagged and no run dir here — ownership unprovable
-        if engine_alive(run_dir):
+        liveness = engine_liveness(run_dir)
+        if liveness == "alive":
             live.append(run_id)
-        else:
-            prunable.append(run_id)
-    return prunable, live
+            continue
+        prunable.append(run_id)
+        if liveness == "unknown":
+            unknown.add(run_id)
+    return prunable, live, unknown
 
 
 def prune_sessions(project: Path, *, dry_run: bool = False) -> list[str]:
     """Kill every prunable bmad-auto-<id> session (see prunable_sessions);
     returns the run ids that were (or, with dry_run, would be) killed."""
-    prunable, _ = prunable_sessions(project)
+    prunable, _, _ = prunable_sessions(project)
     if not dry_run:
         for run_id in prunable:
             kill_session(run_id)

--- a/src/automator/tui/app.py
+++ b/src/automator/tui/app.py
@@ -555,10 +555,9 @@ class BmadAutoApp(App[None]):
 
     @work(thread=True, group="lifecycle")
     def _cleanup_sessions_worker(self) -> None:
-        # sample once for the unknown warning; prune_sessions re-partitions itself
-        # (same double-sample shape as cmd_cleanup — warnings only, never a gate)
-        _prunable, _live, unknown = runs.prunable_sessions(self.project)
-        killed = runs.prune_sessions(self.project)
+        # killed and unknown come from prune_sessions' single partition sample,
+        # so the warning below only ever names sessions that were actually pruned
+        killed, unknown = runs.prune_sessions(self.project)
         windows = launch.prune_ctl_windows(self.project)
         if unknown:
             self.call_from_thread(

--- a/src/automator/tui/app.py
+++ b/src/automator/tui/app.py
@@ -555,8 +555,18 @@ class BmadAutoApp(App[None]):
 
     @work(thread=True, group="lifecycle")
     def _cleanup_sessions_worker(self) -> None:
+        # sample once for the unknown warning; prune_sessions re-partitions itself
+        # (same double-sample shape as cmd_cleanup — warnings only, never a gate)
+        _prunable, _live, unknown = runs.prunable_sessions(self.project)
         killed = runs.prune_sessions(self.project)
         windows = launch.prune_ctl_windows(self.project)
+        if unknown:
+            self.call_from_thread(
+                self.notify,
+                f"{len(unknown)} pruned session(s) had an unverifiable engine pid "
+                f"(may still be live): {', '.join(sorted(unknown))}",
+                severity="warning",
+            )
         self.call_from_thread(
             self.notify,
             f"removed {len(killed)} session(s), {len(windows)} window(s)",

--- a/src/automator/tui/app.py
+++ b/src/automator/tui/app.py
@@ -557,7 +557,7 @@ class BmadAutoApp(App[None]):
     def _cleanup_sessions_worker(self) -> None:
         # killed and unknown come from prune_sessions' single partition sample,
         # so the warning below only ever names sessions that were actually pruned
-        killed, unknown = runs.prune_sessions(self.project)
+        killed, _live, unknown = runs.prune_sessions(self.project)
         windows = launch.prune_ctl_windows(self.project)
         if unknown:
             self.call_from_thread(

--- a/src/automator/tui/data.py
+++ b/src/automator/tui/data.py
@@ -30,8 +30,7 @@ from ..adapters.multiplexer import MultiplexerError, get_multiplexer
 from ..gates import ATTENTION_FILE
 from ..journal import JOURNAL_FILE, LOGS_DIR, STATE_FILE, load_state
 from ..model import RunState
-from ..process_host import get_process_host
-from ..runs import list_run_dirs, read_pid_identity, session_name
+from ..runs import list_run_dirs, probe_liveness, read_pid_identity, session_name
 
 # Run statuses shown by the dashboard.
 RUNNING = "running"
@@ -73,12 +72,10 @@ def liveness(run_dir: Path) -> str:
     pid, identity = read_pid_identity(run_dir)
     if pid is None:
         return _session_liveness(run_dir.name)
-    try:
-        # non-destructive identity-aware tri-state probe
-        return get_process_host().liveness_of(pid, identity)
-    except Exception:
-        # never falsely dead — an unexpected probe failure stays 'unknown'
-        return "unknown"
+    # Probe the pid we just read (shared body with runs.engine_liveness) rather than
+    # re-reading it, so a non-atomic pid rewrite can't split the two reads and flash
+    # a false 'dead' between "pid present" here and a re-read seeing an empty file.
+    return probe_liveness(pid, identity)
 
 
 def _session_liveness(run_id: str) -> str:

--- a/src/automator/tui/data.py
+++ b/src/automator/tui/data.py
@@ -30,6 +30,7 @@ from ..adapters.multiplexer import MultiplexerError, get_multiplexer
 from ..gates import ATTENTION_FILE
 from ..journal import JOURNAL_FILE, LOGS_DIR, STATE_FILE, load_state
 from ..model import RunState
+from ..process_host import ProcessHostError
 from ..runs import list_run_dirs, probe_liveness, read_pid_identity, session_name
 
 # Run statuses shown by the dashboard.
@@ -75,7 +76,13 @@ def liveness(run_dir: Path) -> str:
     # Probe the pid we just read (shared body with runs.engine_liveness) rather than
     # re-reading it, so a non-atomic pid rewrite can't split the two reads and flash
     # a false 'dead' between "pid present" here and a re-read seeing an empty file.
-    return probe_liveness(pid, identity)
+    try:
+        return probe_liveness(pid, identity)
+    except ProcessHostError:
+        # A misconfigured host (bad BMAD_AUTO_PROCESS_HOST) stays a hard error on
+        # CLI decision paths, but the display layer must degrade, not crash: the
+        # dashboard poll worker has no except and would take the whole app down.
+        return "unknown"
 
 
 def _session_liveness(run_id: str) -> str:

--- a/src/automator/tui/launch.py
+++ b/src/automator/tui/launch.py
@@ -209,6 +209,9 @@ def _ctl_window_candidates(project: Path) -> list[tuple[str, str]]:
                 continue  # another project's window
         elif not runs.is_run(run_dir):
             continue  # untagged and no run dir here — ownership unprovable
+        # boolean gate on purpose: an 'unknown' engine stays a candidate (unknown
+        # never blocks cleanup) with no per-window warning — the session-level
+        # unknown warning from prunable_sessions covers the operator surface.
         if runs.engine_alive(run_dir):
             continue
         candidates.append((win_id, name))

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -203,6 +203,20 @@ def test_cmd_clean_dry_run_removes_nothing(project, capsys):
     assert "would remove worktree" in out
 
 
+def test_cmd_clean_warns_unknown_liveness(project, monkeypatch, capsys):
+    # warn-only: 'unknown' stays reclaimable (classification unchanged); the
+    # frontend re-probes just to say so before removal.
+    install_bmad_config(project)
+    repo = project.project
+    run_dir = repo / ".automator" / "runs" / "20260101-000000-aaaa"
+    save_state(run_dir, RunState(run_id="r", project=str(repo), started_at="x", stopped=True))
+    monkeypatch.setattr(runs, "engine_liveness", lambda _rd: "unknown")
+
+    assert cli.cmd_clean(_clean_args(repo)) == 0
+    err = capsys.readouterr().err
+    assert "run 20260101-000000-aaaa: engine may still be live (unverifiable pid)" in err
+
+
 def test_cmd_clean_reclaims_and_keeps_protected(project, capsys):
     install_bmad_config(project)
     repo = project.project

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -797,7 +797,7 @@ def test_cleanup_dry_run_lists_without_pruning(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr(runs, "prunable_sessions", lambda _proj: (["fin-1"], ["live-1"], set()))
     monkeypatch.setattr(launch, "prunable_ctl_windows", lambda _proj: ["sweep-fin-1"])
     pruned: list[str] = []
-    monkeypatch.setattr(runs, "prune_sessions", lambda _proj: pruned.append("x") or [])
+    monkeypatch.setattr(runs, "prune_sessions", lambda _proj: pruned.append("x") or ([], set()))
 
     assert cli.main(["cleanup", "--project", str(tmp_path), "--dry-run"]) == 0
     out = capsys.readouterr().out
@@ -812,7 +812,7 @@ def test_cleanup_prunes_sessions_and_windows(tmp_path, monkeypatch, capsys):
     from automator.tui import launch
 
     monkeypatch.setattr(runs, "prunable_sessions", lambda _proj: (["fin-1"], [], set()))
-    monkeypatch.setattr(runs, "prune_sessions", lambda _proj: ["fin-1"])
+    monkeypatch.setattr(runs, "prune_sessions", lambda _proj: (["fin-1"], set()))
     monkeypatch.setattr(launch, "prune_ctl_windows", lambda _proj: ["sweep-fin-1"])
 
     assert cli.main(["cleanup", "--project", str(tmp_path)]) == 0
@@ -826,7 +826,7 @@ def test_cleanup_warns_per_unknown_session(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr(
         runs, "prunable_sessions", lambda _proj: (["fin-1", "odd-1"], [], {"odd-1"})
     )
-    monkeypatch.setattr(runs, "prune_sessions", lambda _proj: ["fin-1", "odd-1"])
+    monkeypatch.setattr(runs, "prune_sessions", lambda _proj: (["fin-1", "odd-1"], {"odd-1"}))
     monkeypatch.setattr(launch, "prune_ctl_windows", lambda _proj: [])
 
     assert cli.main(["cleanup", "--project", str(tmp_path)]) == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -794,7 +794,7 @@ def test_cleanup_dry_run_lists_without_pruning(tmp_path, monkeypatch, capsys):
     from automator import runs
     from automator.tui import launch
 
-    monkeypatch.setattr(runs, "prunable_sessions", lambda _proj: (["fin-1"], ["live-1"]))
+    monkeypatch.setattr(runs, "prunable_sessions", lambda _proj: (["fin-1"], ["live-1"], set()))
     monkeypatch.setattr(launch, "prunable_ctl_windows", lambda _proj: ["sweep-fin-1"])
     pruned: list[str] = []
     monkeypatch.setattr(runs, "prune_sessions", lambda _proj: pruned.append("x") or [])
@@ -811,12 +811,29 @@ def test_cleanup_prunes_sessions_and_windows(tmp_path, monkeypatch, capsys):
     from automator import runs
     from automator.tui import launch
 
-    monkeypatch.setattr(runs, "prunable_sessions", lambda _proj: (["fin-1"], []))
+    monkeypatch.setattr(runs, "prunable_sessions", lambda _proj: (["fin-1"], [], set()))
     monkeypatch.setattr(runs, "prune_sessions", lambda _proj: ["fin-1"])
     monkeypatch.setattr(launch, "prune_ctl_windows", lambda _proj: ["sweep-fin-1"])
 
     assert cli.main(["cleanup", "--project", str(tmp_path)]) == 0
     assert "removed 1 session(s), 1 ctl window(s)" in capsys.readouterr().out
+
+
+def test_cleanup_warns_per_unknown_session(tmp_path, monkeypatch, capsys):
+    from automator import runs
+    from automator.tui import launch
+
+    monkeypatch.setattr(
+        runs, "prunable_sessions", lambda _proj: (["fin-1", "odd-1"], [], {"odd-1"})
+    )
+    monkeypatch.setattr(runs, "prune_sessions", lambda _proj: ["fin-1", "odd-1"])
+    monkeypatch.setattr(launch, "prune_ctl_windows", lambda _proj: [])
+
+    assert cli.main(["cleanup", "--project", str(tmp_path)]) == 0
+    captured = capsys.readouterr()
+    assert "run odd-1: engine may still be live (unverifiable pid)" in captured.err
+    assert "fin-1: engine may still be live" not in captured.err  # only unknown ids warn
+    assert "removed 2 session(s), 0 ctl window(s)" in captured.out
 
 
 def test_resume_kills_stale_session_before_running(project, monkeypatch):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -553,7 +553,7 @@ def test_delete_unknown_warns_but_proceeds(tmp_path, monkeypatch, capsys):
     from automator import runs
 
     monkeypatch.setattr(runs, "engine_liveness", lambda _rd: "unknown")
-    run_dir = _make_run_with_state(tmp_path, "r1")  # no pid -> engine_alive False
+    run_dir = _make_run_with_state(tmp_path, "r1")
     assert cli.main(["delete", "--project", str(tmp_path), "r1"]) == 0
     assert "unverifiable pid" in capsys.readouterr().err
     assert not run_dir.exists()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -523,7 +523,7 @@ def test_stop_already_finished(tmp_path, monkeypatch, capsys):
 def test_delete_refuses_live_run_without_force(tmp_path, monkeypatch, capsys):
     from automator import runs
 
-    monkeypatch.setattr(runs, "engine_alive", lambda _rd: True)
+    monkeypatch.setattr(runs, "engine_liveness", lambda _rd: "alive")
     run_dir = _make_run_with_state(tmp_path, "r1")
     assert cli.main(["delete", "--project", str(tmp_path), "r1"]) == 1
     assert "stop it first" in capsys.readouterr().err
@@ -534,7 +534,7 @@ def test_delete_force_stops_then_removes(tmp_path, monkeypatch, capsys):
     from automator import runs
 
     stopped = []
-    monkeypatch.setattr(runs, "engine_alive", lambda _rd: True)
+    monkeypatch.setattr(runs, "engine_liveness", lambda _rd: "alive")
     monkeypatch.setattr(runs, "stop_run", lambda rd: stopped.append(rd) or True)
     run_dir = _make_run_with_state(tmp_path, "r1")
     assert cli.main(["delete", "--project", str(tmp_path), "r1", "--force"]) == 0
@@ -546,6 +546,26 @@ def test_delete_force_stops_then_removes(tmp_path, monkeypatch, capsys):
 def test_delete_dead_run(tmp_path, capsys):
     run_dir = _make_run_with_state(tmp_path, "r1")  # no pid -> not alive
     assert cli.main(["delete", "--project", str(tmp_path), "r1"]) == 0
+    assert not run_dir.exists()
+
+
+def test_delete_unknown_warns_but_proceeds(tmp_path, monkeypatch, capsys):
+    from automator import runs
+
+    monkeypatch.setattr(runs, "engine_liveness", lambda _rd: "unknown")
+    run_dir = _make_run_with_state(tmp_path, "r1")  # no pid -> engine_alive False
+    assert cli.main(["delete", "--project", str(tmp_path), "r1"]) == 0
+    assert "unverifiable pid" in capsys.readouterr().err
+    assert not run_dir.exists()
+
+
+def test_archive_unknown_warns_but_proceeds(tmp_path, monkeypatch, capsys):
+    from automator import runs
+
+    monkeypatch.setattr(runs, "engine_liveness", lambda _rd: "unknown")
+    run_dir = _make_run_with_state(tmp_path, "20260611-100000-aaaa")
+    assert cli.main(["archive", "--project", str(tmp_path), "20260611-100000-aaaa"]) == 0
+    assert "unverifiable pid" in capsys.readouterr().err
     assert not run_dir.exists()
 
 
@@ -562,7 +582,7 @@ def test_archive_creates_tarball_and_removes_run(tmp_path, capsys):
 def test_archive_refuses_live_run_without_force(tmp_path, monkeypatch, capsys):
     from automator import runs
 
-    monkeypatch.setattr(runs, "engine_alive", lambda _rd: True)
+    monkeypatch.setattr(runs, "engine_liveness", lambda _rd: "alive")
     run_dir = _make_run_with_state(tmp_path, "r1")
     assert cli.main(["archive", "--project", str(tmp_path), "r1"]) == 1
     assert "stop it first" in capsys.readouterr().err
@@ -594,13 +614,15 @@ def test_resolve_rejects_non_escalation_stage(tmp_path, capsys):
     assert "not paused at an escalation" in capsys.readouterr().err
 
 
-def test_resolve_refuses_live_run(tmp_path, monkeypatch, capsys):
+# resolve refuses 'unknown' too, not just 'alive' — re-driving a possibly-live engine.
+@pytest.mark.parametrize("liveness", ["alive", "unknown"])
+def test_resolve_refuses_live_run(tmp_path, monkeypatch, capsys, liveness):
     from automator import runs
 
-    monkeypatch.setattr(runs, "engine_alive", lambda _rd: True)
+    monkeypatch.setattr(runs, "engine_liveness", lambda _rd: liveness)
     _escalated_run(tmp_path, "r1")
     assert cli.main(["resolve", "--project", str(tmp_path), "r1"]) == 1
-    assert "still live" in capsys.readouterr().err
+    assert "may still be live" in capsys.readouterr().err
 
 
 def test_resolve_no_escalated_story(tmp_path, capsys):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -615,14 +615,50 @@ def test_resolve_rejects_non_escalation_stage(tmp_path, capsys):
 
 
 # resolve refuses 'unknown' too, not just 'alive' — re-driving a possibly-live engine.
-@pytest.mark.parametrize("liveness", ["alive", "unknown"])
-def test_resolve_refuses_live_run(tmp_path, monkeypatch, capsys, liveness):
+@pytest.mark.parametrize(
+    "liveness,msg",
+    [("alive", "is still live — stop it first"), ("unknown", "unverifiable pid")],
+)
+def test_resolve_refuses_live_run(tmp_path, monkeypatch, capsys, liveness, msg):
     from automator import runs
 
     monkeypatch.setattr(runs, "engine_liveness", lambda _rd: liveness)
     _escalated_run(tmp_path, "r1")
     assert cli.main(["resolve", "--project", str(tmp_path), "r1"]) == 1
-    assert "may still be live" in capsys.readouterr().err
+    err = capsys.readouterr().err
+    assert msg in err
+    if liveness == "unknown":
+        assert "--force" in err  # the refusal carries the recovery instructions
+
+
+def test_resolve_force_alive_still_refuses(tmp_path, monkeypatch, capsys):
+    from automator import runs
+
+    monkeypatch.setattr(runs, "engine_liveness", lambda _rd: "alive")
+    _escalated_run(tmp_path, "r1")
+    assert cli.main(["resolve", "--project", str(tmp_path), "r1", "--force"]) == 1
+    assert "is still live — stop it first" in capsys.readouterr().err
+
+
+def test_resolve_force_unknown_proceeds(tmp_path, monkeypatch, capsys):
+    # --force is the only escape from a squatted/unverifiable pid: `stop` cannot
+    # clear 'unknown' (engine.pid is never deleted), so without it resolve would
+    # refuse forever.
+    from automator import runs
+    from automator.journal import load_state
+    from automator.model import Phase
+
+    monkeypatch.setattr(runs, "engine_liveness", lambda _rd: "unknown")
+    run_dir = _escalated_run(tmp_path, "r1")
+    resumed = []
+    monkeypatch.setattr(cli, "_resume_paused_run", lambda proj, rd: resumed.append(rd) or 0)
+    rc = cli.main(
+        ["resolve", "--project", str(tmp_path), "r1", "--force", "--no-interactive", "--resume"]
+    )
+    assert rc == 0
+    assert "proceeding anyway (--force)" in capsys.readouterr().err
+    assert resumed == [run_dir]
+    assert load_state(run_dir).tasks["s1"].phase == Phase.PENDING  # past the gate, re-armed
 
 
 def test_resolve_no_escalated_story(tmp_path, capsys):
@@ -840,6 +876,48 @@ def test_resume_restores_persisted_run_scope(project, monkeypatch):
     assert captured["epic_filter"] == 9
     assert captured["story_filter"] == "9-0"
     assert captured["max_stories"] == 4
+
+
+def test_resume_refuses_live_run(tmp_path, monkeypatch, capsys):
+    from automator import runs
+
+    monkeypatch.setattr(runs, "engine_liveness", lambda _rd: "alive")
+
+    def _fail(*_a, **_k):
+        raise AssertionError("resumed a live run")
+
+    monkeypatch.setattr(cli, "_resume_paused_run", _fail)
+    _make_run_with_state(tmp_path, "r1", paused_reason="x", paused_stage="spec-approval")
+    assert cli.main(["resume", "--project", str(tmp_path), "r1"]) == 1
+    assert "double-drive" in capsys.readouterr().err
+
+
+def test_resume_unknown_warns_but_proceeds(project, monkeypatch, capsys):
+    # resume must remain the unknown-recovery path: it warns, then rewrites
+    # engine.pid via runs.write_pid — blocking here would make a squatted pid
+    # permanently unrecoverable (resolve refuses 'unknown' without --force).
+    from conftest import install_base_skills
+
+    from automator import runs
+
+    install_bmad_config(project)
+    install_base_skills(project)
+    write_sprint(project, {"1-1-a": "ready-for-dev"})
+    run_dir = _make_run_with_state(
+        project.project,
+        "20990101-000000-beef",
+        paused_reason="escalation",
+        paused_stage="escalation",
+    )
+    monkeypatch.setattr(runs, "engine_liveness", lambda _rd: "unknown")
+    monkeypatch.setattr(runs, "kill_session", lambda _rid: None)
+    monkeypatch.setattr(cli, "Engine", _StubEngine)
+    monkeypatch.setattr(cli, "_make_adapters", lambda *a, **k: {r: None for r in cli.ROLES})
+
+    rc = cli.main(["resume", "--project", str(project.project), "20990101-000000-beef"])
+    assert rc == 0
+    assert "may still be live (unverifiable pid)" in capsys.readouterr().err
+    assert (run_dir / "engine.pid").is_file()  # pid rewritten — recovery happened
 
 
 def test_diagnose_default_latest_and_out(project, tmp_path, capsys):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -543,6 +543,38 @@ def test_delete_force_stops_then_removes(tmp_path, monkeypatch, capsys):
     assert not run_dir.exists()
 
 
+def test_delete_force_stop_error_blocks(tmp_path, monkeypatch, capsys):
+    # a failed --force stop must propagate, never fall through to deletion
+    from automator import runs
+
+    monkeypatch.setattr(runs, "engine_liveness", lambda _rd: "alive")
+
+    def _raise(_rd):
+        raise runs.StopRunError("boom")
+
+    monkeypatch.setattr(runs, "stop_run", _raise)
+    run_dir = _make_run_with_state(tmp_path, "r1")
+    assert cli.main(["delete", "--project", str(tmp_path), "r1", "--force"]) == 1
+    assert "boom" in capsys.readouterr().err
+    assert run_dir.exists()
+
+
+def test_archive_force_stop_error_blocks(tmp_path, monkeypatch, capsys):
+    from automator import runs
+    from automator.process_host import ProcessHostError
+
+    monkeypatch.setattr(runs, "engine_liveness", lambda _rd: "alive")
+
+    def _raise(_rd):
+        raise ProcessHostError("host probe failed")
+
+    monkeypatch.setattr(runs, "stop_run", _raise)
+    run_dir = _make_run_with_state(tmp_path, "r1")
+    assert cli.main(["archive", "--project", str(tmp_path), "r1", "--force"]) == 1
+    assert "host probe failed" in capsys.readouterr().err
+    assert run_dir.exists()
+
+
 def test_delete_dead_run(tmp_path, capsys):
     run_dir = _make_run_with_state(tmp_path, "r1")  # no pid -> not alive
     assert cli.main(["delete", "--project", str(tmp_path), "r1"]) == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -826,25 +826,27 @@ def test_cleanup_dry_run_lists_without_pruning(tmp_path, monkeypatch, capsys):
     from automator import runs
     from automator.tui import launch
 
-    monkeypatch.setattr(runs, "prunable_sessions", lambda _proj: (["fin-1"], ["live-1"], set()))
     monkeypatch.setattr(launch, "prunable_ctl_windows", lambda _proj: ["sweep-fin-1"])
-    pruned: list[str] = []
-    monkeypatch.setattr(runs, "prune_sessions", lambda _proj: pruned.append("x") or ([], set()))
+    dry_runs: list[bool] = []
+    monkeypatch.setattr(
+        runs,
+        "prune_sessions",
+        lambda _proj, dry_run=False: dry_runs.append(dry_run) or (["fin-1"], ["live-1"], set()),
+    )
 
     assert cli.main(["cleanup", "--project", str(tmp_path), "--dry-run"]) == 0
     out = capsys.readouterr().out
     assert "would kill session bmad-auto-fin-1" in out
     assert "would close ctl window sweep-fin-1" in out
     assert "leaving 1 live session(s) untouched" in out
-    assert pruned == []  # dry-run prunes nothing
+    assert dry_runs == [True]  # one partition sample, with the kill suppressed
 
 
 def test_cleanup_prunes_sessions_and_windows(tmp_path, monkeypatch, capsys):
     from automator import runs
     from automator.tui import launch
 
-    monkeypatch.setattr(runs, "prunable_sessions", lambda _proj: (["fin-1"], [], set()))
-    monkeypatch.setattr(runs, "prune_sessions", lambda _proj: (["fin-1"], set()))
+    monkeypatch.setattr(runs, "prune_sessions", lambda _proj, dry_run=False: (["fin-1"], [], set()))
     monkeypatch.setattr(launch, "prune_ctl_windows", lambda _proj: ["sweep-fin-1"])
 
     assert cli.main(["cleanup", "--project", str(tmp_path)]) == 0
@@ -856,9 +858,8 @@ def test_cleanup_warns_per_unknown_session(tmp_path, monkeypatch, capsys):
     from automator.tui import launch
 
     monkeypatch.setattr(
-        runs, "prunable_sessions", lambda _proj: (["fin-1", "odd-1"], [], {"odd-1"})
+        runs, "prune_sessions", lambda _proj, dry_run=False: (["fin-1", "odd-1"], [], {"odd-1"})
     )
-    monkeypatch.setattr(runs, "prune_sessions", lambda _proj: (["fin-1", "odd-1"], {"odd-1"}))
     monkeypatch.setattr(launch, "prune_ctl_windows", lambda _proj: [])
 
     assert cli.main(["cleanup", "--project", str(tmp_path)]) == 0

--- a/tests/test_process_host.py
+++ b/tests/test_process_host.py
@@ -107,8 +107,16 @@ def test_alive_and_ours_matches_only_same_identity(host, monkeypatch):
     monkeypatch.setattr(host, "identity", lambda pid: 123.0)
     assert host.alive_and_ours(4242, 123.0) is True
     assert host.alive_and_ours(4242, 999.0) is False  # reused
+    # Unreadable identity is not-ours whether the pid is gone or still running —
+    # 'unknown' must never read as ours on the strict/destructive path. Stub
+    # is_alive too: alive_and_ours (via liveness_of) probes it on this branch, and
+    # the real PosixProcessHost.is_alive would os.kill on a native-Windows CI
+    # runner (WinError 87).
     monkeypatch.setattr(host, "identity", lambda pid: None)
-    assert host.alive_and_ours(4242, 123.0) is False  # gone or unreadable → not-ours
+    monkeypatch.setattr(host, "is_alive", lambda pid: False)
+    assert host.alive_and_ours(4242, 123.0) is False  # gone
+    monkeypatch.setattr(host, "is_alive", lambda pid: True)
+    assert host.alive_and_ours(4242, 123.0) is False  # live but unreadable → unknown
 
 
 def test_liveness_of_reads_alive_dead_and_unknown(host, monkeypatch):

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -80,6 +80,20 @@ class _FakeHost:
             return self.is_alive(pid)
         return self.identity(pid) == identity
 
+    def liveness_of(self, pid, identity):
+        # Mirrors ProcessHost.liveness_of (tri-state, biased away from false-dead):
+        # a still-alive pid with an unreadable identity reads 'unknown', not 'dead'.
+        if pid <= 0:
+            return "dead"
+        if identity is None:
+            return "alive" if self.is_alive(pid) else "dead"
+        current = self.identity(pid)
+        if current == identity:
+            return "alive"
+        if current is None and self.is_alive(pid):
+            return "unknown"
+        return "dead"
+
 
 def test_list_run_dirs_sorted_and_filtered(tmp_path):
     _make_run(tmp_path, "20260611-120000-bbbb")
@@ -201,6 +215,44 @@ def test_read_pid_identity_forms(tmp_path):
     assert runs.read_pid_identity(run_dir) == (4242, 678.5)
     (run_dir / "engine.pid").write_text("not-a-pid 1.0")  # unparseable pid
     assert runs.read_pid_identity(run_dir) == (None, None)
+
+
+def test_engine_liveness(tmp_path, monkeypatch):
+    run_dir = _make_run(tmp_path, "r1")
+    assert runs.engine_liveness(run_dir) == "dead"  # no pid file → nothing to gate on
+
+    (run_dir / "engine.pid").write_text("4242 100.0")
+
+    def use(host):
+        monkeypatch.setattr(runs, "get_process_host", lambda: host)
+
+    use(_FakeHost(alive=True, identity=100.0))
+    assert runs.engine_liveness(run_dir) == "alive"  # identity matches
+
+    use(_FakeHost(alive=True, identity=999.0))
+    assert runs.engine_liveness(run_dir) == "dead"  # reused pid: identity differs
+
+    # live pid whose identity is unreadable (win32 ERROR_ACCESS_DENIED) → unknown, not dead
+    use(_FakeHost(alive=True, identity=None))
+    assert runs.engine_liveness(run_dir) == "unknown"
+
+    class _Boom:  # an unexpected probe failure degrades to unknown, never a false dead
+        def liveness_of(self, pid, identity):
+            raise RuntimeError("probe blew up")
+
+    use(_Boom())
+    assert runs.engine_liveness(run_dir) == "unknown"
+
+    # A misconfigured host (get_process_host itself raising) is a hard error, not a
+    # flaky per-pid probe — it must propagate, never mask as 'unknown'.
+    from automator.process_host import ProcessHostError
+
+    def _boom_host():
+        raise ProcessHostError("BMAD_AUTO_PROCESS_HOST matches no registered host")
+
+    monkeypatch.setattr(runs, "get_process_host", _boom_host)
+    with pytest.raises(ProcessHostError):
+        runs.engine_liveness(run_dir)
 
 
 @pytest.mark.parametrize("identity_token", ["garbage", "nan", "inf", "-inf"])

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -503,10 +503,25 @@ def test_prune_sessions_dry_run_kills_nothing(tmp_path, monkeypatch):
     monkeypatch.setattr(
         runs, "session_project_tags", lambda: {"bmad-auto-fin-1": runs.project_tag(tmp_path)}
     )
-    assert runs.prune_sessions(tmp_path, dry_run=True) == ["fin-1"]
+    assert runs.prune_sessions(tmp_path, dry_run=True) == (["fin-1"], set())
     assert killed == []
-    assert runs.prune_sessions(tmp_path) == ["fin-1"]
+    assert runs.prune_sessions(tmp_path) == (["fin-1"], set())
     assert killed == ["fin-1"]
+
+
+def test_prune_sessions_returns_unknown_from_same_sample(tmp_path, monkeypatch):
+    # the unknown subset must come from the partition prune_sessions itself
+    # killed, so a frontend warning built from it never names an unpruned session
+    mine = runs.project_tag(tmp_path)
+    odd = _make_state_run(tmp_path, "odd-1")
+    (odd / "engine.pid").write_text("4242 123.0")
+    killed: list[str] = []
+    monkeypatch.setattr(runs, "kill_session", lambda rid: killed.append(rid))
+    monkeypatch.setattr(runs, "tmux_sessions", lambda: ["bmad-auto-odd-1"])
+    monkeypatch.setattr(runs, "session_project_tags", lambda: {"bmad-auto-odd-1": mine})
+    monkeypatch.setattr(runs, "get_process_host", lambda: _FakeHost(alive=True, identity=None))
+    assert runs.prune_sessions(tmp_path) == (["odd-1"], {"odd-1"})
+    assert killed == ["odd-1"]
 
 
 def test_delete_run(tmp_path):

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -489,10 +489,26 @@ def test_prunable_sessions_partitions(tmp_path, monkeypatch):
             # untag-* and unrelated intentionally absent (no tag)
         },
     )
-    prunable, alive = runs.prunable_sessions(tmp_path)
+    prunable, alive, unknown = runs.prunable_sessions(tmp_path)
     # other-1 (foreign tag) and untag-orphan (unprovable) are skipped entirely
     assert sorted(prunable) == ["fin-1", "orphan-1", "untag-fin"]
     assert alive == ["live-1"]
+    assert unknown == set()
+
+
+def test_prunable_sessions_flags_unknown(tmp_path, monkeypatch):
+    # live pid, unreadable identity (win32 ERROR_ACCESS_DENIED) → prunable anyway
+    # (unknown never blocks cleanup) but flagged so frontends can warn.
+    mine = runs.project_tag(tmp_path)
+    odd = _make_state_run(tmp_path, "odd-1")
+    (odd / "engine.pid").write_text("4242 123.0")
+    monkeypatch.setattr(runs, "tmux_sessions", lambda: ["bmad-auto-odd-1"])
+    monkeypatch.setattr(runs, "session_project_tags", lambda: {"bmad-auto-odd-1": mine})
+    monkeypatch.setattr(runs, "get_process_host", lambda: _FakeHost(alive=True, identity=None))
+    prunable, live, unknown = runs.prunable_sessions(tmp_path)
+    assert prunable == ["odd-1"]
+    assert live == []
+    assert unknown == {"odd-1"}
 
 
 def test_prune_sessions_dry_run_kills_nothing(tmp_path, monkeypatch):

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -12,6 +12,7 @@ from automator import runs
 from automator.adapters import tmux_base
 from automator.journal import load_state, save_state
 from automator.model import RunState
+from automator.process_host import ProcessHost
 
 
 def _make_run(project, run_id, with_state=True):
@@ -44,11 +45,13 @@ def _dead_pid() -> int:
     return proc.pid
 
 
-class _FakeHost:
-    """A ProcessHost stand-in for driving stop_run's escalation deterministically
-    without spawning real processes. ``alive`` / ``identity`` may be a value or a
-    zero-arg callable (so they can change between the stop-time read and the
-    post-grace check)."""
+class _FakeHost(ProcessHost):
+    """A ProcessHost for driving stop_run's escalation deterministically without
+    spawning real processes. ``alive`` / ``identity`` may be a value or a zero-arg
+    callable (so they can change between the stop-time read and the post-grace
+    check). A real subclass on purpose: ``alive_and_ours`` and ``liveness_of``
+    are inherited, so these tests exercise the production decision table instead
+    of a hand-copied mirror that could silently drift."""
 
     def __init__(self, *, alive, identity=1.0, on_terminate=None):
         self._alive = alive
@@ -71,28 +74,8 @@ class _FakeHost:
     def identity(self, pid):
         return self._identity() if callable(self._identity) else self._identity
 
-    def alive_and_ours(self, pid, identity):
-        # Mirrors ProcessHost.alive_and_ours (strict): pid<=0 short-circuits, identity
-        # None degrades to is_alive, else the recorded identity must still match.
-        if pid <= 0:
-            return False
-        if identity is None:
-            return self.is_alive(pid)
-        return self.identity(pid) == identity
-
-    def liveness_of(self, pid, identity):
-        # Mirrors ProcessHost.liveness_of (tri-state, biased away from false-dead):
-        # a still-alive pid with an unreadable identity reads 'unknown', not 'dead'.
-        if pid <= 0:
-            return "dead"
-        if identity is None:
-            return "alive" if self.is_alive(pid) else "dead"
-        current = self.identity(pid)
-        if current == identity:
-            return "alive"
-        if current is None and self.is_alive(pid):
-            return "unknown"
-        return "dead"
+    def hook_interpreter(self):
+        return "python3"
 
 
 def test_list_run_dirs_sorted_and_filtered(tmp_path):

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -503,9 +503,9 @@ def test_prune_sessions_dry_run_kills_nothing(tmp_path, monkeypatch):
     monkeypatch.setattr(
         runs, "session_project_tags", lambda: {"bmad-auto-fin-1": runs.project_tag(tmp_path)}
     )
-    assert runs.prune_sessions(tmp_path, dry_run=True) == (["fin-1"], set())
+    assert runs.prune_sessions(tmp_path, dry_run=True) == (["fin-1"], [], set())
     assert killed == []
-    assert runs.prune_sessions(tmp_path) == (["fin-1"], set())
+    assert runs.prune_sessions(tmp_path) == (["fin-1"], [], set())
     assert killed == ["fin-1"]
 
 
@@ -520,7 +520,7 @@ def test_prune_sessions_returns_unknown_from_same_sample(tmp_path, monkeypatch):
     monkeypatch.setattr(runs, "tmux_sessions", lambda: ["bmad-auto-odd-1"])
     monkeypatch.setattr(runs, "session_project_tags", lambda: {"bmad-auto-odd-1": mine})
     monkeypatch.setattr(runs, "get_process_host", lambda: _FakeHost(alive=True, identity=None))
-    assert runs.prune_sessions(tmp_path) == (["odd-1"], {"odd-1"})
+    assert runs.prune_sessions(tmp_path) == (["odd-1"], [], {"odd-1"})
     assert killed == ["odd-1"]
 
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1090,8 +1090,7 @@ async def test_cleanup_unknown_sessions_notifies(project, monkeypatch):
     from automator import runs
 
     monkeypatch.setattr(launch, "tmux_available", lambda: True)
-    monkeypatch.setattr(runs, "prunable_sessions", lambda _p: (["odd-1"], [], {"odd-1"}))
-    monkeypatch.setattr(runs, "prune_sessions", lambda _p: ["odd-1"])
+    monkeypatch.setattr(runs, "prune_sessions", lambda _p: (["odd-1"], {"odd-1"}))
     monkeypatch.setattr(launch, "prune_ctl_windows", lambda _p: [])
     make_run(project.project, "20260611-100000-aaaa")
     app = BmadAutoApp(project.project)

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1100,9 +1100,7 @@ async def test_cleanup_unknown_sessions_notifies(project, monkeypatch):
         await pilot.press("c")
         await until(pilot, lambda: isinstance(app.screen, ConfirmModal))
         await pilot.click(await ready(pilot, "#ok"))
-        await until(
-            pilot, lambda: any("unverifiable engine pid" in m for m in notifications(app))
-        )
+        await until(pilot, lambda: any("unverifiable engine pid" in m for m in notifications(app)))
         assert any("removed 1 session(s)" in m for m in notifications(app))
 
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1090,7 +1090,7 @@ async def test_cleanup_unknown_sessions_notifies(project, monkeypatch):
     from automator import runs
 
     monkeypatch.setattr(launch, "tmux_available", lambda: True)
-    monkeypatch.setattr(runs, "prune_sessions", lambda _p: (["odd-1"], {"odd-1"}))
+    monkeypatch.setattr(runs, "prune_sessions", lambda _p: (["odd-1"], [], {"odd-1"}))
     monkeypatch.setattr(launch, "prune_ctl_windows", lambda _p: [])
     make_run(project.project, "20260611-100000-aaaa")
     app = BmadAutoApp(project.project)

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1084,6 +1084,28 @@ async def test_delete_unknown_pid_warns_but_does_not_block(project, monkeypatch)
         assert "cannot be undone" in app.screen._warning
 
 
+async def test_cleanup_unknown_sessions_notifies(project, monkeypatch):
+    # cleanup still prunes 'unknown' sessions (unknown never blocks cleanup) but
+    # must say so instead of silently killing a possibly-live engine's session.
+    from automator import runs
+
+    monkeypatch.setattr(launch, "tmux_available", lambda: True)
+    monkeypatch.setattr(runs, "prunable_sessions", lambda _p: (["odd-1"], [], {"odd-1"}))
+    monkeypatch.setattr(runs, "prune_sessions", lambda _p: ["odd-1"])
+    monkeypatch.setattr(launch, "prune_ctl_windows", lambda _p: [])
+    make_run(project.project, "20260611-100000-aaaa")
+    app = BmadAutoApp(project.project)
+    async with app.run_test() as pilot:
+        await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
+        await pilot.press("c")
+        await until(pilot, lambda: isinstance(app.screen, ConfirmModal))
+        await pilot.click(await ready(pilot, "#ok"))
+        await until(
+            pilot, lambda: any("unverifiable engine pid" in m for m in notifications(app))
+        )
+        assert any("removed 1 session(s)" in m for m in notifications(app))
+
+
 async def test_resume_finished_run_refused(project, monkeypatch):
     monkeypatch.setattr(launch, "tmux_available", lambda: True)
     make_run(project.project, "20260611-100000-aaaa", finished=True)

--- a/tests/test_tui_data.py
+++ b/tests/test_tui_data.py
@@ -130,6 +130,8 @@ def test_discover_runs_classification(tmp_path):
 
 
 def test_live_pid_with_unreadable_identity_is_unknown_not_interrupted(tmp_path, monkeypatch):
+    from automator import runs
+
     run_dir = make_run(tmp_path, "20260611-100000-aaaa")
     (run_dir / "engine.pid").write_text("4242 123.0")
 
@@ -137,8 +139,9 @@ def test_live_pid_with_unreadable_identity_is_unknown_not_interrupted(tmp_path, 
         def liveness_of(self, pid, identity):
             return "unknown"
 
-    host = Host()
-    monkeypatch.setattr(data, "get_process_host", lambda: host)
+    # data.liveness delegates its pid branch to runs.engine_liveness, so the host seam
+    # is now read there; patch it there to exercise the full delegation path.
+    monkeypatch.setattr(runs, "get_process_host", lambda: Host())
     assert data.liveness(run_dir) == "unknown"
     assert data.discover_runs(tmp_path)[0].status == data.UNKNOWN
 

--- a/tests/test_tui_data.py
+++ b/tests/test_tui_data.py
@@ -146,6 +146,24 @@ def test_live_pid_with_unreadable_identity_is_unknown_not_interrupted(tmp_path, 
     assert data.discover_runs(tmp_path)[0].status == data.UNKNOWN
 
 
+def test_process_host_misconfig_degrades_to_unknown(tmp_path, monkeypatch):
+    # A ProcessHostError from get_process_host (bad BMAD_AUTO_PROCESS_HOST) must not
+    # escape the display layer: the dashboard poll worker has no except and would
+    # take the whole app down. The status column degrades to 'unknown' instead.
+    from automator import runs
+    from automator.process_host import ProcessHostError
+
+    run_dir = make_run(tmp_path, "20260611-100000-aaaa")
+    (run_dir / "engine.pid").write_text("4242 123.0")
+
+    def boom():
+        raise ProcessHostError("BMAD_AUTO_PROCESS_HOST matches no registered host")
+
+    monkeypatch.setattr(runs, "get_process_host", boom)
+    assert data.liveness(run_dir) == "unknown"
+    assert data.discover_runs(tmp_path)[0].status == data.UNKNOWN
+
+
 def test_stopped_run_classifies_as_stopped_not_interrupted(tmp_path):
     # a deliberate stop leaves a dead pid; it must read STOPPED, not INTERRUPTED
     run_dir = make_run(tmp_path, "20260611-100000-aaaa", stopped=True)


### PR DESCRIPTION
## What

Routes the CLI's `resolve` / `delete` / `archive` commands through a tri-state liveness read so a live-but-unreadable engine pid (`unknown`) is surfaced instead of silently read as dead — bringing the CLI to parity with the TUI half of the fix.

## Why

On native Windows a running engine whose identity is unreadable (`psutil.create_time()` → `ERROR_ACCESS_DENIED`) reads as tri-state `unknown`. The CLI gated only on the strict boolean `runs.engine_alive`, which collapses `unknown` to `False`, so `resolve` could launch a driver against a possibly-live engine (double-drive) and `delete`/`archive` proceeded with no warning while the engine may still be writing the run dir. POSIX is unaffected.

Fixes #38

## How

- Added `runs.engine_liveness` (plus a shared `probe_liveness` body) wrapping `ProcessHost.liveness_of`, so the CLI reads tri-state liveness without importing TUI modules; `unknown` is preserved and an unexpected probe failure degrades to `unknown`, never a false `dead`.
- `resolve` now refuses on `alive` **or** `unknown` (both possibly-live); `delete`/`archive` warn `engine may still be live (unverifiable pid)` on `unknown` but still proceed — an unverifiable/recycled pid must never block cleanup forever. A single liveness sample drives both the warning and the strict block, so a mid-check identity flip can't fire one without the other.
- Routed `tui.data.liveness` through the shared `probe_liveness`, keeping one copy of the pid-liveness logic and reading the pid file once.

## Testing

`pytest tests/test_runs.py tests/test_cli.py tests/test_tui_data.py tests/test_process_host.py` — added cases for the tri-state read (no-pid→dead, alive, reused→dead, unreadable→unknown, probe-raises→unknown), `resolve` refusing on `unknown`, `delete`/`archive` warn-but-proceed on `unknown`, and the TUI delegation regression. Full suite green (1303 passed; the only failures are a pre-existing skill-sync drift, unrelated to this change).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--force` option to `resolve`, allowing operators to continue when engine liveness is unverifiable (`unknown`) while still blocking provably-live engines.
* **Bug Fixes**
  * Engine liveness is now tri-state (live, dead, unverifiable), improving how resume/resolve/delete/archive/cleanup decisions are made.
  * `delete`, `archive`, `clean`, and cleanup/TUI flows now warn for unverifiable PIDs and proceed safely when appropriate.
  * `resume` now blocks provably-live engines, but warns and recovers when liveness is unverifiable.
* **Tests**
  * Updated and expanded CLI/TUI/run liveness coverage for the new tri-state behavior and `--force` handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->