### PR TITLE
feat(scm): bounded retention for attempt-preserve-dirty worktree-snapshot refs

### DIFF
--- a/src/bmad_loop/data/settings/core.toml
+++ b/src/bmad_loop/data/settings/core.toml
@@ -257,7 +257,7 @@ kind = "int"
 minimum = 0
 default_ref = "ScmPolicy.preserve_keep"
 label = "preserve-ref retention"
-description = "attempt-preserve/* recovery branches kept at each run start · the newest by committer date survive and the tail is deleted (0 = never prune)"
+description = "attempt-preserve/* recovery branches and attempt-preserve-dirty/* worktree snapshots kept at each run start (per family) · the newest by committer date survive and the tail is deleted (0 = never prune)"
 [[section.field]]
 key = "seed_adapter_defaults"
 kind = "switch"

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -848,30 +848,41 @@ class Engine:
         )
 
     def _prune_preserve_refs(self) -> None:
-        """Bounded retention for the attempt-preserve/* recovery branches at run
-        start: keep the newest scm.preserve_keep by committer date, delete the
-        tail (mirrors the runs/cleanup retention knobs — without it the refs
-        grow unbounded on a long-lived project). Best-effort: a git failure is
-        journalled and never blocks or pauses the run — the refs are a safety
-        net, not run state. preserve_keep = 0 disables pruning entirely."""
+        """Bounded retention for both recovery-ref families at run start — the
+        attempt-preserve/* branches and the refs/attempt-preserve-dirty/*
+        worktree snapshots: keep the newest scm.preserve_keep of each by
+        committer date, delete the tail (mirrors the runs/cleanup retention
+        knobs — without it the refs grow unbounded on a long-lived project).
+        Best-effort: a git failure is journalled per family and never blocks or
+        pauses the run — the refs are a safety net, not run state — and a
+        failure in one family never skips the other. preserve_keep = 0 disables
+        pruning entirely."""
         keep = self.policy.scm.preserve_keep
         if keep <= 0:
             return
