### PR TITLE
fix(engine): close resume-replay edges from #62 (final-cycle replay, stale result_json, record bloat)

### DIFF
--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -1509,7 +1509,13 @@ class Engine:
         # (status: done) while still recommending an independent follow-up — the
         # only state the budget-exhaustion rescue below is allowed to commit.
         refileable_followup = False
-        while task.review_cycle < self.policy.limits.max_review_cycles:
+        # A resumed result must enter the loop even when the crash landed in the
+        # post-session window of the *final* allowed cycle (review_cycle already
+        # == max_review_cycles): its recorded pass was already counted, and the
+        # replay branch below skips the re-increment, so no extra budget is
+        # burned. resume_result is nulled after it is consumed, so every later
+        # iteration falls back to the normal budget guard.
+        while resume_result is not None or task.review_cycle < self.policy.limits.max_review_cycles:
             if resume_result is None:
                 # a resumed result replays the cycle it was recorded under: the
                 # counter must not advance, or the replay burns a review-budget
@@ -1759,7 +1765,25 @@ class Engine:
         raw_status = fm.get("status")
         fm_status = "" if raw_status is None else str(raw_status).strip().lower()
         if fm_status == success_status:
-            return  # already finalized — idempotent
+            # Already finalized — idempotent for the spec. But a *resumed* result
+            # is the pre-reconcile snapshot persisted before the original run's
+            # reconcile mutated its in-memory dict (the durable record is now a
+            # defensive copy, so it never saw that mutation). Re-fold the derived
+            # keys from the frontmatter we just read so the replay's
+            # `followup_review_recommended` gate matches the finalized spec
+            # instead of the stale template default. Only fold followup when the
+            # frontmatter actually carries it: on the generic path the frontmatter
+            # is the source `devcontract.synthesize_result` already reads it from,
+            # so a present key can never disagree — but when it is absent, the
+            # value the session put in result.json is authoritative and must not
+            # be clobbered to a phantom False.
+            if isinstance(result_json, dict):
+                result_json["status"] = success_status
+                if success_status == "done" and "followup_review_recommended" in fm:
+                    result_json["followup_review_recommended"] = bool(
+                        fm.get("followup_review_recommended")
+                    )
+            return
         if fm_status not in devcontract.RECONCILABLE_FROM:
             return  # blocked / unknown custom status: never override a deliberate one
         arr = devcontract.parse_auto_run_result(spec_path.read_text(encoding="utf-8"))
@@ -1938,6 +1962,16 @@ class Engine:
         self.journal.set_active_log(task_id)
         self.journal.append("session-start", task_id=task_id, role=role, prompt=prompt)
         result = adapter.run(spec)
+        # Only dev/review sessions are resumable — `_resumable_session` matches
+        # exactly those task ids under DEV_RUNNING/REVIEW_RUNNING. For everything
+        # else (triage/sweep, labeled plugin-workflow sessions) the payload is
+        # never consumed on resume, so persisting it is pure state.json bloat.
+        # For resumable sessions, store a defensive copy: `result.result_json`
+        # is mutated in place downstream (`_reconcile_generic_terminal_status`),
+        # and the durable record must stay a stable snapshot of what the adapter
+        # returned rather than aliasing a later, half-mutated dict. Shallow is
+        # enough — reconcile only touches top-level keys.
+        resumable = label is None and role in ("dev", "review")
         task.record_session(
             SessionRecord(
                 task_id=task_id,
@@ -1945,7 +1979,11 @@ class Engine:
                 status=result.status,
                 session_id=result.session_id,
                 transcript_path=result.transcript_path,
-                result_json=result.result_json,
+                result_json=(
+                    dict(result.result_json)
+                    if resumable and result.result_json is not None
+                    else None
+                ),
             )
         )
         # Make the completed session durable before the usage read, post-session

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -314,6 +314,179 @@ def test_resume_restart_when_session_record_incomplete(project, record):
     assert "resume-verify" not in kinds
 
 
