### PR TITLE
ci: parallelize pytest with xdist, trim PR windows matrix, add job timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
   test:
     name: test (py${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -48,12 +49,13 @@ jobs:
         run: uv sync --locked --all-extras
 
       - name: Run tests
-        run: uv run pytest -q
+        run: uv run pytest -q -n auto --durations=15
 
   test-windows:
     # Real-Windows runner for the deterministic suite (live psmux e2e stays a manual gate).
     name: test (windows, py${{ matrix.python-version }})
     runs-on: windows-latest
+    timeout-minutes: 15
     # The suite reads/writes UTF-8 files; Windows' cp1252 default would break plain
     # text I/O. UTF-8 mode (PEP 686's Python 3.15 default) makes the runner match the
     # files under test; the conftest guard enforces the same for local win32 runs.
@@ -62,7 +64,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.11', '3.12', '3.13', '3.14']
+        # PRs run the version boundaries only (Windows failures here have been
+        # platform-shaped, not version-shaped); push-to-main runs the full spread.
+        python-version: ${{ github.event_name == 'pull_request' && fromJSON('["3.11", "3.14"]') || fromJSON('["3.11", "3.12", "3.13", "3.14"]') }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -78,11 +82,12 @@ jobs:
         run: uv sync --locked --all-extras
 
       - name: Run tests
-        run: uv run pytest -q
+        run: uv run pytest -q -n auto --durations=15
 
   version-sync:
     name: version-sync
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v7
 
@@ -95,6 +100,8 @@ jobs:
   lint:
     name: lint (trunk)
     runs-on: ubuntu-latest
+    # Headroom for a cold trunk tool-download cache; normally ~30s.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dev = [
   "ruff>=0.4",
   "pytest-asyncio>=1.0",
   "pytest-rerunfailures>=16.0",
+  "pytest-xdist>=3.6",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/tests/test_generic_tmux.py
+++ b/tests/test_generic_tmux.py
@@ -11,6 +11,7 @@ import shutil
 import subprocess
 import sys
 import time
+import uuid
 from pathlib import Path
 
 import pytest
@@ -46,7 +47,11 @@ sleep 60  # stay alive like an idle interactive session
 def make_adapter(
     tmp_path, profile_name="claude", binary=None, extra_args=None, **policy_kw
 ) -> GenericTmuxAdapter:
-    run_dir = tmp_path / "run"
+    # session_name derives from run_dir.name, and the live tests all share one
+    # tmux server — a fixed "run" name races one test's kill-session teardown
+    # against another's new-window under pytest-xdist. Production run dirs are
+    # unique run ids, so unique-per-adapter matches reality.
+    run_dir = tmp_path / f"run-{uuid.uuid4().hex[:8]}"
     policy = Policy(limits=LimitsPolicy(**policy_kw) if policy_kw else LimitsPolicy())
     profile = get_profile(profile_name)
     return GenericTmuxAdapter(

--- a/uv.lock
+++ b/uv.lock
@@ -25,6 +25,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-rerunfailures" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
 ]
 
@@ -43,6 +44,7 @@ dev = [
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=1.0" },
     { name = "pytest-rerunfailures", specifier = ">=16.0" },
+    { name = "pytest-xdist", specifier = ">=3.6" },
     { name = "ruff", specifier = ">=0.4" },
 ]
 
@@ -53,6 +55,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
 ]
 
 [[package]]
@@ -230,6 +241,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/4d/f0/74f8e685be7ecd1572c1256132f18fce3a665d7e07649a3f23b7eb2d3bec/pytest_rerunfailures-16.3.tar.gz", hash = "sha256:37c9b1231c8083e9f4e724f50f7a21241822f9516c15c700ebbf218d6452355c", size = 34148, upload-time = "2026-05-22T06:51:22.292Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/98/58a71d68d3126d7f6a6ed1944c37ec207a4ff3dc66cad3bed7b59d38df61/pytest_rerunfailures-16.3-py3-none-any.whl", hash = "sha256:6bdfb8ffb46c46072e6c16bdedee38b6c13eac620d9415ed5b63152cbf283170", size = 15396, upload-time = "2026-05-22T06:51:20.547Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

CI wall clock had grown to ~7–8 min per run (15+ under runner contention). Measured on run 28631887925: ~95% of every test job is the serial `pytest -q` phase — ~2 min on Linux, ~6 min on Windows — on 4-vCPU runners.

## What

- **pytest-xdist (`-n auto`)** on both test jobs. The suite is parallel-safe: every fixture is function-scoped on `tmp_path`, env mutation goes through `monkeypatch`, and the `flaky` reruns (pytest-rerunfailures) are xdist-compatible. One real race surfaced and is fixed first: the live tmux tests all derived the same session name from a fixed `run` basename, so one test's `kill-session` teardown could race another's `new-window` (test-only; production run dirs are unique run ids).
- **Windows matrix trimmed to 3.11/3.14 on PRs**; pushes to main still run the full 3.11–3.14 spread. Windows failures here have been platform-shaped, not version-shaped — the recent WinError 87 failure hit all four versions identically. Check names stay stable across events.
- **`timeout-minutes` on all jobs** (test 15, version-sync 5, lint 10) so a hung test can't burn the 6-hour default and clog the concurrency queue.
- **`--durations=15`** in the CI pytest invocation so slow-test creep stays visible.

## Expected

| | before | after |
|---|---|---|
| Linux test job | ~2.5 min | ~1.2–1.5 min |
| Windows test job | ~6–7.5 min | ~2.5–3.5 min |
| PR wall clock | ~7.5 min | ~3–3.5 min |
| PR runner-minutes | ~36 | ~11–13 |

## Verified locally

Full suite green under `-n auto` and 3× under `-n 4` (1321 passed, 1 skipped, ~35s), targeted parallel runs of `test_tui_app.py` (flaky-rerun machinery) and `test_generic_tmux.py` 3× (live tmux under high parallelism), full `trunk check` clean. This PR's own run exercises the `pull_request` branch of the matrix ternary; the merge exercises `push`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test reliability and reduced flaky failures during concurrent runs.
  * Limited certain CI test matrix runs on pull requests to faster boundary checks, while keeping full coverage on main branch pushes.

* **Chores**
  * Added time limits to several CI jobs and standardized test execution for quicker, more consistent feedback.
  * Updated test tooling to support parallel execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->