### PR TITLE
feat(scm): bounded retention for attempt-preserve recovery refs

### DIFF
--- a/src/bmad_loop/data/settings/core.toml
+++ b/src/bmad_loop/data/settings/core.toml
@@ -252,6 +252,13 @@ default_ref = "ScmPolicy.rollback_on_failure"
 label = "auto-rollback failed attempts"
 description = "⚠ in-place mode (isolation=none): when ON, a failed attempt's tracked changes are auto-reverted and the untracked files this run created are deleted (its uncommitted work is lost). When OFF (default), the orchestrator never touches your tree — it pauses with manual recovery steps. Governs unattended/stopped attempts only: a resolved escalation's re-drive always auto-recovers regardless (reverts the failed source, keeps the corrected spec). Prefer isolation=worktree to keep failures off your main checkout."
 [[section.field]]
+key = "preserve_keep"
+kind = "int"
+minimum = 0
+default_ref = "ScmPolicy.preserve_keep"
+label = "preserve-ref retention"
+description = "attempt-preserve/* recovery branches kept at each run start · the newest by committer date survive and the tail is deleted (0 = never prune)"
+[[section.field]]
 key = "seed_adapter_defaults"
 kind = "switch"
 default_ref = "ScmPolicy.seed_adapter_defaults"

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -215,6 +215,7 @@ class Engine:
                 # repo), so it must sit inside the pause handler, not before it.
                 self._emit_run_boundary("pre_run")
                 self._ensure_target_branch()
+                self._prune_preserve_refs()
                 self._loop()
                 self.state.finished = True
                 self._gc_run_worktrees()
@@ -845,6 +846,32 @@ class Engine:
             keep=(".bmad-loop", *self._protected_relpaths()),
             preserve=preserve,
         )
