### PR TITLE
perf(tests): per-worker template repo cuts Windows CI fixture cost

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ that simulate the side effects skill sessions would have on disk."""
 
 from __future__ import annotations
 
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -107,10 +108,13 @@ def git(repo: Path, *args: str) -> str:
     return proc.stdout.strip()
 
 
-@pytest.fixture
-def project(tmp_path: Path) -> ProjectPaths:
-    """Git repo with BMAD-shaped artifact dirs and an initial commit."""
-    root = tmp_path / "sandbox"
+@pytest.fixture(scope="session")
+def _project_template(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Master sandbox repo, built once per xdist worker. NEVER hand this path to
+    a test — a mutation would poison every later test in the worker; tests get
+    disposable copies via `project`. (Do not chmod it read-only either: copytree
+    preserves modes, so the copies would inherit it and break every write.)"""
+    root = tmp_path_factory.mktemp("project-template") / "sandbox"
     impl = root / "_bmad-output" / "implementation-artifacts"
     plan = root / "_bmad-output" / "planning-artifacts"
     impl.mkdir(parents=True)
@@ -118,11 +122,27 @@ def project(tmp_path: Path) -> ProjectPaths:
     (root / "src.txt").write_text("original\n")
     (root / ".gitignore").write_text(".automator/runs/\n")  # as `bmad-auto init` would
     git(root, "init", "-q", "-b", "main")
+    # Local config: copies (and their worktrees) inherit it via the copied .git/config.
     git(root, "config", "user.email", "test@test")
     git(root, "config", "user.name", "test")
+    git(root, "config", "core.fsync", "none")  # cheapen commits; old git ignores unknown keys
     git(root, "add", "-A")
     git(root, "commit", "-q", "-m", "initial")
-    return ProjectPaths(project=root, implementation_artifacts=impl, planning_artifacts=plan)
+    return root
+
+
+@pytest.fixture
+def project(tmp_path: Path, _project_template: Path) -> ProjectPaths:
+    """Git repo with BMAD-shaped artifact dirs and an initial commit — a copytree
+    clone of the per-worker template, so no git subprocesses per test (git spawn
+    plus fsync made this fixture ~3s per test on Windows CI)."""
+    root = tmp_path / "sandbox"
+    shutil.copytree(_project_template, root)
+    return ProjectPaths(
+        project=root,
+        implementation_artifacts=root / "_bmad-output" / "implementation-artifacts",
+        planning_artifacts=root / "_bmad-output" / "planning-artifacts",
+    )
 
 
 def install_bmad_config(paths: ProjectPaths) -> None:


### PR DESCRIPTION
## Why

Follow-up to #42. Windows test jobs only scaled ~1.5× under xdist (265s vs 412s serial): the `project` fixture git-inits a fresh repo per test — 5 subprocess spawns × 412 tests — and on Windows that's ~3s of *setup* per test (slow process spawn + fsync, 4 workers contending on disk). The `--durations` table on the #42 run showed exactly this: ~3s `setup` entries for test_verify_worktree/test_cli/test_engine.

## What

`tests/conftest.py` only:
- New session-scoped `_project_template` fixture builds the identical sandbox once per xdist worker (same files, same 5 git commands, identity kept in *local* config so copies inherit it).
- `project` now `shutil.copytree`s the template — **zero git spawns per test** (~25 small files, tens of ms on Windows).
- `core.fsync=none` in the template's local config, inherited by copies and their worktrees, cheapening the ~100 remaining inline add/commit calls.

## Safety, verified against the code

- No phantom-dirty from the copied index: all cleanliness checks in `verify.py` are porcelain (`status --porcelain`, `git diff --quiet`, OID compare, throwaway `GIT_INDEX_FILE`) which re-hash stat-dirty entries; `diff-index`/`diff-files` plumbing appears nowhere. Also proven empirically: a copytree'd repo reports clean porcelain status.
- Fresh non-worktree repos contain no absolute paths → fully relocatable; `.git/worktrees/*` is created per-copy, so the real `git worktree add` tests are unaffected.
- All `rev_parse_head` assertions are same-repo; identical initial SHAs across copies are harmless.
- The identity-unset test (`test_verify.py`) `--unset`s *local* config, which the copy carries exactly as before.

## Verified locally

Full suite green serial (1321 passed, 108s — down from ~125s) and 3× under `-n 4`/`-n auto` (28–33s). Targeted canaries green: identity-unset + finalize-commit + commit-paths, all worktree suites (103 passed), ledger-commit suites (77 passed). `--durations=15` now shows **no setup entries at all**. trunk check clean.

Expected on this PR's Windows jobs: test phase ~265s → ~100–150s. The one ~3s template build per worker shows up on whichever test runs first — by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)