### PR TITLE
fix(runs): advance the re-arm baseline so a resolved re-drive cannot orphan resolution commits

### DIFF
--- a/src/bmad_loop/runs.py
+++ b/src/bmad_loop/runs.py
@@ -559,9 +559,16 @@ def rearm_escalation(run_dir: Path, story_key: str | None = None) -> str:
     # just loses this protection).
     try:
         repo = Path(state.project)
-        task.baseline_commit = verify.rev_parse_head(repo)
-        task.baseline_untracked = sorted(verify.untracked_files(repo))
-    except verify.GitError:
+        head = verify.rev_parse_head(repo)
+        untracked = sorted(verify.untracked_files(repo))
+        task.baseline_commit = head
+        task.baseline_untracked = untracked
+    except Exception:  # noqa: BLE001 - best-effort: a git timeout/OSError must not
+        # leave the pair half-updated any more than a GitError does. The two
+        # locals are computed before either field is assigned, so a failure on
+        # either call can't advance baseline_commit while baseline_untracked
+        # stays stale (same broad-except-for-best-effort contract as
+        # verify._prune_refs).
         pass
 
     if task.spec_file:

--- a/src/bmad_loop/runs.py
+++ b/src/bmad_loop/runs.py
@@ -511,8 +511,11 @@ def rearm_escalation(run_dir: Path, story_key: str | None = None) -> str:
     Flips the escalated task out of its terminal ESCALATED phase back to
     PENDING — which makes `_finish_inflight` reset the tree to the story's
     baseline and re-run it (clean rebuild) against the now-corrected frozen
-    spec. Deterministically sets that spec's status to `ready-for-dev` so the
-    dev session routes straight to implement, and strips the escalated
+    spec. The baseline itself is advanced to the project's current HEAD (and
+    the untracked snapshot refreshed) so commits and files the resolve session
+    produced count as the rebuild's starting point, not as attempt debris to
+    roll back. Deterministically sets that spec's status to `ready-for-dev` so
+    the dev session routes straight to implement, and strips the escalated
     attempt's stale `## Auto Run Result` section so the re-drive cannot read
     as terminal from its first save. Does NOT clear the pause; the caller
     resumes the run separately.
@@ -544,6 +547,23 @@ def rearm_escalation(run_dir: Path, story_key: str | None = None) -> str:
     task.rearmed = True  # resume-time recovery notice describes a clean rebuild,
     # not a failed attempt (engine._finish_inflight clears it once the rebuild runs)
 
+    # Advance the attempt baseline to the project's current HEAD and refresh the
+    # untracked snapshot: whatever the human-driven resolve session left on the
+    # branch (a committed fixture, a corrected ledger, ...) is authorized input
+    # for the re-drive, not failed-attempt debris. Without this, the re-drive's
+    # reset-to-baseline in engine._rollback_or_pause parks the resolution
+    # commits on an attempt-preserve ref and rebuilds against a tree that
+    # contradicts the corrected spec — the re-driven dev session then hits the
+    # very gap the human just resolved. Best-effort: on a git failure the old
+    # baseline stands (the redrive rollback path tolerates a stale baseline; it
+    # just loses this protection).
+    try:
+        repo = Path(state.project)
+        task.baseline_commit = verify.rev_parse_head(repo)
+        task.baseline_untracked = sorted(verify.untracked_files(repo))
+    except verify.GitError:
+        pass
+
     if task.spec_file:
         # route /bmad-dev-auto to re-implement (decision table: ready-for-dev
         # -> step-03); independent of the resolve agent having set it.
@@ -555,5 +575,7 @@ def rearm_escalation(run_dir: Path, story_key: str | None = None) -> str:
         devcontract.strip_auto_run_result(Path(task.spec_file))
 
     save_state(run_dir, state)
-    Journal(run_dir).append("story-escalation-resolved", story_key=key)
+    Journal(run_dir).append(
+        "story-escalation-resolved", story_key=key, baseline=task.baseline_commit or ""
+    )
     return key

--- a/src/bmad_loop/runs.py
+++ b/src/bmad_loop/runs.py
@@ -557,18 +557,16 @@ def rearm_escalation(run_dir: Path, story_key: str | None = None) -> str:
     # very gap the human just resolved. Best-effort: on a git failure the old
     # baseline stands (the redrive rollback path tolerates a stale baseline; it
     # just loses this protection).
+    # The two locals are computed before either task field is assigned, so a
+    # failure on either git call can't advance baseline_commit while
+    # baseline_untracked stays stale, or vice versa.
     try:
         repo = Path(state.project)
         head = verify.rev_parse_head(repo)
         untracked = sorted(verify.untracked_files(repo))
         task.baseline_commit = head
         task.baseline_untracked = untracked
-    except Exception:  # noqa: BLE001 - best-effort: a git timeout/OSError must not
-        # leave the pair half-updated any more than a GitError does. The two
-        # locals are computed before either field is assigned, so a failure on
-        # either call can't advance baseline_commit while baseline_untracked
-        # stays stale (same broad-except-for-best-effort contract as
-        # verify._prune_refs).
+    except Exception:  # noqa: BLE001  # nosec B110 - best-effort git read, must not fail re-arm
         pass
 
     if task.spec_file:

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -3,6 +3,7 @@
 import json
 
 import pytest