+
+    def _prune_preserve_refs(self) -> None:
+        """Bounded retention for the attempt-preserve/* recovery branches at run
+        start: keep the newest scm.preserve_keep by committer date, delete the
+        tail (mirrors the runs/cleanup retention knobs — without it the refs
+        grow unbounded on a long-lived project). Best-effort: a git failure is
+        journalled and never blocks or pauses the run — the refs are a safety
+        net, not run state. preserve_keep = 0 disables pruning entirely."""
+        keep = self.policy.scm.preserve_keep
+        if keep <= 0:
+            return
+        try:
+            deleted = verify.prune_preserve_refs(self.workspace.root, keep)
+        except Exception as exc:  # noqa: BLE001 - housekeeping must never crash the
+            # run: a git timeout/OSError here would otherwise escape to the crash
+            # handler, so anything beyond the expected GitError is journalled too
+            # A partial prune (PrunePreserveError) already deleted refs before one
+            # stuck — that destructive half must stay structurally auditable, not
+            # buried in the error string.
+            partial = getattr(exc, "deleted", [])
+            if partial:
+                self.journal.append("attempt-preserve-pruned", count=len(partial), refs=partial)
+            self.journal.append("attempt-preserve-prune-failed", error=str(exc))
+            return
+        if deleted:
+            self.journal.append("attempt-preserve-pruned", count=len(deleted), refs=deleted)
 
     def _preserve_attempt_commits(self, task: StoryTask, *, allow_pause: bool) -> None:
         """Before an auto-rollback's hard reset, park any commits the attempt made

--- a/src/bmad_loop/policy.py
+++ b/src/bmad_loop/policy.py
@@ -255,6 +255,13 @@ class ScmPolicy:
     # attempt's source but preserves the corrected spec under the BMAD artifact
     # folders, which it treats as orchestrator-owned.
     rollback_on_failure: bool = False
+    # preserve_keep bounds the attempt-preserve/* recovery branches auto-rollback
+    # parks before its hard reset: each run start keeps only the N most recent
+    # (by committer date) and deletes the tail, so a long-lived project with
+    # rollback_on_failure on doesn't accumulate them forever. 0 = never prune
+    # (maximum safety). The refs/attempt-preserve-dirty/* worktree snapshots are
+    # never touched by this.
+    preserve_keep: int = 20
     # failed_diff_max_mb caps the per-file size (MB) of untracked files captured
     # into a kept-failed unit's forensic changes.patch, so a stray build dir or
     # huge log can't blow it up; oversized files are skipped with a labelled
@@ -552,6 +559,13 @@ def loads(text: str, plugin_schemas: dict[str, Any] | None = None) -> Policy:
     requested_parallel = int(scm_d.get("max_parallel", ScmPolicy.max_parallel))
     if requested_parallel < 1:
         raise PolicyError(f"scm.max_parallel must be >= 1: got {requested_parallel}")
+    preserve_keep = scm_d.get("preserve_keep", ScmPolicy.preserve_keep)
+    # strict on purpose, unlike the sibling int knobs: a TOML `true` (int(True)=1)
+    # or `1.9` coercing through int() would silently shrink a safety-net budget
+    if isinstance(preserve_keep, bool) or not isinstance(preserve_keep, int):
+        raise PolicyError(f"scm.preserve_keep must be an integer: got {preserve_keep!r}")
+    if preserve_keep < 0:
+        raise PolicyError(f"scm.preserve_keep must be >= 0: got {preserve_keep}")
     scm = ScmPolicy(
         isolation=str(scm_d.get("isolation", ScmPolicy.isolation)),
         branch_per=str(scm_d.get("branch_per", ScmPolicy.branch_per)),
@@ -560,6 +574,7 @@ def loads(text: str, plugin_schemas: dict[str, Any] | None = None) -> Policy:
         delete_branch=bool(scm_d.get("delete_branch", ScmPolicy.delete_branch)),
         keep_failed=bool(scm_d.get("keep_failed", ScmPolicy.keep_failed)),
         rollback_on_failure=bool(scm_d.get("rollback_on_failure", ScmPolicy.rollback_on_failure)),
+        preserve_keep=preserve_keep,
         failed_diff_max_mb=int(scm_d.get("failed_diff_max_mb", ScmPolicy.failed_diff_max_mb)),
         failed_diff_unlimited=bool(
             scm_d.get("failed_diff_unlimited", ScmPolicy.failed_diff_unlimited)
@@ -764,6 +779,7 @@ merge_strategy = "merge"     # ff | merge | squash (worktree mode merges the uni
 delete_branch = true         # delete the unit branch after a successful merge
 keep_failed = true           # keep a failed unit's worktree+branch for inspection
 rollback_on_failure = false  # in-place (isolation="none") recovery after a failed attempt. false = never touch the tree; pause with manual recovery steps. true = auto-revert the attempt's tracked changes + remove only the untracked files this run created (WARNING: discards the attempt's uncommitted work; never a blanket git clean). Governs unattended/stopped attempts only: a resolved escalation's re-drive always auto-recovers regardless (reverts the failed source, keeps the corrected spec). Prefer isolation="worktree" to avoid touching your main checkout.
+preserve_keep = 20           # attempt-preserve/* recovery branches kept at run start, newest by committer date; the tail is deleted (0 = never prune)
 failed_diff_max_mb = 5       # per-file size cap (MB) for untracked files in a kept-failed unit's changes.patch; oversized files are skipped with a marker
 failed_diff_unlimited = false # true = capture the failed-unit diff with no size cap (may produce very large patches; warns when active)
 # commit_message_template: when set, the commit message dev sessions use for a

--- a/src/bmad_loop/verify.py
+++ b/src/bmad_loop/verify.py
@@ -249,6 +249,73 @@ def preserve_commits(
     return ref_name
 
 
+class PrunePreserveError(GitError):
+    """Partial :func:`prune_preserve_refs` failure. The prune is per-ref
+    best-effort, so refs may already be gone when a later one sticks — the
+    ``deleted`` list keeps that destructive half structurally auditable (a
+    caller can journal it, not just grep the message) and ``failed`` names
+    each stuck ref with its git detail."""
+
+    def __init__(self, message: str, *, deleted: list[str], failed: list[str]) -> None:
+        super().__init__(message)
+        self.deleted = deleted
+        self.failed = failed
+
+
+def prune_preserve_refs(repo: Path, keep: int) -> list[str]:
+    """Bounded retention for the ``attempt-preserve/*`` recovery branches that
+    :func:`preserve_commits` parks before an auto-rollback reset: keep the
+    ``keep`` most recent refs by committer date, force-delete the rest, and
+    return the deleted branch names (empty when nothing is over budget). Only
+    ``refs/heads/attempt-preserve/`` is ever listed, so branches outside that
+    prefix and the ``refs/attempt-preserve-dirty/*`` snapshot refs are
+    untouchable by construction — but the prefix itself is owned by the pruner:
+    anything parked under it, however it got there, is subject to deletion.
+    ``keep <= 0`` means "never prune" — returns ``[]`` without running git.
+
+    Raises :class:`GitError` when the listing fails, or
+    :class:`PrunePreserveError` — after attempting every tail ref — when any
+    individual delete failed (e.g. the ref is checked out here or in a
+    worktree). One stuck ref must not wedge the retention for everything
+    behind it, so deletes are per-ref best-effort and the error carries both
+    what was deleted and what was not."""
+    if keep <= 0:
+        return []
+    rc, out = _git(
+        repo,
+        "for-each-ref",
+        # ties on committerdate (same-second rollbacks) break by ascending
+        # refname — an explicit, observable order rather than git's implicit
+        # stable-sort fallback. Last --sort key is the primary one.
+        "--sort=refname",
+        "--sort=-committerdate",
+        # full refname, not :short — a tag or remote ref sharing the name would
+        # make :short emit "heads/attempt-preserve/x", which `branch -D` can't use
+        "--format=%(refname)",
+        "refs/heads/attempt-preserve/",
+    )
+    if rc != 0:
+        raise GitError(f"git for-each-ref attempt-preserve failed in {repo}: {out}")
+    refs = [line.removeprefix("refs/heads/") for line in out.splitlines() if line]
+    deleted: list[str] = []
+    failed: list[str] = []
+    for name in refs[keep:]:
+        try:
+            delete_branch(repo, name, force=True)
+        except GitError as exc:
+            failed.append(f"{name} ({exc})")
+            continue
+        deleted.append(name)
+    if failed:
+        raise PrunePreserveError(
+            f"attempt-preserve prune in {repo}: deleted {deleted or 'nothing'}, "
+            f"could not delete {'; '.join(failed)}",
+            deleted=deleted,
+            failed=failed,
+        )
+    return deleted
+
+
 def snapshot_worktree(
     repo: Path, ref_name: str, *, baseline_untracked: list[str] | None
 ) -> str | None:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -41,7 +41,13 @@ from bmad_loop.policy import (
     VerifyPolicy,
 )
 from bmad_loop.runs import rearm_escalation
-from bmad_loop.verify import GitError, read_frontmatter, rev_parse_head, worktree_clean
+from bmad_loop.verify import (
+    GitError,
+    PrunePreserveError,
+    read_frontmatter,
+    rev_parse_head,
+    worktree_clean,
+)
 
 QUIET = NotifyPolicy(desktop=False, file=True)
 
@@ -1182,6 +1188,92 @@ def test_rollback_preserves_distinct_refs_across_repeated_dirty_rollbacks(projec
     # both snapshots remain reachable and carry their own attempt's uncommitted edit
     assert git(repo, "show", f"{refs[0]}:src.txt") == "attempt 0 edit"
     assert git(repo, "show", f"{refs[1]}:src.txt") == "attempt 1 edit"
+
+
+def test_run_start_prunes_excess_preserve_refs(project):
+    """Run start with scm.preserve_keep set and more attempt-preserve/* refs than
+    the budget: the tail is deleted before the loop, only preserve_keep refs
+    survive, and the deletions are journalled."""
+    policy = Policy(
+        gates=GatesPolicy(mode="none"),
+        notify=QUIET,
+        scm=ScmPolicy(rollback_on_failure=True, preserve_keep=2),
+    )
+    repo = project.project
+    write_sprint(project, {"epic-1": "backlog"})  # nothing actionable: run start + finish only
+    for i in range(3):
+        (repo / "impl.txt").write_text(f"parked attempt {i}\n")
+        git(repo, "add", "-A")
+        git(repo, "commit", "-q", "-m", f"attempt {i}")
+        git(repo, "branch", "-f", f"attempt-preserve/run-{i}")
+    engine, _ = make_engine(project, [], policy=policy)
+
+    engine.run()
+
+    remaining = git(
+        repo, "for-each-ref", "--format=%(refname:short)", "refs/heads/attempt-preserve/"
+    ).splitlines()
+    assert len(remaining) == 2  # tail pruned down to the budget
+    entry = next(e for e in engine.journal.entries() if e["kind"] == "attempt-preserve-pruned")
+    assert entry["count"] == 1
+    assert set(entry["refs"]) | set(remaining) == {f"attempt-preserve/run-{i}" for i in range(3)}
+
+
+def test_run_start_prune_failure_journals_and_run_proceeds(project, monkeypatch):
+    """A failing prune at run start is journalled and never blocks the run —
+    the recovery refs are a housekeeping concern, not run state."""
+    policy = Policy(
+        gates=GatesPolicy(mode="none"),
+        notify=QUIET,
+        scm=ScmPolicy(rollback_on_failure=True, preserve_keep=2),
+    )
+    write_sprint(project, {"epic-1": "backlog"})  # nothing actionable: run start + finish only
+
+    def _fail(*a, **k):
+        raise GitError("simulated for-each-ref failure")
+
+    monkeypatch.setattr("bmad_loop.verify.prune_preserve_refs", _fail)
+    engine, _ = make_engine(project, [], policy=policy)
+
+    engine.run()
+
+    entry = next(
+        e for e in engine.journal.entries() if e["kind"] == "attempt-preserve-prune-failed"
+    )
+    assert "simulated for-each-ref failure" in entry["error"]
+    assert engine.state.finished  # the prune failure never blocked or crashed the run
+
+
+def test_run_start_partial_prune_journals_deletions_and_failure(project, monkeypatch):
+    """A partial prune (some refs deleted before one stuck) journals BOTH the
+    structured deletions and the failure — the destructive half of a stuck
+    prune must never be auditable only via the error string."""
+    policy = Policy(
+        gates=GatesPolicy(mode="none"),
+        notify=QUIET,
+        scm=ScmPolicy(rollback_on_failure=True, preserve_keep=1),
+    )
+    write_sprint(project, {"epic-1": "backlog"})  # nothing actionable: run start + finish only
+
+    def _partial(*a, **k):
+        raise PrunePreserveError(
+            "one ref stuck",
+            deleted=["attempt-preserve/gone"],
+            failed=["attempt-preserve/stuck (checked out)"],
+        )
+
+    monkeypatch.setattr("bmad_loop.verify.prune_preserve_refs", _partial)
+    engine, _ = make_engine(project, [], policy=policy)
+
+    engine.run()
+
+    pruned = next(e for e in engine.journal.entries() if e["kind"] == "attempt-preserve-pruned")
+    assert pruned["count"] == 1 and pruned["refs"] == ["attempt-preserve/gone"]
+    failed = next(
+        e for e in engine.journal.entries() if e["kind"] == "attempt-preserve-prune-failed"
+    )
+    assert "one ref stuck" in failed["error"]
+    assert engine.state.finished
 
 
 def test_rollback_worktree_preserve_failure_journals_git_error(project, monkeypatch):

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -327,6 +327,7 @@ def test_scm_defaults_reproduce_today(tmp_path):
     assert pol.scm.merge_strategy == "merge"
     assert pol.scm.delete_branch is True
     assert pol.scm.keep_failed is True
+    assert pol.scm.preserve_keep == 20
     assert pol.scm.failed_diff_max_mb == 5
     assert pol.scm.failed_diff_unlimited is False
     assert pol.scm.commit_message_template == ""
@@ -381,6 +382,23 @@ def test_scm_max_parallel_clamped_to_one(tmp_path):
     p.write_text("[scm]\nmax_parallel = 0\n")
     with pytest.raises(policy.PolicyError, match="scm.max_parallel"):
         policy.load(p)
+
+
+def test_scm_preserve_keep_settings(tmp_path):
+    p = tmp_path / "policy.toml"
+    p.write_text("[scm]\npreserve_keep = 5\n")
+    assert policy.load(p).scm.preserve_keep == 5
+    # 0 = never prune (maximum safety) — valid
+    p.write_text("[scm]\npreserve_keep = 0\n")
+    assert policy.load(p).scm.preserve_keep == 0
+    p.write_text("[scm]\npreserve_keep = -1\n")
+    with pytest.raises(policy.PolicyError, match="scm.preserve_keep"):
+        policy.load(p)
+    # strict typing: bool/float/string must not coerce into a smaller budget
+    for bad in ("true", "1.9", '"5"'):
+        p.write_text(f"[scm]\npreserve_keep = {bad}\n")
+        with pytest.raises(policy.PolicyError, match="scm.preserve_keep must be an integer"):
+            policy.load(p)
 
 
 def test_scm_failed_diff_settings(tmp_path):

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1,4 +1,6 @@
 import dataclasses
+import os
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -826,6 +828,122 @@ def test_preserve_commits_raises_on_branch_failure(project):
     git(repo, "commit", "-q", "-m", "attempt work")
     with pytest.raises(verify.GitError):
         verify.preserve_commits(repo, baseline, "bad..ref")  # ".." is an illegal git ref name
+
+
+def _dated_commit(repo, message, date):
+    """Empty commit with a forced committer date, so ref-age ordering across
+    branches is deterministic (back-to-back commits share a same-second date)."""
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "-q", "--allow-empty", "-m", message],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "GIT_AUTHOR_DATE": date, "GIT_COMMITTER_DATE": date},
+    )
+
+
+def _preserve_ref_names(repo):
+    out = git(repo, "for-each-ref", "--format=%(refname:short)", "refs/heads/attempt-preserve/")
+    return sorted(line for line in out.splitlines() if line)
+
+
+def test_prune_preserve_refs_deletes_oldest_beyond_keep(project):
+    """5 preserve refs, keep=3: the 2 oldest by committer date are deleted (and
+    returned); the 3 newest survive. Dates deliberately disagree with creation/
+    name order, so this proves committer-date ordering — not name or creation
+    order."""
+    repo = project.project
+    # ref index -> date rank: run-2 is oldest, run-4 second-oldest, run-1 newest
+    for i, day in ((0, 3), (1, 5), (2, 1), (3, 4), (4, 2)):
+        _dated_commit(repo, f"attempt {i}", f"2026-01-0{day}T12:00:00")
+        git(repo, "branch", "-f", f"attempt-preserve/run-{i}")
+
+    deleted = verify.prune_preserve_refs(repo, keep=3)
+
+    assert sorted(deleted) == ["attempt-preserve/run-2", "attempt-preserve/run-4"]
+    assert _preserve_ref_names(repo) == [f"attempt-preserve/run-{i}" for i in (0, 1, 3)]
+
+
+def test_prune_preserve_refs_at_or_under_budget_noop(project):
+    """At/under budget (refs <= keep) nothing is deleted."""
+    repo = project.project
+    for i in range(3):
+        _dated_commit(repo, f"attempt {i}", f"2026-01-0{i + 1}T12:00:00")
+        git(repo, "branch", "-f", f"attempt-preserve/run-{i}")
+    assert verify.prune_preserve_refs(repo, keep=3) == []
+    assert len(_preserve_ref_names(repo)) == 3
+
+
+def test_prune_preserve_refs_keep_zero_never_prunes(project):
+    """keep=0 means "never prune" — no ref is deleted no matter how many exist."""
+    repo = project.project
+    for i in range(4):
+        _dated_commit(repo, f"attempt {i}", f"2026-01-0{i + 1}T12:00:00")
+        git(repo, "branch", "-f", f"attempt-preserve/run-{i}")
+    assert verify.prune_preserve_refs(repo, keep=0) == []
+    assert len(_preserve_ref_names(repo)) == 4
+
+
+def test_prune_preserve_refs_ignores_other_branches(project):
+    """Only attempt-preserve/* refs are considered or deleted: user and unit
+    branches alongside them never count against the budget and are never
+    touched, however old they are."""
+    repo = project.project
+    _dated_commit(repo, "old user work", "2025-06-01T12:00:00")
+    git(repo, "branch", "-f", "feature/user-branch")
+    git(repo, "branch", "-f", "bmad-loop/test-run/1-1-a")
+    for i in range(2):
+        _dated_commit(repo, f"attempt {i}", f"2026-01-0{i + 1}T12:00:00")
+        git(repo, "branch", "-f", f"attempt-preserve/run-{i}")
+
+    deleted = verify.prune_preserve_refs(repo, keep=1)
+
+    assert deleted == ["attempt-preserve/run-0"]  # only the older preserve ref
+    assert _preserve_ref_names(repo) == ["attempt-preserve/run-1"]
+    assert git(repo, "branch", "--list", "feature/user-branch").strip() != ""
+    assert git(repo, "branch", "--list", "bmad-loop/test-run/1-1-a").strip() != ""
+
+
+def test_prune_preserve_refs_ties_break_by_refname(project):
+    """Equal committer dates (same-second rollbacks, or two refs parked on the
+    same commit) break by ascending refname — an explicit deterministic order,
+    so the same repo state always prunes the same ref."""
+    repo = project.project
+    _dated_commit(repo, "tied attempts", "2026-01-01T12:00:00")
+    git(repo, "branch", "-f", "attempt-preserve/tie-a")  # same commit ⇒ same date
+    git(repo, "branch", "-f", "attempt-preserve/tie-b")
+    _dated_commit(repo, "fresh attempt", "2026-01-02T12:00:00")
+    git(repo, "branch", "-f", "attempt-preserve/newer")
+
+    deleted = verify.prune_preserve_refs(repo, keep=2)
+
+    # newest survives outright; within the tie, ascending refname wins (tie-a kept)
+    assert deleted == ["attempt-preserve/tie-b"]
+    assert _preserve_ref_names(repo) == ["attempt-preserve/newer", "attempt-preserve/tie-a"]
+
+
+def test_prune_preserve_refs_continues_past_undeletable_ref(project):
+    """A tail ref that can't be deleted (here: checked out) must not wedge the
+    prune — the rest of the tail is still deleted, and the error raised at the
+    end names both what was deleted and what was not."""
+    repo = project.project
+    for i in range(3):
+        _dated_commit(repo, f"attempt {i}", f"2026-01-0{i + 1}T12:00:00")
+        git(repo, "branch", "-f", f"attempt-preserve/run-{i}")
+    git(repo, "checkout", "-q", "attempt-preserve/run-0")  # oldest tail ref is checked out
+
+    with pytest.raises(verify.GitError) as excinfo:
+        verify.prune_preserve_refs(repo, keep=1)
+
+    # run-1 (the deletable tail ref) is gone; run-0 survived only because git
+    # refuses to delete the checked-out branch; run-2 (newest) was kept
+    assert _preserve_ref_names(repo) == ["attempt-preserve/run-0", "attempt-preserve/run-2"]
+    assert "attempt-preserve/run-1" in str(excinfo.value)  # deleted, still auditable
+    assert "attempt-preserve/run-0" in str(excinfo.value)  # the stuck ref is named
+    # the destructive half is carried structurally, not just in the message
+    assert isinstance(excinfo.value, verify.PrunePreserveError)
+    assert excinfo.value.deleted == ["attempt-preserve/run-1"]
+    assert len(excinfo.value.failed) == 1 and "run-0" in excinfo.value.failed[0]
 
 
 def test_snapshot_worktree_survives_reset_and_gc(project):


### PR DESCRIPTION
## Summary

Closes #32

Auto-rollback parks committed attempt work under `attempt-preserve/*` branches (#29), but nothing ever removed them — with `scm.rollback_on_failure` on they grew unbounded. This adds bounded retention at run start, mirroring the existing retention knobs:

- **`verify.prune_preserve_refs(repo, keep)`** — lists `refs/heads/attempt-preserve/` via `for-each-ref --sort=refname --sort=-committerdate` (newest by committer date kept; ties break deterministically by ascending refname) and force-deletes the tail. Full refnames (not `:short`) so a tag sharing the name can't derail the delete.
- **`ScmPolicy.preserve_keep`** (default 20, `0` = never prune) — strictly typed at policy load (`PolicyError` on bool/float/string/negative, so a TOML typo can't silently shrink a safety budget), plus settings-UI field and policy-template line.
- **Engine hook at run start** — best-effort: any failure is journalled (`attempt-preserve-prune-failed`) and never blocks or crashes the run.

Hardening from adversarial review:

- Per-ref best-effort deletes: one stuck ref (e.g. checked out for inspection) never wedges the refs behind it. All deletions are attempted first; `PrunePreserveError(GitError)` then carries `.deleted`/`.failed` so the engine journals the destructive half structurally (`attempt-preserve-pruned`) alongside the failure event — a partial prune is never auditable only via an error string.
- `refs/attempt-preserve-dirty/*` snapshot refs are untouched by design; their symmetric retention gap is tracked in #49.

## Tests

11 new/extended tests: keep-N boundary, committer-date ordering proven with dates deliberately disagreeing with creation order, refname tie-break, keep=0 no-op, non-preserve branches untouched, stuck-ref partial failure (structured attrs + both journal events), engine wiring at run start, prune failure never blocking the run, and strict config typing (`true`/`1.9`/`"5"`/`-1` all rejected).

Verified on Windows (`201 passed`, ruff clean) and Linux/WSL (`202 passed`, includes the signal test Windows skips).