-        try:
-            deleted = verify.prune_preserve_refs(self.workspace.root, keep)
-        except Exception as exc:  # noqa: BLE001 - housekeeping must never crash the
-            # run: a git timeout/OSError here would otherwise escape to the crash
-            # handler, so anything beyond the expected GitError is journalled too
-            # A partial prune (PrunePreserveError) already deleted refs before one
-            # stuck — that destructive half must stay structurally auditable, not
-            # buried in the error string.
-            partial = getattr(exc, "deleted", [])
-            if partial:
-                self.journal.append("attempt-preserve-pruned", count=len(partial), refs=partial)
-            self.journal.append("attempt-preserve-prune-failed", error=str(exc))
-            return
-        if deleted:
-            self.journal.append("attempt-preserve-pruned", count=len(deleted), refs=deleted)
+        for family, prune in (
+            ("attempt-preserve", verify.prune_preserve_refs),
+            ("attempt-preserve-dirty", verify.prune_preserve_dirty_refs),
+        ):
+            try:
+                deleted = prune(self.workspace.root, keep)
+            except Exception as exc:  # noqa: BLE001 - housekeeping must never crash the
+                # run: a git timeout/OSError here would otherwise escape to the crash
+                # handler, so anything beyond the expected GitError is journalled too
+                # A partial prune (PrunePreserveError) already deleted refs before one
+                # stuck — that destructive half must stay structurally auditable, not
+                # buried in the error string.
+                partial = getattr(exc, "deleted", [])
+                if partial:
+                    self.journal.append(f"{family}-pruned", count=len(partial), refs=partial)
+                failed = getattr(exc, "failed", [])
+                if failed:
+                    self.journal.append(f"{family}-prune-failed", error=str(exc), failed=failed)
+                else:
+                    self.journal.append(f"{family}-prune-failed", error=str(exc))
+                continue
+            if deleted:
+                self.journal.append(f"{family}-pruned", count=len(deleted), refs=deleted)
 
     def _preserve_attempt_commits(self, task: StoryTask, *, allow_pause: bool) -> None:
         """Before an auto-rollback's hard reset, park any commits the attempt made

--- a/src/bmad_loop/policy.py
+++ b/src/bmad_loop/policy.py
@@ -255,12 +255,12 @@ class ScmPolicy:
     # attempt's source but preserves the corrected spec under the BMAD artifact
     # folders, which it treats as orchestrator-owned.
     rollback_on_failure: bool = False
-    # preserve_keep bounds the attempt-preserve/* recovery branches auto-rollback
-    # parks before its hard reset: each run start keeps only the N most recent
-    # (by committer date) and deletes the tail, so a long-lived project with
-    # rollback_on_failure on doesn't accumulate them forever. 0 = never prune
-    # (maximum safety). The refs/attempt-preserve-dirty/* worktree snapshots are
-    # never touched by this.
+    # preserve_keep bounds both recovery-ref families auto-rollback parks before
+    # its hard reset — the attempt-preserve/* branches and the
+    # refs/attempt-preserve-dirty/* worktree snapshots: each run start keeps only
+    # the N most recent per family (by committer date) and deletes the tail, so a
+    # long-lived project with rollback_on_failure on doesn't accumulate them
+    # forever. 0 = never prune (maximum safety).
     preserve_keep: int = 20
     # failed_diff_max_mb caps the per-file size (MB) of untracked files captured
     # into a kept-failed unit's forensic changes.patch, so a stray build dir or
@@ -779,7 +779,7 @@ merge_strategy = "merge"     # ff | merge | squash (worktree mode merges the uni
 delete_branch = true         # delete the unit branch after a successful merge
 keep_failed = true           # keep a failed unit's worktree+branch for inspection
 rollback_on_failure = false  # in-place (isolation="none") recovery after a failed attempt. false = never touch the tree; pause with manual recovery steps. true = auto-revert the attempt's tracked changes + remove only the untracked files this run created (WARNING: discards the attempt's uncommitted work; never a blanket git clean). Governs unattended/stopped attempts only: a resolved escalation's re-drive always auto-recovers regardless (reverts the failed source, keeps the corrected spec). Prefer isolation="worktree" to avoid touching your main checkout.
-preserve_keep = 20           # attempt-preserve/* recovery branches kept at run start, newest by committer date; the tail is deleted (0 = never prune)
+preserve_keep = 20           # attempt-preserve/* branches and attempt-preserve-dirty/* snapshots kept at run start (per family), newest by committer date; the tail is deleted (0 = never prune)
 failed_diff_max_mb = 5       # per-file size cap (MB) for untracked files in a kept-failed unit's changes.patch; oversized files are skipped with a marker
 failed_diff_unlimited = false # true = capture the failed-unit diff with no size cap (may produce very large patches; warns when active)
 # commit_message_template: when set, the commit message dev sessions use for a

--- a/src/bmad_loop/verify.py
+++ b/src/bmad_loop/verify.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import os
 import subprocess
 import tempfile
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -250,16 +251,76 @@ def preserve_commits(
 
 
 class PrunePreserveError(GitError):
-    """Partial :func:`prune_preserve_refs` failure. The prune is per-ref
-    best-effort, so refs may already be gone when a later one sticks — the
-    ``deleted`` list keeps that destructive half structurally auditable (a
-    caller can journal it, not just grep the message) and ``failed`` names
-    each stuck ref with its git detail."""
+    """Partial :func:`prune_preserve_refs` / :func:`prune_preserve_dirty_refs`
+    failure. The prune is per-ref best-effort, so refs may already be gone when
+    a later one sticks — the ``deleted`` list keeps that destructive half
+    structurally auditable (a caller can journal it, not just grep the message)
+    and ``failed`` names each stuck ref with its git detail."""
 
     def __init__(self, message: str, *, deleted: list[str], failed: list[str]) -> None:
         super().__init__(message)
         self.deleted = deleted
         self.failed = failed
+
+
+def _prune_refs(
+    repo: Path,
+    keep: int,
+    prefix: str,
+    *,
+    label: str,
+    strip: str,
+    delete: Callable[[str], None],
+) -> list[str]:
+    """Shared retention loop behind the per-family pruners: list the refs under
+    ``prefix``, keep the ``keep`` newest by committer date, best-effort delete
+    the tail via ``delete``, and return the deleted names. ``strip`` is removed
+    from each refname before it is deleted/reported (``refs/heads/`` for the
+    branch family, nothing for bare refs). ``keep <= 0`` means "never prune" —
+    returns ``[]`` without running git.
+
+    Raises :class:`GitError` when the listing fails, or
+    :class:`PrunePreserveError` — after attempting every tail ref — when any
+    individual delete failed. One stuck ref must not wedge the retention for
+    everything behind it, so deletes are per-ref best-effort and the error
+    carries both what was deleted and what was not."""
+    if keep <= 0:
+        return []
+    rc, out = _git(
+        repo,
+        "for-each-ref",
+        # ties on committerdate (same-second rollbacks) break by ascending
+        # refname — an explicit, observable order rather than git's implicit
+        # stable-sort fallback. Last --sort key is the primary one.
+        "--sort=refname",
+        "--sort=-committerdate",
+        # full refname, not :short — a tag or remote ref sharing the name would
+        # make :short emit an ambiguous form the deleter can't use
+        "--format=%(refname)",
+        prefix,
+    )
+    if rc != 0:
+        raise GitError(f"git for-each-ref {label} failed in {repo}: {out}")
+    refs = [line.removeprefix(strip) for line in out.splitlines() if line]
+    deleted: list[str] = []
+    failed: list[str] = []
+    for name in refs[keep:]:
+        try:
+            delete(name)
+        except Exception as exc:  # noqa: BLE001 - a git timeout/OSError on one ref
+            # must not wedge the tail behind it any more than a GitError does; the
+            # per-ref best-effort contract holds for the whole subprocess surface
+            failed.append(f"{name} ({exc})")
+            continue
+        deleted.append(name)
+    if failed:
+        raise PrunePreserveError(
+            f"{label} prune in {repo}: deleted {deleted or 'nothing'}, "
+            f"could not delete {'; '.join(failed)}",
+            deleted=deleted,
+            failed=failed,
+        )
+    return deleted
 
 
 def prune_preserve_refs(repo: Path, keep: int) -> list[str]:
@@ -276,44 +337,46 @@ def prune_preserve_refs(repo: Path, keep: int) -> list[str]:
     Raises :class:`GitError` when the listing fails, or
     :class:`PrunePreserveError` — after attempting every tail ref — when any
     individual delete failed (e.g. the ref is checked out here or in a
-    worktree). One stuck ref must not wedge the retention for everything
-    behind it, so deletes are per-ref best-effort and the error carries both
-    what was deleted and what was not."""
-    if keep <= 0:
-        return []
-    rc, out = _git(
+    worktree); see :func:`_prune_refs` for the best-effort contract."""
+    return _prune_refs(
         repo,
-        "for-each-ref",
-        # ties on committerdate (same-second rollbacks) break by ascending
-        # refname — an explicit, observable order rather than git's implicit
-        # stable-sort fallback. Last --sort key is the primary one.
-        "--sort=refname",
-        "--sort=-committerdate",
-        # full refname, not :short — a tag or remote ref sharing the name would
-        # make :short emit "heads/attempt-preserve/x", which `branch -D` can't use
-        "--format=%(refname)",
+        keep,
         "refs/heads/attempt-preserve/",
+        label="attempt-preserve",
+        strip="refs/heads/",
+        delete=lambda name: delete_branch(repo, name, force=True),
     )
-    if rc != 0:
-        raise GitError(f"git for-each-ref attempt-preserve failed in {repo}: {out}")
-    refs = [line.removeprefix("refs/heads/") for line in out.splitlines() if line]
-    deleted: list[str] = []
-    failed: list[str] = []
-    for name in refs[keep:]:
-        try:
-            delete_branch(repo, name, force=True)
-        except GitError as exc:
-            failed.append(f"{name} ({exc})")
-            continue
-        deleted.append(name)
-    if failed:
-        raise PrunePreserveError(
-            f"attempt-preserve prune in {repo}: deleted {deleted or 'nothing'}, "
-            f"could not delete {'; '.join(failed)}",
-            deleted=deleted,
-            failed=failed,
-        )
-    return deleted
+
+
+def prune_preserve_dirty_refs(repo: Path, keep: int) -> list[str]:
+    """Bounded retention for the ``refs/attempt-preserve-dirty/*`` worktree
+    snapshots that :func:`snapshot_worktree` parks before an auto-rollback
+    reset: keep the ``keep`` most recent by committer date (the snapshot
+    commit's committer date is its park time), delete the rest via
+    ``git update-ref -d``, and return the deleted names. These refs live
+    outside ``refs/heads/`` — they are not branches, so ``branch -D`` cannot
+    touch them and the reported names are full refnames (there is no
+    ``refs/heads/`` to strip). Only ``refs/attempt-preserve-dirty/`` is ever
+    listed, so branches and every other ref are untouchable by construction.
+    ``keep <= 0`` means "never prune" — returns ``[]`` without running git.
+
+    Raises :class:`GitError` when the listing fails, or
+    :class:`PrunePreserveError` on a partial delete failure; see
+    :func:`_prune_refs` for the best-effort contract."""
+
+    def _delete(refname: str) -> None:
+        rc, out = _git(repo, "update-ref", "-d", refname)
+        if rc != 0:
+            raise GitError(f"git update-ref -d {refname} failed in {repo}: {out}")
+
+    return _prune_refs(
+        repo,
+        keep,
+        "refs/attempt-preserve-dirty/",
+        label="attempt-preserve-dirty",
+        strip="",
+        delete=_delete,
+    )
 
 
 def snapshot_worktree(

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1276,6 +1276,109 @@ def test_run_start_partial_prune_journals_deletions_and_failure(project, monkeyp
     assert engine.state.finished
 
 
+def _park_dirty_snapshots(repo, count):
+    """Write `count` refs/attempt-preserve-dirty/* snapshot refs, each on its
+    own commit so committer-date ordering is well defined."""
+    for i in range(count):
+        (repo / "impl.txt").write_text(f"snapshot {i}\n")
+        git(repo, "add", "-A")
+        git(repo, "commit", "-q", "-m", f"snapshot {i}")
+        git(repo, "update-ref", f"refs/attempt-preserve-dirty/run-{i}", "HEAD")
+
+
+def test_run_start_prunes_excess_dirty_snapshot_refs(project):
+    """Run start with scm.preserve_keep set and more attempt-preserve-dirty
+    snapshot refs than the budget: the tail is deleted before the loop, only
+    preserve_keep refs survive, and the deletions are journalled under the
+    family's own event kind."""
+    policy = Policy(
+        gates=GatesPolicy(mode="none"),
+        notify=QUIET,
+        scm=ScmPolicy(rollback_on_failure=True, preserve_keep=2),
+    )
+    repo = project.project
+    write_sprint(project, {"epic-1": "backlog"})  # nothing actionable: run start + finish only
+    _park_dirty_snapshots(repo, 3)
+    engine, _ = make_engine(project, [], policy=policy)
+
+    engine.run()
+
+    remaining = git(
+        repo, "for-each-ref", "--format=%(refname)", "refs/attempt-preserve-dirty/"
+    ).splitlines()
+    assert len(remaining) == 2  # tail pruned down to the budget
+    entry = next(
+        e for e in engine.journal.entries() if e["kind"] == "attempt-preserve-dirty-pruned"
+    )
+    assert entry["count"] == 1
+    assert set(entry["refs"]) | set(remaining) == {
+        f"refs/attempt-preserve-dirty/run-{i}" for i in range(3)
+    }
+
+
+def test_run_start_dirty_prune_failure_journals_and_run_proceeds(project, monkeypatch):
+    """A failing dirty-snapshot prune at run start is journalled under its own
+    event kind and never blocks the run."""
+    policy = Policy(
+        gates=GatesPolicy(mode="none"),
+        notify=QUIET,
+        scm=ScmPolicy(rollback_on_failure=True, preserve_keep=2),
+    )
+    write_sprint(project, {"epic-1": "backlog"})  # nothing actionable: run start + finish only
+
+    def _fail(*a, **k):
+        raise GitError("simulated dirty for-each-ref failure")
+
+    monkeypatch.setattr("bmad_loop.verify.prune_preserve_dirty_refs", _fail)
+    engine, _ = make_engine(project, [], policy=policy)
+
+    engine.run()
+
+    entry = next(
+        e for e in engine.journal.entries() if e["kind"] == "attempt-preserve-dirty-prune-failed"
+    )
+    assert "simulated dirty for-each-ref failure" in entry["error"]
+    assert engine.state.finished  # the prune failure never blocked or crashed the run
+
+
+def test_run_start_branch_prune_failure_does_not_skip_dirty_prune(project, monkeypatch):
+    """A failing branch-family prune must not skip the dirty family: with excess
+    dirty snapshot refs present, the branch failure is journalled AND the dirty
+    tail is still pruned and journalled."""
+    policy = Policy(
+        gates=GatesPolicy(mode="none"),
+        notify=QUIET,
+        scm=ScmPolicy(rollback_on_failure=True, preserve_keep=1),
+    )
+    repo = project.project
+    write_sprint(project, {"epic-1": "backlog"})  # nothing actionable: run start + finish only
+    _park_dirty_snapshots(repo, 2)
+
+    def _fail(*a, **k):
+        raise GitError("simulated branch prune failure")
+
+    monkeypatch.setattr("bmad_loop.verify.prune_preserve_refs", _fail)
+    engine, _ = make_engine(project, [], policy=policy)
+
+    engine.run()
+
+    failed = next(
+        e for e in engine.journal.entries() if e["kind"] == "attempt-preserve-prune-failed"
+    )
+    assert "simulated branch prune failure" in failed["error"]
+    pruned = next(
+        e for e in engine.journal.entries() if e["kind"] == "attempt-preserve-dirty-pruned"
+    )
+    remaining = git(
+        repo, "for-each-ref", "--format=%(refname)", "refs/attempt-preserve-dirty/"
+    ).splitlines()
+    assert pruned["count"] == 1 and len(remaining) == 1  # pruned down to the budget
+    assert set(pruned["refs"]) | set(remaining) == {
+        f"refs/attempt-preserve-dirty/run-{i}" for i in range(2)
+    }
+    assert engine.state.finished
+
+
 def test_rollback_worktree_preserve_failure_journals_git_error(project, monkeypatch):
     """When the uncommitted-work snapshot can't be captured, the best-effort path still
     resets (rollback ON, no commits above baseline -> no pause) but journals the underlying

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -946,6 +946,120 @@ def test_prune_preserve_refs_continues_past_undeletable_ref(project):
     assert len(excinfo.value.failed) == 1 and "run-0" in excinfo.value.failed[0]
 
 
+def _dirty_ref(repo, name):
+    """Point a refs/attempt-preserve-dirty/* snapshot ref at HEAD — the same
+    plain `update-ref` write snapshot_worktree uses (these are not branches)."""
+    git(repo, "update-ref", f"refs/attempt-preserve-dirty/{name}", "HEAD")
+
+
+def _dirty_ref_names(repo):
+    out = git(repo, "for-each-ref", "--format=%(refname)", "refs/attempt-preserve-dirty/")
+    return sorted(line for line in out.splitlines() if line)
+
+
+def test_prune_preserve_dirty_refs_deletes_oldest_beyond_keep(project):
+    """5 dirty snapshot refs, keep=3: the 2 whose commits are oldest by
+    committer date are deleted (and returned as full refnames); the 3 newest
+    survive. Dates disagree with creation order, so this proves committer-date
+    ordering. A second call at budget is then a no-op."""
+    repo = project.project
+    for i, day in ((0, 3), (1, 5), (2, 1), (3, 4), (4, 2)):
+        _dated_commit(repo, f"snapshot {i}", f"2026-01-0{day}T12:00:00")
+        _dirty_ref(repo, f"run-{i}")
+
+    deleted = verify.prune_preserve_dirty_refs(repo, keep=3)
+
+    assert sorted(deleted) == [f"refs/attempt-preserve-dirty/run-{i}" for i in (2, 4)]
+    assert _dirty_ref_names(repo) == [f"refs/attempt-preserve-dirty/run-{i}" for i in (0, 1, 3)]
+    assert verify.prune_preserve_dirty_refs(repo, keep=3) == []  # at budget now
+
+
+def test_prune_preserve_dirty_refs_keep_zero_never_runs_git(project, monkeypatch):
+    """keep=0 means "never prune" — return [] without even invoking git."""
+    repo = project.project
+    _dirty_ref(repo, "run-0")
+
+    def _boom(*a, **k):
+        raise AssertionError("git must not run when keep=0")
+
+    monkeypatch.setattr(verify, "_git", _boom)
+    assert verify.prune_preserve_dirty_refs(repo, keep=0) == []
+    monkeypatch.undo()
+    assert _dirty_ref_names(repo) == ["refs/attempt-preserve-dirty/run-0"]
+
+
+def test_prune_preserve_dirty_refs_ignores_branches_and_other_refs(project):
+    """Only refs/attempt-preserve-dirty/* is considered or deleted: user
+    branches, attempt-preserve/* branches, and tags never count against the
+    budget and are never touched, however old they are."""
+    repo = project.project
+    _dated_commit(repo, "old work", "2025-06-01T12:00:00")
+    git(repo, "branch", "-f", "feature/user-branch")
+    git(repo, "branch", "-f", "attempt-preserve/run-old")
+    git(repo, "tag", "old-tag")
+    for i in range(2):
+        _dated_commit(repo, f"snapshot {i}", f"2026-01-0{i + 1}T12:00:00")
+        _dirty_ref(repo, f"run-{i}")
+
+    deleted = verify.prune_preserve_dirty_refs(repo, keep=1)
+
+    assert deleted == ["refs/attempt-preserve-dirty/run-0"]
+    assert _dirty_ref_names(repo) == ["refs/attempt-preserve-dirty/run-1"]
+    assert git(repo, "branch", "--list", "feature/user-branch").strip() != ""
+    assert git(repo, "branch", "--list", "attempt-preserve/run-old").strip() != ""
+    assert git(repo, "tag", "--list", "old-tag").strip() != ""
+
+
+def test_prune_preserve_dirty_refs_ties_break_by_refname(project):
+    """Equal committer dates (two snapshots parked on the same commit) break by
+    ascending refname — the same repo state always prunes the same ref."""
+    repo = project.project
+    _dated_commit(repo, "tied snapshots", "2026-01-01T12:00:00")
+    _dirty_ref(repo, "tie-a")  # same commit ⇒ same date
+    _dirty_ref(repo, "tie-b")
+    _dated_commit(repo, "fresh snapshot", "2026-01-02T12:00:00")
+    _dirty_ref(repo, "newer")
+
+    deleted = verify.prune_preserve_dirty_refs(repo, keep=2)
+
+    # newest survives outright; within the tie, ascending refname wins (tie-a kept)
+    assert deleted == ["refs/attempt-preserve-dirty/tie-b"]
+    assert _dirty_ref_names(repo) == [
+        "refs/attempt-preserve-dirty/newer",
+        "refs/attempt-preserve-dirty/tie-a",
+    ]
+
+
+def test_prune_preserve_dirty_refs_continues_past_undeletable_ref(project):
+    """A tail ref that can't be deleted (here: a stale .lock blocks update-ref)
+    must not wedge the prune — the rest of the tail is still deleted, and the
+    error raised at the end names both what was deleted and what was not."""
+    repo = project.project
+    for i in range(3):
+        _dated_commit(repo, f"snapshot {i}", f"2026-01-0{i + 1}T12:00:00")
+        _dirty_ref(repo, f"run-{i}")
+    lock = repo / ".git" / "refs" / "attempt-preserve-dirty" / "run-0.lock"
+    lock.write_text("")  # stale lock: update-ref -d on run-0 now fails
+
+    try:
+        with pytest.raises(verify.GitError) as excinfo:
+            verify.prune_preserve_dirty_refs(repo, keep=1)
+    finally:
+        lock.unlink(missing_ok=True)  # let the fixture's teardown git calls run
+        # unimpeded even when the block above fails in an unexpected way
+    # run-1 (the deletable tail ref) is gone; run-0 survived only because of the
+    # lock; run-2 (newest) was kept
+    assert _dirty_ref_names(repo) == [
+        "refs/attempt-preserve-dirty/run-0",
+        "refs/attempt-preserve-dirty/run-2",
+    ]
+    assert isinstance(excinfo.value, verify.PrunePreserveError)
+    assert excinfo.value.deleted == ["refs/attempt-preserve-dirty/run-1"]
+    assert len(excinfo.value.failed) == 1 and "run-0" in excinfo.value.failed[0]
+    assert "run-1" in str(excinfo.value)  # deleted, still auditable
+    assert "run-0" in str(excinfo.value)  # the stuck ref is named
+
+
 def test_snapshot_worktree_survives_reset_and_gc(project):
     """The parked ref keeps an attempt's *uncommitted* work — both a tracked edit
     and a run-created untracked file — reachable through the exact destructive


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #50** — this branch is based on `feat/preserve-ref-retention` and reuses its `_prune_refs`/`preserve_keep` machinery. Review only the top commit; the diff collapses to it once #50 merges. Marked draft until then.

## What

Extends the run-start bounded retention from #50 to the second recovery-ref family: `refs/attempt-preserve-dirty/*` worktree-snapshot refs (written before each dirty auto-rollback) now share the same `scm.preserve_keep` budget — newest by committer date survive, tail deleted, `0` = never prune. No new config knob.

Closes #49

## How

- `verify.py`: the #32 retention loop is extracted into one shared `_prune_refs` helper; the branch family delegates to it unchanged (public behavior byte-identical, existing tests untouched). New `prune_preserve_dirty_refs` lists `refs/attempt-preserve-dirty/` and deletes via `git update-ref -d` — these are not branches, so no `branch -D`. Per-ref deletes are best-effort across the whole subprocess surface (a timeout/OSError on one ref no longer wedges the tail), with `PrunePreserveError.deleted/.failed` keeping partial prunes structurally auditable.
- `engine.py`: the run-start hook loops both families; each journals its own `*-pruned` / `*-prune-failed` events (stuck refs now journalled as a structured `failed` field), and a failure in one family never skips the other.
- `preserve_keep` docs (policy comment, TOML template, settings UI) updated — they previously claimed dirty snapshots were never touched.

## Tests

8 new tests: keep-N boundary, committer-date ordering, refname tie-break, keep=0 proves zero git invocations, branches/tags untouchable, stuck ref via a real `.lock` file (rest of tail still deleted, structured error attrs), engine wiring at run start, and family independence (branch-family failure does not skip the dirty prune).

Verified on Windows: `pytest tests/test_verify.py tests/test_engine.py tests/test_policy.py` — 209 passed; ruff clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded retention handling to cover both recovery branches and dirty worktree snapshots at run start.
  * Added clearer status reporting when pruning succeeds or fails, including separate outcomes for each ref family.

* **Bug Fixes**
  * Pruning now continues for the remaining ref family even if one family fails.
  * Retention behavior is clearer and more consistent, including the “0 means never prune” setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->