+from conftest import git
 
 from bmad_loop import devcontract, resolve, runs, verify
 from bmad_loop.journal import load_state, save_state
@@ -172,6 +173,36 @@ def test_rearm_journals_event(tmp_path):
     runs.rearm_escalation(run_dir)
     journal = (run_dir / "journal.jsonl").read_text(encoding="utf-8")
     assert "story-escalation-resolved" in journal
+
+
+def test_rearm_advances_baseline_to_resolved_head(project):
+    # The resolve session committed work on the project branch (e.g. a fixture
+    # the human authorized). Re-arm must adopt that state as the new attempt
+    # baseline, or the redrive's reset-to-baseline parks the resolution commit
+    # on an attempt-preserve ref and re-drives against the unresolved tree.
+    root = project.project
+    old_head = git(root, "rev-parse", "HEAD")
+    run_dir, _, _ = _escalated_run(root)
+    (root / "fixture.txt").write_text("captured baseline\n", encoding="utf-8")
+    git(root, "add", "fixture.txt")
+    git(root, "commit", "-q", "-m", "resolution: capture fixture")
+    # a file the resolve session (or the user) left untracked must enter the
+    # snapshot, so the redrive reset treats it as pre-existing, not run-created
+    (root / "leftover.txt").write_text("keep me\n", encoding="utf-8")
+    runs.rearm_escalation(run_dir)
+    task = load_state(run_dir).tasks["6-4-cli-list-command"]
+    assert task.baseline_commit == git(root, "rev-parse", "HEAD")
+    assert task.baseline_commit != old_head
+    assert "leftover.txt" in task.baseline_untracked
+
+
+def test_rearm_keeps_stale_baseline_outside_a_repo(tmp_path):
+    # best-effort contract: a project dir that is not a git repo (or a broken
+    # one) must not make re-arm fail — the old baseline simply stands
+    run_dir, _, _ = _escalated_run(tmp_path)
+    runs.rearm_escalation(run_dir)
+    task = load_state(run_dir).tasks["6-4-cli-list-command"]
+    assert task.baseline_commit == "abc123"
 
 
 def test_rearm_rejects_non_escalation_stage(tmp_path):

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -196,6 +196,24 @@ def test_rearm_advances_baseline_to_resolved_head(project):
     assert "leftover.txt" in task.baseline_untracked
 
 
+def test_rearm_baseline_all_or_nothing_on_partial_git_failure(monkeypatch, project):
+    """rev_parse_head succeeding but untracked_files failing must not advance
+    baseline_commit while leaving baseline_untracked stale: both locals are
+    computed before either field is assigned, so a failure on the second call
+    leaves the pair exactly as it was, same as a failure on the first."""
+    root = project.project
+    run_dir, _, _ = _escalated_run(root)
+
+    def boom(repo):
+        raise verify.GitError("simulated failure")
+
+    monkeypatch.setattr(runs.verify, "untracked_files", boom)
+    runs.rearm_escalation(run_dir)
+    task = load_state(run_dir).tasks["6-4-cli-list-command"]
+    assert task.baseline_commit == "abc123"
+    assert task.baseline_untracked is None
+
+
 def test_rearm_keeps_stale_baseline_outside_a_repo(tmp_path):
     # best-effort contract: a project dir that is not a git repo (or a broken
     # one) must not make re-arm fail — the old baseline simply stands


### PR DESCRIPTION
## What

`rearm_escalation` now advances `baseline_commit` to the project's current HEAD (and refreshes the untracked-files snapshot) instead of leaving it at the pre-attempt snapshot.

## Why

A resolve session can legitimately commit work (e.g. the fixture the escalation asked for). The re-drive's reset-to-baseline still targeted the *old* baseline, so it parked that commit on an `attempt-preserve/*` ref and rebuilt against the unresolved tree, and the re-driven session hit the same gap and re-escalated verbatim. This complements other recent fixes for stale `Auto Run Result` handling and resume durability.

Rebased onto v0.8.1; the only conflict was a docstring/adjacent-lines overlap in `rearm_escalation` with an upstream addition to the same function, resolved by keeping both. Independent of the other pending PR (ledger-only proof-of-work fix); different files, either can land first.

## How

- At re-arm: set `baseline_commit = verify.rev_parse_head(project)`, re-snapshot `baseline_untracked`.
- Best-effort: a `GitError` leaves the old baseline in place.
- Journal the adopted baseline.

## Testing

Three new tests in `tests/test_resolve.py` (adopts HEAD + re-snapshots; all-or-nothing on a partial git failure — no half-advanced baseline; stays stale outside a repo). Full suite: 1407 passed, 7 skipped; ruff clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved escalation re-drive handling so resumed work starts from the latest resolved state and preserves the current untracked file snapshot.
  * Added safer fallback behavior when repository metadata can’t be read, keeping the previous baseline intact.
  * Included baseline information in escalation-resolution records for better continuity.

* **Tests**
  * Added coverage for baseline updates after resolution and for fallback behavior when git data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