+def _final_review_cycle_policy() -> Policy:
+    # max_review_cycles=1 → the first (and only) review cycle IS the final one,
+    # so a crash in its post-session window lands the resume with
+    # review_cycle already == the budget ceiling.
+    return Policy(
+        gates=GatesPolicy(mode="none"),
+        notify=QUIET,
+        limits=LimitsPolicy(max_review_cycles=1),
+        scm=ScmPolicy(rollback_on_failure=True),
+    )
+
+
+def test_resume_final_review_cycle_replays_clean_result(project):
+    """A host death in the post-session window of the *last* allowed review
+    cycle must still consume the durably-recorded clean pass: the resume
+    continuation enters the loop even though review_cycle already == the budget,
+    so the story reaches DONE instead of dropping a recorded clean review to
+    defer. Regression guard for the final-cycle replay edge from #62."""
+    write_sprint(project, {"1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(
+        project,
+        [dev_effect(project, "1-1-a"), review_effect(project, "1-1-a", clean=True)],
+        policy=_final_review_cycle_policy(),
+    )
+    post_sessions = []
+
+    def crashing_emit(stage, *args, **kwargs):
+        if stage == "post_session":
+            post_sessions.append(stage)
+            if len(post_sessions) == 2:  # the (final) review session's post_session
+                raise RuntimeError("host died in the post-session window")
+        return original_emit(stage, *args, **kwargs)
+
+    original_emit = engine._emit
+    engine._emit = crashing_emit
+    assert engine.run().crashed
+    crashed = load_state(engine.run_dir).tasks["1-1-a"]
+    assert crashed.phase == Phase.REVIEW_RUNNING
+    assert crashed.review_cycle == 1  # already at the budget ceiling
+    assert crashed.sessions[-1].result_json is not None
+
+    resumed, adapter = resume_engine(project, engine, [])
+    summary = resumed.run()
+
+    assert summary.done == 1 and summary.deferred == 0 and not summary.crashed
+    final = load_state(resumed.run_dir).tasks["1-1-a"]
+    assert final.phase == Phase.DONE
+    assert final.review_cycle == 1  # the replay did not burn an extra cycle
+    assert adapter.sessions == []  # nothing re-run — the recorded pass was replayed
+    kinds = [e["kind"] for e in resumed.journal.entries()]
+    assert "resume-verify" in kinds
+    assert "resume-restart" not in kinds
+
+
+def test_resume_final_review_cycle_dirty_replay_defers_without_extra_budget(project):
+    """The same final-cycle replay for a non-convergent review consumes the
+    recorded pass, then the loop exits on the normal budget guard — no fresh
+    session, no extra cycle — and the story defers. Proves the relaxed guard
+    burns no extra budget once the replayed result is consumed."""
+    write_sprint(project, {"1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(
+        project,
+        [
+            dev_effect(project, "1-1-a"),
+            review_effect(project, "1-1-a", clean=False, finalized=False),
+        ],
+        policy=_final_review_cycle_policy(),
+    )
+    post_sessions = []
+
+    def crashing_emit(stage, *args, **kwargs):
+        if stage == "post_session":
+            post_sessions.append(stage)
+            if len(post_sessions) == 2:
+                raise RuntimeError("host died in the post-session window")
+        return original_emit(stage, *args, **kwargs)
+
+    original_emit = engine._emit
+    engine._emit = crashing_emit
+    assert engine.run().crashed
+    assert load_state(engine.run_dir).tasks["1-1-a"].review_cycle == 1
+
+    resumed, adapter = resume_engine(project, engine, [])
+    summary = resumed.run()
+
+    assert summary.deferred == 1 and summary.done == 0 and not summary.crashed
+    final = load_state(resumed.run_dir).tasks["1-1-a"]
+    assert final.phase == Phase.DEFERRED
+    assert final.review_cycle == 1  # replay consumed; no extra budget burned
+    assert adapter.sessions == []  # loop exited without a fresh session
+    kinds = [e["kind"] for e in resumed.journal.entries()]
+    assert "resume-verify" in kinds
+
+
+def test_reconcile_early_return_heals_stale_resumed_dict(project):
+    """On the idempotent early-return path (frontmatter already at the success
+    status), the reconcile still syncs a stale *resumed* result dict from the
+    frontmatter — a resumed record is the pre-reconcile snapshot, so without the
+    heal its `followup_review_recommended` gate would read the template default
+    and silently skip the follow-up review."""
+    engine, _ = make_engine(project, [])
+    sp = spec_path(project, "1-1-a")
+    sp.parent.mkdir(parents=True, exist_ok=True)
+    sp.write_text(
+        "---\ntitle: 'test'\ntype: 'feature'\nstatus: 'done'\n"
+        "followup_review_recommended: true\nbaseline_commit: 'abc'\n---\n\n## Intent\n\ntest\n"
+    )
+    task = StoryTask(story_key="1-1-a", epic=1)
+    # the pre-reconcile snapshot persisted before the original run mutated its
+    # in-memory dict: frontmatter template default status, no followup key.
+    stale = {"workflow": "auto-dev", "spec_file": str(sp), "status": "in-progress"}
+    engine._reconcile_generic_terminal_status(task, stale)
+
+    assert stale["status"] == "done"  # synced from the finalized frontmatter
+    assert stale["followup_review_recommended"] is True  # folded from the frontmatter
+    # the idempotent path never rewrites the spec, so nothing is journaled
+    assert not [e for e in engine.journal.entries() if e["kind"] == "spec-status-reconciled"]
+
+
+def test_run_session_record_result_json_isolated_from_later_mutation(project):
+    """The durable SessionRecord holds a defensive copy of result_json, so the
+    in-place mutation `_reconcile_generic_terminal_status` performs on the live
+    result after the session is recorded cannot retroactively rewrite the
+    persisted snapshot."""
+    write_sprint(project, {"1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(
+        project, [SessionResult(status="completed", result_json={"workflow": "auto-dev"})]
+    )
+    task = StoryTask(story_key="1-1-a", epic=1)
+    engine.state.tasks[task.story_key] = task
+    engine._save()
+
+    result = engine._run_session(task, role="dev", prompt="/bmad-dev-auto 1-1-a", seq=1)
+    # reconcile-style in-place mutation of the live result AFTER it was recorded
+    result.result_json["status"] = "done"
+    result.result_json["followup_review_recommended"] = True
+
+    assert task.sessions[-1].result_json == {"workflow": "auto-dev"}  # in-memory record
+    saved = load_state(engine.run_dir).tasks["1-1-a"]
+    assert saved.sessions[-1].result_json == {"workflow": "auto-dev"}  # on-disk snapshot
+
+
+def test_run_session_persists_result_json_only_for_resumable_roles(project):
+    """Only dev/review sessions (never a label) are consumed on resume, so only
+    they persist result_json; triage/sweep and labeled plugin-workflow records
+    store None — the payload would be pure state.json bloat otherwise."""
+    write_sprint(project, {"1-1-a": "ready-for-dev"})
+    engine, adapter = make_engine(
+        project,
+        [
+            SessionResult(status="completed", result_json={"role": "dev"}),
+            SessionResult(status="completed", result_json={"role": "review"}),
+            SessionResult(status="completed", result_json={"role": "triage"}),
+            SessionResult(status="completed", result_json={"role": "labeled"}),
+        ],
+    )
+    engine.adapters["triage"] = adapter  # SweepEngine registers this; wire it here
+    task = StoryTask(story_key="1-1-a", epic=1)
+    engine.state.tasks[task.story_key] = task
+    engine._save()
+
+    engine._run_session(task, role="dev", prompt="p", seq=1)
+    engine._run_session(task, role="review", prompt="p", seq=1)
+    engine._run_session(task, role="triage", prompt="p", seq=1)
+    engine._run_session(task, role="dev", prompt="p", seq=1, label="tea-trace")
+
+    by_id = {r.task_id: r.result_json for r in task.sessions}
+    assert by_id["1-1-a-dev-1"] == {"role": "dev"}  # resumable → persisted
+    assert by_id["1-1-a-review-1"] == {"role": "review"}  # resumable → persisted
+    assert by_id["1-1-a-triage-1"] is None  # role not resumable → None
+    assert by_id["1-1-a-tea-trace-1"] is None  # labeled → None
+
+
 def test_token_budget_discounts_cache_reads(project):
     """Raw totals dominated by cache reads must not trip the budget; the
     weighted total (cache reads at 0.1x) is what's checked."""


### PR DESCRIPTION
## Summary

Maintainer follow-up to #62 (which closed #57), closing the three non-blocking edges called out in that PR's review. Each only surfaces on the new crash-in-the-post-session-window replay path #62 introduced, so none regress steady-state behavior.

**(a) Final-review-cycle replay dropped a recorded clean review to defer.** `_review_and_commit`'s loop was guarded by `while task.review_cycle < max_review_cycles`. A host death in the post-session window of the *last* allowed review cycle resumes with `review_cycle` already `== max_review_cycles`, so the replayed continuation evaluated the guard as false, never entered the loop body, and the durably-recorded clean review was dropped — the story fell through to defer. The guard now also enters while a `resume_result` is pending; the replay branch already skips the `review_cycle += 1` re-increment, so no extra budget is burned, and `resume_result` is nulled once consumed so every later iteration falls back to the normal budget guard.

**(b) `SessionRecord.result_json` aliased the dict `_reconcile_generic_terminal_status` mutates in place.** `_run_session` stored `result_json=result.result_json` (same object) and saved it *before* `_dev_phase` ran reconcile, which mutates that dict in place. A crash between reconcile's spec write and the dev-decision `_save()` persisted a **pre-reconcile** dict; on replay reconcile early-returns (`fm_status == success_status`) and never re-folded `followup_review_recommended`, so `task.followup_review_recommended` read stale and the follow-up review could be silently skipped. Two-part fix:

- Persist a **defensive shallow copy** at record time so the durable record is a stable snapshot of what the adapter returned, decoupled from downstream in-place mutation (`HookContext` already copies; reconcile only touches top-level keys).
- On reconcile's idempotent early-return, **heal the stale dict** from the already-read frontmatter (sync `status`, fold `followup_review_recommended`).

  Scoping note: the heal folds `followup_review_recommended` **only when the frontmatter carries the key**, rather than defaulting an absent key to `False`. On the generic path the spec frontmatter is exactly the source `devcontract.synthesize_result` already derives the flag from, so a *present* key can never disagree with the session's own value — but when it is absent (a signal the session may have carried only in its `result.json`), defaulting to `False` would clobber a real recommendation on the ordinary, non-resumed path. Gating on key presence is behaviorally identical for real generic sessions and avoids that clobber.

**(c) Triage/sweep + labeled plugin-workflow sessions persisted never-consumed `result_json` (state.json bloat).** `_run_session` recorded `result_json` for every session, but `_resumable_session` only ever matches `dev`/`review` task ids under `DEV_RUNNING`/`REVIEW_RUNNING`. `role="triage"` sweep sessions and labeled plugin-workflow sessions can never be consumed on resume, so their payloads were pure bloat. The same defensive-copy site gates them to `None` via `resumable = label is None and role in ("dev", "review")`.

## Tests

Added to `tests/test_engine.py`, reusing the existing `make_engine`/`resume_engine`/`dev_effect`/`review_effect` helpers and #62's crashing-`_emit` pattern:

- **final-cycle clean replay → DONE**: `max_review_cycles=1`, review completes clean, host dies at its `post_session`; resume drives the story to DONE, `review_cycle == 1`, zero re-run sessions, no `resume-restart`, no defer.
- **final-cycle dirty replay → defer**: same setup, non-convergent review; the replay is consumed, the loop exits on the normal budget guard (no fresh session, `review_cycle == 1`), and the story defers.
- **reconcile early-return heal**: frontmatter `done` + `followup_review_recommended: true`, stale dict → `status` synced and followup folded; idempotent path journals nothing.
- **record isolation**: mutating `result.result_json` after `_run_session` leaves both the in-memory and on-disk record's `result_json` unchanged.
- **resumable-role gating**: dev/review records persist `result_json`; triage and labeled records persist `None`.

Full suite: `1410 passed, 1 skipped`. Full `trunk check` clean on both modified files.

Refs #62, #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resumed sessions now continue correctly at the final review cycle instead of stopping early.
  * Finalized results now restore the expected status and review recommendation data more reliably when resuming.
  * Saved session results are protected from later in-memory changes, and only resumable session types keep stored result details.

* **Tests**
  * Added regression coverage for resume behavior, result reconciliation, and persistent result handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->