### PR TITLE
fix(engine): session-end durability + raw KeyboardInterrupt handling

### DIFF
--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -1363,13 +1363,22 @@ class Engine:
     def _dev_phase(self, task: StoryTask, resume_result: SessionResult | None = None) -> bool:
         if self._vetoed(self._emit("pre_dev_phase", task), task):
             return False
-        task.baseline_commit = verify.rev_parse_head(self.workspace.root)
-        # snapshot untracked files now so a later rollback removes only what THIS
-        # attempt creates, never files the user already had on disk.
-        task.baseline_untracked = sorted(verify.untracked_files(self.workspace.root))
+        if resume_result is None:
+            task.baseline_commit = verify.rev_parse_head(self.workspace.root)
+            # snapshot untracked files now so a later rollback removes only what
+            # THIS attempt creates, never files the user already had on disk.
+            # A resumed result keeps the persisted baseline: re-capturing here
+            # would shift the rollback/squash reference onto the completed
+            # session's own tree.
+            task.baseline_untracked = sorted(verify.untracked_files(self.workspace.root))
         feedback: Path | None = None
         while True:
-            task.attempt += 1
+            if resume_result is None:
+                # a resumed result replays the attempt it was recorded under, so
+                # the counter (and the session task_id derived from it) must not
+                # advance; a second host death then still finds the record and
+                # re-enters this continuation instead of falling back to restart.
+                task.attempt += 1
             advance(task, Phase.DEV_RUNNING)
             self._save()
             if resume_result is not None:
@@ -1501,7 +1510,11 @@ class Engine:
         # only state the budget-exhaustion rescue below is allowed to commit.
         refileable_followup = False
         while task.review_cycle < self.policy.limits.max_review_cycles:
-            task.review_cycle += 1
+            if resume_result is None:
+                # a resumed result replays the cycle it was recorded under: the
+                # counter must not advance, or the replay burns a review-budget
+                # slot and mislabels its journal/session ids.
+                task.review_cycle += 1
             refileable_followup = False  # only a completed pass this cycle can set it
             advance(task, Phase.REVIEW_RUNNING)
             self._save()

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -9,6 +9,7 @@ verify. All creative work happens inside disposable adapter sessions.
 from __future__ import annotations
 
 import contextlib
+import functools
 import shutil
 import signal
 import sys
@@ -245,6 +246,22 @@ class Engine:
                     raise  # nested auto-sweep: let the owner record the stop
                 self.state.stopped = True
                 self.journal.append("run-stop")
+            except KeyboardInterrupt:
+                # Some Windows console/control events can still surface as a raw
+                # KeyboardInterrupt without routing through the installed signal
+                # handler. Persist a controlled stop rather than letting the
+                # engine disappear with stale state.
+                self._stopping = True  # swallow stop signals landing mid-teardown
+                try:
+                    kill_session(self.state.run_id)
+                except (
+                    BaseException
+                ):  # noqa: BLE001  # nosec B110 - best-effort teardown; the stop must still record
+                    pass
+                if self._is_nested:
+                    raise
+                self.state.stopped = True
+                self.journal.append("run-stop", reason="KeyboardInterrupt")
             except Exception as exc:
                 # an unexpected exception escaped the loop (e.g. a transport
                 # hang that leaked past the seam). Don't let it die to the lossy
@@ -1043,6 +1060,36 @@ class Engine:
                     self._integrate_unit(task, unit)
                 else:
                     self._review_and_commit(task)
