### PR TITLE
fix(engine): bound workflow-session stall nudges + spell out the completion contract

### DIFF
--- a/src/automator/adapters/base.py
+++ b/src/automator/adapters/base.py
@@ -32,6 +32,13 @@ class SessionSpec:
     model: str = ""  # empty = CLI default
     # fallback only; real dev/review/retro sessions get limits.session_timeout_min * 60
     timeout_s: float = 90 * 60
+    # total stall wake-nudges this session may ever receive; None = unbounded
+    # (today's behavior). Unlike the adapter's refillable per-silence budget,
+    # this cap is monotonic — a session that keeps ending its turn without a
+    # result cannot re-earn nudges forever. Set for injected workflow sessions
+    # so a forgotten completion marker degrades to "stalled" instead of
+    # livelocking until timeout_s.
+    stall_nudges_cap: int | None = None
 
 
 @dataclass(frozen=True)

--- a/src/automator/adapters/generic.py
+++ b/src/automator/adapters/generic.py
@@ -189,6 +189,12 @@ class GenericAdapter(CodingCLIAdapter):
         # fresh Stop — proof it woke and acted — restores the budget; only an
         # unresponsive session burns through it. Bounded overall by spec.timeout_s.
         stall_nudges_left = self._stall_nudges
+        # monotonic total of stall nudges sent this session — never restored,
+        # unlike stall_nudges_left. When spec.stall_nudges_cap is set (injected
+        # workflow sessions), a session that keeps ending its turn without a
+        # result cannot ride the fresh-Stop refill forever: after cap total
+        # nudges it is declared stalled. cap=None (dev/review) skips the check.
+        stall_nudges_sent = 0
         # internal observability counter: counts ticks where the liveness probe
         # raised a transport error (e.g. a 30s tmux hang). It deliberately does
         # NOT escalate to "crashed" — a transient transport hiccup is not proof
@@ -259,13 +265,16 @@ class GenericAdapter(CodingCLIAdapter):
                             session_id=session_id,
                             transcript_path=transcript_path,
                         )
-                    if stall_nudges_left > 0:
+                    if stall_nudges_left > 0 and (
+                        spec.stall_nudges_cap is None or stall_nudges_sent < spec.stall_nudges_cap
+                    ):
                         # The wake nudge IS the re-invocation bmad-auto otherwise
                         # lacks: prod the idle session and re-arm. Budget is
                         # restored only by a fresh Stop (a real turn-end), so the
                         # nudge's own echoed keystrokes can't be mistaken for the
                         # agent waking; an unresponsive session keeps draining it.
                         stall_nudges_left -= 1
+                        stall_nudges_sent += 1
                         self.send_text(handle, STALL_NUDGE_TEXT)
                         stall_deadline = time.monotonic() + self._stall_grace_s
                         last_activity = self._log_activity_key(handle.task_id)

--- a/src/automator/data/settings/core.toml
+++ b/src/automator/data/settings/core.toml
@@ -82,6 +82,12 @@ minimum = 0
 default_ref = "LimitsPolicy.dev_stall_nudges"
 description = "times an idle dev session is nudged awake on grace expiry before it is called stalled (bmad-auto has no background-completion re-invocation); pane output re-arms the grace window and a fresh Stop restores the budget · 0 = stall on grace expiry"
 [[section.field]]
+key = "workflow_stall_nudges_cap"
+kind = "int"
+minimum = 0
+default_ref = "LimitsPolicy.workflow_stall_nudges_cap"
+description = "total (never-restored) stall nudges for an injected plugin-workflow session before it is called stalled; bounds a session that finished its work but never wrote its completion marker · 0 = stall on first grace expiry"
+[[section.field]]
 key = "max_tokens_per_story"
 kind = "int"
 minimum = 1

--- a/src/automator/engine.py
+++ b/src/automator/engine.py
@@ -98,6 +98,35 @@ class RunSummary:
 # "-code" suffix; codex/gemini/cursor and any custom profile pass through as-is.
 _SETUP_MCP_AGENT_IDS = {"claude": "claude-code"}
 
