### PR TITLE
fix(install): guard strip_legacy_hooks against non-string command; add agy probe glob

### DIFF
--- a/src/bmad_loop/install.py
+++ b/src/bmad_loop/install.py
@@ -175,8 +175,10 @@ def strip_legacy_hooks(config: dict) -> tuple[dict, int]:
             if not isinstance(entry, dict):
                 kept.append(entry)
                 continue
-            # copilot: the handler dict is the entry itself
-            if LEGACY_HOOK_MARKER in entry.get("command", ""):
+            # copilot: the handler dict is the entry itself. Guard the command
+            # against a non-string (present-but-null) value so a malformed
+            # hand-edited config can't crash the strip with a TypeError.
+            if isinstance(cmd := entry.get("command"), str) and LEGACY_HOOK_MARKER in cmd:
                 removed += 1
                 continue
             # claude/codex/gemini: handlers nest under "hooks"
@@ -185,7 +187,11 @@ def strip_legacy_hooks(config: dict) -> tuple[dict, int]:
                 pruned = [
                     h
                     for h in nested
-                    if not (isinstance(h, dict) and LEGACY_HOOK_MARKER in h.get("command", ""))
+                    if not (
+                        isinstance(h, dict)
+                        and isinstance(cmd := h.get("command"), str)
+                        and LEGACY_HOOK_MARKER in cmd
+                    )
                 ]
                 if len(pruned) != len(nested):
                     removed += len(nested) - len(pruned)

--- a/src/bmad_loop/probe.py
+++ b/src/bmad_loop/probe.py
@@ -51,12 +51,16 @@ TRANSCRIPT_GLOBS = {
     "copilot-events": "~/.copilot/session-state/*/events.jsonl",
 }
 # Fallback family glob keyed by the `cli` name, so a CLI whose usage_parser is
-# still "none" (e.g. copilot, freshly added) still gets transcript discovery.
+# still "none" (e.g. antigravity, freshly added) still gets transcript discovery.
 FAMILY_GLOBS = {
     "claude": "~/.claude/projects/*/*.jsonl",
     "codex": "~/.codex/sessions/*/*/*/rollout-*.jsonl",
     "gemini": "~/.gemini/tmp/*/chats/session-*.jsonl",
     "copilot": "~/.copilot/session-state/*/events.jsonl",
+    # agy (Antigravity CLI) writes a per-conversation transcript.jsonl; this path
+    # is community-doc-sourced (agy 1.0.x) — confirm against your build with
+    # `probe-adapter antigravity --probe` before trusting auto-discovery.
+    "antigravity": "~/.gemini/antigravity-cli/brain/*/.system_generated/logs/transcript.jsonl",
 }
 
 _TOKEN_KEY_RE = re.compile(

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -168,6 +168,33 @@ def test_strip_legacy_hooks_prunes_within_matcher():
     assert [h["command"] for h in handlers] == ["python3 .bmad-loop/bmad_loop_hook.py Stop"]
 
 
+def test_strip_legacy_hooks_tolerates_non_string_command():
+    # a pre-existing handler whose "command" is a non-string (e.g. null) must not
+    # crash the legacy strip — it just isn't a bmad_auto hook, so it's kept.
+    # Guarded at both walks: the flat (copilot) entry and the nested handler.
+    flat = {"hooks": {"agentStop": [{"type": "command", "command": None}]}}
+    config, removed = strip_legacy_hooks(flat)
+    assert removed == 0
+    assert config["hooks"]["agentStop"] == [{"type": "command", "command": None}]
+
+    nested = {
+        "hooks": {
+            "Stop": [
+                {
+                    "hooks": [
+                        {"type": "command", "command": None},
+                        {"type": "command", "command": LEGACY_CMD},
+                    ]
+                }
+            ]
+        }
+    }
+    config, removed = strip_legacy_hooks(nested)
+    assert removed == 1  # only the legacy handler is pruned; the null one survives
+    handlers = config["hooks"]["Stop"][0]["hooks"]
+    assert handlers == [{"type": "command", "command": None}]
+
+
 def test_strip_legacy_hooks_noop_without_hooks():
     assert strip_legacy_hooks({}) == ({}, 0)
     assert strip_legacy_hooks({"hooks": {}})[1] == 0


### PR DESCRIPTION
## What

Two small follow-ups to #67 (Antigravity `agy` adapter), both flagged during its validation.

### 1. Harden `strip_legacy_hooks` against a non-string command (`install.py`)

#67 hardened the idempotency dedupe in `merge_hooks` so a present-but-`null` `command` can't crash it, but `strip_legacy_hooks` had the same latent `TypeError` at **both** its dedupe walks — the flat copilot entry (`entry.get("command", "")`) and the nested claude/codex/gemini handler (`h.get("command", "")`). A malformed hand-edited hook config would blow up `bmad-loop init` with `TypeError: argument of type 'NoneType' is not iterable` instead of skipping the entry.

Applies the identical `isinstance(cmd := ..., str)` guard #67 landed in `merge_hooks`. A non-string command simply isn't a `bmad_auto` hook, so it's preserved. Pre-existing across all dialects; not introduced by #67 (and unreachable via the antigravity path, whose hooks live under the `bmad-loop` group that `strip_legacy_hooks` never walks). New regression test covers both walks.

### 2. Add an `agy` transcript family glob (`probe.py`)

The antigravity profile ships `usage_parser = "none"`, so `probe-adapter antigravity` had no transcript-location convention and couldn't auto-discover a transcript — the exact artifact needed to capture the schema and write the deferred token parser. Adds a `FAMILY_GLOBS` entry so probe can find `agy`'s per-conversation `transcript.jsonl`.

The path is **community-doc-sourced** (agy 1.0.x); it degrades safely to the existing "no convention — pass `--transcript`/`--session-dir`" note if wrong, and the inline comment says to confirm it against a live build with `probe-adapter antigravity --probe` — the same posture #67's flags were landed with.

## Sequencing

Fix 1 is independent and lands regardless. **Fix 2 activates once #67's antigravity profile is on `main`** (the glob is inert until then, keyed by the `antigravity` CLI name) — merge this **after #67**.

## Tests

New `test_strip_legacy_hooks_tolerates_non_string_command` (flat + nested null-command shapes). Full suite green locally (1412 passed, 1 skipped); `ruff check`, `ruff format`, and `trunk check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