+            elif (resumable := self._resumable_session(task)) is not None:
+                # the host died inside the post-session window: the session
+                # itself completed and its recorded result is on disk, so
+                # continue into the normal verify/decide pipeline instead of
+                # rolling the finished work back through resume-restart.
+                role, result = resumable
+                self.journal.append("resume-verify", story_key=task.story_key, role=role)
+                if role == "dev":
+                    # deliberate reset like the restart arm: _dev_phase re-enters
+                    # its loop and consumes the recorded result instead of
+                    # running a session
+                    task.phase = Phase.PENDING
+                    continuation = functools.partial(self._drive_story, task, dev_resume=result)
+                else:
+                    # deliberate reset to the legal pre-review phase
+                    task.phase = Phase.DEV_VERIFY
+                    continuation = functools.partial(
+                        self._review_and_commit, task, resume_result=result
+                    )
+                if isolated:
+                    unit = self._reopen_unit(task)
+                    prev = self.workspace
+                    self.workspace = unit.workspace
+                    try:
+                        continuation()
+                    finally:
+                        self.workspace = prev
+                    self._integrate_unit(task, unit)
+                else:
+                    continuation()
             else:
                 self.journal.append(
                     "resume-restart", story_key=task.story_key, phase=str(task.phase)
@@ -1061,6 +1108,33 @@ class Engine:
                 task.phase = Phase.PENDING  # deliberate reset, not a normal transition
                 self._save()
                 self._run_story(task)
+
+    def _resumable_session(self, task: StoryTask) -> tuple[str, SessionResult] | None:
+        """The in-flight session's durably-recorded result, when complete enough
+        to act on: the task died mid-phase but its current attempt/cycle record
+        is ``completed`` and carries the parsed result. Consumes only evidence
+        the adapter vouched for at session end — no artifact re-scan, no
+        loosening of completion authority. Anything less returns None and the
+        caller falls through to resume-restart."""
+        if task.phase == Phase.DEV_RUNNING:
+            role, seq = "dev", task.attempt
+        elif task.phase == Phase.REVIEW_RUNNING:
+            role, seq = "review", task.review_cycle
+        else:
+            return None
+        task_id = f"{task.story_key}-{role}-{seq}"
+        for record in reversed(task.sessions):
+            if record.task_id != task_id:
+                continue
+            if record.status != "completed" or record.result_json is None:
+                return None
+            return role, SessionResult(
+                status="completed",
+                result_json=record.result_json,
+                session_id=record.session_id,
+                transcript_path=record.transcript_path,
+            )
+        return None
 
     # ------------------------------------------------------------- per story
 
@@ -1269,8 +1343,8 @@ class Engine:
             self._drive_story(task)
         self._emit("post_story", task)
 
-    def _drive_story(self, task: StoryTask) -> None:
-        if not self._dev_phase(task):
+    def _drive_story(self, task: StoryTask, dev_resume: SessionResult | None = None) -> None:
+        if not self._dev_phase(task, resume_result=dev_resume):
             return
         if gates.pause_after_spec(self.policy):
             gates.notify(
@@ -1286,7 +1360,7 @@ class Engine:
             )
         self._review_and_commit(task)
 
-    def _dev_phase(self, task: StoryTask) -> bool:
+    def _dev_phase(self, task: StoryTask, resume_result: SessionResult | None = None) -> bool:
         if self._vetoed(self._emit("pre_dev_phase", task), task):
             return False
         task.baseline_commit = verify.rev_parse_head(self.workspace.root)
@@ -1298,12 +1372,19 @@ class Engine:
             task.attempt += 1
             advance(task, Phase.DEV_RUNNING)
             self._save()
-            result = self._run_session(
-                task,
-                role="dev",
-                prompt=self._dev_prompt(task, feedback),
-                seq=task.attempt,
-            )
+            if resume_result is not None:
+                # the session already ran before the host died; its recorded
+                # result re-enters the verify/decide pipeline. Consumed exactly
+                # once — later iterations run sessions normally.
+                result = resume_result
+                resume_result = None
+            else:
+                result = self._run_session(
+                    task,
+                    role="dev",
+                    prompt=self._dev_prompt(task, feedback),
+                    seq=task.attempt,
+                )
             advance(task, Phase.DEV_VERIFY)
             outcome = None
             if result.status == "completed":
@@ -1384,7 +1465,9 @@ class Engine:
         if spec_path.is_file():
             task.spec_file = str(spec_path)
 
-    def _review_and_commit(self, task: StoryTask) -> None:
+    def _review_and_commit(
+        self, task: StoryTask, resume_result: SessionResult | None = None
+    ) -> None:
         if not self.policy.review.enabled:
             # review.enabled = false: the bmad-dev-auto session's own inline
             # review is the only review; verify the deterministic gates + commit.
@@ -1422,12 +1505,19 @@ class Engine:
             refileable_followup = False  # only a completed pass this cycle can set it
             advance(task, Phase.REVIEW_RUNNING)
             self._save()
-            result = self._run_session(
-                task,
-                role="review",
-                prompt=self._review_prompt(task),
-                seq=task.review_cycle,
-            )
+            if resume_result is not None:
+                # the session already ran before the host died; its recorded
+                # result re-enters the decision pipeline. Consumed exactly
+                # once — later cycles run sessions normally.
+                result = resume_result
+                resume_result = None
+            else:
+                result = self._run_session(
+                    task,
+                    role="review",
+                    prompt=self._review_prompt(task),
+                    seq=task.review_cycle,
+                )
             advance(task, Phase.REVIEW_VERIFY)
             self._save()
             self._emit(
@@ -1835,7 +1925,6 @@ class Engine:
         self.journal.set_active_log(task_id)
         self.journal.append("session-start", task_id=task_id, role=role, prompt=prompt)
         result = adapter.run(spec)
-        usage = adapter.read_usage(result)
         task.record_session(
             SessionRecord(
                 task_id=task_id,
@@ -1843,15 +1932,24 @@ class Engine:
                 status=result.status,
                 session_id=result.session_id,
                 transcript_path=result.transcript_path,
-                usage=usage,
+                result_json=result.result_json,
             )
         )
+        # Make the completed session durable before the usage read, post-session
+        # hooks, and follow-up verification. If the host kills the process in
+        # that window, the resume path can see the session instead of a stale
+        # dev-running task with no evidence; usage stays best-effort metadata,
+        # not a durability gate.
+        self._save()
+        usage = adapter.read_usage(result)
+        task.attach_session_usage(task_id, usage)
         self.journal.append(
             "session-end",
             task_id=task_id,
             status=result.status,
             tokens=usage.total if usage else None,
         )
+        self._save()
         self._emit(
             "post_session",
             task,

--- a/src/bmad_loop/model.py
+++ b/src/bmad_loop/model.py
@@ -91,6 +91,9 @@ class SessionRecord:
     session_id: str | None = None
     transcript_path: str | None = None
     usage: TokenUsage | None = None
+    # the session's parsed result payload, persisted so a durably-saved
+    # completed session is actionable on resume, not just forensics
+    result_json: dict[str, Any] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -100,6 +103,7 @@ class SessionRecord:
             "session_id": self.session_id,
             "transcript_path": self.transcript_path,
             "usage": self.usage.to_dict() if self.usage else None,
+            "result_json": self.result_json,
         }
 
     @classmethod
@@ -112,6 +116,7 @@ class SessionRecord:
             session_id=d.get("session_id"),
             transcript_path=d.get("transcript_path"),
             usage=TokenUsage.from_dict(usage) if usage else None,
+            result_json=d.get("result_json"),
         )
 
 
@@ -167,6 +172,21 @@ class StoryTask:
         self.sessions.append(record)
         if record.usage:
             self.tokens.add(record.usage)
+
+    def attach_session_usage(self, task_id: str, usage: TokenUsage | None) -> None:
+        """Fold usage into the most recent session for `task_id`. Usage is
+        best-effort metadata attached after the session itself is saved, so a
+        failed usage read never costs the recorded session."""
+        if usage is None:
+            return
+        for record in reversed(self.sessions):
+            if record.task_id != task_id:
+                continue
+            if record.usage is None:
+                record.usage = usage
+                self.tokens.add(usage)
+            return
+        raise KeyError(task_id)
 
     def to_dict(self) -> dict[str, Any]:
         return {

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,5 +1,6 @@
 """Engine scenario tests against the mock adapter — no tmux, no LLM."""
 
+import json
 import re
 import signal
 from pathlib import Path
@@ -26,6 +27,7 @@ from bmad_loop.model import (
     PAUSE_SPEC_APPROVAL,
     Phase,
     RunState,
+    SessionRecord,
     StoryTask,
     TokenUsage,
 )
@@ -94,6 +96,216 @@ def resume_engine(project, engine, script, policy=None) -> tuple[Engine, MockAda
         max_stories=state.max_stories,
     )
     return new_engine, adapter
+
+
+def test_run_session_saves_completed_session_checkpoint(project):
+    """The completed session must already be on disk when post_session fires:
+    a host kill inside the hooks cannot lose it."""
+    write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(project, [SessionResult(status="completed")])
+    task = StoryTask(story_key="1-1-a", epic=1)
+    engine.state.tasks[task.story_key] = task
+    engine._save()
+
+    original_emit = engine._emit
+    on_disk_at_post_session = []
+
+    def spying_emit(stage, *args, **kwargs):
+        if stage == "post_session":
+            on_disk = load_state(engine.run_dir)
+            on_disk_at_post_session.append(bool(on_disk.tasks["1-1-a"].sessions))
+        return original_emit(stage, *args, **kwargs)
+
+    engine._emit = spying_emit
+    engine._run_session(task, role="dev", prompt="/bmad-dev-auto 1-1-a", seq=1)
+
+    saved = load_state(engine.run_dir)
+    saved_task = saved.tasks["1-1-a"]
+    assert len(saved_task.sessions) == 1
+    assert saved_task.sessions[0].status == "completed"
+    assert saved_task.sessions[0].usage is not None
+    assert saved_task.sessions[0].usage.total == 15
+    assert saved_task.tokens.total == 15
+    assert on_disk_at_post_session == [True]
+
+
+def test_run_session_persists_session_when_usage_read_raises(project):
+    """A failed usage read propagates, but the completed session is already
+    saved — usage is metadata, not a durability gate."""
+    write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
+    engine, adapter = make_engine(
+        project,
+        [SessionResult(status="completed", session_id="sess-1", transcript_path="events.jsonl")],
+    )
+    task = StoryTask(story_key="1-1-a", epic=1)
+    engine.state.tasks[task.story_key] = task
+    engine._save()
+
+    def boom(result):
+        raise RuntimeError("usage read failed")
+
+    adapter.read_usage = boom
+    with pytest.raises(RuntimeError):
+        engine._run_session(task, role="dev", prompt="/bmad-dev-auto 1-1-a", seq=1)
+
+    saved = load_state(engine.run_dir)
+    saved_task = saved.tasks["1-1-a"]
+    assert len(saved_task.sessions) == 1
+    assert saved_task.sessions[0].status == "completed"
+    assert saved_task.sessions[0].session_id == "sess-1"
+    assert saved_task.sessions[0].transcript_path == "events.jsonl"
+    assert saved_task.sessions[0].usage is None
+
+
+def test_keyboard_interrupt_records_stopped_run(project, monkeypatch):
+    """A raw KeyboardInterrupt (Windows console-ctrl bypassing the signal
+    handler) records a controlled stop, not a crash."""
+    killed = []
+    monkeypatch.setattr("bmad_loop.engine.kill_session", lambda rid: killed.append(rid))
+
+    def interrupt(_spec):
+        raise KeyboardInterrupt()
+
+    write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(project, [interrupt])
+
+    summary = engine.run()
+
+    saved = load_state(engine.run_dir)
+    assert saved.stopped
+    assert not summary.crashed
+    assert not saved.crashed
+    assert killed == ["test-run"]
+    entries = [
+        json.loads(line) for line in (engine.run_dir / "journal.jsonl").read_text().splitlines()
+    ]
+    stops = [e for e in entries if e["kind"] == "run-stop"]
+    assert stops and stops[0]["reason"] == "KeyboardInterrupt"
+
+
+def test_nested_engine_reraises_keyboard_interrupt(project, monkeypatch):
+    """A nested engine re-raises KeyboardInterrupt for the outer (owning)
+    engine to record — it still tears down its own agent session."""
+    killed = []
+    monkeypatch.setattr("bmad_loop.engine.kill_session", lambda rid: killed.append(rid))
+    engine, _ = make_engine(project, [])
+
+    def boom():
+        raise KeyboardInterrupt()
+
+    monkeypatch.setattr(engine, "_loop", boom)
+    sentinel = object()
+    Engine._stop_signals_owner = sentinel  # pretend an outer engine owns signals
+    try:
+        with pytest.raises(KeyboardInterrupt):
+            engine.run()
+    finally:
+        Engine._stop_signals_owner = None
+
+    assert load_state(engine.run_dir).stopped is False  # owner records it, not us
+    assert killed == ["test-run"]
+
+
+def test_resume_continues_from_completed_dev_session(project):
+    """A host kill inside the post-session window of a completed dev session
+    must not roll the work back: resume consumes the durably-recorded result
+    and drives verify/decide as if the session had just returned."""
+    write_sprint(project, {"1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(project, [dev_effect(project, "1-1-a")])
+
+    def crashing_emit(stage, *args, **kwargs):
+        if stage == "post_session":
+            raise RuntimeError("host died in the post-session window")
+        return original_emit(stage, *args, **kwargs)
+
+    original_emit = engine._emit
+    engine._emit = crashing_emit
+    summary = engine.run()
+
+    assert summary.crashed
+    saved = load_state(engine.run_dir)
+    assert saved.tasks["1-1-a"].phase == Phase.DEV_RUNNING
+    assert saved.tasks["1-1-a"].sessions[0].result_json is not None
+
+    resumed, adapter = resume_engine(project, engine, [review_effect(project, "1-1-a", clean=True)])
+    summary2 = resumed.run()
+
+    assert summary2.done == 1 and not summary2.crashed
+    assert load_state(resumed.run_dir).tasks["1-1-a"].phase == Phase.DONE
+    assert [s.role for s in adapter.sessions] == ["review"]  # dev NOT re-run
+    kinds = [e["kind"] for e in resumed.journal.entries()]
+    assert "resume-verify" in kinds
+    assert "resume-restart" not in kinds
+    assert not any(k.startswith("rollback") for k in kinds)
+
+
+def test_resume_continues_from_completed_review_session(project):
+    """A host kill inside the post-session window of a completed review session
+    resumes into the review decision path — the dev phase is not re-entered."""
+    write_sprint(project, {"1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(
+        project,
+        [dev_effect(project, "1-1-a"), review_effect(project, "1-1-a", clean=True)],
+    )
+    post_sessions = []
+
+    def crashing_emit(stage, *args, **kwargs):
+        if stage == "post_session":
+            post_sessions.append(stage)
+            if len(post_sessions) == 2:  # the review session's post_session
+                raise RuntimeError("host died in the post-session window")
+        return original_emit(stage, *args, **kwargs)
+
+    original_emit = engine._emit
+    engine._emit = crashing_emit
+    summary = engine.run()
+
+    assert summary.crashed
+    saved = load_state(engine.run_dir)
+    assert saved.tasks["1-1-a"].phase == Phase.REVIEW_RUNNING
+
+    resumed, adapter = resume_engine(project, engine, [])
+    summary2 = resumed.run()
+
+    assert summary2.done == 1 and not summary2.crashed
+    assert load_state(resumed.run_dir).tasks["1-1-a"].phase == Phase.DONE
+    assert adapter.sessions == []  # neither dev nor review re-run
+    entries = resumed.journal.entries()
+    verifies = [e for e in entries if e["kind"] == "resume-verify"]
+    assert verifies and verifies[-1]["role"] == "review"
+    kinds = [e["kind"] for e in entries]
+    assert "resume-restart" not in kinds
+
+
+@pytest.mark.parametrize(
+    "record",
+    [
+        SessionRecord(task_id="1-1-a-dev-1", role="dev", status="stalled"),
+        # completed but without a recorded result (legacy state.json shape)
+        SessionRecord(task_id="1-1-a-dev-1", role="dev", status="completed"),
+    ],
+)
+def test_resume_restart_when_session_record_incomplete(project, record):
+    """A dev-running task whose current-attempt record is not a completed
+    session with a recorded result still takes today's resume-restart."""
+    write_sprint(project, {"1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(project, [])
+    task = StoryTask(story_key="1-1-a", epic=1, phase=Phase.DEV_RUNNING, attempt=1)
+    task.record_session(record)
+    engine.state.tasks[task.story_key] = task
+    engine._save()
+
+    resumed, _ = resume_engine(
+        project,
+        engine,
+        [dev_effect(project, "1-1-a"), review_effect(project, "1-1-a", clean=True)],
+    )
+    summary = resumed.run()
+
+    assert summary.done == 1
+    kinds = [e["kind"] for e in resumed.journal.entries()]
+    assert "resume-restart" in kinds
+    assert "resume-verify" not in kinds
 
 
 def test_token_budget_discounts_cache_reads(project):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,6 +1,5 @@
 """Engine scenario tests against the mock adapter — no tmux, no LLM."""
 
-import json
 import re
 import signal
 from pathlib import Path
@@ -176,10 +175,7 @@ def test_keyboard_interrupt_records_stopped_run(project, monkeypatch):
     assert not summary.crashed
     assert not saved.crashed
     assert killed == ["test-run"]
-    entries = [
-        json.loads(line) for line in (engine.run_dir / "journal.jsonl").read_text().splitlines()
-    ]
-    stops = [e for e in entries if e["kind"] == "run-stop"]
+    stops = [e for e in engine.journal.entries() if e["kind"] == "run-stop"]
     assert stops and stops[0]["reason"] == "KeyboardInterrupt"
 
 
@@ -224,14 +220,22 @@ def test_resume_continues_from_completed_dev_session(project):
 
     assert summary.crashed
     saved = load_state(engine.run_dir)
-    assert saved.tasks["1-1-a"].phase == Phase.DEV_RUNNING
-    assert saved.tasks["1-1-a"].sessions[0].result_json is not None
+    crashed_task = saved.tasks["1-1-a"]
+    assert crashed_task.phase == Phase.DEV_RUNNING
+    assert crashed_task.sessions[0].result_json is not None
+    assert crashed_task.attempt == 1
 
     resumed, adapter = resume_engine(project, engine, [review_effect(project, "1-1-a", clean=True)])
     summary2 = resumed.run()
 
     assert summary2.done == 1 and not summary2.crashed
-    assert load_state(resumed.run_dir).tasks["1-1-a"].phase == Phase.DONE
+    final = load_state(resumed.run_dir).tasks["1-1-a"]
+    assert final.phase == Phase.DONE
+    # the replay stays the attempt it was recorded under, against the persisted
+    # baseline — re-capturing either would shift the rollback/squash reference
+    # and desync the counter from the recorded session's task_id
+    assert final.attempt == 1
+    assert final.baseline_commit == crashed_task.baseline_commit
     assert [s.role for s in adapter.sessions] == ["review"]  # dev NOT re-run
     kinds = [e["kind"] for e in resumed.journal.entries()]
     assert "resume-verify" in kinds
@@ -268,7 +272,9 @@ def test_resume_continues_from_completed_review_session(project):
     summary2 = resumed.run()
 
     assert summary2.done == 1 and not summary2.crashed
-    assert load_state(resumed.run_dir).tasks["1-1-a"].phase == Phase.DONE
+    final = load_state(resumed.run_dir).tasks["1-1-a"]
+    assert final.phase == Phase.DONE
+    assert final.review_cycle == 1  # replay does not burn a review-budget slot
     assert adapter.sessions == []  # neither dev nor review re-run
     entries = resumed.journal.entries()
     verifies = [e for e in entries if e["kind"] == "resume-verify"]

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,10 +1,65 @@
 """RunState serialization + lifecycle-flag tests."""
 
-from bmad_loop.model import RunState, StoryTask
+import pytest
+
+from bmad_loop.model import RunState, SessionRecord, StoryTask, TokenUsage
 
 
 def _state(**kw) -> RunState:
     return RunState(run_id="r1", project="/p", started_at="now", **kw)
+
+
+def _task_with_session(usage: TokenUsage | None = None) -> StoryTask:
+    task = StoryTask(story_key="1-1-a", epic=1)
+    task.record_session(
+        SessionRecord(task_id="1-1-a-dev-1", role="dev", status="completed", usage=usage)
+    )
+    return task
+
+
+def test_attach_session_usage_folds_usage_into_record_and_totals():
+    task = _task_with_session()
+    task.attach_session_usage("1-1-a-dev-1", TokenUsage(input_tokens=10, output_tokens=5))
+    assert task.sessions[0].usage is not None
+    assert task.sessions[0].usage.total == 15
+    assert task.tokens.total == 15
+
+
+def test_attach_session_usage_raises_on_unknown_task_id():
+    task = _task_with_session()
+    with pytest.raises(KeyError):
+        task.attach_session_usage("nope", TokenUsage(input_tokens=1))
+
+
+def test_attach_session_usage_is_noop_on_none():
+    task = _task_with_session()
+    task.attach_session_usage("1-1-a-dev-1", None)
+    assert task.sessions[0].usage is None
+    assert task.tokens.total == 0
+
+
+def test_attach_session_usage_does_not_double_count_existing_usage():
+    task = _task_with_session(usage=TokenUsage(input_tokens=10, output_tokens=5))
+    task.attach_session_usage("1-1-a-dev-1", TokenUsage(input_tokens=100))
+    assert task.sessions[0].usage.total == 15  # original usage kept
+    assert task.tokens.total == 15
+
+
+def test_session_record_result_json_round_trips():
+    record = SessionRecord(
+        task_id="1-1-a-dev-1",
+        role="dev",
+        status="completed",
+        result_json={"workflow": "auto-dev", "status": "done"},
+    )
+    back = SessionRecord.from_dict(record.to_dict())
+    assert back.result_json == {"workflow": "auto-dev", "status": "done"}
+
+
+def test_session_record_result_json_defaults_none_for_legacy_state():
+    doc = SessionRecord(task_id="1-1-a-dev-1", role="dev", status="completed").to_dict()
+    del doc["result_json"]  # state.json from before the field existed
+    assert SessionRecord.from_dict(doc).result_json is None
 
 
 def test_followup_review_recommended_round_trips():


### PR DESCRIPTION
## Summary

- **Session-end durability barrier**: `_run_session` records the completed `SessionRecord` *without* usage and saves immediately; usage is folded in afterwards via the new `StoryTask.attach_session_usage` and a second save lands before `post_session` fires. A host kill during usage read, hooks, or follow-up verification can no longer lose a completed session. Usage stays best-effort metadata, never a durability gate.
- **Resume continuation**: `SessionRecord` now persists the session's `result_json`, and `_finish_inflight` continues from a durably-completed dev/review session into the existing verify/decide pipeline (journaled `resume-verify`) instead of re-driving finished work through resume-restart rollback. Incomplete evidence (record missing / not completed / no result) falls through to today's restart path unchanged. Checked against #61 first — different mechanism (that is the live-run stalled-verdict reconcile seam; this is the resume path acting on durably-recorded completed evidence).
- **Raw `KeyboardInterrupt` branch** in the run loop, mirroring `RunStopped`: kill the agent session, persist a controlled stop (`run-stop` with `reason="KeyboardInterrupt"`), re-raise when nested. The branch latches `_stopping` and guards `kill_session` so a second interrupt or a stop signal landing mid-teardown still records the stop.
- Per the issue's non-goals, none of the `SESSION_END_TRACE_FILE`/`trace_run` diagnostic scaffolding from the reference patches is ported.

## Tests

- Durability proven at the moment `post_session` fires (spied `_emit` loads state from disk); `read_usage` raising leaves the completed session persisted with `usage=None`.
- `attach_session_usage` unit matrix: fold into record + totals, `KeyError` on unknown task, no-op on `None`, no double-count.
- KeyboardInterrupt: controlled stop journaled with reason, session killed, nested re-raise.
- Resume continuation: dev and review continuations complete the story with zero re-run sessions and no rollback; incomplete-evidence cases (stalled record, legacy record without `result_json`) still take resume-restart; `SessionRecord.result_json` serialization round-trip incl. legacy dicts.
- Full suite: 1388 passed; only the known pre-existing win32 environmental failures in `test_module_skills_sync.py` remain. black/ruff/isort/bandit clean at trunk-pinned versions.

Closes #57


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved resume behavior so completed sessions can continue from the right step after an interruption, without redoing finished work.
  * Added support for preserving session results and usage details across saves and reloads.

* **Bug Fixes**
  * Controlled raw keyboard interruptions now stop runs cleanly instead of being treated like crashes.
  * Session progress is saved more reliably before follow-up processing, helping protect completed work during unexpected shutdowns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->