+# Appended to every injected plugin-workflow session prompt. The dev/review
+# skills carry their own result conventions, but a workflow prompt is arbitrary
+# text from a plugin manifest — without an explicit protocol the session has to
+# *infer* the completion-marker convention, and one that finishes its work but
+# never writes the marker leaves the orchestrator waiting (a completion-signal
+# livelock, bounded only by session_timeout_min). The orchestrator's adapter
+# discovers the marker by its `bmad-dev-auto-result-` filename prefix and
+# mtime, not by exact name.
+WORKFLOW_COMPLETION_CONTRACT = """
+
+## Completion signal (required)
+
+When you have finished this workflow — fully done OR blocked and unable to
+proceed — you MUST create the file:
+
+    {marker_path}
+
+containing YAML frontmatter that declares the outcome, then end your turn:
+
+    ---
+    status: done
+    ---
+
+Use `status: blocked` (plus a short explanation in the body) if you could not
+finish. This marker is the orchestrator's only completion signal for this
+session; it is required in addition to any artifacts the workflow itself
+produces. If you end your turn without it, the session is eventually declared
+stalled and its work may be discarded."""
+
 
 def _setup_mcp_agent_id(profile_name: str) -> str:
     """Map a CLI profile name to its Unity-MCP `setup-mcp` agent id."""
@@ -1730,6 +1759,18 @@ class Engine:
                     role=role,
                 )
                 return SessionResult(status="vetoed")
+        if label is not None:
+            # Injected workflow session: spell out the completion-marker protocol
+            # and bound its stall nudges (see WORKFLOW_COMPLETION_CONTRACT).
+            # Appended after the session-gate hooks so a pre_workflow_session /
+            # pre_session prompt rewrite cannot strip it. The marker path lands in
+            # the same implementation-artifacts dir the dev adapter already
+            # searches — correct in place and under worktree isolation alike,
+            # because spec.cwd is self.workspace.root either way.
+            marker_path = (
+                self.workspace.paths.implementation_artifacts / f"bmad-dev-auto-result-{task_id}.md"
+            )
+            prompt += WORKFLOW_COMPLETION_CONTRACT.format(marker_path=marker_path)
         spec = SessionSpec(
             task_id=task_id,
             role=role,
@@ -1738,6 +1779,9 @@ class Engine:
             env=env,
             model=cfg.model,
             timeout_s=self.policy.limits.session_timeout_min * 60,
+            stall_nudges_cap=(
+                self.policy.limits.workflow_stall_nudges_cap if label is not None else None
+            ),
         )
         self.journal.set_active_log(task_id)
         self.journal.append("session-start", task_id=task_id, role=role, prompt=prompt)

--- a/src/automator/policy.py
+++ b/src/automator/policy.py
@@ -62,6 +62,14 @@ class LimitsPolicy:
     # the full grace, nudge after nudge, drains the budget and stalls. 0 = stall
     # on grace expiry.
     dev_stall_nudges: int = 2
+    # monotonic cap on stall wake-nudges for injected plugin-workflow sessions
+    # (SessionSpec.stall_nudges_cap). Dev/review sessions stay uncapped: their
+    # nudge budget is deliberately restored on every fresh Stop so a session
+    # awaiting a slow background process can wait up to session_timeout_min. A
+    # workflow session that keeps ending its turn without writing its completion
+    # marker would ride that refill forever; after this many total nudges it is
+    # declared stalled instead (non-blocking workflows then advance the phase).
+    workflow_stall_nudges_cap: int = 3
     max_tokens_per_story: int = 2_000_000
     # weight of cache-read tokens in the budget check (1.0 = count raw)
     cache_read_weight: float = 0.1
@@ -453,6 +461,9 @@ def loads(text: str, plugin_schemas: dict[str, Any] | None = None) -> Policy:
         ),
         dev_stall_grace_s=int(limits_d.get("dev_stall_grace_s", LimitsPolicy.dev_stall_grace_s)),
         dev_stall_nudges=int(limits_d.get("dev_stall_nudges", LimitsPolicy.dev_stall_nudges)),
