### PR TITLE
fix(adapters): complete dev sessions only on Stop or window death

### DIFF
--- a/src/bmad_loop/adapters/generic.py
+++ b/src/bmad_loop/adapters/generic.py
@@ -232,17 +232,13 @@ class GenericAdapter(CodingCLIAdapter):
                     # died without a SessionEnd hook (killed, crashed hard)
                     return self._final(handle, spec, "crashed", session_id, transcript_path)
                 if stall_deadline is not None:
-                    # A terminal result can land mid-grace without a fresh Stop to
-                    # wake us; check non-blocking on each idle tick so completion
-                    # isn't deferred to grace expiry (up to dev_stall_grace_s late).
-                    result_json = self._result_json(handle, spec, wait=False)
-                    if result_json is not None:
-                        return SessionResult(
-                            status="completed",
-                            result_json=result_json,
-                            session_id=session_id,
-                            transcript_path=transcript_path,
-                        )
+                    # No artifact shortcut here: the window is alive on this tick
+                    # (a dead one returned "crashed" above), and a terminal
+                    # artifact under a live window is advisory only — the agent
+                    # may still be mid-turn (or the artifact stale from a prior
+                    # drive), and run()'s finally-kill would terminate it before
+                    # its remaining work flushes. Only a Stop event or window
+                    # death completes the session.
                     # The grace window measures inactivity, not time-since-Stop:
                     # a session still streaming to the tee'd pane log (a long
                     # productive turn building a diff, a streaming subagent) is
@@ -254,17 +250,6 @@ class GenericAdapter(CodingCLIAdapter):
                         stall_deadline = time.monotonic() + self._stall_grace_s
                         continue
                 if stall_deadline is not None and time.monotonic() >= stall_deadline:
-                    # the grace window elapsed with no re-invocation; one last
-                    # non-blocking check in case the spec landed without a fresh
-                    # Stop.
-                    result_json = self._result_json(handle, spec, wait=False)
-                    if result_json is not None:
-                        return SessionResult(
-                            status="completed",
-                            result_json=result_json,
-                            session_id=session_id,
-                            transcript_path=transcript_path,
-                        )
                     if stall_nudges_left > 0 and (
                         spec.stall_nudges_cap is None or stall_nudges_sent < spec.stall_nudges_cap
                     ):
@@ -279,7 +264,12 @@ class GenericAdapter(CodingCLIAdapter):
                         stall_deadline = time.monotonic() + self._stall_grace_s
                         last_activity = self._log_activity_key(handle.task_id)
                         continue
-                    return self._final(handle, spec, "stalled", session_id, transcript_path)
+                    # The window is alive here, so an artifact on disk cannot
+                    # upgrade the stall verdict to completed — it may be stale
+                    # or mid-write; only a Stop or window death vouches for it.
+                    return self._final(
+                        handle, spec, "stalled", session_id, transcript_path, accept_result=False
+                    )
                 continue
             if (
                 event.event == "Stop"
@@ -355,10 +345,14 @@ class GenericAdapter(CodingCLIAdapter):
         fallback: str,
         session_id: str | None,
         transcript: str | None,
+        *,
+        accept_result: bool = True,
     ) -> SessionResult:
         """Session is gone or done responding: completed if the result file
-        landed anyway, otherwise the fallback status."""
-        result_json = self._result_json(handle, spec, wait=False)
+        landed anyway, otherwise the fallback status. ``accept_result=False``
+        (a stall verdict reached under a live window) pins the fallback: an
+        artifact that appeared without a Stop or window death is not trusted."""
+        result_json = self._result_json(handle, spec, wait=False) if accept_result else None
         status = "completed" if result_json is not None else fallback
         return SessionResult(
             status=status,

--- a/src/bmad_loop/adapters/generic.py
+++ b/src/bmad_loop/adapters/generic.py
@@ -264,9 +264,23 @@ class GenericAdapter(CodingCLIAdapter):
                         stall_deadline = time.monotonic() + self._stall_grace_s
                         last_activity = self._log_activity_key(handle.task_id)
                         continue
-                    # The window is alive here, so an artifact on disk cannot
-                    # upgrade the stall verdict to completed — it may be stale
-                    # or mid-write; only a Stop or window death vouches for it.
+                    # Re-probe liveness before finalizing: this return exits the
+                    # loop, so a hard death (no SessionEnd) in the gap since the
+                    # top-of-tick probe would otherwise never be caught. Window
+                    # death is authoritative — a now-dead window flows through the
+                    # crash path (which honors its artifact via accept_result=True)
+                    # instead of a stall that discards a just-flushed result. A
+                    # transport error is not proof of death (as at the top of the
+                    # tick); fall through to the stall — spec.timeout_s bounds a
+                    # persistent failure.
+                    try:
+                        if not self._window_alive(handle):
+                            return self._final(handle, spec, "crashed", session_id, transcript_path)
+                    except MultiplexerError:
+                        pass
+                    # Still alive: an artifact on disk cannot upgrade the stall to
+                    # completed — it may be stale or mid-write; only a Stop or
+                    # window death vouches for it.
                     return self._final(
                         handle, spec, "stalled", session_id, transcript_path, accept_result=False
                     )

--- a/src/bmad_loop/devcontract.py
+++ b/src/bmad_loop/devcontract.py
@@ -263,3 +263,45 @@ def reset_spec_status(spec_path: Path, new_status: str) -> bool:
         return False
     spec_path.write_text(head + new_body + tail + text[fm.end() :], encoding="utf-8")
     return True
+
+
+def _fenced(text: str, offset: int) -> bool:
+    """True when `offset` falls inside a ``` / ~~~ fenced code block. Counting
+    fence lines before the offset suffices: an odd count means a fence is open.
+    Fences may be indented up to three spaces (CommonMark; a tab would make an
+    indented code block instead, so tabs are excluded). Deleting content is
+    destructive, so unlike the read-only heading scans (`find_result_artifact`,
+    `parse_auto_run_result`) the strip below must not mistake a fenced example
+    for a real section boundary."""
+    return sum(1 for _ in re.finditer(r"^ {0,3}(?:```|~~~)", text[:offset], re.MULTILINE)) % 2 == 1
+
+
+def strip_auto_run_result(spec_path: Path) -> bool:
+    """Remove every ``## Auto Run Result`` section from a spec, in place.
+
+    Companion to `reset_spec_status` on the re-drive path: re-opening a spec by
+    flipping only its frontmatter would leave the stale terminal section behind,
+    and `find_result_artifact` keys on that heading — the re-driven session's
+    very first save of the spec would then qualify as a terminal result. Each
+    section spans its heading to the next same-level heading (mirroring
+    `parse_auto_run_result`'s boundary) or end-of-file; headings quoted inside
+    fenced code blocks are ignored on both ends. Returns True when a section was
+    removed, False when none was present."""
+    text = spec_path.read_text(encoding="utf-8")
+    matches = [m for m in AUTO_RUN_HEADING_RE.finditer(text) if not _fenced(text, m.start())]
+    if not matches:
+        return False
+    kept: list[str] = []
+    pos = 0
+    for m in matches:
+        if m.start() < pos:
+            continue  # heading inside a section already being removed
+        kept.append(text[pos : m.start()])
+        pos = len(text)
+        for nxt in re.finditer(r"^##\s", text, re.MULTILINE):
+            if nxt.start() >= m.end() and not _fenced(text, nxt.start()):
+                pos = nxt.start()
+                break
+    kept.append(text[pos:])
+    spec_path.write_text("".join(kept), encoding="utf-8")
+    return True

