### PR TITLE
docs(adapters): pin new_window command contract as shlex-joined argv

### DIFF
--- a/src/bmad_loop/adapters/multiplexer.py
+++ b/src/bmad_loop/adapters/multiplexer.py
@@ -80,7 +80,12 @@ class TerminalMultiplexer(ABC):
         self, session: str, name: str, cwd: Path, env: dict[str, str], command: str
     ) -> str:
         """Create a window running ``command`` (with ``env`` layered on) in
-        ``session``, rooted at ``cwd``. Returns the backend-native window id."""
+        ``session``, rooted at ``cwd``. Returns the backend-native window id.
+
+        ``command`` is a POSIX shlex-joined argv string, not a shell line:
+        shell-operator behavior (``&&``, ``|``, ...) is backend-defined —
+        one backend may hand the string to a shell, another may shlex
+        re-split it into literal argv — so callers must not rely on it."""
 
     @abstractmethod
     def new_parked_window(

--- a/tests/test_multiplexer.py
+++ b/tests/test_multiplexer.py
@@ -9,6 +9,7 @@ role for the transport axis.
 
 import json
 import os
+import shlex
 import subprocess
 
 import pytest
@@ -400,6 +401,33 @@ def test_new_window_posix_argv_byte_identical(monkeypatch, tmp_path):
         "-e",
         "B=2",
         "cmd",
+    ]
+
+
+def test_new_window_posix_command_reaches_tmux_verbatim(monkeypatch, tmp_path):
+    # The contract says `command` is a shlex-joined argv, not a shell line.
+    # The POSIX leaf must not parse or re-quote it: whatever the caller built
+    # arrives at tmux as one verbatim trailing argument, so operator-looking
+    # tokens the caller quoted (here a literal "&&" argument) survive intact.
+    rec = _RecordRun()
+    monkeypatch.setattr(tmux_base.subprocess, "run", rec)
+
+    command = shlex.join(["echo", "a b", "&&", "reboot"])
+    TmuxMultiplexer().new_window("s", "n", tmp_path, {}, command)
+
+    assert rec.argv == [
+        "tmux",
+        "new-window",
+        "-t",
+        "=s:",
+        "-n",
+        "n",
+        "-c",
+        str(tmp_path),
+        "-P",
+        "-F",
+        "#{window_id}",
+        command,
     ]
 
 


### PR DESCRIPTION
## Summary

`Multiplexer.new_window`'s `command: str` parameter had unspecified semantics: the POSIX/tmux backend hands it to a shell (operators like `&&` would be interpreted) while a backend that re-splits the string treats operators as literal argv. Both existing callers build the command with `shlex.quote`-joins, so nothing is broken today — but a future caller passing a real shell line would break platform-specifically.

Docs-only contract pin, no behavior change:

- **`multiplexer.py`** — the `new_window` docstring now states the contract: `command` is a POSIX shlex-joined argv string, not a shell line; shell-operator behavior is backend-defined and callers must not rely on it.
- **`test_multiplexer.py`** — one new test pins the POSIX leaf's side of the contract: an operator-bearing shlex-joined command reaches tmux verbatim as the single trailing argument (full argv asserted, symmetric with the existing byte-identity tests).

## Testing

- `ruff check` + `ruff format --check` clean
- `pytest tests/test_multiplexer.py` — 12 passed

Closes #59