+        workflow_stall_nudges_cap=int(
+            limits_d.get("workflow_stall_nudges_cap", LimitsPolicy.workflow_stall_nudges_cap)
+        ),
         max_tokens_per_story=int(
             limits_d.get("max_tokens_per_story", LimitsPolicy.max_tokens_per_story)
         ),
@@ -468,6 +479,10 @@ def loads(text: str, plugin_schemas: dict[str, Any] | None = None) -> Policy:
         raise PolicyError(f"limits.dev_stall_grace_s must be >= 0: got {limits.dev_stall_grace_s}")
     if limits.dev_stall_nudges < 0:
         raise PolicyError(f"limits.dev_stall_nudges must be >= 0: got {limits.dev_stall_nudges}")
+    if limits.workflow_stall_nudges_cap < 0:
+        raise PolicyError(
+            f"limits.workflow_stall_nudges_cap must be >= 0: got {limits.workflow_stall_nudges_cap}"
+        )
 
     verify = VerifyPolicy(commands=tuple(str(c) for c in verify_d.get("commands", ())))
     notify = NotifyPolicy(
@@ -666,6 +681,7 @@ session_timeout_min = 90
 stop_without_result_nudges = 1
 dev_stall_grace_s = 600      # grace for a dev session that ended its turn awaiting a background process (e.g. a slow PlayMode/test run) before it is called stalled; each re-invocation resets it. 0 = fail fast on the first result-less Stop
 dev_stall_nudges = 2         # times an idle dev session is nudged awake on grace expiry before it is called stalled (bmad-auto has no background-completion re-invocation); pane output re-arms the grace window and a fresh Stop restores the budget. 0 = stall on grace expiry
+workflow_stall_nudges_cap = 3 # total (never-restored) stall nudges for an injected plugin-workflow session before it is called stalled; bounds a session that finished its work but never wrote its completion marker. 0 = stall on first grace expiry
 max_tokens_per_story = 2000000
 cache_read_weight = 0.1      # cache reads bill at ~0.1x input on all vendors; 1.0 = count raw
 

--- a/tests/test_generic_tmux.py
+++ b/tests/test_generic_tmux.py
@@ -342,6 +342,19 @@ def test_generic_dev_finds_no_spec_fallback(tmp_path):
     assert rj["escalations"][0]["type"] == "blocked"
 
 
+def test_generic_dev_fallback_done_marker_frontmatter_only(tmp_path):
+    """The workflow completion contract instructs exactly this shape: a
+    ``bmad-dev-auto-result-*.md`` with ``status: done`` frontmatter and no
+    ``## Auto Run Result`` heading. It must be located by filename prefix and
+    synthesize a done result."""
+    adapter, impl = make_dev_adapter(tmp_path)
+    (impl / "bmad-dev-auto-result-1-1-tea.automate-1.md").write_text(
+        "---\nstatus: done\n---\n\nCompletion signal; artifacts live elsewhere.\n"
+    )
+    rj = adapter._result_json(_dev_handle(), _dev_spec(tmp_path), wait=True)
+    assert rj["status"] == "done"
+
+
 def test_generic_dev_ignores_pre_launch_artifact(tmp_path, monkeypatch):
     """A spec left by a prior cycle (mtime below the launch floor) is not this
     session's output and must not be read as a stale completion."""
@@ -627,6 +640,114 @@ def test_dev_stall_nudge_wakes_session_that_then_completes(tmp_path, monkeypatch
     result = adapter.wait_for_completion(_dev_handle(), _dev_spec(tmp_path))
     assert result.status == "completed"
     assert sent == [generic.STALL_NUDGE_TEXT]  # one nudge was enough to wake it
+
+
+def _capped_spec(tmp_path, cap: int) -> SessionSpec:
+    """A workflow-session spec: same shape as _dev_spec but with the monotonic
+    stall-nudge cap the engine sets for injected plugin workflows."""
+    return SessionSpec(
+        task_id="3-1-dev-1",
+        role="dev",
+        prompt="/tea-automate 3-1",
+        cwd=tmp_path,
+        env={"BMAD_AUTO_STORY_KEY": "3-1"},
+        stall_nudges_cap=cap,
+    )
+
+
+def _stall_loop_adapter(tmp_path, monkeypatch):
+    """Adapter + clock + sent-nudge recorder for driving the refill loop: a
+    session that answers every wake nudge with a fresh result-less Stop."""
+    monkeypatch.setattr(generic, "RESULT_GRACE_S", 0.0)
+    monkeypatch.setattr(generic, "RESULT_POLL_S", 0.0)
+    adapter, impl = make_dev_adapter(tmp_path)
+    adapter._stall_grace_s = 10.0
+    adapter._stall_nudges = 2
+    adapter._window_alive = lambda handle: True
+    sent: list[str] = []
+    adapter.send_text = lambda handle, text: sent.append(text)
+
+    clock = {"t": 1000.0}
+
+    class _Clock:
+        monotonic = staticmethod(lambda: clock["t"])
+        sleep = staticmethod(lambda *_: None)
+        time_ns = staticmethod(lambda: 0)
+
+    monkeypatch.setattr(generic, "time", _Clock)
+    return adapter, impl, clock, sent
+
+
+def test_workflow_cap_bounds_refilled_stall_nudges(tmp_path, monkeypatch):
+    """The completion-signal livelock: a session that answers every wake nudge
+    with a fresh result-less Stop gets its per-silence budget refilled each time
+    and can ride the loop until session timeout. A capped spec (what the engine
+    sets for injected workflow sessions) bounds the TOTAL nudges ever sent:
+    exactly cap sends, then stalled."""
+    adapter, _, clock, sent = _stall_loop_adapter(tmp_path, monkeypatch)
+
+    def advance(call_n):
+        if call_n >= 2:
+            clock["t"] += 11.0
+
+    stop = _stop_event("3-1-dev-1", "sess", "/run/events.jsonl")
+    adapter.watcher = _ScriptedWatcher(
+        # each None is an idle tick past the grace -> a nudge; each fresh Stop is
+        # the session answering result-less -> the per-silence budget refills
+        [stop, None, stop, None, stop, None],
+        on_call=advance,
+    )
+    result = adapter.wait_for_completion(_dev_handle(), _capped_spec(tmp_path, cap=2))
+    assert result.status == "stalled"
+    assert sent == [generic.STALL_NUDGE_TEXT] * 2
+
+
+def test_uncapped_spec_keeps_refilling_nudges_past_cap(tmp_path, monkeypatch):
+    """cap=None (dev/review sessions) preserves the pre-cap behavior byte-
+    identical: every fresh Stop restores the budget and nudging continues well
+    past any workflow cap — a legitimately slow background wait (e.g. a Unity
+    PlayMode run) may need every one of them, bounded only by spec.timeout_s."""
+    adapter, _, clock, sent = _stall_loop_adapter(tmp_path, monkeypatch)
+
+    def advance(call_n):
+        if call_n >= 2:
+            clock["t"] += 11.0
+
+    stop = _stop_event("3-1-dev-1", "sess", "/run/events.jsonl")
+    adapter.watcher = _ScriptedWatcher(
+        [stop, None, stop, None, stop, None],  # then None forever
+        on_call=advance,
+    )
+    result = adapter.wait_for_completion(_dev_handle(), _dev_spec(tmp_path))
+    assert result.status == "stalled"
+    # one nudge per refilled silence cycle, then the final budget (2) drains in
+    # genuine silence: 4 total sends, strictly more than a cap of 2 would allow
+    assert sent == [generic.STALL_NUDGE_TEXT] * 4
+
+
+def test_capped_session_still_completes_when_marker_lands_late(tmp_path, monkeypatch):
+    """Exhausting the cap must not discard a session whose completion marker
+    lands afterwards: the result check runs before any stall verdict, so a
+    marker that races in wins and the session completes."""
+    adapter, impl, clock, sent = _stall_loop_adapter(tmp_path, monkeypatch)
+
+    def script(call_n):
+        if call_n >= 2:
+            clock["t"] += 11.0
+        if call_n == 4:  # after the cap was spent: the marker finally lands
+            (impl / "bmad-dev-auto-result-3-1-tea.automate-1.md").write_text(
+                "---\nstatus: done\n---\n"
+            )
+
+    stop = _stop_event("3-1-dev-1", "sess", "/run/events.jsonl")
+    adapter.watcher = _ScriptedWatcher(
+        [stop, None, stop, None],  # nudge -> answered result-less -> idle again
+        on_call=script,
+    )
+    result = adapter.wait_for_completion(_dev_handle(), _capped_spec(tmp_path, cap=1))
+    assert result.status == "completed"
+    assert result.result_json["status"] == "done"
+    assert sent == [generic.STALL_NUDGE_TEXT]  # the cap was already exhausted
 
 
 def test_wait_for_completion_tolerates_transient_liveness_probe_failure(tmp_path, monkeypatch):

--- a/tests/test_plugin_workflows.py
+++ b/tests/test_plugin_workflows.py
@@ -208,12 +208,48 @@ def test_workflow_injects_a_session_at_post_dev_phase(project):
     # exactly one workflow session ran, between dev and review
     assert len(captured) == 1
     spec = captured[0]
-    assert spec.prompt == "/doc 1-1-a"  # {story_key} substituted
+    assert spec.prompt.startswith("/doc 1-1-a")  # {story_key} substituted
     assert spec.task_id == "1-1-a-wf.doc-1"  # label = "<plugin>.<workflow>"
+    # the framework appends the completion contract to every workflow prompt:
+    # the absolute marker path plus the frontmatter shape to write
+    assert "bmad-dev-auto-result-1-1-a-wf.doc-1.md" in spec.prompt
+    assert "status: done" in spec.prompt
+    # and bounds its stall nudges so a forgotten marker degrades instead of
+    # livelocking until session timeout
+    assert spec.stall_nudges_cap == engine.policy.limits.workflow_stall_nudges_cap
     kinds = [e["kind"] for e in engine.journal.entries()]
     assert "workflow-start" in kinds and "workflow-end" in kinds
     starts = [e for e in engine.journal.entries() if e["kind"] == "workflow-start"]
     assert starts[0]["plugin"] == "wf" and starts[0]["workflow"] == "doc"
+
+
+def test_dev_and_review_sessions_carry_no_workflow_contract(project):
+    """The completion contract + stall-nudge cap are workflow-session-only: the
+    main dev/review sessions (their skills own their result conventions, and a
+    slow background wait may legitimately need unbounded re-nudging) must stay
+    byte-identical — no appended contract, no cap."""
+    captured: list = []
+    setup_story(project)
+
+    def capture(effect):
+        def inner(spec):
+            captured.append(spec)
+            return effect(spec)
+
+        return inner
+
+    script = [
+        capture(dev_effect(project, "1-1-a")),
+        capture(review_effect(project, "1-1-a", clean=True)),
+    ]
+    engine, _ = make_engine(project, script)
+    summary = engine.run()
+    assert summary.done == 1
+    assert len(captured) == 2
+    for spec in captured:
+        assert spec.stall_nudges_cap is None
+        assert "Completion signal" not in spec.prompt
+        assert "bmad-dev-auto-result-" not in spec.prompt
 
 
 def test_blocking_workflow_failure_defers_the_unit(project):

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -235,6 +235,21 @@ def test_zero_budget_rejected(tmp_path):
         policy.load(p)
 
 
+def test_workflow_stall_nudges_cap_default_parse_and_template():
+    import tomllib
+
+    assert policy.loads("").limits.workflow_stall_nudges_cap == 3
+    loaded = policy.loads("[limits]\nworkflow_stall_nudges_cap = 0\n")
+    assert loaded.limits.workflow_stall_nudges_cap == 0
+    # the emitted template documents the knob at its dataclass default
+    doc = tomllib.loads(policy.POLICY_TEMPLATE)
+    assert (
+        doc["limits"]["workflow_stall_nudges_cap"] == policy.LimitsPolicy.workflow_stall_nudges_cap
+    )
+    with pytest.raises(policy.PolicyError, match="workflow_stall_nudges_cap"):
+        policy.loads("[limits]\nworkflow_stall_nudges_cap = -1\n")
+
+
 def test_cache_read_weight_default_and_override(tmp_path):
     assert policy.load(None).limits.cache_read_weight == 0.1
     p = tmp_path / "policy.toml"


### PR DESCRIPTION
## Problem

An injected plugin-workflow session that finishes its work but never writes its `bmad-dev-auto-result-*.md` completion marker **livelocks the run** until `session_timeout_min`. Hit live by hey-dad's `tea.automate` session (4 h configured timeout): the session generated its whole test suite, ended its turn — and the orchestrator nudged it awake forever.

Two conspiring causes:

1. **The marker convention is never stated.** Workflow prompts are arbitrary manifest text; the dev/review skills carry their own result conventions, but a workflow session has to *infer* the marker protocol. hey-dad's `td`/`atdd` sessions guessed right; the longer `automate` run didn't.
2. **The stall-nudge budget refills on every result-less Stop** (`generic.py`, deliberate for slow background waits). A truly silent session already degrades to `stalled` after `dev_stall_nudges`, but a *cooperative-but-signal-less* one answers every nudge with a fresh Stop, re-earning its budget each time — unbounded except by session timeout. (There is no separate Unity code path — the refill at `generic.py` is the single site; Unity PlayMode is the motivating example in its comments.)

## Fix (two layers, workflow sessions only)

- **A — completion contract:** `_run_session` appends `WORKFLOW_COMPLETION_CONTRACT` to every workflow-session prompt (`label is not None`): the absolute marker path (`<implementation-artifacts>/bmad-dev-auto-result-<task_id>.md` — correct in place and under worktree isolation, since `spec.cwd == workspace.root`) plus the exact `status: done` / `status: blocked` frontmatter to write. Appended *after* the session-gate hooks so a `pre_workflow_session`/`pre_session` prompt rewrite cannot strip it. Discovery is unchanged (prefix + mtime via `devcontract.find_result_artifact`, never exact-filename).
- **B — bounded backstop:** new `SessionSpec.stall_nudges_cap` — a **monotonic** total-nudges cap that a fresh Stop does *not* restore — set from new `limits.workflow_stall_nudges_cap` (default 3) for workflow sessions only. A still-forgotten marker now degrades to `stalled` in ~cap × `dev_stall_grace_s` (~30 min at defaults) instead of hours; a non-blocking workflow then advances the phase (existing advisory path). A marker that races in after cap exhaustion still completes the session (the result check precedes every stall verdict).

**Dev/review sessions are byte-identical:** they get no contract and `cap=None`, preserving the unbounded refill that legitimate long background waits (Unity PlayMode, slow tests) rely on.

## Tests

- Livelock reproduction: capped spec + a session answering every nudge with a result-less Stop → exactly `cap` nudges, then `stalled`.
- `cap=None` regression guard: same script keeps refilling past the cap (4 sends).
- Late marker after cap exhaustion → `completed`, work preserved.
- Frontmatter-only `status: done` fallback marker (the contract's exact instructed shape) synthesizes a done result.
- Workflow `SessionSpec` carries marker path + contract + cap; dev/review specs carry neither.
- Policy: default / parse / template round-trip / negative rejection; settings-schema coverage (`core.toml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable limit for how many stall “wake” nudges injected workflows can receive.
  * Workflow sessions now carry clearer completion guidance so finished tasks are detected more reliably.

* **Bug Fixes**
  * Improved handling of completion markers so a valid finished result is recognized even if the marker file only contains status details.
  * Ensured capped sessions still complete normally when the result appears after nudges are exhausted.

* **Tests**
  * Expanded coverage for the new stall-nudge limit, workflow completion detection, and default policy behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->