### PR TITLE
feat(plugins): pre_commit_gate injection stage; rebind TEA gates to it

### DIFF
--- a/docs/plugin-authoring-guide.md
+++ b/docs/plugin-authoring-guide.md
@@ -152,7 +152,7 @@ An extra agent session injected at a stage. See [Workflows](#workflows-provides)
 
 ```toml
 [workflows.lint-sweep]
-stage = "post_dev_phase"   # post_dev_phase | post_review_result
+stage = "post_dev_phase"   # post_dev_phase | post_review_result | pre_commit_gate
 role = "dev"               # dev | review
 prompt = "/lint-sweep {story_key}"
 blocking = false           # true: a failed session defers the unit
@@ -403,10 +403,11 @@ there.
 
 ### Commit
 
-| Stage         | When              | Mutable surface                                                                        |
-| ------------- | ----------------- | -------------------------------------------------------------------------------------- |
-| `pre_commit`  | before committing | **`proposed_commit_message`**; only a `pause` veto is honored (the unit is mid-commit) |
-| `post_commit` | after committing  | —                                                                                      |
+| Stage             | When                                        | Mutable surface                                                                          |
+| ----------------- | ------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `pre_commit_gate` | just before every commit, on every path     | a [workflow injection point](#workflows-provides); defer-safe (the unit may still defer) |
+| `pre_commit`      | before committing (after `pre_commit_gate`) | **`proposed_commit_message`**; only a `pause` veto is honored (the unit is mid-commit)   |
+| `post_commit`     | after committing                            | —                                                                                        |
 
 ### Generic session boundary
 
@@ -447,8 +448,14 @@ blocking = false           # true: a non-completed session defers the unit
 
 - **Injection stages** are deliberately limited to where the unit's worktree is
   live and the dev/review work is on disk: **`post_dev_phase`** (right after dev
-  lands) and **`post_review_result`** (after a review verdict). Other stages lack
-  a worktree or run after teardown.
+  lands), **`post_review_result`** (after a review verdict — fires only when the
+  orchestrator review loop actually runs; `review.trigger = "recommended"` skips
+  it on stories whose dev session recommends no follow-up), and
+  **`pre_commit_gate`** (unconditionally just before every commit — review, skip,
+  and budget-rescue paths alike — so a session there evaluates the exact tree
+  about to commit). `pre_commit_gate` is **defer-safe**: it fires before the unit
+  enters COMMITTING, so a _blocking_ workflow whose session doesn't complete
+  still defers cleanly. Other stages lack a worktree or run after teardown.
 - **`prompt`** expands `{story_key}`, `{run_id}`, and `{scripts}`.
 - The injected session is a **first-class session**: it fires `pre_workflow_session`
   → `pre_session` → `post_session`, is recorded on the task, and counts toward the
@@ -487,7 +494,7 @@ documented, surfaced in the settings UI) and operators can flip them from
 ```toml
 # A gate step: generated advisory by default, an operator can make it block.
 [workflows.nfr]
-stage = "post_review_result"
+stage = "pre_commit_gate"
 role = "review"
 prompt = "Run the NFR assessment for the changes in {story_key}."
 blocking = false              # manifest default: advisory

--- a/docs/tea-plugin-guide.md
+++ b/docs/tea-plugin-guide.md
@@ -4,9 +4,9 @@ The bundled **`tea`** plugin wires the BMAD **Test Architect Enterprise (TEA)**
 module — the "Murat" agent and its `bmad-testarch-*` workflows — into every
 bmad-auto run and sweep as **advisory-by-default quality steps**. It injects
 six TEA sessions across the pipeline (test-design, ATDD, automate after dev;
-trace, NFR, test-review after review), and an operator can flip any of the three
-gate steps to **blocking** so a failing quality gate escalates the unit for human
-review instead of committing.
+trace, NFR, test-review just before commit), and an operator can flip any of the
+three gate steps to **blocking** so a failing quality gate escalates the unit for
+human review instead of committing.
 
 Like the [game-engine layer](game-engine-plugin-guide.md), TEA is **just a
 plugin** on the general [plugin system](plugin-authoring-guide.md) — same
