### PR TITLE
fix(verify): stop treating ledger/spec-only stories as "no changes since baseline"

### DIFF
--- a/src/bmad_loop/verify.py
+++ b/src/bmad_loop/verify.py
@@ -955,11 +955,19 @@ def verify_dev_exclude_relpaths(paths: ProjectPaths, spec_path: Path) -> tuple[s
     dirs — the deferred-work ledger, other stories' specs — is deliberately left
     un-excluded, so a story whose entire authorized scope is ledger/spec
     reconciliation registers as real work instead of a permanent false "no changes
-    since baseline"."""
+    since baseline".
+
+    `spec_path` comes from a session-reported (untrusted) `spec_file` string, so
+    it is `.resolve()`d before deriving the relpath, same as `spec_within_roots`:
+    an un-normalized `..`/`.` segment would still resolve to the real on-disk
+    file (the OS resolves it), but as a raw string it wouldn't match git's own
+    normalized path output, silently defeating this exclude and letting a bare
+    status flip on the session's own spec count as real work."""
     out: list[str] = []
+    project = paths.project.resolve()
     for path in (paths.sprint_status, spec_path):
         try:
-            rel = path.relative_to(paths.project).as_posix()
+            rel = path.resolve().relative_to(project).as_posix()
         except ValueError:
             continue  # outside the project tree; nothing to exclude here
         if rel and rel != ".":

--- a/src/bmad_loop/verify.py
+++ b/src/bmad_loop/verify.py
@@ -938,6 +938,35 @@ def artifact_relpaths(paths: ProjectPaths) -> tuple[str, ...]:
     return tuple(out)
 
 
+def verify_dev_exclude_relpaths(paths: ProjectPaths, spec_path: Path) -> tuple[str, ...]:
+    """Repo-relative posix paths the dev/bundle proof-of-work gate excludes from
+    `has_changes_since` — file-granularity, unlike `artifact_relpaths`' whole-folder
+    exclusion (still used as-is by `Engine._protected_relpaths` for rollback
+    protection, a different job). Deliberately does NOT exclude `output_folder`:
+    in the standard layout it is the parent directory of `implementation_artifacts`/
+    `planning_artifacts`, so excluding it as a directory prefix would swallow those
+    two folders' content right back out of view via the same git-pathspec prefix
+    match this function exists to avoid.
+
+    Excludes only what a session rewrites regardless of whether it did any real
+    work: `paths.sprint_status` (every session advances it as routine bookkeeping)
+    and the session's own claimed `spec_path` (so a bare frontmatter status flip on
+    it doesn't count). Sibling content under the implementation/planning artifact
+    dirs — the deferred-work ledger, other stories' specs — is deliberately left
+    un-excluded, so a story whose entire authorized scope is ledger/spec
+    reconciliation registers as real work instead of a permanent false "no changes
+    since baseline"."""
+    out: list[str] = []
+    for path in (paths.sprint_status, spec_path):
+        try:
+            rel = path.relative_to(paths.project).as_posix()
+        except ValueError:
+            continue  # outside the project tree; nothing to exclude here
+        if rel and rel != ".":
+            out.append(rel)
+    return tuple(out)
+
+
 def spec_within_roots(spec_path: Path, paths: ProjectPaths) -> bool:
     """True if ``spec_path`` is, or sits under, an orchestrator-owned root (the
     project root or an artifact dir). A mutating repair (the frontmatter-status
@@ -1013,7 +1042,9 @@ def verify_dev(
     if task.baseline_commit:
         try:
             if not has_changes_since(
-                paths.project, task.baseline_commit, exclude=artifact_relpaths(paths)
+                paths.project,
+                task.baseline_commit,
+                exclude=verify_dev_exclude_relpaths(paths, spec_path),
             ):
                 return VerifyOutcome.retry("no changes in worktree since baseline commit")
         except GitError as e:
@@ -1074,7 +1105,9 @@ def verify_dev_bundle(
     if task.baseline_commit:
         try:
             if not has_changes_since(
-                paths.project, task.baseline_commit, exclude=artifact_relpaths(paths)
+                paths.project,
+                task.baseline_commit,
+                exclude=verify_dev_exclude_relpaths(paths, spec_path),
             ):
                 return VerifyOutcome.retry("no changes in worktree since baseline commit")
         except GitError as e:

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -329,6 +329,19 @@ def test_verify_dev_bundle_absent_dw_ids_passes(project, claim):
     assert task.spec_file == str(sp)
 
 
+def test_verify_dev_bundle_ledger_only_counts_as_real_work(project):
+    """Same false-negative as verify_dev (KNOWN-BUG-ledger-only-story-false-no-
+    changes.md), on the bundle path: a dw-bundle's entire authorized diff is
+    the ledger reconciliation itself, with no sprint-status entry to touch."""
+    task = make_bundle_task(project)
+    sp = project.implementation_artifacts / "spec-dw-test-bundle.md"
+    write_spec(sp, "in-review", task.baseline_commit)
+    bundle_ledger(project, {"DW-1": "done 2026-06-11", "DW-2": "done 2026-06-11"})
+    rj = {"workflow": "auto-dev", "spec_file": str(sp)}
+    out = verify.verify_dev_bundle(task, project, rj)
+    assert out.ok
+
+
 def test_verify_review_bundle_ledger_gate(project):
     task = make_bundle_task(project)
     sp = project.implementation_artifacts / "spec-dw-test-bundle.md"
@@ -748,6 +761,68 @@ def test_has_changes_since_excludes_artifact_only_edit(project):
         )
         is True
     )
+
+
+def test_verify_dev_exclude_relpaths_is_file_granular(project):
+    """Unlike artifact_relpaths (whole-folder), this excludes only the
+    sprint-status ledger and the session's own claimed spec file — sibling
+    artifact-folder content (deferred-work.md, other stories' specs) is left
+    un-excluded so it can register as real work."""
+    sp = spec_path(project, "1-1-a")
+    rels = verify.verify_dev_exclude_relpaths(project, sp)
+    assert "_bmad-output/implementation-artifacts/sprint-status.yaml" in rels
+    assert "_bmad-output/implementation-artifacts/spec-1-1-a.md" in rels
+    assert "_bmad-output/implementation-artifacts" not in rels
+    # output_folder itself is NOT excluded here — it is the parent dir of
+    # implementation_artifacts in the standard layout, so excluding it as a
+    # prefix would swallow the artifact dirs' content right back out of view.
+    assert "_bmad-output" not in rels
+    assert "_bmad-output/implementation-artifacts/deferred-work.md" not in rels
+
+
+def test_has_changes_since_ledger_content_counts_with_narrow_exclude(project):
+    """Reproduces KNOWN-BUG-ledger-only-story-false-no-changes.md: a story whose
+    entire authorized diff is sibling ledger content must not read as 'no
+    changes', while a bare own-spec + sprint-status bookkeeping edit still does."""
+    baseline = verify.rev_parse_head(project.project)
+    sp = spec_path(project, "1-1-a")
+    exclude = verify.verify_dev_exclude_relpaths(project, sp)
+
+    sp.write_text("bookkeeping\n")
+    project.sprint_status.write_text("bookkeeping\n")
+    assert verify.has_changes_since(project.project, baseline, exclude=exclude) is False
+
+    project.deferred_work.parent.mkdir(parents=True, exist_ok=True)
+    project.deferred_work.write_text("### DW-1: reconciled\n\nstatus: done\n")
+    assert verify.has_changes_since(project.project, baseline, exclude=exclude) is True
+
+
+def test_verify_dev_ledger_only_story_counts_as_real_work(project):
+    """A 'paper-trail reconciliation only' story (KNOWN-BUG-ledger-only-story-
+    false-no-changes.md) whose entire real diff sits under implementation_artifacts
+    (e.g. deferred-work.md) must pass, not false-negative 'no changes'."""
+    write_sprint(project, {"1-1-a": "review"})
+    task = make_task(project)
+    sp = spec_path(project, "1-1-a")
+    write_spec(sp, "in-review", task.baseline_commit)
+    project.deferred_work.parent.mkdir(parents=True, exist_ok=True)
+    project.deferred_work.write_text("### DW-1: reconciled\n\nstatus: done\n")
+
+    out = verify.verify_dev(task, project, dev_result(sp))
+    assert out.ok
+
+
+def test_verify_dev_own_spec_status_flip_alone_is_not_real_work(project):
+    """Guards the original loophole the exclusion targets: flipping only the
+    session's own spec status (plus routine sprint-status bookkeeping) must
+    still retry as 'no changes', even with the narrower file-level exclude."""
+    write_sprint(project, {"1-1-a": "review"})
+    task = make_task(project)
+    sp = spec_path(project, "1-1-a")
+    write_spec(sp, "in-review", task.baseline_commit)
+
+    out = verify.verify_dev(task, project, dev_result(sp))
+    assert not out.ok and "no changes" in out.reason
 
 
 def test_spec_within_roots(project, tmp_path):

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -780,6 +780,38 @@ def test_verify_dev_exclude_relpaths_is_file_granular(project):
     assert "_bmad-output/implementation-artifacts/deferred-work.md" not in rels
 
 
+def test_verify_dev_exclude_relpaths_normalizes_dotdot_segments(project):
+    """A spec_path with a lexical '..' hop (as an un-normalized session-reported
+    spec_file could produce) must resolve to the same exclude entry as the plain
+    path — otherwise the raw string wouldn't match git's own normalized path
+    output, silently defeating the exclude for that spec."""
+    sp = spec_path(project, "1-1-a")
+    messy = (
+        project.output_folder / "planning-artifacts" / ".." / "implementation-artifacts" / sp.name
+    )
+    assert messy != sp  # genuinely a different (messier) Path object
+    assert verify.verify_dev_exclude_relpaths(project, sp) == verify.verify_dev_exclude_relpaths(
+        project, messy
+    )
+
+
+def test_verify_dev_own_spec_status_flip_via_dotdot_path_is_not_real_work(project):
+    """End-to-end regression: a dev result.json claiming its own spec through a
+    '..'-laden path (but pointing at the same on-disk file) must not let a bare
+    status flip slip past the proof-of-work gate."""
+    write_sprint(project, {"1-1-a": "review"})
+    task = make_task(project)
+    sp = spec_path(project, "1-1-a")
+    write_spec(sp, "in-review", task.baseline_commit)
+    messy = (
+        project.output_folder / "planning-artifacts" / ".." / "implementation-artifacts" / sp.name
+    )
+    assert messy.is_file()  # same on-disk file as sp, reached via a messier path
+
+    out = verify.verify_dev(task, project, dev_result(messy))
+    assert not out.ok and "no changes" in out.reason
+
+
 def test_has_changes_since_ledger_content_counts_with_narrow_exclude(project):
     """Reproduces KNOWN-BUG-ledger-only-story-false-no-changes.md: a story whose
     entire authorized diff is sibling ledger content must not read as 'no


### PR DESCRIPTION
## What

`verify_dev`/`verify_dev_bundle`'s proof-of-work gate now excludes only the session's own spec file and the sprint-status ledger from `has_changes_since`, via a new `verify_dev_exclude_relpaths(paths, spec_path)`, instead of the whole `implementation_artifacts`/`planning_artifacts` folders.

## Why

The old exclusion existed so a session couldn't fake completion by only flipping its own spec's `status:` field, but it hid *everything* under those folders, including sibling content like the deferred-work ledger. A story whose entire authorized scope is ledger/spec reconciliation (no src/tests touched, by design) therefore always false-negatived "no changes since baseline" and got rolled back or deferred, no matter how much real, reviewed work landed.

## How

- New `verify_dev_exclude_relpaths`: excludes `paths.sprint_status` and the claimed `spec_path` only (file, not folder, granularity).
- Wired into both `has_changes_since` call sites, replacing `artifact_relpaths(paths)` (which stays as-is for `Engine`'s rollback-protection use, a different job).
- `output_folder` deliberately stays out of the new exclude set: it's the parent dir of `implementation_artifacts` in the standard layout, so excluding it as a prefix would swallow that folder's content right back out of view.

## Testing

Seven new tests in `tests/test_verify.py`: exclude-helper granularity plus a `..`-segment normalization guard on the helper, a direct `has_changes_since` repro (ledger content counts, own-spec + sprint bookkeeping alone doesn't), both the `verify_dev` and `verify_dev_bundle` gates passing end-to-end on a ledger-only diff, and regression guards that a bare own-spec status flip still retries as "no changes" — both directly and when the spec is claimed via a `..`-laden path. Full suite: 1412 passed, 7 skipped; ruff clean.

## Related

Independent of the other pending PR (`fix/resolve-baseline-advance`); different files, either can land first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened the “no changes since baseline” check so it only ignores specific bookkeeping files instead of whole artifact folders.
  * Prevents false positives/negatives when validating work that includes ledger updates or status changes.
  * Improved path handling so claimed files are recognized consistently even when referenced through different relative paths.

* **Tests**
  * Added coverage for ledger-only work, file-level exclusions, and status-only changes to verify the new behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