--- a/src/bmad_loop/devcontract.py
+++ b/src/bmad_loop/devcontract.py
@@ -273,8 +273,10 @@ def reset_spec_status(spec_path: Path, new_status: str) -> bool:
     prose body (e.g. the ``## Auto Run Result`` section). A present-but-empty status
     is filled, and a frontmatter block with NO ``status:`` line at all gets one
     inserted before the closing fence (the skill's template can leave it blank or
-    absent). Returns True on a real change, False when the spec has no frontmatter
-    block or is already at ``new_status``."""
+    absent). Returns True on a real change, False when the spec is absent, has no
+    frontmatter block, or is already at ``new_status``."""
+    if not spec_path.is_file():
+        return False
     text = spec_path.read_text(encoding="utf-8")
     fm = _FRONTMATTER_RE.match(text)
     if not fm:
@@ -325,7 +327,16 @@ def strip_auto_run_result(spec_path: Path) -> bool:
     section spans its heading to the next same-level heading (the shared
     `parse_auto_run_result` boundary) or end-of-file; headings quoted inside
     fenced code blocks are ignored on both ends. Returns True when a section was
-    removed, False when none was present."""
+    removed, False when the spec is absent or no section was present.
+
+    Only an absent spec is guarded (a clean no-op, mirroring
+    `verify.set_frontmatter_status`); a present-but-unreadable spec or a failing
+    write is left to raise. Silently skipping the strip after the caller has
+    already flipped the frontmatter status would leave the re-opened spec carrying
+    its stale terminal section — the exact state that makes the re-driven session's
+    first save read as a result — so that failure must surface, not be swallowed."""
+    if not spec_path.is_file():
+        return False
     text = spec_path.read_text(encoding="utf-8")
     matches = _section_headings(text)
     if not matches:

--- a/src/bmad_loop/devcontract.py
+++ b/src/bmad_loop/devcontract.py
@@ -83,21 +83,47 @@ class AutoRunResult:
     detail: str  # the prose body after the heading, trimmed (human-readable)
 
 
+def _fenced(text: str, offset: int) -> bool:
+    """True when `offset` falls inside a ``` / ~~~ fenced code block. Counting
+    fence lines before the offset suffices: an odd count means a fence is open.
+    Fences may be indented up to three spaces (CommonMark; a tab would make an
+    indented code block instead, so tabs are excluded)."""
+    return sum(1 for _ in re.finditer(r"^ {0,3}(?:```|~~~)", text[:offset], re.MULTILINE)) % 2 == 1
+
+
+def _section_headings(text: str) -> list[re.Match[str]]:
+    """`AUTO_RUN_HEADING_RE` matches that are real section headings. A heading
+    quoted inside a fenced code block (a frozen intent showing an example of the
+    terminal section, a log excerpt) is documentation, not structure — treating
+    it as terminal would let such a spec read as a result artifact from the
+    agent's first save (#52)."""
+    return [m for m in AUTO_RUN_HEADING_RE.finditer(text) if not _fenced(text, m.start())]
+
+
+def _next_heading_start(text: str, offset: int) -> int:
+    """Offset of the first non-fenced same-level (`## `) heading at/after
+    `offset`, or end-of-text — the shared section boundary. Fenced `## ` lines
+    inside the section (quoted shell comments, log output) are content, not
+    boundaries."""
+    for nxt in re.finditer(r"^##\s", text, re.MULTILINE):
+        if nxt.start() >= offset and not _fenced(text, nxt.start()):
+            return nxt.start()
+    return len(text)
+
+
 def parse_auto_run_result(text: str) -> AutoRunResult:
     """Tolerantly extract the trailing `## Auto Run Result` section from a spec.
 
-    Reads the LAST such heading (the finalize step appends; a re-derivation loop
-    could in principle append more than one — the last is the live outcome) and
-    pulls its `Status:` value plus the remaining prose as detail.
+    Reads the LAST real (non-fenced) such heading (the finalize step appends; a
+    re-derivation loop could in principle append more than one — the last is the
+    live outcome) and pulls its `Status:` value plus the remaining prose as
+    detail, spanning to the next real same-level heading.
     """
-    matches = list(AUTO_RUN_HEADING_RE.finditer(text))
+    matches = _section_headings(text)
     if not matches:
         return AutoRunResult(present=False, status="", detail="")
-    body = text[matches[-1].end() :]
-    # stop at the next top-level heading if the skill ever appends past it
-    nxt = re.search(r"^##\s+", body, re.MULTILINE)
-    if nxt:
-        body = body[: nxt.start()]
+    last = matches[-1]
+    body = text[last.end() : _next_heading_start(text, last.end())]
     status_m = STATUS_LINE_RE.search(body)
     status = status_m.group(1).strip().lower() if status_m else ""
     return AutoRunResult(present=True, status=status, detail=body.strip())
@@ -198,13 +224,14 @@ def find_result_artifact(impl_artifacts: Path, *, since_ns: int) -> Path | None:
         if mtime_ns < since_ns:
             continue
         # The no-spec fallback is recognized by name (it has no Auto Run Result
-        # heading); every other artifact must carry the terminal section.
+        # heading); every other artifact must carry a real (non-fenced) terminal
+        # section — a fence-quoted example must not qualify the spec (#52).
         if not path.name.startswith(FALLBACK_RESULT_PREFIX):
             try:
                 text = path.read_text(encoding="utf-8")
             except OSError:
                 continue
-            if not AUTO_RUN_HEADING_RE.search(text):
+            if not _section_headings(text):
                 continue
         if best is None or mtime_ns > best[0]:
             best = (mtime_ns, path)
@@ -265,17 +292,6 @@ def reset_spec_status(spec_path: Path, new_status: str) -> bool:
     return True
 
 
-def _fenced(text: str, offset: int) -> bool:
-    """True when `offset` falls inside a ``` / ~~~ fenced code block. Counting
-    fence lines before the offset suffices: an odd count means a fence is open.
-    Fences may be indented up to three spaces (CommonMark; a tab would make an
-    indented code block instead, so tabs are excluded). Deleting content is
-    destructive, so unlike the read-only heading scans (`find_result_artifact`,
-    `parse_auto_run_result`) the strip below must not mistake a fenced example
-    for a real section boundary."""
-    return sum(1 for _ in re.finditer(r"^ {0,3}(?:```|~~~)", text[:offset], re.MULTILINE)) % 2 == 1
-
-
 def strip_auto_run_result(spec_path: Path) -> bool:
     """Remove every ``## Auto Run Result`` section from a spec, in place.
 
@@ -283,12 +299,12 @@ def strip_auto_run_result(spec_path: Path) -> bool:
     flipping only its frontmatter would leave the stale terminal section behind,
     and `find_result_artifact` keys on that heading — the re-driven session's
     very first save of the spec would then qualify as a terminal result. Each
-    section spans its heading to the next same-level heading (mirroring
-    `parse_auto_run_result`'s boundary) or end-of-file; headings quoted inside
+    section spans its heading to the next same-level heading (the shared
+    `parse_auto_run_result` boundary) or end-of-file; headings quoted inside
     fenced code blocks are ignored on both ends. Returns True when a section was
     removed, False when none was present."""
     text = spec_path.read_text(encoding="utf-8")
-    matches = [m for m in AUTO_RUN_HEADING_RE.finditer(text) if not _fenced(text, m.start())]
+    matches = _section_headings(text)
     if not matches:
         return False
     kept: list[str] = []
@@ -297,11 +313,7 @@ def strip_auto_run_result(spec_path: Path) -> bool:
         if m.start() < pos:
             continue  # heading inside a section already being removed
         kept.append(text[pos : m.start()])
-        pos = len(text)
-        for nxt in re.finditer(r"^##\s", text, re.MULTILINE):
-            if nxt.start() >= m.end() and not _fenced(text, nxt.start()):
-                pos = nxt.start()
-                break
+        pos = _next_heading_start(text, m.end())
     kept.append(text[pos:])
     spec_path.write_text("".join(kept), encoding="utf-8")
     return True

--- a/src/bmad_loop/devcontract.py
+++ b/src/bmad_loop/devcontract.py
@@ -83,12 +83,35 @@ class AutoRunResult:
     detail: str  # the prose body after the heading, trimmed (human-readable)
 
 
+# A fence line: up to three spaces of indent, then a maximal run of >= 3 backticks
+# or tildes (its char AND length both matter per CommonMark), then the rest of the
+# line — an info string on an opener; on a close, only whitespace is allowed.
+_FENCE_LINE_RE = re.compile(r"^ {0,3}(`{3,}|~{3,})([^\n]*)$", re.MULTILINE)
+
+
 def _fenced(text: str, offset: int) -> bool:
-    """True when `offset` falls inside a ``` / ~~~ fenced code block. Counting
-    fence lines before the offset suffices: an odd count means a fence is open.
-    Fences may be indented up to three spaces (CommonMark; a tab would make an
-    indented code block instead, so tabs are excluded)."""
-    return sum(1 for _ in re.finditer(r"^ {0,3}(?:```|~~~)", text[:offset], re.MULTILINE)) % 2 == 1
+    """True when `offset` falls inside a ``` / ~~~ fenced code block.
+
+    A fence opens on a line of three-or-more backticks or tildes (indentable up
+    to three spaces; a tab would make an indented code block instead). Per
+    CommonMark it closes only on a later line using the SAME character, at least
+    as long as the opener, with no trailing non-whitespace — so a shorter run, a
+    different fence char, or an info-bearing line inside the block is content,
+    not a close. Tracking the open fence's char+length (not a bare line-parity
+    count) is what stops a nested-or-mismatched inner fence from flipping state
+    early and exposing a quoted `## Auto Run Result` as a real heading — a
+    destructive misread on the strip path."""
+    open_marker: str | None = None
+    for m in _FENCE_LINE_RE.finditer(text):
+        if m.start() >= offset:
+            break
+        marker, rest = m.group(1), m.group(2)
+        if open_marker is None:
+            open_marker = marker  # opening fence — an info string is allowed
+        elif marker[0] == open_marker[0] and len(marker) >= len(open_marker) and not rest.strip():
+            open_marker = None  # valid closing fence
+        # else: a shorter / mismatched / info-bearing fence line — literal content
+    return open_marker is not None
 
 
 def _section_headings(text: str) -> list[re.Match[str]]:

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -1850,10 +1850,14 @@ class Engine:
         "ingest as context, do not resume," so a repair must flip the frontmatter
         `status` back to `in-progress` to re-enter implement/review in place against
         the frozen intent contract. No-op when no spec is recorded yet (the prompt
-        then falls back to the story key)."""
+        then falls back to the story key). The stale terminal section is stripped
+        too: `find_result_artifact` keys on its heading, so leaving it would let
+        the re-driven session's first save of the spec read as a terminal result."""
         if not task.spec_file:
             return
-        devcontract.reset_spec_status(Path(task.spec_file), "in-progress")
+        spec_path = Path(task.spec_file)
+        devcontract.reset_spec_status(spec_path, "in-progress")
+        devcontract.strip_auto_run_result(spec_path)
 
     def _write_feedback(self, task: StoryTask, reason: str) -> Path:
         """Persist a verification failure where the next session can read it —

--- a/src/bmad_loop/runs.py
+++ b/src/bmad_loop/runs.py
@@ -10,7 +10,7 @@ import tarfile
 import time
 from pathlib import Path
 
-from . import verify
+from . import devcontract, verify
 from .adapters.multiplexer import get_multiplexer
 from .journal import STATE_FILE, Journal, load_state, save_state
 from .model import PAUSE_ESCALATION, Phase
@@ -512,8 +512,10 @@ def rearm_escalation(run_dir: Path, story_key: str | None = None) -> str:
     PENDING — which makes `_finish_inflight` reset the tree to the story's
     baseline and re-run it (clean rebuild) against the now-corrected frozen
     spec. Deterministically sets that spec's status to `ready-for-dev` so the
-    dev session routes straight to implement. Does NOT clear the pause; the
-    caller resumes the run separately.
+    dev session routes straight to implement, and strips the escalated
+    attempt's stale `## Auto Run Result` section so the re-drive cannot read
+    as terminal from its first save. Does NOT clear the pause; the caller
+    resumes the run separately.
 
     Returns the re-armed story key. Raises RearmError when the run is not
     paused at the escalation stage or the target story is not escalated.
@@ -546,6 +548,11 @@ def rearm_escalation(run_dir: Path, story_key: str | None = None) -> str:
         # route /bmad-dev-auto to re-implement (decision table: ready-for-dev
         # -> step-03); independent of the resolve agent having set it.
         verify.set_frontmatter_status(Path(task.spec_file), "ready-for-dev")
+        # drop the stale `## Auto Run Result` section along with the status flip
+        # (mirrors engine._reset_spec_for_repair): find_result_artifact keys on
+        # that heading, so leaving it would let the re-driven session's first
+        # save of the spec parse as the prior attempt's terminal outcome.
+        devcontract.strip_auto_run_result(Path(task.spec_file))
 
     save_state(run_dir, state)
     Journal(run_dir).append("story-escalation-resolved", story_key=key)

--- a/tests/test_devcontract.py
+++ b/tests/test_devcontract.py
@@ -64,6 +64,35 @@ def test_parse_stops_at_next_heading():
     assert arr.status == "done" and "blocked" not in arr.detail
 
 
+def test_parse_ignores_fence_quoted_heading():
+    """A heading quoted inside a fenced example (a frozen intent showing the
+    section format) is documentation, not a terminal section (#52)."""
+    text = "## Intent\n\n```md\n## Auto Run Result\n\nStatus: done\n```\n\nbody\n"
+    arr = devcontract.parse_auto_run_result(text)
+    assert not arr.present and arr.status == ""
+
+
+def test_parse_real_section_wins_over_later_fenced_example():
+    """A fenced copy of the heading inside the real section's detail must not
+    displace it as the 'last' section — the real outcome stays authoritative."""
+    text = (
+        "## Auto Run Result\n\nStatus: done\n\n"
+        "the format appended was:\n\n```md\n## Auto Run Result\n\nStatus: blocked\n```\n"
+    )
+    arr = devcontract.parse_auto_run_result(text)
+    assert arr.status == "done"
+
+
+def test_parse_detail_spans_fenced_heading_line():
+    """Column-0 `## ` lines inside a fenced block within the section (quoted
+    shell comments, log output) are content, not the next-section boundary —
+    the detail must not truncate there (#52)."""
+    text = "## Auto Run Result\n\nStatus: done\n\n```sh\n## run tests\npytest -q\n```\n\ntrailing\n"
+    arr = devcontract.parse_auto_run_result(text)
+    assert arr.status == "done"
+    assert "pytest -q" in arr.detail and "trailing" in arr.detail
+
+
 # ------------------------------------------------------------- synthesize_result
 
 
@@ -182,6 +211,19 @@ def test_find_artifact_accepts_no_spec_fallback_prefix(tmp_path):
         encoding="utf-8",
     )
     assert devcontract.find_result_artifact(tmp_path, since_ns=0) == fallback
+
+
+def test_find_artifact_ignores_fence_quoted_heading(tmp_path):
+    """A spec whose only `## Auto Run Result` is a fenced example must not
+    qualify as a terminal artifact, even with a fresh mtime — otherwise the
+    agent's first save of such a spec reads as this session's result (#52)."""
+    sp = tmp_path / "spec-1-1-a.md"
+    sp.write_text(
+        "---\nstatus: in-progress\n---\n\n## Intent\n\n"
+        "```md\n## Auto Run Result\n\nStatus: done\n```\n\nbody\n",
+        encoding="utf-8",
+    )
+    assert devcontract.find_result_artifact(tmp_path, since_ns=0) is None
 
 
 # ----------------------------------------------------------- reset_spec_status

--- a/tests/test_devcontract.py
+++ b/tests/test_devcontract.py
@@ -93,6 +93,39 @@ def test_parse_detail_spans_fenced_heading_line():
     assert "pytest -q" in arr.detail and "trailing" in arr.detail
 
 
+def test_parse_ignores_heading_in_longer_outer_fence():
+    """A shorter ``` line inside a longer ```` fence does NOT close it
+    (CommonMark), so a `## Auto Run Result` after that inner line is still fenced
+    documentation. A bare line-parity count would flip on the inner ``` and wrongly
+    expose the heading as a real, terminal section."""
+    text = (
+        "## Intent\n\n"
+        "````\n"  # open a 4-backtick fence
+        "```\n"  # lone 3-backtick line — literal content, not a close
+        "## Auto Run Result\n\nStatus: done\n"
+        "````\n\nbody\n"  # the real close
+    )
+    arr = devcontract.parse_auto_run_result(text)
+    assert not arr.present and arr.status == ""
+
+
+def test_parse_ignores_heading_in_mismatched_fence_char():
+    """A ``` line inside a ~~~ fence is content (a different fence char cannot
+    close), so a `## Auto Run Result` after it stays fenced."""
+    text = "## Intent\n\n" "~~~\n" "```\n" "## Auto Run Result\n\nStatus: done\n" "~~~\n\nbody\n"
+    arr = devcontract.parse_auto_run_result(text)
+    assert not arr.present and arr.status == ""
+
+
+def test_parse_recognizes_real_heading_after_closed_longer_fence():
+    """Positive control: after a properly-closed 4-backtick fence, a real
+    `## Auto Run Result` IS recognized — the tracker must actually close, not
+    over-correct into a fence that never ends."""
+    text = "## Intent\n\n````\ncode\n````\n\n## Auto Run Result\n\nStatus: done\n"
+    arr = devcontract.parse_auto_run_result(text)
+    assert arr.present and arr.status == "done"
+
+
 # ------------------------------------------------------------- synthesize_result
 
 
@@ -221,6 +254,19 @@ def test_find_artifact_ignores_fence_quoted_heading(tmp_path):
     sp.write_text(
         "---\nstatus: in-progress\n---\n\n## Intent\n\n"
         "```md\n## Auto Run Result\n\nStatus: done\n```\n\nbody\n",
+        encoding="utf-8",
+    )
+    assert devcontract.find_result_artifact(tmp_path, since_ns=0) is None
+
+
+def test_find_artifact_ignores_heading_in_longer_outer_fence(tmp_path):
+    """A `## Auto Run Result` fenced inside a 4-backtick block (past a lone inner
+    ``` line) must not qualify the spec as a terminal artifact — the char+length
+    tracker keeps the outer fence open where line-parity would not."""
+    sp = tmp_path / "spec-1-1-a.md"
+    sp.write_text(
+        "---\nstatus: in-progress\n---\n\n## Intent\n\n"
+        "````\n```\n## Auto Run Result\n\nStatus: done\n````\n\nbody\n",
         encoding="utf-8",
     )
     assert devcontract.find_result_artifact(tmp_path, since_ns=0) is None
@@ -447,3 +493,30 @@ def test_strip_auto_run_result_skips_fenced_boundary_lines(tmp_path):
     text = sp.read_text()
     assert "Auto Run Result" not in text and "trailing stale prose" not in text
     assert "## Intent\n\nbody\n" in text
+
+
+def test_strip_auto_run_result_ignores_heading_in_longer_outer_fence(tmp_path):
+    """Destructive-op guard: a `## Auto Run Result` fenced inside a 4-backtick
+    block that contains a lone inner ``` line must be preserved (no-op). Line
+    parity would flip on the inner ``` and strip the fenced documentation."""
+    sp = tmp_path / "spec.md"
+    original = (
+        "---\nstatus: draft\n---\n\n## Intent\n\n"
+        "````\n```\n## Auto Run Result\n\nStatus: done\n````\n\nmore body\n"
+    )
+    sp.write_text(original, encoding="utf-8")
+    assert devcontract.strip_auto_run_result(sp) is False
+    assert sp.read_text() == original
+
+
+def test_strip_auto_run_result_ignores_heading_in_mismatched_fence_char(tmp_path):
+    """A ``` line inside a ~~~ fence is content, not a close — the fenced
+    `## Auto Run Result` after it is documentation and must survive."""
+    sp = tmp_path / "spec.md"
+    original = (
+        "---\nstatus: draft\n---\n\n## Intent\n\n"
+        "~~~\n```\n## Auto Run Result\n\nStatus: done\n~~~\n\nmore body\n"
+    )
+    sp.write_text(original, encoding="utf-8")
+    assert devcontract.strip_auto_run_result(sp) is False
+    assert sp.read_text() == original

--- a/tests/test_devcontract.py
+++ b/tests/test_devcontract.py
@@ -479,6 +479,25 @@ def test_strip_auto_run_result_ignores_heading_in_indented_fence(tmp_path):
     assert sp.read_text() == original
 
 
+def test_strip_auto_run_result_ignores_list_indented_fence(tmp_path):
+    """Reviewer guard (#53): a `## Auto Run Result` quoted inside a fence nested
+    under list indentation (4+ absolute leading spaces) is co-indented with the
+    fence. `_FENCE_LINE_RE` only recognizes 0-3-space fences, so this fence is not
+    tracked — but the heading is likewise indented and can never match the
+    column-0-anchored `AUTO_RUN_HEADING_RE`, so there is nothing to strip. Locks
+    that symmetry: giving the heading regex any leading-space tolerance would
+    reopen this as a destructive false-positive on quoted spec prose."""
+    sp = tmp_path / "spec.md"
+    original = (
+        "---\nstatus: draft\n---\n\n## Intent\n\n"
+        "- outer bullet\n  - inner bullet, fenced example:\n"
+        "    ```md\n    ## Auto Run Result\n\n    Status: done\n    ```\n\nmore body\n"
+    )
+    sp.write_text(original, encoding="utf-8")
+    assert devcontract.strip_auto_run_result(sp) is False
+    assert sp.read_text() == original
+
+
 def test_strip_auto_run_result_skips_fenced_boundary_lines(tmp_path):
     """Column-0 `## `/`# ` lines inside a fenced block within the section (quoted
     shell comments, log output) are not boundaries — the whole stale section goes."""

--- a/tests/test_devcontract.py
+++ b/tests/test_devcontract.py
@@ -64,6 +64,19 @@ def test_parse_stops_at_next_heading():
     assert arr.status == "done" and "blocked" not in arr.detail
 
 
+def test_parse_stops_at_bare_empty_heading():
+    """Reviewer guard (#53, comment 3522512350): a bare `##` line is a valid empty
+    CommonMark ATX heading, so `_next_heading_start` (`^##\\s`) bounding the section
+    there is correct, not a premature truncation. Locks that intent: the `Status:`
+    gate is parsed above the boundary and is unaffected, and tightening `\\s` to a
+    space/tab delimiter would stop recognizing empty headings — a false-negative
+    boundary that, on the destructive strip path, deletes MORE, not less."""
+    text = "## Auto Run Result\n\nStatus: done\n\n##\n\nlater section body\n"
+    arr = devcontract.parse_auto_run_result(text)
+    assert arr.status == "done"
+    assert "later section body" not in arr.detail
+
+
 def test_parse_ignores_fence_quoted_heading():
     """A heading quoted inside a fenced example (a frozen intent showing the
     section format) is documentation, not a terminal section (#52)."""
@@ -450,6 +463,24 @@ def test_strip_auto_run_result_stops_at_next_heading(tmp_path):
     text = sp.read_text()
     assert "Auto Run Result" not in text and "stale" not in text
     assert "## Change Log\n\nkept\n" in text
+
+
+def test_strip_auto_run_result_stops_at_bare_empty_heading(tmp_path):
+    """Reviewer guard (#53, comment 3522512350): a bare `##` line is a valid empty
+    CommonMark heading, so the strip bounds the removed section there and keeps the
+    empty-heading region after it. This is the safe direction on a destructive strip
+    (truncate early -> delete less); requiring a space/tab delimiter instead of `\\s`
+    would run the strip PAST the empty heading and over-delete."""
+    sp = tmp_path / "spec.md"
+    sp.write_text(
+        "---\nstatus: done\n---\n\n## Auto Run Result\n\nStatus: done\n\n"
+        "##\n\nkept after empty heading\n",
+        encoding="utf-8",
+    )
+    assert devcontract.strip_auto_run_result(sp) is True
+    text = sp.read_text()
+    assert "Auto Run Result" not in text
+    assert "##\n\nkept after empty heading\n" in text
 
 
 def test_strip_auto_run_result_noop_without_section(tmp_path):

--- a/tests/test_devcontract.py
+++ b/tests/test_devcontract.py
@@ -320,6 +320,14 @@ def test_reset_status_no_frontmatter(tmp_path):
     assert "status: done\n" in sp.read_text()  # body status not touched
 
 
+def test_reset_spec_status_noop_when_spec_absent(tmp_path):
+    """A re-drive against a spec that no longer exists on disk no-ops cleanly
+    rather than raising (mirrors verify.set_frontmatter_status)."""
+    sp = tmp_path / "missing.md"
+    assert not sp.exists()
+    assert devcontract.reset_spec_status(sp, "in-progress") is False
+
+
 # ----------------------------------------------------------- RECONCILABLE_FROM
 
 
@@ -450,6 +458,16 @@ def test_strip_auto_run_result_noop_without_section(tmp_path):
     sp.write_text(original, encoding="utf-8")
     assert devcontract.strip_auto_run_result(sp) is False
     assert sp.read_text() == original
+
+
+def test_strip_auto_run_result_noop_when_spec_absent(tmp_path):
+    """The re-arm path calls strip after flipping frontmatter status; if the spec
+    was removed out from under the run the strip no-ops cleanly rather than crashing
+    the re-drive (only an absent file is guarded — a present-but-unreadable spec
+    still raises so the stale section can't silently survive the re-open)."""
+    sp = tmp_path / "missing.md"
+    assert not sp.exists()
+    assert devcontract.strip_auto_run_result(sp) is False
 
 
 def test_strip_auto_run_result_ignores_heading_quoted_in_code_fence(tmp_path):

--- a/tests/test_devcontract.py
+++ b/tests/test_devcontract.py
@@ -319,3 +319,89 @@ def test_reset_status_inserts_missing_line(tmp_path):
     assert "status: done\n" in text  # inserted
     assert "title: 'x'\n" in text and "baseline_revision: 'abc'\n" in text  # kept
     assert "## Intent\n\nbody\n" in text  # body untouched
+
+
+# ------------------------------------------------------- strip_auto_run_result
+
+
+def test_strip_auto_run_result_removes_trailing_section(tmp_path):
+    """The stale terminal section goes; frontmatter and body above it survive.
+    The stripped spec must no longer qualify as a result artifact even with a
+    fresh mtime — that is the whole point of stripping on re-arm."""
+    sp = tmp_path / "spec.md"
+    sp.write_text(
+        "---\nstatus: in-progress\n---\n\n## Intent\n\nbody\n\n"
+        "## Auto Run Result\n\nStatus: done\nAll done.\n",
+        encoding="utf-8",
+    )
+    assert devcontract.strip_auto_run_result(sp) is True
+    text = sp.read_text()
+    assert "Auto Run Result" not in text and "All done." not in text
+    assert "status: in-progress\n" in text and "## Intent\n\nbody\n" in text
+    assert devcontract.find_result_artifact(tmp_path, since_ns=0) is None
+
+
+def test_strip_auto_run_result_stops_at_next_heading(tmp_path):
+    """A section wedged mid-document is excised up to the next same-level
+    heading; sub-headings inside the section are removed with it."""
+    sp = tmp_path / "spec.md"
+    sp.write_text(
+        "---\nstatus: done\n---\n\n## Auto Run Result\n\nStatus: done\n"
+        "### Detail\n\nstale\n\n## Change Log\n\nkept\n",
+        encoding="utf-8",
+    )
+    assert devcontract.strip_auto_run_result(sp) is True
+    text = sp.read_text()
+    assert "Auto Run Result" not in text and "stale" not in text
+    assert "## Change Log\n\nkept\n" in text
+
+
+def test_strip_auto_run_result_noop_without_section(tmp_path):
+    sp = tmp_path / "spec.md"
+    original = "---\nstatus: draft\n---\n\n## Intent\n\nbody\n"
+    sp.write_text(original, encoding="utf-8")
+    assert devcontract.strip_auto_run_result(sp) is False
+    assert sp.read_text() == original
+
+
+def test_strip_auto_run_result_ignores_heading_quoted_in_code_fence(tmp_path):
+    """A spec whose frozen intent quotes the heading inside a fenced example must
+    not lose that content — stripping is destructive, so fenced pseudo-headings
+    are not sections."""
+    sp = tmp_path / "spec.md"
+    original = (
+        "---\nstatus: draft\n---\n\n## Intent\n\n"
+        "```md\n## Auto Run Result\n\nStatus: done\n```\n\nmore body\n"
+    )
+    sp.write_text(original, encoding="utf-8")
+    assert devcontract.strip_auto_run_result(sp) is False
+    assert sp.read_text() == original
+
+
+def test_strip_auto_run_result_ignores_heading_in_indented_fence(tmp_path):
+    """Fences may be indented up to three spaces (CommonMark) — a heading quoted
+    inside one is still fenced content, not a section."""
+    sp = tmp_path / "spec.md"
+    original = (
+        "---\nstatus: draft\n---\n\n## Intent\n\n"
+        "  ```md\n## Auto Run Result\n\nStatus: done\n  ```\n\nmore body\n"
+    )
+    sp.write_text(original, encoding="utf-8")
+    assert devcontract.strip_auto_run_result(sp) is False
+    assert sp.read_text() == original
+
+
+def test_strip_auto_run_result_skips_fenced_boundary_lines(tmp_path):
+    """Column-0 `## `/`# ` lines inside a fenced block within the section (quoted
+    shell comments, log output) are not boundaries — the whole stale section goes."""
+    sp = tmp_path / "spec.md"
+    sp.write_text(
+        "---\nstatus: done\n---\n\n## Intent\n\nbody\n\n"
+        "## Auto Run Result\n\nStatus: done\n\n"
+        "```sh\n## run tests\npytest -q\n```\n\ntrailing stale prose\n",
+        encoding="utf-8",
+    )
+    assert devcontract.strip_auto_run_result(sp) is True
+    text = sp.read_text()
+    assert "Auto Run Result" not in text and "trailing stale prose" not in text
+    assert "## Intent\n\nbody\n" in text

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -633,6 +633,29 @@ def test_generic_reconcile_idempotent_when_already_done(project):
     assert recon == []
 
 
+def test_reset_spec_for_repair_strips_stale_terminal_section(project):
+    """Re-arming a self-finalized spec must remove the stale `## Auto Run Result`
+    section along with the status flip — find_result_artifact keys on that
+    heading, so leaving it would let the re-driven session's first save of the
+    spec qualify as a terminal result mid-turn."""
+    engine, _ = make_engine(project, [])
+    spec = project.implementation_artifacts / "spec-1-1-a.md"
+    spec.parent.mkdir(parents=True, exist_ok=True)
+    spec.write_text(
+        "---\nstatus: done\n---\n\n## Intent\n\nbody\n\n"
+        "## Auto Run Result\n\nStatus: done\nAll done.\n",
+        encoding="utf-8",
+    )
+    task = StoryTask(story_key="1-1-a", epic=1, spec_file=str(spec))
+
+    engine._reset_spec_for_repair(task)
+
+    text = spec.read_text(encoding="utf-8")
+    assert "status: in-progress\n" in text  # re-opened
+    assert "Auto Run Result" not in text  # stale terminal section gone
+    assert "## Intent\n\nbody\n" in text  # frozen intent untouched
+
+
 def test_generic_reconcile_skips_blocked_prose(project):
     """A blocked outcome (prose Status: blocked) is NEVER reconciled: the
     frontmatter stays non-terminal, no `spec-status-reconciled` is emitted, and the

--- a/tests/test_generic_tmux.py
+++ b/tests/test_generic_tmux.py
@@ -488,6 +488,92 @@ def test_dev_result_less_stop_awaits_reinvocation_then_completes(tmp_path, monke
     assert result.status == "completed"
 
 
+def test_dev_idle_result_is_ignored_while_window_alive(tmp_path, monkeypatch):
+    """A terminal artifact observed on an idle tick while the window is alive is
+    advisory only — the agent may still be mid-turn (returning early would let
+    run()'s finally-kill terminate it). Completion waits for the next Stop."""
+    monkeypatch.setattr(generic, "RESULT_GRACE_S", 0.0)
+    monkeypatch.setattr(generic, "RESULT_POLL_S", 0.0)
+    adapter, impl = make_dev_adapter(tmp_path)
+    adapter._window_alive = lambda handle: True
+
+    def flush_terminal_spec(call_n):
+        if call_n == 2:  # idle tick after a result-less Stop, before final turn-end
+            (impl / "spec-3-1-foo.md").write_text(
+                "---\nstatus: done\n---\n\n## Auto Run Result\n\nStatus: done\n"
+            )
+
+    adapter.watcher = _ScriptedWatcher(
+        [
+            _stop_event("3-1-dev-1", "sess", "/run/events.jsonl"),  # arms the grace window
+            None,  # idle tick: artifact on disk, window alive -> must keep waiting
+            _stop_event("3-1-dev-1", "sess", "/run/events.jsonl"),  # authoritative turn-end
+        ],
+        on_call=flush_terminal_spec,
+    )
+
+    result = adapter.wait_for_completion(_dev_handle(), _dev_spec(tmp_path))
+
+    assert result.status == "completed"
+    assert adapter.watcher.calls == 3  # completed on the Stop, not the idle tick
+
+
+def test_dev_grace_result_does_not_complete_while_window_alive(tmp_path, monkeypatch):
+    """Grace expiry under a live window must not upgrade to completed on artifact
+    presence — the stall verdict stands until a Stop or window death vouches."""
+    monkeypatch.setattr(generic, "RESULT_GRACE_S", 0.0)
+    monkeypatch.setattr(generic, "RESULT_POLL_S", 0.0)
+    adapter, impl = make_dev_adapter(tmp_path)
+    adapter._stall_grace_s = 10.0
+    adapter._stall_nudges = 0
+    adapter._window_alive = lambda handle: True
+
+    clock = {"t": 1000.0}
+
+    class _Clock:  # scoped shim so we don't mutate the real time module
+        monotonic = staticmethod(lambda: clock["t"])
+        sleep = staticmethod(lambda *_: None)
+        time_ns = staticmethod(lambda: 0)
+
+    monkeypatch.setattr(generic, "time", _Clock)
+
+    def flush_terminal_spec(call_n):
+        if call_n == 2:  # artifact lands, then the grace window expires in silence
+            clock["t"] += 11.0
+            (impl / "spec-3-1-foo.md").write_text(
+                "---\nstatus: done\n---\n\n## Auto Run Result\n\nStatus: done\n"
+            )
+
+    adapter.watcher = _ScriptedWatcher(
+        [_stop_event("3-1-dev-1", "sess", "/run/events.jsonl")],
+        on_call=flush_terminal_spec,
+    )
+
+    result = adapter.wait_for_completion(_dev_handle(), _dev_spec(tmp_path))
+
+    assert result.status == "stalled"
+    assert result.result_json is None
+
+
+def test_dev_window_death_with_artifact_completes(tmp_path, monkeypatch):
+    """Window death is authoritative: a terminal artifact on disk when the window
+    is gone upgrades the crash fallback to completed."""
+    monkeypatch.setattr(generic, "RESULT_GRACE_S", 0.0)
+    monkeypatch.setattr(generic, "RESULT_POLL_S", 0.0)
+    adapter, impl = make_dev_adapter(tmp_path)
+    adapter._window_alive = lambda handle: False
+    (impl / "spec-3-1-foo.md").write_text(
+        "---\nstatus: done\n---\n\n## Auto Run Result\n\nStatus: done\n"
+    )
+
+    adapter.watcher = _ScriptedWatcher([None])  # no hook event, window already gone
+
+    result = adapter.wait_for_completion(_dev_handle(), _dev_spec(tmp_path))
+
+    assert result.status == "completed"
+    assert result.result_json["status"] == "done"
+
+
 def test_dev_stalls_when_grace_elapses_without_reinvocation(tmp_path, monkeypatch):
     """A result-less Stop with no re-invocation before the grace window elapses is
     a genuine stall — the grace must not hang until the session timeout."""
@@ -727,8 +813,9 @@ def test_uncapped_spec_keeps_refilling_nudges_past_cap(tmp_path, monkeypatch):
 
 def test_capped_session_still_completes_when_marker_lands_late(tmp_path, monkeypatch):
     """Exhausting the cap must not discard a session whose completion marker
-    lands afterwards: the result check runs before any stall verdict, so a
-    marker that races in wins and the session completes."""
+    lands afterwards: the marker plus its turn-end Stop still complete the
+    session (a bare marker under a live window is advisory — only the Stop,
+    the authoritative signal, seals it)."""
     adapter, impl, clock, sent = _stall_loop_adapter(tmp_path, monkeypatch)
 
     def script(call_n):
@@ -741,7 +828,7 @@ def test_capped_session_still_completes_when_marker_lands_late(tmp_path, monkeyp
 
     stop = _stop_event("3-1-dev-1", "sess", "/run/events.jsonl")
     adapter.watcher = _ScriptedWatcher(
-        [stop, None, stop, None],  # nudge -> answered result-less -> idle again
+        [stop, None, stop, stop],  # nudge -> answered result-less -> final turn-end
         on_call=script,
     )
     result = adapter.wait_for_completion(_dev_handle(), _capped_spec(tmp_path, cap=1))

--- a/tests/test_generic_tmux.py
+++ b/tests/test_generic_tmux.py
@@ -605,6 +605,99 @@ def test_dev_stalls_when_grace_elapses_without_reinvocation(tmp_path, monkeypatc
     assert result.status == "stalled"
 
 
+def test_dev_grace_expiry_rechecks_liveness_and_honors_just_dead_window(tmp_path, monkeypatch):
+    """A window that dies in the gap between the top-of-tick liveness probe and the
+    grace-expiry stall return must flow through the crash path — window death is
+    authoritative, so its just-flushed artifact is honored (completed), not
+    discarded by the stall's accept_result=False."""
+    monkeypatch.setattr(generic, "RESULT_GRACE_S", 0.0)
+    monkeypatch.setattr(generic, "RESULT_POLL_S", 0.0)
+    adapter, impl = make_dev_adapter(tmp_path)
+    adapter._stall_grace_s = 10.0
+    adapter._stall_nudges = 0
+
+    # alive at the top-of-tick probe (call 1), dead at the pre-stall re-probe (call 2)
+    alive_calls = {"n": 0}
+
+    def flaky_alive(handle):
+        alive_calls["n"] += 1
+        return alive_calls["n"] == 1
+
+    adapter._window_alive = flaky_alive
+
+    clock = {"t": 1000.0}
+
+    class _Clock:  # scoped shim so we don't mutate the real time module
+        monotonic = staticmethod(lambda: clock["t"])
+        sleep = staticmethod(lambda *_: None)
+        time_ns = staticmethod(lambda: 0)
+
+    monkeypatch.setattr(generic, "time", _Clock)
+
+    def flush_terminal_spec(call_n):
+        if call_n == 2:  # artifact lands, then the grace window expires in silence
+            clock["t"] += 11.0
+            (impl / "spec-3-1-foo.md").write_text(
+                "---\nstatus: done\n---\n\n## Auto Run Result\n\nStatus: done\n"
+            )
+
+    adapter.watcher = _ScriptedWatcher(
+        [_stop_event("3-1-dev-1", "sess", "/run/events.jsonl")],
+        on_call=flush_terminal_spec,
+    )
+
+    result = adapter.wait_for_completion(_dev_handle(), _dev_spec(tmp_path))
+
+    assert result.status == "completed"
+    assert result.result_json["status"] == "done"
+    assert alive_calls["n"] == 2  # top-of-tick probe + pre-stall re-probe
+
+
+def test_dev_grace_expiry_stall_recheck_transport_error_still_stalls(tmp_path, monkeypatch):
+    """A transport error on the pre-stall liveness re-probe is not proof of death
+    (as at the top of the tick): the verdict falls through to stalled rather than
+    crashing on the hiccup."""
+    monkeypatch.setattr(generic, "RESULT_GRACE_S", 0.0)
+    monkeypatch.setattr(generic, "RESULT_POLL_S", 0.0)
+    adapter, _ = make_dev_adapter(tmp_path)
+    adapter._stall_grace_s = 10.0
+    adapter._stall_nudges = 0
+
+    alive_calls = {"n": 0}
+
+    def flaky_alive(handle):
+        alive_calls["n"] += 1
+        if alive_calls["n"] == 1:
+            return True  # top-of-tick probe
+        raise MultiplexerError("tmux hang")  # pre-stall re-probe
+
+    adapter._window_alive = flaky_alive
+
+    clock = {"t": 1000.0}
+
+    class _Clock:  # scoped shim so we don't mutate the real time module
+        monotonic = staticmethod(lambda: clock["t"])
+        sleep = staticmethod(lambda *_: None)
+        time_ns = staticmethod(lambda: 0)
+
+    monkeypatch.setattr(generic, "time", _Clock)
+
+    def advance_past_grace(call_n):
+        if call_n == 2:
+            clock["t"] += 11.0
+
+    adapter.watcher = _ScriptedWatcher(
+        [_stop_event("3-1-dev-1", "sess", "/run/events.jsonl")],
+        on_call=advance_past_grace,
+    )
+
+    result = adapter.wait_for_completion(_dev_handle(), _dev_spec(tmp_path))
+
+    assert result.status == "stalled"
+    assert result.result_json is None
+    assert alive_calls["n"] == 2  # probe raised on the re-check, fell through to stall
+
+
 def test_dev_log_activity_keeps_grace_window_alive(tmp_path, monkeypatch):
     """A session still streaming to the tee'd pane log is working, not stalled:
     pane growth must re-arm the grace window even with no fresh Stop, so only

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -4,7 +4,7 @@ import json
 
 import pytest
 
-from bmad_loop import resolve, runs, verify
+from bmad_loop import devcontract, resolve, runs, verify
 from bmad_loop.journal import load_state, save_state
 from bmad_loop.model import (
     PAUSE_ESCALATION,
@@ -146,6 +146,25 @@ def test_rearm_flips_phase_and_spec_status(tmp_path):
     assert verify.read_frontmatter(spec)["status"] == "ready-for-dev"
     # pause is NOT cleared here — resume does that
     assert state.paused_stage == PAUSE_ESCALATION
+
+
+def test_rearm_strips_stale_terminal_section(tmp_path):
+    """Re-arm must drop the escalated attempt's `## Auto Run Result` along with
+    the status flip (mirroring engine._reset_spec_for_repair): the heading is
+    what find_result_artifact keys on, so leaving it would let the re-driven
+    session's first save of the spec parse as the prior attempt's outcome."""
+    spec = tmp_path / "spec-6-4.md"
+    spec.write_text(
+        SPEC + "\n## Auto Run Result\n\nStatus: blocked\nnames not unique\n",
+        encoding="utf-8",
+    )
+    run_dir, _, _ = _escalated_run(tmp_path, spec_file=str(spec))
+    runs.rearm_escalation(run_dir)
+    text = spec.read_text(encoding="utf-8")
+    assert "Auto Run Result" not in text and "names not unique" not in text
+    assert verify.read_frontmatter(spec)["status"] == "ready-for-dev"
+    assert "<frozen-after-approval>" in text  # intent body untouched
+    assert devcontract.find_result_artifact(tmp_path, since_ns=0) is None
 
 
 def test_rearm_journals_event(tmp_path):


### PR DESCRIPTION
## Summary

Fixes #48

`GenericAdapter.wait_for_completion` could return `completed` from the idle-tick and grace-expiry shortcuts on terminal-artifact presence alone, while the agent window was still alive — `run()`'s `finally: kill()` then terminated the agent mid-turn and the engine post-processed half-written state (feeding the destructive auto-rollback path).

**Changes:**
- **Stop events and window death are now the only authoritative completion signals.** Both artifact shortcuts in the idle branch are removed outright — the window is provably alive at those points (a dead window returns `crashed` earlier in the same tick), so the checks could never legitimately complete.
- `_final` gains a keyword-only `accept_result` flag; the grace-expiry stall verdict passes `False` so an artifact under a live window cannot silently upgrade `stalled` to `completed`. Window-death paths (`crashed`, `SessionEnd`) keep the trusting default — death is authoritative.
- **Re-drive amplifier closed:** `strip_auto_run_result` (new, in `devcontract`) removes the stale `## Auto Run Result` section when the escalation re-arm re-opens a spec, so a re-driven spec no longer qualifies as a terminal artifact from the agent's first mid-session save. The helper is fence-aware (incl. fences indented up to 3 spaces per CommonMark) since deletion is destructive; the read-only heading scans are intentionally untouched (follow-up: #52).
- The diagnostic trace scaffolding from the original prototype branch was deliberately **not** ported — it hunted an engine-death window already fixed on main.

**Behavioral notes:**
- Stop-path completion (artifact + Stop, window alive) is untouched; stall-nudge and pane-activity re-arm logic identical.
- One existing test amended to the new invariant: a completion marker landing after the nudge cap now completes via its turn-end Stop, not via the bare grace-expiry artifact.

## Tests

- New: idle-tick artifact under a live window does not complete (completes on the subsequent Stop); grace-expiry artifact under a live window stalls with `result_json=None`; window death with artifact still completes; strip unit tests incl. fenced/indented-fence edge cases; engine re-arm strips the stale section with the intent body untouched.
- Full suite green on Windows (1324 passed) and Linux/WSL (1335 passed); only the two pre-existing `test_module_skills_sync` drift failures, unrelated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents stale terminal “Auto Run Result” sections from being treated as fresh completion when a spec is reopened or re-armed.
  * Improves fence-aware handling so “Auto Run Result” headings inside fenced code blocks are ignored for both detection and removal.
  * Enhances terminal-session completion reliability: late `result.json` no longer overrides an in-progress/stalled verdict while the window is alive; grace expiry and window death are honored correctly.
* **Tests**
  * Expanded coverage for fenced-heading edge cases, repair/re-arm stale-section stripping, and terminal completion timing/grace/liveness scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->