@@ -54,26 +54,32 @@ is toggled on — see the [TUI guide](tui-guide.md).
 
 ## The six steps and where they run
 
-TEA work injects at the **two** lifecycle stages that have a live worktree
-(`post_dev_phase` and `post_review_result` — the only stages workflow injection
-is permitted; see the [stage reference](plugin-authoring-guide.md#stage-reference)).
+TEA work injects at **two** lifecycle stages that have a live worktree
+(`post_dev_phase` and `pre_commit_gate`; see the
+[stage reference](plugin-authoring-guide.md#stage-reference)).
 Each step runs as an extra agent session through the `dev` or `review` adapter,
 with `workflow-start` / `workflow-end` journal entries.
 
-| Step       | TEA workflow                | Stage                | Adapter | What it does                                                           |
-| ---------- | --------------------------- | -------------------- | ------- | ---------------------------------------------------------------------- |
-| `td`       | `bmad-testarch-test-design` | `post_dev_phase`     | dev     | Risk assessment + risk-based coverage strategy for the change.         |
-| `atdd`     | `bmad-testarch-atdd`        | `post_dev_phase`     | dev     | Failing acceptance tests + an implementation checklist.                |
-| `automate` | `bmad-testarch-automate`    | `post_dev_phase`     | dev     | Prioritized API/E2E tests, fixtures, and a Definition-of-Done summary. |
-| `trace`    | `bmad-testarch-trace`       | `post_review_result` | review  | Map requirements → tests and record the quality-gate decision.         |
-| `nfr`      | `bmad-testarch-nfr`         | `post_review_result` | review  | Assess non-functional requirements and record the gate decision.       |
-| `review`   | `bmad-testarch-test-review` | `post_review_result` | review  | Quality-check the written tests against TEA's knowledge base.          |
+| Step       | TEA workflow                | Stage             | Adapter | What it does                                                           |
+| ---------- | --------------------------- | ----------------- | ------- | ---------------------------------------------------------------------- |
+| `td`       | `bmad-testarch-test-design` | `post_dev_phase`  | dev     | Risk assessment + risk-based coverage strategy for the change.         |
+| `atdd`     | `bmad-testarch-atdd`        | `post_dev_phase`  | dev     | Failing acceptance tests + an implementation checklist.                |
+| `automate` | `bmad-testarch-automate`    | `post_dev_phase`  | dev     | Prioritized API/E2E tests, fixtures, and a Definition-of-Done summary. |
+| `trace`    | `bmad-testarch-trace`       | `pre_commit_gate` | review  | Map requirements → tests and record the quality-gate decision.         |
+| `nfr`      | `bmad-testarch-nfr`         | `pre_commit_gate` | review  | Assess non-functional requirements and record the gate decision.       |
+| `review`   | `bmad-testarch-test-review` | `pre_commit_gate` | review  | Quality-check the written tests against TEA's knowledge base.          |
 
 The three `post_dev_phase` steps run **after** the dev phase, in the order above;
-the three `post_review_result` steps run **after** review. Each prompt is
-**CLI-agnostic** — natural-language intent plus the explicit `bmad-testarch-*`
-workflow name, phrased around "the changes currently in the working tree for
-`{story_key}`" so the same step works for a single story **and** a sweep bundle.
+the three `pre_commit_gate` steps run **just before the commit**. That stage fires
+on **every** path into a commit — the review-converged path, the skip path
+(`review.trigger = "recommended"` with no follow-up recommended, where
+`post_review_result` never fires because the review loop never runs), and the
+review-budget rescue — so the gates always evaluate the exact tree about to
+commit, and the `*_blocking` flags enforce even on stories that skip the review
+loop. Each prompt is **CLI-agnostic** — natural-language intent plus the explicit
+`bmad-testarch-*` workflow name, phrased around "the changes currently in the
+working tree for `{story_key}`" so the same step works for a single story **and**
+a sweep bundle.
 
 ### Runs and sweeps, no extra wiring
 
@@ -100,15 +106,17 @@ Two key families, both keyed on the step name:
 | ----------------------------------------------------- | ------- | ----------------------------------------------------------------------------------------------- |
 | `require_tea`                                         | `true`  | Fail fast at startup if TEA isn't installed. `false` = run the steps advisory-only without TEA. |
 | `td_enabled` / `atdd_enabled` / `automate_enabled`    | `true`  | Enable each `post_dev_phase` generation step.                                                   |
-| `trace_enabled` / `nfr_enabled` / `review_enabled`    | `true`  | Enable each `post_review_result` gate step.                                                     |
+| `trace_enabled` / `nfr_enabled` / `review_enabled`    | `true`  | Enable each `pre_commit_gate` gate step.                                                        |
 | `trace_blocking` / `nfr_blocking` / `review_blocking` | `false` | When `true`, a FAIL/CONCERNS verdict from that gate escalates the unit at commit.               |
 
 ## Escalate-on-gate: how blocking works
 
 A workflow's manifest `blocking` flag only checks session **completion**, not test
 pass/fail — so true quality gating lives in the plugin's in-process
-`on_pre_commit` hook, the first vetoable stage **after** the `post_review_result`
-sessions have written their artifacts.
+`on_pre_commit` hook, the first vetoable stage **after** the `pre_commit_gate`
+sessions have written their artifacts. Both fire unconditionally before every
+commit, so enforcement holds even when `review.trigger = "recommended"` skips
+the orchestrator review loop entirely.
 
 When you mark a gate blocking (e.g. `nfr_blocking = true`), at commit time the
 plugin:

--- a/src/automator/data/plugins/tea/plugin.toml
+++ b/src/automator/data/plugins/tea/plugin.toml
@@ -4,11 +4,18 @@
 # `bmad-testarch-*` workflows) into every run and sweep as advisory-by-default
 # quality steps. It assumes TEA is already installed in the project
 # (`npx bmad-method install` -> Test Architect), and orchestrates by injecting
-# natural-language sessions that invoke the relevant TEA workflow at the two
+# natural-language sessions that invoke the relevant TEA workflow at two
 # stages that have a live worktree:
 #
 #   post_dev_phase     test-design (TD) + atdd (AT) + automate (TA)   [role=dev]
-#   post_review_result trace (TR) + nfr (NR) + test-review (RV)       [role=review]
+#   pre_commit_gate    trace (TR) + nfr (NR) + test-review (RV)       [role=review]
+#
+# The gate steps bind to pre_commit_gate — the injection point that fires
+# unconditionally just before every commit — NOT post_review_result, which fires
+# only when the orchestrator review loop runs (review.trigger="recommended"
+# skips it whenever the dev session doesn't recommend a follow-up). Gates
+# therefore evaluate the exact tree about to commit, and the `*_blocking` flags
+# enforce on every path.
 #
 # Because sweep bundles run the same inherited dev/review pipeline, these
 # workflows fire for runs AND sweep bundles with no sweep-specific code.
@@ -93,21 +100,21 @@ key = "trace_enabled"
 type = "bool"
 default = true
 label = "Enable trace (TR)"
-help = "post_review_result: map requirements to tests + record the quality-gate decision (bmad-testarch-trace)."
+help = "pre_commit_gate: map requirements to tests + record the quality-gate decision (bmad-testarch-trace)."
 
 [[settings]]
 key = "nfr_enabled"
 type = "bool"
 default = true
 label = "Enable NFR (NR)"
-help = "post_review_result: assess non-functional requirements + record the gate decision (bmad-testarch-nfr)."
+help = "pre_commit_gate: assess non-functional requirements + record the gate decision (bmad-testarch-nfr)."
 
 [[settings]]
 key = "review_enabled"
 type = "bool"
 default = true
 label = "Enable test-review (RV)"
-help = "post_review_result: quality check against the written tests (bmad-testarch-test-review)."
+help = "pre_commit_gate: quality check against the written tests (bmad-testarch-test-review)."
 
 # Per-gate blocking flags (workflow-overlay convention: <name>_blocking). The
 # gate steps ship advisory; flip one true so a FAIL/CONCERNS verdict escalates
@@ -159,19 +166,19 @@ prompt = "Run the TEA Test Automation workflow (skill `bmad-testarch-automate`) 
 blocking = false
 
 [workflows.trace]
-stage = "post_review_result"
+stage = "pre_commit_gate"
 role = "review"
 prompt = "Run the TEA Trace Requirements workflow (skill `bmad-testarch-trace`) for `{story_key}`. Map the requirements to the tests covering the changes currently in the working tree and record the quality-gate decision under TEA's configured test_artifacts directory."
 blocking = false
 
 [workflows.nfr]
-stage = "post_review_result"
+stage = "pre_commit_gate"
 role = "review"
 prompt = "Run the TEA Non-Functional Requirements workflow (skill `bmad-testarch-nfr`) for `{story_key}`. Assess the NFRs of the changes currently in the working tree and record the gate decision under TEA's configured test_artifacts directory."
 blocking = false
 
 [workflows.review]
-stage = "post_review_result"
+stage = "pre_commit_gate"
 role = "review"
 prompt = "Run the TEA Test Review workflow (skill `bmad-testarch-test-review`) for `{story_key}`. Perform a quality check against the tests covering the changes currently in the working tree, using TEA's knowledge base and best practices, and record findings under TEA's configured test_artifacts directory."
 blocking = false

--- a/src/automator/data/plugins/tea/tea_plugin.py
+++ b/src/automator/data/plugins/tea/tea_plugin.py
@@ -1,7 +1,7 @@
 """In-process brain for the bundled Test Architect Enterprise (TEA) plugin.
 
 The plugin's behaviour is mostly declarative — six ``[workflows.*]`` inject TEA
-sessions at ``post_dev_phase`` / ``post_review_result``, and the generic
+sessions at ``post_dev_phase`` / ``pre_commit_gate``, and the generic
 workflow-overlay convention (``<name>_enabled`` / ``<name>_blocking``) turns the
 per-step settings into enable/blocking switches with no code. This module owns
 the two things that need logic:
@@ -15,8 +15,10 @@ the two things that need logic:
     = true), parse that gate's latest TEA artifact at commit time and, on a
     FAIL/CONCERNS verdict, escalate the unit (``ctx.veto("pause", …)``) instead of
     letting it land. ``pre_commit`` is the first vetoable stage *after* the
-    ``post_review_result`` workflows have written their artifacts (a same-stage
-    Python hook fires before the workflows, so it can't read their output).
+    ``pre_commit_gate`` workflows have written their artifacts, and both fire
+    unconditionally on every path into a commit — review-converged, skip-review
+    (``review.trigger="recommended"`` with no follow-up recommended), and the
+    review-budget rescue — so the gates evaluate the exact tree about to commit.
 
 Enforcement is **fail-open by design**: if a gate has no blocking flag, no
 artifact, or an artifact that can't be parsed into a known verdict, the commit is
@@ -35,7 +37,7 @@ from automator.plugins.model import Plugin, PluginError
 if TYPE_CHECKING:
     from automator.plugins.context import HookContext
 
-# The gate steps that expose a ``*_blocking`` flag (the post_review_result steps
+# The gate steps that expose a ``*_blocking`` flag (the pre_commit_gate steps
 # an operator is likely to enforce). Generation steps (td/atdd/automate) stay
 # advisory by design and are deliberately absent — they are never gate-enforced.
 GATE_STEPS = ("trace", "nfr", "review")
@@ -155,7 +157,7 @@ class TeaPlugin(Plugin):
             return  # nothing flagged blocking -> advisory only, no artifact read
 
         # Resolve the tree TEA wrote into: the unit's worktree (where the
-        # post_review_result sessions just ran), falling back to the repo root.
+        # pre_commit_gate sessions just ran), falling back to the repo root.
         # Under isolation = none the two coincide.
         root = ctx.worktree or ctx.repo_root
         if not root:

--- a/src/automator/engine.py
+++ b/src/automator/engine.py
@@ -1473,6 +1473,17 @@ class Engine:
         self._commit(task)
 
     def _commit(self, task: StoryTask) -> None:
+        # pre_commit_gate: the unconditional workflow-injection point before a
+        # commit, on every path here (review-converged, skip-review, and the
+        # review-budget rescue) — unlike post_review_result, which fires only
+        # when the orchestrator review loop runs. Gate sessions (e.g. TEA's
+        # trace/nfr/review) evaluate the exact tree about to commit and write
+        # the artifacts the pre_commit hook then enforces on. Placed BEFORE
+        # advance(COMMITTING): the task is still DEV_VERIFY / REVIEW_VERIFY,
+        # both of which may legally defer, so a blocking gate whose session
+        # does not complete can unwind cleanly (COMMITTING cannot defer).
+        if self._run_workflows("pre_commit_gate", task, task.review_cycle):
+            return
         advance(task, Phase.COMMITTING)
         self._save()
         message = self._commit_message(task)

--- a/src/automator/plugins/model.py
+++ b/src/automator/plugins/model.py
@@ -33,12 +33,16 @@ SUPPORTED_API: frozenset[int] = frozenset({1})
 SETTING_TYPES = {"bool", "int", "float", "str", "select"}
 
 # Stages at which a plugin-provided workflow may inject an extra agent session
-# (Phase 4). Deliberately small + conservative: both fire *inside* the unit's
+# (Phase 4). Deliberately small + conservative: all fire *inside* the unit's
 # live worktree with the dev/review work already on disk, so an injected session
-# sees the real tree. Other stages either lack a worktree (run-boundary) or run
-# after teardown (post_story restores the main checkout), so a session there
+# sees the real tree. post_review_result fires only when the orchestrator review
+# loop actually runs (review.trigger="recommended" skips it on most stories);
+# pre_commit_gate fires unconditionally just before commit on every path —
+# review, skip, and budget-rescue alike — so a gate session evaluates the exact
+# tree about to commit. Other stages either lack a worktree (run-boundary) or
+# run after teardown (post_story restores the main checkout), so a session there
 # would target the wrong tree — they are intentionally excluded.
-WORKFLOW_STAGES = frozenset({"post_dev_phase", "post_review_result"})
+WORKFLOW_STAGES = frozenset({"post_dev_phase", "post_review_result", "pre_commit_gate"})
 
 # Roles a workflow session may run as — the engine's two adapters. A workflow
 # names one so it reuses that role's resolved adapter config (model, timeout).

--- a/tests/test_plugin_tea.py
+++ b/tests/test_plugin_tea.py
@@ -200,7 +200,9 @@ def test_builtin_tea_plugin_workflows_shape():
     for name in DEV_STEPS:
         assert by_name[name].stage == "post_dev_phase" and by_name[name].role == "dev"
     for name in REVIEW_STEPS:
-        assert by_name[name].stage == "post_review_result" and by_name[name].role == "review"
+        # gates bind to pre_commit_gate (fires on EVERY path into a commit),
+        # not post_review_result (fires only when the review loop runs)
+        assert by_name[name].stage == "pre_commit_gate" and by_name[name].role == "review"
     # ship advisory: nothing blocking in the manifest (operators flip *_blocking).
     assert not any(w.blocking for w in tea.workflows)
     # prompts name the explicit TEA workflow/skill so they degrade across CLIs.
@@ -308,6 +310,85 @@ def test_runs_inject_six_tea_workflows_in_order(project, monkeypatch):
     starts, ends = workflow_trail(engine)
     assert starts == [("tea", n) for n in DEV_STEPS + REVIEW_STEPS]
     assert ends == list(DEV_STEPS + REVIEW_STEPS)
+
+
+def test_gates_run_even_when_review_loop_is_skipped(project, monkeypatch):
+    """The hey-dad regression: with review.trigger="recommended" (the default)
+    and a dev session that recommends no follow-up, the orchestrator review loop
+    never runs, so post_review_result never fires. The gates bind to
+    pre_commit_gate, which fires on the skip path too — the three gate sessions
+    must still run, at that stage, before the story commits."""
+    install_tea(project)
+    monkeypatch.chdir(project.project)
+    write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
+    policy = tea_policy()
+    reg = PluginRegistry.build(project.project, policy)
+
+    captured: list = []
+    script = [
+        dev_effect(project, "1-1-a", followup_review=False),
+        workflow_effect(captured),  # td
+        workflow_effect(captured),  # atdd
+        workflow_effect(captured),  # automate
+        # NO review session: the review loop is skipped entirely
+        workflow_effect(captured),  # trace
+        workflow_effect(captured),  # nfr
+        workflow_effect(captured),  # review
+    ]
+    engine = make_engine(project, script, reg, policy)
+    summary = engine.run()
+
+    assert summary.done == 1
+    # gate seq is task.review_cycle — still 0 here, since no review ever ran
+    assert [s.task_id for s in captured] == [
+        "1-1-a-tea.td-1",
+        "1-1-a-tea.atdd-1",
+        "1-1-a-tea.automate-1",
+        "1-1-a-tea.trace-0",
+        "1-1-a-tea.nfr-0",
+        "1-1-a-tea.review-0",
+    ]
+    entries = engine.journal.entries()
+    kinds = [e["kind"] for e in entries]
+    assert "review-skipped" in kinds  # the review loop really was skipped
+    gate_starts = [
+        e for e in entries if e["kind"] == "workflow-start" and e["workflow"] in REVIEW_STEPS
+    ]
+    assert [e["workflow"] for e in gate_starts] == list(REVIEW_STEPS)
+    assert all(e["stage"] == "pre_commit_gate" for e in gate_starts)
+    # every gate finished before the commit landed
+    assert max(i for i, k in enumerate(kinds) if k == "workflow-end") < kinds.index("story-done")
+
+
+def test_blocking_gate_fail_escalates_even_when_review_skipped(project, monkeypatch):
+    """End-to-end enforcement on the skip path (the half of the hey-dad failure
+    that made *_blocking inert): a FAIL nfr artifact with nfr_blocking=true must
+    escalate at commit — the story must NOT land — even though the review loop
+    never ran."""
+    install_tea(project)
+    monkeypatch.chdir(project.project)
+    write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
+    policy = tea_policy(nfr_blocking=True)
+    reg = PluginRegistry.build(project.project, policy)
+
+    write_gate_artifact(project, "nfr", "FAIL")
+    script = [
+        dev_effect(project, "1-1-a", followup_review=False),
+        workflow_effect([]),  # td
+        workflow_effect([]),  # atdd
+        workflow_effect([]),  # automate
+        workflow_effect([]),  # trace
+        workflow_effect([]),  # nfr — its FAIL verdict artifact is on disk
+        workflow_effect([]),  # review
+    ]
+    engine = make_engine(project, script, reg, policy)
+    summary = engine.run()
+
+    assert summary.escalated == 1
+    assert summary.done == 0
+    assert summary.paused  # pre_commit pause-veto escalates + pauses the run
+    kinds = [e["kind"] for e in engine.journal.entries()]
+    assert "story-escalated" in kinds and "story-done" not in kinds
 
 
 def test_automate_enabled_false_suppresses_only_that_step(project, monkeypatch):

--- a/tests/test_plugin_workflows.py
+++ b/tests/test_plugin_workflows.py
@@ -247,6 +247,49 @@ def test_nonblocking_workflow_failure_is_advisory(project):
     assert ends and ends[0]["status"] == "error"
 
 
+def test_pre_commit_gate_workflow_injects_before_commit(project):
+    """A workflow bound to pre_commit_gate runs just before the commit — on the
+    review-skip path too (dev recommends no follow-up, so the review loop and
+    its post_review_result stage never run)."""
+    captured: list = []
+    setup_story(project)
+    reg = PluginRegistry([LoadedPlugin(manifest=wf_manifest("wf", stage="pre_commit_gate"))])
+    script = [
+        dev_effect(project, "1-1-a", followup_review=False),
+        workflow_effect(captured),  # no review session between dev and this
+    ]
+    engine, _ = make_engine(project, script, reg)
+    summary = engine.run()
+    assert summary.done == 1
+    # seq is task.review_cycle, still 0 on the skip path (no review ever ran)
+    assert len(captured) == 1 and captured[0].task_id == "1-1-a-wf.doc-0"
+    entries = engine.journal.entries()
+    starts = [e for e in entries if e["kind"] == "workflow-start"]
+    assert [e["stage"] for e in starts] == ["pre_commit_gate"]
+    kinds = [e["kind"] for e in entries]
+    # the gate session finished before the commit landed
+    assert kinds.index("workflow-end") < kinds.index("story-done")
+
+
+def test_blocking_pre_commit_gate_failure_defers_the_unit(project):
+    """A blocking pre_commit_gate workflow whose session doesn't complete defers
+    the unit cleanly: the stage fires before the task enters COMMITTING (which
+    has no legal move to DEFERRED), so the defer is a legal transition."""
+    setup_story(project)
+    reg = PluginRegistry(
+        [LoadedPlugin(manifest=wf_manifest("wf", stage="pre_commit_gate", blocking=True))]
+    )
+    script = [
+        dev_effect(project, "1-1-a", followup_review=False),
+        workflow_effect([], status="error"),
+    ]
+    engine, _ = make_engine(project, script, reg)
+    summary = engine.run()
+    assert summary.deferred == 1 and summary.done == 0
+    kinds = [e["kind"] for e in engine.journal.entries()]
+    assert "story-deferred" in kinds and "story-done" not in kinds
+
+
 def test_no_workflow_no_extra_session(project):
     # a plugin with hooks but no workflow injects nothing; the guard is O(1).
     reg = PluginRegistry([])


### PR DESCRIPTION
## Problem

TEA's `trace`/`nfr`/`review` quality gates bind to `post_review_result` — a stage emitted **only inside the orchestrator review loop**. Under the default `review.trigger="recommended"` flow, a dev session that sets `followup_review_recommended: false` takes `_skip_review_and_commit`, the loop never runs, `post_review_result` never fires, the three gate sessions never run, and `on_pre_commit` **fail-opens on the missing artifacts** (by design). Net effect: `trace_blocking`/`nfr_blocking`/`review_blocking = true` were completely inert on most stories. Hit live by hey-dad, whose all-blocking gate config never enforced once.

## Fix

**Framework — new `pre_commit_gate` injection stage.** Fires unconditionally at the top of `_commit`, i.e. on **every** path into a commit: review-converged, skip, and the review-budget rescue (that third path already passes through the `pre_commit` veto today, so gating it too is consistent). Placement is *before* `advance(COMMITTING)`: the task is still `DEV_VERIFY`/`REVIEW_VERIFY`, both of which legally transition to `DEFERRED`, so a *blocking* gate workflow whose session doesn't complete defers cleanly — `COMMITTING` itself has no legal move to `DEFERRED`. Ordering is inherent: gate sessions write their artifacts, then the existing `pre_commit` bus hook reads them and enforces. Gate sessions evaluate the **exact tree about to commit**.

- `WORKFLOW_STAGES` += `pre_commit_gate` (`plugins/model.py`); manifest load-time validation and `registry.workflow_stages()` pick it up with no registry change.
- `engine._commit`: `if self._run_workflows("pre_commit_gate", task, task.review_cycle): return` (note: on the skip path `review_cycle` is still `0`, so gate task_ids there end `-0`).

**TEA — rebind the gates.** `[workflows.trace|nfr|review]` → `stage = "pre_commit_gate"` (role stays `review`); `td`/`atdd`/`automate` stay at `post_dev_phase`. `on_pre_commit` enforcement is unchanged — it's stage-agnostic; comments/docs updated (`plugin-authoring-guide` stage reference + injection-stage list, `tea-plugin-guide` six-step table + blocking section).

## Tests

- **The hey-dad regression:** `dev_effect(followup_review=False)` + NO review session → the three gate workflows still run, at `pre_commit_gate`, before `story-done` (`review-skipped` present in the journal).
- **Enforcement on the skip path:** seeded FAIL nfr artifact + `nfr_blocking=true` → `summary.escalated == 1`, `done == 0`, run paused, no `story-done`.
- Framework: a `pre_commit_gate` workflow injects before commit on the skip path; a blocking one whose session errors defers legally (`deferred == 1`).
- Updated the stage-pinned shape test; the ordering tests (`test_runs_inject_six_tea_workflows_in_order`, sweep-bundle variant) pass unchanged — on the review path the gates' temporal position is identical.

Companion to #44 (livelock fix); the two are independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)