### PR TITLE
feat(stories): TUI HITL surface + docs + E2E matrix (Phase 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to `bmad-loop` are documented here. The format is based on
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html). While the project is pre-1.0,
 breaking changes may land in a minor release.
 
+## [Unreleased]
+
+### Added
+
+- **Stories mode — a second planning pipeline that drives the loop off a typed `stories.yaml` (folder+id dispatch) instead of `sprint-status.yaml`.** Opt in with `[stories] source = "stories"` + `spec_folder`, or per run with `bmad-loop run --spec <folder>` (overrides policy); `--story` then filters by story id. Each entry dispatches by folder + id — the dev skill creates-or-resumes the story spec at `<folder>/stories/<id>-<slug>.md` and the orchestrator reads that id-keyed path back deterministically (no shared board to line-edit, no result-artifact mtime-scan). Strictly linear schedule (list order, no `depends_on`); `bmad-loop run --dry-run --spec <folder>` and `bmad-loop status` print the board (id · live disk state · checkpoint markers · title). Sprint mode is unchanged and remains the default. Requires a `bmad-dev-auto` new enough for folder+id dispatch — the run preflight checks and remediates.
+- **Per-story human checkpoints (stories mode).** Independent `spec_checkpoint` (pause before code to review the plan — dev halts at `ready-for-dev`; approve to implement, or request a replan that resets the spec to `draft`) and `done_checkpoint` (pause after the story commits, skipped when it is the last story); both additive to `gates.mode`. A blocked story escalates + resolves as in sprint mode, with a pre-planning-halt sentinel auto-deleted (a copy preserved under the run dir) on re-arm.
+- **TUI human-in-the-loop surface for stories mode.** The sprint tree is replaced by a stories board (id · live disk state · spec/done checkpoint markers · title) when a stories-mode run is selected; paused runs carry a per-run pause-kind badge and the run list shows a global _⚑ N need attention_ count; `p` opens the stage-appropriate viewer — plan-checkpoint spec review (Approve & resume / Request replan), story-checkpoint summary card (Continue / Stop), escalation with story context (Resolve / Re-arm & resume), and a gate spec viewer that the existing spec-approval/epic pauses reuse. The start-run modal gains a source select + spec-folder field with a live schedule preview. Every TUI action calls the same code paths as the CLI.
+
 ## [0.8.1] — 2026-07-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -385,6 +385,8 @@ low_frame_rate = false     # true = cap to 15fps + disable animations (= bmad-lo
 
 **Gate modes:** `none` runs everything unattended; `per-epic` (default) pauses at epic boundaries; `per-story-spec-approval` pauses after each spec is written so you approve it before implementation is reviewed.
 
+> In **stories mode** the `stories.yaml` list is flat — there are no epics — so the default `per-epic` gate never fires (nothing to bound). Use the per-story `spec_checkpoint` / `done_checkpoint` flags for HITL there, or `per-story-spec-approval` for a run-global spec gate. `none` and `per-story-spec-approval` behave the same as in sprint mode.
+
 **Review:** `[review].enabled = false` drops the separate fresh-context review session; the dev pass instead runs `bmad-dev-auto`'s own internal two-layer review (Blind Hunter / Edge Case Hunter) and finalizes the story straight to `done` — one session per story instead of two, verify commands still gating the commit. Governs deferred-work sweeps too. When review is enabled, `[review].trigger` decides _when_ that separate pass runs: `recommended` (default) only when the `bmad-dev-auto` session flags `followup_review_recommended` — it already triple-reviews inline and recommends an independent pass only when its changes were significant; `always` runs it every story. The follow-up loop is bounded by `limits.max_review_cycles` (default 3), which caps oscillation.
 
 `bmad-loop init` (without `--cli`) registers hooks for every CLI profile the policy references, so a dual-client setup needs no extra flags.

--- a/README.md
+++ b/README.md
@@ -63,13 +63,13 @@ bmad-loop tui                    # …or drive everything from the dashboard
 | -------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `bmad-loop init`                                         | Install the bundled `bmad-loop-*` skills, the hook relay, `.bmad-loop/policy.toml`, and a runs-dir gitignore. `--cli <profile>` (repeatable) targets specific agents; `--no-skills` / `--force-skills` control skill copying.                                                                                                                                                                                                                                                       |
 | `bmad-loop validate`                                     | Preflight every prerequisite: BMAD config, sprint-status, git, CLI binary, hook registration, and a platform check that reports the selected multiplexer's readiness and process host.                                                                                                                                                                                                                                                                                              |
-| `bmad-loop run`                                          | Drive the dev → review → verify → commit loop. `--epic N`, `--story KEY`, `--max-stories N`, `--dry-run`.                                                                                                                                                                                                                                                                                                                                                                           |
+| `bmad-loop run`                                          | Drive the dev → review → verify → commit loop. `--epic N`, `--story KEY`, `--max-stories N`, `--dry-run`. `--spec <folder>` forces **stories mode** (folder+id dispatch off `<folder>/stories.yaml`), overriding `[stories].source`; `--story` then filters by story id.                                                                                                                                                                                                            |
 | `bmad-loop sweep`                                        | Triage + execute open `deferred-work.md` entries. `--no-prompt`, `--decisions-only`, `--max-bundles N`, `--repeat`, `--max-cycles N`, `--dry-run`.                                                                                                                                                                                                                                                                                                                                  |
 | `bmad-loop resume <run-id>`                              | Continue a run paused at a gate, escalation, or interruption.                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | `bmad-loop resolve <run-id>`                             | Resolve a CRITICAL escalation: open an interactive resolve agent to fix the frozen spec, then re-arm the story and resume. `--story KEY`, `--no-interactive`, `--resume` / `--no-resume`.                                                                                                                                                                                                                                                                                           |
 | `bmad-loop decisions`                                    | Answer deferred-work decisions earlier sweeps left unanswered (skipped by `--no-prompt`, or an abandoned interactive sweep). Recorded so the next sweep acts on them without re-asking. `--list` shows them without answering.                                                                                                                                                                                                                                                      |
 | `bmad-loop list` (`ls`)                                  | List every run/sweep with its short ref, type, and status — the handle you pass to the commands below.                                                                                                                                                                                                                                                                                                                                                                              |
-| `bmad-loop status [<run-id>]`                            | Run + sprint summary with per-story token totals (plus a count of decisions awaiting an answer).                                                                                                                                                                                                                                                                                                                                                                                    |
+| `bmad-loop status [<run-id>]`                            | Run + sprint summary with per-story token totals (plus a count of decisions awaiting an answer). A stories-mode run instead prints its stories board — id, live on-disk state, checkpoint markers, title.                                                                                                                                                                                                                                                                           |
 | `bmad-loop diagnose [<run-id>]` (`diag`)                 | Emit a **sanitized** diagnostic dump of a run/sweep to hand maintainers when reporting a bug — phase/token/session histograms, escalation counts, adapter/model, env, and run-dir file sizes, with no code, spec content, prompts, transcripts, paths, or PII. Identifiers are pseudonymized to stable per-dump aliases and the output is re-scanned by a fail-closed leak check before writing. Defaults to the latest run. `--all`, `--out`, `--json`, `--max-journal-entries N`. |
 | `bmad-loop attach [<run-id>]`                            | tmux-attach to a run's live agent session.                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 | `bmad-loop stop <run-id>`                                | Stop a live run — the engine and its agent tmux session.                                                                                                                                                                                                                                                                                                                                                                                                                            |
@@ -99,7 +99,7 @@ A live, read-only dashboard over everything below — and a launcher for new run
 <img src="docs/images/dashboard.png" alt="Dashboard: runs table, run header with token totals, per-story phase table, sprint tree, deferred-work ledger, and the journal tab." width="880">
 </div>
 
-The left column stacks the **runs table** (newest auto-selected), an expandable **sprint tree** (epics → stories/retro, completed items checked green), and the **deferred-work ledger** (severity colour-coded). The right column shows the selected run's **header** (status, epic, task counts, cost-weighted token total), a **per-story table** (phase · dev attempts · review cycles · tokens · commit/defer info), and tabs tailing the **journal**, the active session's **pane log**, and the **ATTENTION** file.
+The left column stacks the **runs table** (newest auto-selected; a per-run pause badge tags paused runs by kind, and the title carries a global _⚑ N need attention_ count), an expandable **sprint tree** (epics → stories/retro, completed items checked green) — replaced by a **stories board** (id · live disk state · spec/done checkpoint markers · title) when the selected run is in stories mode — and the **deferred-work ledger** (severity colour-coded). The right column shows the selected run's **header** (status, epic, task counts, cost-weighted token total), a **per-story table** (phase · dev attempts · review cycles · tokens · commit/defer info), and tabs tailing the **journal**, the active session's **pane log**, and the **ATTENTION** file. On a paused run, **`p`** opens the stage-appropriate HITL viewer — a plan-checkpoint spec viewer (Approve & resume / Request replan), a story-checkpoint summary card (Continue / Stop), the escalation view with story context (Resolve / Re-arm & resume), or a gate spec viewer — each calling the exact code paths the CLI uses.
 
 ### A sweep blocked on a human decision
 
@@ -124,7 +124,7 @@ Unattended sweeps (`--no-prompt`) skip decisions, and an attended one can be aba
 <img src="docs/images/start-run-modal.png" alt="The start-run modal with epic, story, max-stories, and dry-run fields." width="430">
 </div>
 
-`enter` on any ledger row opens the full entry; `r` / `s` open modals to launch a run or sweep (epic, story, max-stories, dry-run).
+`enter` on any ledger row opens the full entry; `r` / `s` open modals to launch a run or sweep (epic, story, max-stories, dry-run). The start-run modal also carries a **source select** (sprint vs. stories mode, prefilled from `[stories]`) and a spec-folder field with a live schedule preview that validates `stories.yaml` and lists the linear schedule with checkpoint markers.
 
 ### The policy editor
 
@@ -136,26 +136,49 @@ Press **`g`** to edit `.bmad-loop/policy.toml` in a form grouped by section — 
 
 ### Key bindings
 
-| Key       | Action                                                             |
-| --------- | ------------------------------------------------------------------ |
-| `r` / `s` | start a run / sweep (modal for epic, story, max-stories, dry-run…) |
-| `e`       | resume the selected paused/interrupted run                         |
-| `R`       | resolve a run paused at an escalation (interactive, then re-arm)   |
-| `d`       | answer deferred-work decisions past sweeps left unanswered         |
-| `a`       | attach to the live agent session (or the orchestrator window)      |
-| `x`       | stop the selected live run (engine + agent session)                |
-| `D` / `A` | delete / archive the selected run (force-stops a live run first)   |
-| `c`       | clean up tmux sessions/windows for finished & stopped runs         |
-| `v`       | run `bmad-loop validate`, output in a modal                        |
-| `g`       | settings editor for `.bmad-loop/policy.toml`                       |
-| `y`       | copy the active Log/Attention pane to the clipboard                |
-| `M` / `q` | toggle theme (light/dark mode) / quit                              |
+| Key       | Action                                                                                                   |
+| --------- | -------------------------------------------------------------------------------------------------------- |
+| `r` / `s` | start a run / sweep (modal for epic, story, max-stories, dry-run…)                                       |
+| `e`       | resume the selected paused/interrupted run                                                               |
+| `p`       | review the selected paused run in the stage-appropriate viewer (plan/story checkpoint, gate, escalation) |
+| `R`       | resolve a run paused at an escalation (interactive, then re-arm)                                         |
+| `d`       | answer deferred-work decisions past sweeps left unanswered                                               |
+| `a`       | attach to the live agent session (or the orchestrator window)                                            |
+| `x`       | stop the selected live run (engine + agent session)                                                      |
+| `D` / `A` | delete / archive the selected run (force-stops a live run first)                                         |
+| `c`       | clean up tmux sessions/windows for finished & stopped runs                                               |
+| `v`       | run `bmad-loop validate`, output in a modal                                                              |
+| `g`       | settings editor for `.bmad-loop/policy.toml`                                                             |
+| `y`       | copy the active Log/Attention pane to the clipboard                                                      |
+| `M` / `q` | toggle theme (light/dark mode) / quit                                                                    |
 
 **The TUI is an observer/launcher, never the engine.** Runs started with `r`/`s` are detached `bmad-loop` processes in windows of a dedicated tmux session (`bmad-loop-ctl`), so they survive a TUI exit or crash; the dashboard watches runs purely through the run-dir artifacts the engine writes atomically, so runs started from a plain shell show up identically. Launch and attach need tmux; the dashboard itself does not. Pid-based liveness is local-only — a run whose engine died shows `interrupted` (press `e`); runs on other hosts show `unknown`.
 
 > 📖 See **[docs/tui-guide.md](docs/tui-guide.md)** for the full guide — layout, every key and modal, status glyphs, the settings field reference, and troubleshooting. Vector (SVG) versions of every screenshot live in [`docs/images/`](docs/images).
 
+## Two planning pipelines, one loop
+
+bmad-loop drives the same dev → verify → review → commit loop from **either** of two story sources — chosen per project, or per run:
+
+- **Sprint mode (default).** Stories come from `sprint-status.yaml` (written by `bmad-sprint-planning` from your PRD/epics). The loop walks the board by `ready-for-dev` status, keyed by story ref (`1-2-account-mgmt`). This is what the rest of this README describes.
+- **Stories mode (opt-in).** Stories come from a typed `stories.yaml` — the **Story Breakdown** output of `bmad-spec`, a fixed-name sibling of `SPEC.md` in the epic's spec folder. The loop dispatches each entry by **folder + id** (`/bmad-dev-auto Spec folder: <folder>. Story id: <id>.`); the dev skill creates-or-resumes the story spec at `<folder>/stories/<id>-<slug>.md`, and the orchestrator reads that id-keyed path back deterministically — no shared board to line-edit, no mtime-scan of result artifacts.
+
+Turn it on per project with `[stories] source = "stories"` + `spec_folder = "<epic folder>"`, or per run with `bmad-loop run --spec <epic folder>` (which overrides the policy). Everything downstream — dev/verify/review/commit, worktree isolation, gates, crash resume, the TUI — is identical; only the story source and the per-story controls below differ.
+
+**Per-story human checkpoints (stories mode).** Each `stories.yaml` entry carries two independent boolean flags:
+
+- **`spec_checkpoint`** — pause _before_ code, to review the plan. The dev session halts right after planning (`Halt after planning.`) with the spec at `ready-for-dev`; the run pauses at a **plan checkpoint**. Approve to resume straight to implementation, or request a replan (resets the spec to `draft` so the next dispatch re-plans).
+- **`done_checkpoint`** — pause _after_ the story commits, to review the result before the loop moves on (skipped automatically when it is the last story).
+
+A story may set both (it pauses twice); `gates.mode` pauses stack on top. A blocked story escalates exactly as in sprint mode — `bmad-loop resolve`, then re-arm + resume — now with the story's title/description and the blocking condition surfaced; a pre-planning-halt **sentinel** spec is auto-deleted (a copy preserved under the run dir) on re-arm for a clean re-dispatch.
+
+`bmad-loop run --dry-run --spec <folder>` prints the linear schedule (list order, checkpoint markers, live on-disk state); `bmad-loop status` shows the same stories board.
+
+> Stories mode requires a `bmad-dev-auto` new enough to support folder+id dispatch; the run preflight (and `bmad-loop validate`) checks for it and tells you to update the BMAD module if it is missing. Sprint mode is unaffected and remains the default indefinitely.
+
 ## How a story flows
+
+> This is sprint mode's flow. Stories mode swaps the story source (above) and adds the per-story plan/done checkpoints — the loop below is otherwise identical.
 
 ```text
 sprint-status.yaml: 1-2-account-mgmt: ready-for-dev

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -11,6 +11,8 @@ See [README.md](../README.md) for the narrative overview and [setup-guide.md](se
 | Capability                           | What it does                                                                                                                                                                         | Problem it addresses                                                                      |
 | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------- |
 | Deterministic control loop           | Story selection, retries, gates, completion checks run in plain Python                                                                                                               | LLM-as-orchestrator is nondeterministic, hard to debug, and costs tokens for control flow |
+| Dual planning pipelines              | Same loop from either `sprint-status.yaml` (sprint mode, default) or a typed `stories.yaml` dispatched by folder+id (stories mode, opt-in)                                           | Sprint boards need `bmad-sprint-planning`; a `bmad-spec` Story Breakdown has no board     |
+| Per-story human checkpoints          | Stories-mode `spec_checkpoint` pauses to review the plan before code; `done_checkpoint` pauses after the commit; both independent, both surfaced in the TUI                          | Coarse run-global gates can't ask for a plan review on _this_ story only                  |
 | Trust-nothing verification           | Checks on-disk artifacts (spec status, baseline-commit match, non-empty diff, sprint sync) + runs your test/lint commands before commit                                              | Agents claim success without working code; broken builds slip through                     |
 | Fresh-context adversarial review     | Dev and review are separate sessions; review uses 2 parallel layers (Blind Hunter / Edge Case Hunter)                                                                                | Self-review anchoring bias; implementer marks own work correct                            |
 | Hook-based transport                 | Coding-agent hooks write structured event files; skills write `result.json`                                                                                                          | Brittle terminal pane-scraping                                                            |
@@ -105,9 +107,19 @@ See [README.md](../README.md) for the narrative overview and [setup-guide.md](se
 - Repeat mode (`--repeat` / `[sweep] repeat`): re-triages after each cycle to absorb newly generated deferred work, stopping when a cycle does nothing addressable or hits `max_cycles`.
 - Sweeps are their own resumable runs (`bmad-loop resume <id>`).
 
+### Stories mode (folder+id dispatch)
+
+- Opt-in second story source (`[stories] source = "stories"` + `spec_folder`, or `bmad-loop run --spec <folder>`): drives the same loop off a typed `stories.yaml` (a `bmad-spec` Story Breakdown, sibling of `SPEC.md`) instead of `sprint-status.yaml`.
+- Dispatches each entry by **folder + id** (`/bmad-dev-auto Spec folder: <folder>. Story id: <id>.`); the story spec lands at `<folder>/stories/<id>-<slug>.md` and is read back by a deterministic id-keyed glob — no shared board to line-edit, no result-artifact mtime-scan.
+- Strictly linear schedule (list order, no `depends_on`); `done` skipped, non-terminal statuses resumed on re-dispatch, `blocked`/sentinel/ambiguous stops the run for resolve. `bmad-loop run --dry-run --spec <folder>` and `bmad-loop status` print the schedule/board (id · live disk state · checkpoint markers · title).
+- Preflight content-probe: stories mode requires a `bmad-dev-auto` new enough for folder+id dispatch, or the run aborts with remediation. Sprint mode keeps working with any installed version.
+- Sentinel recovery: a pre-planning-halt sentinel spec (`<id>-unresolved.md` / `<id>-ambiguous.md`) is auto-deleted with a preserved copy under the run dir on re-arm, matching the contract's delete-to-retry.
+
 ### Gates & human checkpoints
 
 - Gate modes (`[gates].mode`): `none` (fully unattended) / `per-epic` (pause at epic boundaries, default) / `per-story-spec-approval` (pause after each spec for approval).
+- Per-story checkpoints (stories mode): independent `spec_checkpoint` (pause before code to review the plan; approve → implement, or request a replan) and `done_checkpoint` (pause after the story commits; skipped when it is the last story). Additive to `gates.mode` — a story can pause twice.
+- Every mid-run pause is surfaced in the TUI: a per-run pause-kind badge, a global attention count, and a `p` viewer per stage (plan-checkpoint spec review, story-checkpoint summary card, escalation with story context, gate spec review) — all calling the same CLI code paths.
 - Retrospective handling (`retrospective = never | notify | auto`) and notification on epic boundaries.
 
 ### Multi-CLI / multi-agent support

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -117,7 +117,7 @@ See [README.md](../README.md) for the narrative overview and [setup-guide.md](se
 
 ### Gates & human checkpoints
 
-- Gate modes (`[gates].mode`): `none` (fully unattended) / `per-epic` (pause at epic boundaries, default) / `per-story-spec-approval` (pause after each spec for approval).
+- Gate modes (`[gates].mode`): `none` (fully unattended) / `per-epic` (pause at epic boundaries, default) / `per-story-spec-approval` (pause after each spec for approval). Note: `per-epic` is inert in stories mode — the flat `stories.yaml` list has no epics, so the boundary never fires; use the per-story checkpoints (below) or `per-story-spec-approval` there.
 - Per-story checkpoints (stories mode): independent `spec_checkpoint` (pause before code to review the plan; approve → implement, or request a replan) and `done_checkpoint` (pause after the story commits; skipped when it is the last story). Additive to `gates.mode` — a story can pause twice.
 - Every mid-run pause is surfaced in the TUI: a per-run pause-kind badge, a global attention count, and a `p` viewer per stage (plan-checkpoint spec review, story-checkpoint summary card, escalation with story context, gate spec review) — all calling the same CLI code paths.
 - Retrospective handling (`retrospective = never | notify | auto`) and notification on epic boundaries.

--- a/docs/tui-guide.md
+++ b/docs/tui-guide.md
@@ -90,9 +90,12 @@ the pane recovers on the next poll once the file is readable again.
 
 One row per run dir under `.bmad-loop/runs/`, oldest first (run ids are
 `YYYYMMDD-HHMMSS-<hex>` and sort chronologically). Columns: `st` (status
-glyph, see below), `run` (the id), `type` (`story` or `sweep`). On first load
-the newest run is auto-selected; arrow keys or mouse select another. A run you
-just launched is selected immediately, before its directory even exists.
+glyph, see below), `run` (the id), `type` (`story` or `sweep`), `note` (a
+colored pause-kind badge on a paused run — `plan` / `story` / `spec` / `epic` /
+`gate` / `esc`). When any run is paused awaiting a human the pane's title shows
+a global **`⚑ N need attention`** count. On first load the newest run is
+auto-selected; arrow keys or mouse select another. A run you just launched is
+selected immediately, before its directory even exists.
 
 #### Sprint tree (middle)
 
@@ -112,6 +115,29 @@ a status glyph:
 
 Expansion state and the cursor survive the 3-second refresh — only labels are
 updated in place unless an epic's story set actually changes.
+
+#### Stories board (middle, stories mode)
+
+When the selected run is in **stories mode** (`source = "stories"`), the sprint
+tree is replaced in place by a flat **stories board** read from that run's
+`stories.yaml` + the id-keyed story specs on disk. One row per story: a state
+glyph + label, the story `id`, a two-slot checkpoint cell (`S` = `spec_checkpoint`,
+`D` = `done_checkpoint`, dim `·` for an unset slot), and the title. The state
+column reflects live disk state:
+
+| Glyph | State                                    | Color    |
+| ----- | ---------------------------------------- | -------- |
+| `✓`   | done                                     | green    |
+| `▶`   | in-progress                              | cyan     |
+| `◆`   | in-review                                | magenta  |
+| `○`   | ready-for-dev                            | cyan     |
+| `◦`   | draft                                    | dim      |
+| `·`   | pending (no spec on disk yet)            | dim      |
+| `✖`   | blocked                                  | bold red |
+| `⚠`   | ambiguous / sentinel (`sentinel:<kind>`) | bold red |
+
+Selecting a sprint-mode run swaps the sprint tree back. The board re-derives
+each poll so it tracks the dev sessions writing story specs.
 
 #### Deferred work (bottom)
 
@@ -220,6 +246,7 @@ Journal kinds are styled by substring, first match wins:
 | `r` | start a run (modal)                                                        |
 | `s` | start a sweep (modal)                                                      |
 | `e` | resume the selected paused/interrupted run (confirm modal)                 |
+| `p` | review the selected paused run in the stage-appropriate HITL viewer        |
 | `R` | resolve a run paused at an escalation (interactive, then re-arm)           |
 | `d` | answer deferred-work decisions past sweeps left unanswered (modal walk)    |
 | `a` | attach to the selected run's live session or orchestrator window           |
@@ -240,10 +267,14 @@ sections, `escape` goes back without saving. In any modal: `escape` cancels.
 
 `r` opens the **start run** modal — all fields optional:
 
-- **epic** — integer, restrict to one epic; blank = all
-- **story key** — restrict to one story; blank = all
+- **source** — `sprint mode` (walks `sprint-status.yaml`) or `stories mode` (folder+id dispatch), prefilled from `[stories]`
+- **spec folder** — stories mode only: the epic spec folder holding `stories.yaml` + `SPEC.md`; feeds a live **schedule preview** that validates the manifest and lists the linear schedule with `[spec/done]` checkpoint markers and each story's live disk state
+- **epic** — integer, restrict to one epic (sprint mode); blank = all
+- **story key** — restrict to one story; a story id in stories mode; blank = all
 - **max stories** — stop after N stories; blank = no limit
 - **dry run** — print the plan, spawn nothing (output shown in a modal)
+
+Selecting stories mode with an empty spec folder is refused with a toast; the run's preflight also validates the manifest + `SPEC.md` before spawning.
 
 `s` opens the **start sweep** modal:
 
@@ -318,6 +349,39 @@ in place — a clean rebuild against the corrected spec, then on through the res
 of the sprint. Detach (`Ctrl-b d`) to return to the dashboard, which observes the
 resumed run like any other. Exiting the agent without recording a resolution
 leaves the story escalated and the run paused — the safe default.
+
+## Reviewing a paused run (`p`)
+
+`p` opens the **stage-appropriate HITL viewer** for the selected paused run,
+dispatched on `RunState.paused_stage`. Every action calls the exact code path the
+CLI uses — no duplicated logic — and every viewer is a read-only presentation of
+artifacts the engine already wrote.
+
+- **Plan checkpoint** (`spec_checkpoint`, stories mode) — a read-only viewer of
+  the planned `ready-for-dev` spec at its id-keyed path (shown prominently, with a
+  copy-path action). **Approve & resume** resumes straight to implementation;
+  **Request replan** resets the spec to `draft` and strips its Auto Run Result
+  (via the same `devcontract` primitives the engine's repair path uses), then
+  resumes so the next dispatch re-plans. Edit the markdown in your own editor — the
+  TUI never edits specs.
+- **Story checkpoint** (`done_checkpoint`, stories mode) — a summary card for the
+  just-committed story: id/title, commit subject + short hash, verification
+  outcome, and cost-weighted + raw token totals. **Continue run** resumes the
+  schedule; **Stop run** marks the run stopped.
+- **Escalation** — the escalation view enriched with story context: the story
+  entry's title/description (from `stories.yaml`), the blocking condition parsed
+  from the spec's `## Auto Run Result`, and a sentinel indicator when the matched
+  spec is a fixed-slug pre-planning-halt sentinel. **Resolve** launches the same
+  interactive agent as `R`; **Re-arm & resume** (offered once the resolve agent has
+  recorded a resolution) re-arms and resumes — deleting a sentinel with a preserved
+  copy for a clean re-dispatch. Both refuse a still-live engine.
+- **Spec-approval / epic gate** — reuses the spec viewer (view the finalized spec,
+  then **Approve & resume**), so the pre-existing sprint-mode gates inherit the same
+  richer surface.
+
+`p` and `R` overlap for an escalation (both reach Resolve); `p` also exposes
+Re-arm & resume inline once a resolution exists. Pause badges in the run list and
+the run header name the stage so you know which viewer `p` will open.
 
 ## Attaching (`a`) and the sweep decision flow
 

--- a/src/bmad_loop/tui/app.py
+++ b/src/bmad_loop/tui/app.py
@@ -610,11 +610,28 @@ class BmadLoopApp(App[None]):
         """Request-replan: reset the planned spec to draft + strip its Auto Run
         Result, then resume — the next dispatch re-enters step-02 planning. Uses
         the same devcontract primitives the engine's repair path uses."""
+        # Guard a possibly-live engine BEFORE mutating the spec — a draft-reset +
+        # strip under a still-running session would race its writes (the rearm path
+        # already checks liveness first; match it so replan can't corrupt a live
+        # drive, and only then does _do_resume re-check before relaunching).
+        run_dir = self.project / RUNS_DIR / run_id
+        if self._resolve_blocked_by_liveness(run_id, run_dir):
+            return
         try:
-            devcontract.reset_spec_status(spec_path, "draft")
+            reset = devcontract.reset_spec_status(spec_path, "draft")
             devcontract.strip_auto_run_result(spec_path)
         except OSError as e:
             self.notify(f"replan failed: {e}", severity="error")
+            return
+        if not reset:
+            # honor the reset bool: nothing was flipped (the spec has no frontmatter
+            # status, or is already draft), so the next dispatch would NOT re-enter
+            # planning. Surface it instead of a misleading "reset" notice + resume.
+            self.notify(
+                "replan: could not reset the plan to draft (no frontmatter status?) "
+                "— not resuming",
+                severity="error",
+            )
             return
         self.notify("plan reset to draft — the next dispatch re-plans")
         self._do_resume(run_id)
@@ -674,8 +691,14 @@ class BmadLoopApp(App[None]):
     def _sentinel_kind(self, state: RunState, key: str) -> str:
         if state.source != "stories" or not state.spec_folder:
             return ""
-        folder = stories.resolve_spec_folder(self.project, state.spec_folder)
-        st = stories.resolve_story_spec(folder, key)
+        # resolve_story_spec globs + reads frontmatter; a file removed mid-scan (a
+        # re-arm clearing the sentinel while the viewer refreshes) can raise OSError.
+        # Degrade to "" rather than let a race-window read crash the render.
+        try:
+            folder = stories.resolve_spec_folder(self.project, state.spec_folder)
+            st = stories.resolve_story_spec(folder, key)
+        except OSError:
+            return ""
         return st.sentinel_kind if st.kind == stories.KIND_SENTINEL else ""
 
     @staticmethod

--- a/src/bmad_loop/tui/app.py
+++ b/src/bmad_loop/tui/app.py
@@ -534,15 +534,36 @@ class BmadLoopApp(App[None]):
         )
         self.push_screen(modal, lambda verb: self._do_resume(run_id) if verb == "resume" else None)
 
+    @staticmethod
+    def _checkpoint_gate_line(review_cycle: int) -> str:
+        """The story-checkpoint card's gate line, derived from real task state.
+
+        A done_checkpoint fires only after the story's verify + review gates
+        passed and it committed, so the pass is backed by the commit's existence
+        — but we do not persist per-command verify output, so we state the gates
+        cleared plus the follow-up review-cycle count the task actually records,
+        never a blanket hardcoded "verification passed" claim."""
+        if review_cycle == 0:
+            note = "no follow-up review cycles"
+        elif review_cycle == 1:
+            note = "1 follow-up review cycle"
+        else:
+            note = f"{review_cycle} follow-up review cycles"
+        return f"verify + review gates passed · {note}"
+
     def _review_story_checkpoint(self, run_id: str, run_dir: Path, state: RunState) -> None:
         story_key = state.paused_story_key or "?"
         task = state.tasks.get(story_key)
         commit = ""
         tokens = "-"
+        # Defensive default: a done_checkpoint implies a commit, but if none is
+        # recorded say so rather than assert a verify outcome we cannot back.
+        verify_line = "no commit recorded for this story"
         if task is not None:
             if task.commit_sha:
                 subject = self._commit_subject(task.commit_sha)
                 commit = f"{task.commit_sha[:12]} {subject}".strip()
+                verify_line = self._checkpoint_gate_line(task.review_cycle)
             weight = state.cache_read_weight()
             raw = task.tokens.total
             if raw:
@@ -551,7 +572,7 @@ class BmadLoopApp(App[None]):
             story_key=story_key,
             title=self._story_context(state, story_key)[0],
             commit=commit,
-            verify_line="✓ verification passed (story committed)",
+            verify_line=verify_line,
             tokens=tokens,
         )
 

--- a/src/bmad_loop/tui/app.py
+++ b/src/bmad_loop/tui/app.py
@@ -15,24 +15,37 @@ import time
 from collections.abc import Callable
 from pathlib import Path
 
+from rich.text import Text
 from textual import work
 from textual.app import App, SuspendNotSupported
 from textual.binding import Binding
 from tomlkit.exceptions import ParseError
 
-from .. import bmadconfig, decisions, runs, verify
+from .. import bmadconfig, decisions, devcontract, policy, resolve, runs, stories, verify
 from ..journal import load_state
+from ..model import (
+    PAUSE_EPIC_BOUNDARY,
+    PAUSE_ESCALATION,
+    PAUSE_PLAN_CHECKPOINT,
+    PAUSE_SPEC_APPROVAL,
+    PAUSE_STORY_CHECKPOINT,
+    PAUSE_STORY_GATE,
+    RunState,
+)
 from ..policy import POLICY_FILE
 from ..process_host import ProcessHostError
-from ..runs import RUNS_DIR, StopRunError
+from ..runs import RUNS_DIR, RearmError, StopRunError
 from . import data, launch
 from .screens.dashboard import DashboardScreen
 from .screens.modals import (
     ConfirmModal,
     ConfirmResumeModal,
     DecisionModal,
+    EscalationModal,
+    SpecReviewModal,
     StartRunModal,
     StartSweepModal,
+    StoryCheckpointModal,
     TextOutputModal,
 )
 from .screens.settings_screen import SettingsScreen
@@ -62,11 +75,11 @@ class BmadLoopApp(App[None]):
         min-height: 4;
         border-top: solid $primary-darken-2;
     }
-    #runs, #sprint-tree, #deferred {
+    #runs, #sprint-tree, #stories-table, #deferred {
         border-title-color: $text;
         border-title-style: bold;
     }
-    #sprint-tree {
+    #sprint-tree, #stories-table {
         height: 3fr;
         min-height: 4;
         border-top: solid $primary-darken-2;
@@ -108,6 +121,7 @@ class BmadLoopApp(App[None]):
         Binding("r", "start_run", "run"),
         Binding("s", "start_sweep", "sweep"),
         Binding("e", "resume_run", "resume"),
+        Binding("p", "review_pause", "review"),
         Binding("R", "resolve_run", "resolve"),
         Binding("d", "answer_decisions", "decisions"),
         Binding("a", "attach", "attach"),
@@ -172,13 +186,33 @@ class BmadLoopApp(App[None]):
     def action_start_run(self) -> None:
         if self._tmux_missing():
             return
-        self.push_screen(StartRunModal(), self._start_run_result)
+        source, spec_folder = self._stories_defaults()
+        self.push_screen(
+            StartRunModal(self.project, default_source=source, default_spec_folder=spec_folder),
+            self._start_run_result,
+        )
+
+    def _stories_defaults(self) -> tuple[str, str]:
+        """The [stories] policy source + spec_folder to prefill the start-run
+        modal, or the sprint-mode default when policy is unreadable."""
+        try:
+            pol = policy.load(self.project / POLICY_FILE)
+        except (policy.PolicyError, OSError, ParseError):
+            return "sprint-status", ""
+        return pol.stories.source, pol.stories.spec_folder
 
     def _start_run_result(self, result: dict | None) -> None:
         if not result:
             return
+        stories_on = result["source"] == "stories"
+        spec_folder = result["spec_folder"] if stories_on else ""
+        if stories_on and not spec_folder:
+            self.notify("stories mode needs a spec folder", severity="error")
+            return
         if result["dry_run"]:
             tail = ["run", "--project", str(self.project), "--dry-run"]
+            if stories_on:
+                tail += ["--spec", spec_folder]
             if result["epic"] is not None:
                 tail += ["--epic", str(result["epic"])]
             if result["story"]:
@@ -194,6 +228,7 @@ class BmadLoopApp(App[None]):
                 launch.start_run_detached(
                     self.project,
                     run_id,
+                    spec=spec_folder or None,
                     epic=result["epic"],
                     story=result["story"],
                     max_stories=result["max_stories"],
@@ -395,23 +430,6 @@ class BmadLoopApp(App[None]):
             return
         story = state.paused_story_key or "?"
 
-        def done(ok: bool | None) -> None:
-            if not ok:
-                return
-            try:
-                win_id = launch.start_resolve_detached(self.project, run_id)
-            except launch.LaunchError as e:
-                self.notify(str(e), severity="error")
-                return
-            if not win_id:
-                self.notify(
-                    "resolve launched but its window id was not captured",
-                    severity="error",
-                )
-                return
-            launch.select_ctl_window_id(win_id)
-            self._attach_to_target(f"={launch.CTL_SESSION}", return_window=win_id)
-
         self.push_screen(
             ConfirmModal(
                 "resolve escalation",
@@ -419,8 +437,264 @@ class BmadLoopApp(App[None]):
                 "converse to fix the frozen spec, then confirm re-arm + resume in that window.",
                 confirm_label="resolve",
             ),
-            done,
+            lambda ok: self._launch_resolve(run_id) if ok else None,
         )
+
+    def _launch_resolve(self, run_id: str) -> None:
+        """Open the interactive resolve agent for run_id in a ctl window and
+        attach — the same path `bmad-loop resolve` drives. The caller has already
+        confirmed and (for the escalation viewer) gated on liveness."""
+        try:
+            win_id = launch.start_resolve_detached(self.project, run_id)
+        except launch.LaunchError as e:
+            self.notify(str(e), severity="error")
+            return
+        if not win_id:
+            self.notify("resolve launched but its window id was not captured", severity="error")
+            return
+        launch.select_ctl_window_id(win_id)
+        self._attach_to_target(f"={launch.CTL_SESSION}", return_window=win_id)
+
+    # -------------------------------------------------------- HITL pause review
+
+    def action_review_pause(self) -> None:
+        """Open the stage-appropriate review viewer for the selected paused run.
+        Each viewer's actions call the exact code paths the CLI uses (resume,
+        reset-to-draft + resume, rearm + resume, resolve, stop) — no duplicated
+        logic. Pause kind is read from RunState.paused_stage."""
+        selected = self._paused_selection()
+        if selected is None:
+            return
+        run_id, run_dir, state = selected
+        stage = state.paused_stage
+        if stage == PAUSE_PLAN_CHECKPOINT:
+            self._review_plan_checkpoint(run_id, run_dir, state)
+        elif stage == PAUSE_STORY_CHECKPOINT:
+            self._review_story_checkpoint(run_id, run_dir, state)
+        elif stage == PAUSE_ESCALATION:
+            self._review_escalation(run_id, run_dir, state)
+        elif stage in (PAUSE_SPEC_APPROVAL, PAUSE_EPIC_BOUNDARY, PAUSE_STORY_GATE):
+            self._review_gate(run_id, run_dir, state)
+        else:
+            self.notify(f"no review viewer for pause stage {stage!r}", severity="warning")
+
+    def _paused_selection(self) -> tuple[str, Path, RunState] | None:
+        run_id = self._dashboard.selected_run_id
+        if run_id is None:
+            self.notify("no run selected", severity="warning")
+            return None
+        run_dir = self.project / RUNS_DIR / run_id
+        try:
+            state = load_state(run_dir)
+        except (OSError, KeyError, ValueError):
+            self.notify(f"state for run {run_id} is unreadable", severity="error")
+            return None
+        if not state.paused:
+            self.notify("run is not paused — nothing to review", severity="warning")
+            return None
+        return run_id, run_dir, state
+
+    def _review_plan_checkpoint(self, run_id: str, run_dir: Path, state: RunState) -> None:
+        spec_path, spec_text = self._paused_spec(state)
+        modal = SpecReviewModal(
+            title="plan checkpoint — review the planned spec before implementation",
+            subtitle=self._story_subtitle(state),
+            spec_path=spec_path,
+            spec_text=spec_text,
+            actions=[
+                ("approve", "Approve & resume", "primary"),
+                ("replan", "Request replan", "warning"),
+            ],
+        )
+
+        def done(verb: str | None) -> None:
+            if verb == "approve":
+                self._do_resume(run_id)
+            elif verb == "replan":
+                if spec_path is None:
+                    self.notify("no spec file to reset for replan", severity="error")
+                    return
+                self._do_replan(run_id, spec_path)
+
+        self.push_screen(modal, done)
+
+    def _review_gate(self, run_id: str, run_dir: Path, state: RunState) -> None:
+        labels = {
+            PAUSE_SPEC_APPROVAL: "spec-approval gate",
+            PAUSE_EPIC_BOUNDARY: "epic gate",
+            PAUSE_STORY_GATE: "story gate",
+        }
+        spec_path, spec_text = self._paused_spec(state)
+        modal = SpecReviewModal(
+            title=f"{labels.get(state.paused_stage, 'gate')} — review the finalized spec",
+            subtitle=self._story_subtitle(state),
+            spec_path=spec_path,
+            spec_text=spec_text,
+            actions=[("resume", "Approve & resume", "primary")],
+        )
+        self.push_screen(modal, lambda verb: self._do_resume(run_id) if verb == "resume" else None)
+
+    def _review_story_checkpoint(self, run_id: str, run_dir: Path, state: RunState) -> None:
+        story_key = state.paused_story_key or "?"
+        task = state.tasks.get(story_key)
+        commit = ""
+        tokens = "-"
+        if task is not None:
+            if task.commit_sha:
+                subject = self._commit_subject(task.commit_sha)
+                commit = f"{task.commit_sha[:12]} {subject}".strip()
+            weight = state.cache_read_weight()
+            raw = task.tokens.total
+            if raw:
+                tokens = f"{task.tokens.weighted_total(weight):,} ({raw:,} raw)"
+        modal = StoryCheckpointModal(
+            story_key=story_key,
+            title=self._story_context(state, story_key)[0],
+            commit=commit,
+            verify_line="✓ verification passed (story committed)",
+            tokens=tokens,
+        )
+
+        def done(verb: str | None) -> None:
+            if verb == "continue":
+                self._do_resume(run_id)
+            elif verb == "stop":
+                self._stop_run_worker(run_id, run_dir)
+
+        self.push_screen(modal, done)
+
+    def _review_escalation(self, run_id: str, run_dir: Path, state: RunState) -> None:
+        story_key = state.paused_story_key or "?"
+        spec_path, spec_text = self._paused_spec(state)
+        title, description = self._story_context(state, story_key)
+        modal = EscalationModal(
+            story_key=story_key,
+            title=title,
+            description=description,
+            blocking=self._blocking_condition(spec_text),
+            sentinel_kind=self._sentinel_kind(state, story_key),
+            resolution_ready=resolve.resolution_path(run_dir, story_key).is_file(),
+            engine_live=_engine_possibly_live(run_dir),
+        )
+
+        def done(verb: str | None) -> None:
+            if verb == "resolve":
+                if self._tmux_missing() or self._resolve_blocked_by_liveness(run_id, run_dir):
+                    return
+                self._launch_resolve(run_id)
+            elif verb == "rearm":
+                self._do_rearm(run_id, run_dir, story_key)
+
+        self.push_screen(modal, done)
+
+    # --------------------------------------------------- shared pause code paths
+
+    def _do_resume(self, run_id: str) -> None:
+        """Resume a paused run — the `bmad-loop resume` / `e` path, minus the
+        confirm modal (the viewer was the confirmation). Guards tmux + a
+        possibly-live engine so an approve/continue can't double-drive."""
+        if self._tmux_missing():
+            return
+        run_dir = self.project / RUNS_DIR / run_id
+        if _engine_possibly_live(run_dir):
+            self.notify(f"run {run_id} may still be live — stop it first", severity="warning")
+            return
+        try:
+            launch.resume_detached(self.project, run_id)
+        except launch.LaunchError as e:
+            self.notify(str(e), severity="error")
+            return
+        self.notify(f"resume of {run_id} launched (tmux session {launch.CTL_SESSION})")
+
+    def _do_replan(self, run_id: str, spec_path: Path) -> None:
+        """Request-replan: reset the planned spec to draft + strip its Auto Run
+        Result, then resume — the next dispatch re-enters step-02 planning. Uses
+        the same devcontract primitives the engine's repair path uses."""
+        try:
+            devcontract.reset_spec_status(spec_path, "draft")
+            devcontract.strip_auto_run_result(spec_path)
+        except OSError as e:
+            self.notify(f"replan failed: {e}", severity="error")
+            return
+        self.notify("plan reset to draft — the next dispatch re-plans")
+        self._do_resume(run_id)
+
+    def _do_rearm(self, run_id: str, run_dir: Path, story_key: str) -> None:
+        """Re-arm a resolved escalation + resume — the `resolve --no-interactive`
+        path (rearm_escalation handles sentinel auto-delete-with-preservation)."""
+        if self._resolve_blocked_by_liveness(run_id, run_dir):
+            return
+        try:
+            runs.rearm_escalation(run_dir, story_key)
+        except RearmError as e:
+            self.notify(f"re-arm failed: {e}", severity="error")
+            return
+        self.notify(f"re-armed {story_key}")
+        self._do_resume(run_id)
+
+    def _resolve_blocked_by_liveness(self, run_id: str, run_dir: Path) -> bool:
+        if _engine_possibly_live(run_dir):
+            self.notify(f"run {run_id} may still be live — stop it first", severity="warning")
+            return True
+        return False
+
+    # ---------------------------------------------------- pause-context readers
+
+    def _paused_spec(self, state: RunState) -> tuple[Path | None, str]:
+        """(spec path, spec text) for the paused story, or (None, "") when the
+        task has no spec file (e.g. an ambiguous-match escalation)."""
+        task = state.tasks.get(state.paused_story_key) if state.paused_story_key else None
+        if task is None or not task.spec_file:
+            return None, ""
+        path = Path(task.spec_file)
+        try:
+            return path, path.read_text(encoding="utf-8")
+        except OSError:
+            return path, ""
+
+    def _story_subtitle(self, state: RunState) -> Text:
+        key = state.paused_story_key or "?"
+        title = self._story_context(state, key)[0]
+        text = Text(key, style="bold")
+        if title:
+            text.append(f" — {title}")
+        return text
+
+    def _story_context(self, state: RunState, key: str) -> tuple[str, str]:
+        """(title, description) from stories.yaml in stories mode, else ("", "")."""
+        if state.source != "stories" or not state.spec_folder:
+            return "", ""
+        try:
+            folder = stories.resolve_spec_folder(self.project, state.spec_folder)
+            entry = stories.load_stories(folder).get(key)
+        except stories.StoriesError:
+            return "", ""
+        return (entry.title, entry.description) if entry else ("", "")
+
+    def _sentinel_kind(self, state: RunState, key: str) -> str:
+        if state.source != "stories" or not state.spec_folder:
+            return ""
+        folder = stories.resolve_spec_folder(self.project, state.spec_folder)
+        st = stories.resolve_story_spec(folder, key)
+        return st.sentinel_kind if st.kind == stories.KIND_SENTINEL else ""
+
+    @staticmethod
+    def _blocking_condition(spec_text: str) -> str:
+        """The `## Auto Run Result` block a blocked spec records its halt in."""
+        idx = spec_text.find("## Auto Run Result")
+        return spec_text[idx:].strip() if idx != -1 else ""
+
+    def _commit_subject(self, sha: str) -> str:
+        try:
+            proc = subprocess.run(
+                ["git", "-C", str(self.project), "log", "-1", "--format=%s", sha],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return ""
+        return proc.stdout.strip() if proc.returncode == 0 else ""
 
     # ------------------------------------------------------ stop / delete / archive
 

--- a/src/bmad_loop/tui/data.py
+++ b/src/bmad_loop/tui/data.py
@@ -25,7 +25,7 @@ import pyte
 from rich.style import Style
 from rich.text import Text
 
-from .. import bmadconfig, deferredwork, sprintstatus
+from .. import bmadconfig, deferredwork, sprintstatus, stories
 from ..adapters.multiplexer import MultiplexerError, get_multiplexer
 from ..gates import ATTENTION_FILE
 from ..journal import JOURNAL_FILE, LOGS_DIR, STATE_FILE, load_state
@@ -131,10 +131,12 @@ class RunInfo:
     run_type: str
     started_at: str
     status: str
+    paused_stage: str = ""  # RunState.paused_stage when PAUSED, else ""; drives the badge
 
 
-# state.json path -> (stat sig, (run_type, started_at, finished, paused, stopped, crashed))
-_header_cache: dict[Path, tuple[_StatSig, tuple[str, str, bool, bool, bool, bool]]] = {}
+# state.json path -> (stat sig, header fields tuple)
+_HeaderFields = tuple[str, str, bool, bool, bool, bool, str]
+_header_cache: dict[Path, tuple[_StatSig, _HeaderFields]] = {}
 
 
 def discover_runs(project: Path) -> list[RunInfo]:
@@ -150,7 +152,7 @@ def discover_runs(project: Path) -> list[RunInfo]:
         sig = _stat_sig(state_path)
         cached = _header_cache.get(state_path)
         if sig is not None and cached is not None and cached[0] == sig:
-            run_type, started_at, finished, paused, stopped, crashed = cached[1]
+            run_type, started_at, finished, paused, stopped, crashed, paused_stage = cached[1]
         else:
             try:
                 doc = json.loads(state_path.read_text(encoding="utf-8"))
@@ -160,16 +162,20 @@ def discover_runs(project: Path) -> list[RunInfo]:
                 paused = doc.get("paused_reason") is not None
                 stopped = bool(doc.get("stopped", False))
                 crashed = bool(doc.get("crashed", False))
+                paused_stage = str(doc.get("paused_stage") or "")
             except (OSError, json.JSONDecodeError):
                 out.append(RunInfo(run_dir.name, run_dir, "?", "", UNKNOWN))
                 continue
             if sig is not None:
                 _header_cache[state_path] = (
                     sig,
-                    (run_type, started_at, finished, paused, stopped, crashed),
+                    (run_type, started_at, finished, paused, stopped, crashed, paused_stage),
                 )
         status = _classify(finished, paused, stopped, crashed, run_dir)
-        out.append(RunInfo(run_dir.name, run_dir, run_type, started_at, status))
+        # paused_stage is advisory: only meaningful while the run is actually PAUSED
+        # (a resumed run keeps the last stage in state until it re-pauses/finishes).
+        stage = paused_stage if status == PAUSED else ""
+        out.append(RunInfo(run_dir.name, run_dir, run_type, started_at, status, stage))
     return out
 
 
@@ -693,6 +699,26 @@ def sprint_overview(project: Path) -> sprintstatus.SprintStatus | None:
             overview = None
     _sprint_cache[sprint_path] = (sig, overview)
     return overview
+
+
+def stories_overview(project: Path, spec_folder: str) -> list[stories.StoryRow] | None:
+    """The stories-mode board for a run's pinned spec folder: one StoryRow per
+    ``stories.yaml`` entry joined with the live on-disk state of its id-keyed
+    story spec. None when unavailable (no spec folder, or a missing/invalid
+    ``stories.yaml``).
+
+    Unlike :func:`sprint_overview` this is per-run (keyed by the run's
+    ``spec_folder``) and is re-derived on every call rather than stat-gated: the
+    per-story spec files under ``stories/`` change independently, so there is no
+    single file to gate on. It reads a handful of small files, called on the
+    dashboard's rescan cadence."""
+    if not spec_folder:
+        return None
+    folder = stories.resolve_spec_folder(project, spec_folder)
+    try:
+        return stories.story_rows(folder)
+    except stories.StoriesError:
+        return None
 
 
 @dataclass(frozen=True)

--- a/src/bmad_loop/tui/launch.py
+++ b/src/bmad_loop/tui/launch.py
@@ -289,11 +289,14 @@ def start_run_detached(
     project: Path,
     run_id: str,
     *,
+    spec: str | None = None,
     epic: int | None = None,
     story: str | None = None,
     max_stories: int | None = None,
 ) -> None:
     tail = ["run", "--project", str(project), "--run-id", run_id]
+    if spec:
+        tail += ["--spec", spec]  # forces stories mode (folder+id dispatch)
     if epic is not None:
         tail += ["--epic", str(epic)]
     if story:

--- a/src/bmad_loop/tui/screens/dashboard.py
+++ b/src/bmad_loop/tui/screens/dashboard.py
@@ -34,7 +34,7 @@ from textual.widgets import (
 )
 from textual.widgets.option_list import Option, OptionDoesNotExist
 
-from ... import sprintstatus
+from ... import sprintstatus, stories
 from ...model import RunState
 from ...runs import RUNS_DIR
 from .. import data
@@ -44,6 +44,8 @@ from ..widgets import (
     RunHeader,
     SelectableRichLog,
     SprintTree,
+    StoriesTable,
+    pause_tag,
     status_cell,
 )
 from .modals import DeferredEntryModal
@@ -107,6 +109,8 @@ class _Snapshot:
     run_id: str = ""
     status: str = data.UNKNOWN
     state: RunState | None = None
+    stories_mode: bool = False  # selected run is stories mode (source == "stories")
+    stories: list[stories.StoryRow] | None = None  # stories board rows, when stories_mode
     new_entries: list[dict[str, Any]] = field(default_factory=list)
     log_task: str | None = None
     log_reset: bool = False
@@ -165,6 +169,9 @@ class DashboardScreen(Screen[None]):
                 tree = SprintTree("sprint", id="sprint-tree")
                 tree.border_title = "Sprint"
                 yield tree
+                stories = StoriesTable(id="stories-table")
+                stories.border_title = "Stories"
+                yield stories
                 deferred = OptionList(id="deferred")
                 deferred.border_title = "Deferred Work"
                 yield deferred
@@ -187,6 +194,10 @@ class DashboardScreen(Screen[None]):
         runs.add_column("st", key="st", width=2)
         runs.add_column("run", key="run")
         runs.add_column("type", key="type")
+        runs.add_column("note", key="note", width=6)  # pause-kind badge for paused runs
+        # the stories board shares the sprint-tree slot; hidden until a stories-mode
+        # run is selected (the poll worker toggles both by the run's source).
+        self.query_one("#stories-table", StoriesTable).display = False
         tasks = self.query_one("#tasks", DataTable)
         tasks.add_column("story", key="story", width=30)
         tasks.add_column("phase", key="phase", width=16)
@@ -375,6 +386,11 @@ class DashboardScreen(Screen[None]):
                 snap.run_id = ctx.run_dir.name
                 snap.state = ctx.watcher.state()
                 snap.status = ctx.watcher.status()
+                if snap.state is not None and snap.state.source == "stories":
+                    # per-run board: re-derived each tick (only while a stories run
+                    # is selected) so it tracks the dev sessions writing story specs.
+                    snap.stories_mode = True
+                    snap.stories = data.stories_overview(self.project, snap.state.spec_folder)
                 snap.new_entries = ctx.journal.read_new()
                 ctx.entries.extend(snap.new_entries)
                 del ctx.entries[:-_MAX_ENTRIES]
@@ -439,6 +455,7 @@ class DashboardScreen(Screen[None]):
             if snap.run_id == self._pending_run:
                 self._pending_run = None  # the engine is up
             header.show_run(snap.run_id, snap.status, snap.state, snap.decision)
+        self._apply_board(snap)
         if snap.state is not None:
             self._apply_tasks(snap.state)
         if snap.toast_decision and snap.decision is not None:
@@ -510,6 +527,7 @@ class DashboardScreen(Screen[None]):
 
     def _apply_runs(self, runs: list[data.RunInfo]) -> None:
         table = self.query_one("#runs", DataTable)
+        self._apply_attention(table, runs)
         ids = [r.run_id for r in runs]
         if not runs:
             if self._run_rows:
@@ -527,11 +545,13 @@ class DashboardScreen(Screen[None]):
         for run in runs:
             if run.run_id in self._run_rows:
                 table.update_cell(run.run_id, "st", status_cell(run.status))
+                table.update_cell(run.run_id, "note", pause_tag(run.paused_stage))
             else:
                 table.add_row(
                     status_cell(run.status),
                     run.run_id,
                     run.run_type,
+                    pause_tag(run.paused_stage),
                     key=run.run_id,
                 )
                 self._run_rows.append(run.run_id)
@@ -574,6 +594,25 @@ class DashboardScreen(Screen[None]):
             else:
                 table.add_row(key, *cells.values(), key=key)
                 self._task_rows.add(key)
+
+    def _apply_attention(self, table: DataTable, runs: list[data.RunInfo]) -> None:
+        """Global attention indicator: how many runs are paused awaiting a human.
+        Shown on the runs-table border title, consistent with the per-run pause
+        badge and the ATTENTION-file notify machinery."""
+        waiting = sum(1 for r in runs if r.status == data.PAUSED)
+        table.border_title = f"Runs — ⚑ {waiting} need attention" if waiting else "Runs"
+
+    def _apply_board(self, snap: _Snapshot) -> None:
+        """Toggle the sprint tree vs the stories board by the selected run's mode
+        and refresh whichever is live. The stories board is per-run (keyed by the
+        run's spec folder); the sprint tree is project-level and painted
+        separately on rescan."""
+        sprint_tree = self.query_one("#sprint-tree", SprintTree)
+        stories_table = self.query_one("#stories-table", StoriesTable)
+        sprint_tree.display = not snap.stories_mode
+        stories_table.display = snap.stories_mode
+        if snap.stories_mode:
+            stories_table.update_stories(snap.stories)
 
     def _apply_sprint_tree(self, ss: sprintstatus.SprintStatus | None) -> None:
         if ss is self._last_sprint:

--- a/src/bmad_loop/tui/screens/modals.py
+++ b/src/bmad_loop/tui/screens/modals.py
@@ -472,9 +472,10 @@ class SpecReviewModal(BaseDialog):
 
 class StoryCheckpointModal(BaseDialog):
     """done_checkpoint summary card shown after a story commits: id/title, the
-    commit subject + short hash, the verify-command outcome and token totals.
-    Dismisses with 'continue' (resume the schedule) or 'stop' (mark the run
-    stopped), None on close/escape."""
+    commit subject + short hash, a gate line derived from real task state (the
+    verify + review gates the commit cleared, plus the follow-up review-cycle
+    count) and token totals. Dismisses with 'continue' (resume the schedule) or
+    'stop' (mark the run stopped), None on close/escape."""
 
     def __init__(
         self,

--- a/src/bmad_loop/tui/screens/modals.py
+++ b/src/bmad_loop/tui/screens/modals.py
@@ -8,15 +8,18 @@ rich Text, never markup.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 from rich.text import Text
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.css.query import NoMatches
 from textual.screen import ModalScreen
-from textual.widgets import Button, Checkbox, Input, Label, Static
+from textual.widgets import Button, Checkbox, Input, Label, Select, Static
 
+from ... import stories
 from ...model import RunState
 from .. import data
 
@@ -62,31 +65,130 @@ class BaseDialog(ModalScreen):
 
 
 class StartRunModal(BaseDialog):
-    """Options for `bmad-loop run` → {epic, story, max_stories, dry_run}."""
+    """Options for `bmad-loop run`.
+
+    Dual-flow: a source select (prefilled from ``[stories]``) picks sprint mode
+    vs. stories mode; the spec-folder input feeds a live schedule preview that
+    validates ``stories.yaml`` (parses + rules pass, SPEC.md present) and lists
+    the linear schedule with independent spec/done checkpoint markers — the same
+    projection `run --dry-run` prints. Returns
+    ``{source, spec_folder, epic, story, max_stories, dry_run}``."""
+
+    DEFAULT_CSS = """
+    StartRunModal #dialog {
+        height: 90%;
+    }
+    StartRunModal #fields {
+        height: 1fr;
+    }
+    StartRunModal #preview {
+        height: auto;
+        max-height: 14;
+        border: solid $primary-darken-2;
+        padding: 0 1;
+        margin-top: 1;
+    }
+    """
+
+    def __init__(
+        self,
+        project: Path,
+        *,
+        default_source: str = "sprint-status",
+        default_spec_folder: str = "",
+    ):
+        super().__init__()
+        self._project = project
+        self._default_source = default_source
+        self._default_spec_folder = default_spec_folder
 
     def compose(self) -> ComposeResult:
         with Vertical(id="dialog"):
             yield Label("start run", classes="title")
-            yield Input(
-                placeholder="epic — blank for all",
-                type="integer",
-                valid_empty=True,
-                id="epic",
-            )
-            yield Input(
-                placeholder="story — 3-1, 3.1, slug, or full key (blank for all)",
-                id="story",
-            )
-            yield Input(
-                placeholder="max stories — blank for no limit",
-                type="integer",
-                valid_empty=True,
-                id="max-stories",
-            )
-            yield Checkbox("dry run (print the plan, spawn nothing)", id="dry-run")
+            # fields scroll; the button row is docked below so it stays clickable
+            # in any terminal size (the modal is tall in stories mode).
+            with VerticalScroll(id="fields"):
+                yield Select(
+                    [
+                        ("sprint mode — sprint-status.yaml", "sprint-status"),
+                        ("stories mode — folder+id dispatch", "stories"),
+                    ],
+                    value=self._default_source,
+                    allow_blank=False,
+                    id="source",
+                )
+                yield Input(
+                    value=self._default_spec_folder,
+                    placeholder="stories mode: spec folder holding stories.yaml + SPEC.md",
+                    id="spec-folder",
+                )
+                yield Input(
+                    placeholder="epic — blank for all (sprint mode)",
+                    type="integer",
+                    valid_empty=True,
+                    id="epic",
+                )
+                yield Input(
+                    placeholder="story — 3-1 / slug / full key (sprint), or story id (stories)",
+                    id="story",
+                )
+                yield Input(
+                    placeholder="max stories — blank for no limit",
+                    type="integer",
+                    valid_empty=True,
+                    id="max-stories",
+                )
+                yield Checkbox("dry run (print the plan, spawn nothing)", id="dry-run")
+                with VerticalScroll(id="preview"):
+                    yield Static(id="preview-body")
             with Horizontal(classes="buttons"):
                 yield Button("start", variant="primary", id="ok")
                 yield Button("cancel", id="cancel")
+
+    def on_mount(self) -> None:
+        self._refresh_preview()
+
+    def on_select_changed(self, event: Select.Changed) -> None:
+        self._refresh_preview()
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        if event.input.id == "spec-folder":
+            self._refresh_preview()
+
+    def _refresh_preview(self) -> None:
+        try:
+            body = self.query_one("#preview-body", Static)
+            source = self.query_one("#source", Select).value
+            spec_folder = self.query_one("#spec-folder", Input).value.strip()
+        except NoMatches:
+            return  # a Changed message during mount, before the tree is built
+        if source != "stories":
+            body.update(Text("sprint mode — walks sprint-status.yaml", style="dim"))
+            return
+        if not spec_folder:
+            body.update(
+                Text("stories mode needs a spec folder (stories.yaml + SPEC.md)", style="yellow")
+            )
+            return
+        folder = stories.resolve_spec_folder(self._project, spec_folder)
+        try:
+            rows = stories.story_rows(folder)
+        except stories.StoriesError as e:
+            body.update(Text(f"⚠ {e}", style="red"))
+            return
+        text = Text()
+        text.append(f"{len(rows)} stories · linear order", style="bold")
+        if not (folder / "SPEC.md").is_file():
+            text.append("  ⚠ SPEC.md missing", style="red")
+        for r in rows:
+            text.append(f"\n  {r.position}. {r.id} ({r.label})")
+            marks = [
+                m for m, on in (("spec", r.spec_checkpoint), ("done", r.done_checkpoint)) if on
+            ]
+            if marks:
+                text.append(f" [{'/'.join(marks)}]", style="magenta")
+            text.append(f"  {r.title}", style="dim")
+        body.update(text)
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id != "ok":
@@ -94,6 +196,8 @@ class StartRunModal(BaseDialog):
             return
         self.dismiss(
             {
+                "source": self.query_one("#source", Select).value,
+                "spec_folder": self.query_one("#spec-folder", Input).value.strip(),
                 "epic": _int_or_none(self.query_one("#epic", Input).value),
                 "story": self.query_one("#story", Input).value.strip() or None,
                 "max_stories": _int_or_none(self.query_one("#max-stories", Input).value),
@@ -290,6 +394,223 @@ class DecisionModal(BaseDialog):
             self.dismiss(self._decision.option(bid[len("opt-") :]))
         else:
             self.dismiss(None)
+
+
+class SpecReviewModal(BaseDialog):
+    """Read-only story-spec viewer with a configurable action row.
+
+    Shared by the plan-checkpoint viewer (Approve & resume / Request replan) and
+    the spec-approval / epic gate viewer (Approve & resume). Dismisses with the
+    chosen action verb, or None on close/escape. The spec path is shown
+    prominently with a copy-path action; the spec body is LLM-written markdown so
+    it renders as plain Text, never markup. The modal owns no logic — the caller
+    maps each verb to the exact CLI code path (resume / reset-to-draft + resume)."""
+
+    DEFAULT_CSS = """
+    SpecReviewModal #dialog {
+        width: 100;
+        height: 85%;
+    }
+    SpecReviewModal #spec {
+        height: 1fr;
+        border: solid $primary-darken-2;
+        padding: 0 1;
+    }
+    SpecReviewModal .path {
+        color: $text-muted;
+        margin-bottom: 1;
+    }
+    """
+
+    def __init__(
+        self,
+        *,
+        title: str,
+        subtitle: str | Text,
+        spec_path: Path | None,
+        spec_text: str,
+        actions: list[tuple[str, str, str]],
+    ):
+        super().__init__()
+        self._title = title
+        self._subtitle = subtitle if isinstance(subtitle, Text) else Text(subtitle)
+        self._spec_path = spec_path
+        self._spec_text = spec_text
+        self._actions = actions
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="dialog"):
+            yield Label(self._title, classes="title")
+            yield Static(self._subtitle)
+            path_line = Text()
+            if self._spec_path is not None:
+                path_line.append(str(self._spec_path))
+            else:
+                path_line.append("(no spec file resolved)", style="dim")
+            yield Static(path_line, classes="path")
+            with VerticalScroll(id="spec"):
+                body = self._spec_text.strip()
+                yield Static(Text(body) if body else Text("(empty spec)", style="dim"))
+            with Horizontal(classes="buttons"):
+                if self._spec_path is not None:
+                    yield Button("copy path", id="copy-path")
+                for verb, label, variant in self._actions:
+                    yield Button(label, variant=variant, id=f"act-{verb}")  # type: ignore[arg-type]
+                yield Button("close", id="cancel")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        bid = event.button.id or ""
+        if bid == "copy-path" and self._spec_path is not None:
+            self.app.copy_to_clipboard(str(self._spec_path))
+            self.app.notify("spec path copied to clipboard")
+            return
+        if bid.startswith("act-"):
+            self.dismiss(bid[len("act-") :])
+            return
+        self.dismiss(None)
+
+
+class StoryCheckpointModal(BaseDialog):
+    """done_checkpoint summary card shown after a story commits: id/title, the
+    commit subject + short hash, the verify-command outcome and token totals.
+    Dismisses with 'continue' (resume the schedule) or 'stop' (mark the run
+    stopped), None on close/escape."""
+
+    def __init__(
+        self,
+        *,
+        story_key: str,
+        title: str,
+        commit: str,
+        verify_line: str,
+        tokens: str,
+    ):
+        super().__init__()
+        self._story_key = story_key
+        self._title = title
+        self._commit = commit
+        self._verify_line = verify_line
+        self._tokens = tokens
+
+    def compose(self) -> ComposeResult:
+        head = Text()
+        head.append(f"story checkpoint — {self._story_key}", style="bold")
+        with Vertical(id="dialog"):
+            yield Label(head, classes="title")
+            if self._title:
+                yield Static(Text(self._title))
+            card = Text()
+            card.append("\ncommit  ", style="dim")
+            card.append(self._commit or "(none)", style="green")
+            card.append("\nverify  ", style="dim")
+            card.append(self._verify_line)
+            card.append("\ntokens  ", style="dim")
+            card.append(self._tokens, style="dim")
+            yield Static(card)
+            with Horizontal(classes="buttons"):
+                yield Button("Continue run", variant="primary", id="act-continue")
+                yield Button("Stop run", variant="warning", id="act-stop")
+                yield Button("close", id="cancel")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        bid = event.button.id or ""
+        self.dismiss(bid[len("act-") :] if bid.startswith("act-") else None)
+
+
+class EscalationModal(BaseDialog):
+    """Blocked-story escalation view with story context: the story entry's
+    title/description (stories mode), the blocking condition parsed from the
+    spec's ``## Auto Run Result``, and a sentinel indicator when the matched spec
+    is a fixed-slug pre-planning-halt sentinel. Dismisses with 'resolve' (launch
+    the interactive resolve agent) or 'rearm' (re-arm + resume — only offered once
+    the resolution marker exists), None on close/escape."""
+
+    DEFAULT_CSS = """
+    EscalationModal #dialog {
+        width: 90;
+        height: auto;
+        max-height: 90%;
+    }
+    EscalationModal #blocking {
+        height: auto;
+        max-height: 40%;
+        margin-top: 1;
+        border: solid $primary-darken-2;
+        padding: 0 1;
+    }
+    """
+
+    def __init__(
+        self,
+        *,
+        story_key: str,
+        title: str,
+        description: str,
+        blocking: str,
+        sentinel_kind: str,
+        resolution_ready: bool,
+        engine_live: bool,
+    ):
+        super().__init__()
+        self._story_key = story_key
+        self._title = title
+        self._description = description
+        self._blocking = blocking
+        self._sentinel_kind = sentinel_kind
+        self._resolution_ready = resolution_ready
+        self._engine_live = engine_live
+
+    def compose(self) -> ComposeResult:
+        head = Text()
+        head.append(f"escalation — {self._story_key}", style="bold red")
+        with Vertical(id="dialog"):
+            yield Label(head, classes="title")
+            if self._title:
+                yield Static(Text(self._title, style="bold"))
+            if self._description:
+                yield Static(Text(self._description, style="dim"))
+            if self._sentinel_kind:
+                yield Static(
+                    Text(
+                        f"⚠ pre-planning-halt sentinel ({self._sentinel_kind}) — "
+                        "re-arm deletes it (a copy is preserved) for a clean re-dispatch",
+                        style="yellow",
+                    )
+                )
+            with VerticalScroll(id="blocking"):
+                body = self._blocking.strip()
+                yield Static(
+                    Text(body) if body else Text("(no blocking condition recorded)", style="dim")
+                )
+            if self._engine_live:
+                yield Static(
+                    Text("engine may still be live — stop it before resolving", style="yellow")
+                )
+            hint = Text()
+            if self._resolution_ready:
+                hint.append("resolution recorded — re-arm & resume when ready", style="green")
+            else:
+                hint.append(
+                    "resolve opens an interactive agent to fix the frozen spec; "
+                    "re-arm unlocks once it records a resolution",
+                    style="dim",
+                )
+            yield Static(hint)
+            with Horizontal(classes="buttons"):
+                yield Button(
+                    "Resolve", variant="primary", id="act-resolve", disabled=self._engine_live
+                )
+                yield Button(
+                    "Re-arm & resume",
+                    variant="warning",
+                    id="act-rearm",
+                    disabled=not self._resolution_ready or self._engine_live,
+                )
+                yield Button("close", id="cancel")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        bid = event.button.id or ""
+        self.dismiss(bid[len("act-") :] if bid.startswith("act-") else None)
 
 
 class TextOutputModal(BaseDialog):

--- a/src/bmad_loop/tui/widgets.py
+++ b/src/bmad_loop/tui/widgets.py
@@ -14,12 +14,22 @@ from typing import Any
 from rich.table import Table
 from rich.text import Text
 from textual.selection import Selection
-from textual.widgets import RichLog, Static, Tree
+from textual.widgets import DataTable, RichLog, Static, Tree
 from textual.widgets.option_list import Option
 from textual.widgets.tree import TreeNode
 
-from ..model import Phase, RunState
+from ..model import (
+    PAUSE_EPIC_BOUNDARY,
+    PAUSE_ESCALATION,
+    PAUSE_PLAN_CHECKPOINT,
+    PAUSE_SPEC_APPROVAL,
+    PAUSE_STORY_CHECKPOINT,
+    PAUSE_STORY_GATE,
+    Phase,
+    RunState,
+)
 from ..sprintstatus import SprintStatus, Story
+from ..stories import StoryRow
 from . import data
 
 STATUS_GLYPHS = {
@@ -45,6 +55,36 @@ STATUS_STYLES = {
 
 def status_cell(status: str) -> Text:
     return Text(STATUS_GLYPHS.get(status, "?"), style=STATUS_STYLES.get(status, ""))
+
+
+# ------------------------------------------------------------- pause badges
+#
+# Every mid-run pause that awaits a human maps to a visually distinct badge,
+# shown as a short tag in the runs table and a full label in the run header.
+# (short tag, full label, rich style)
+_PAUSE_BADGES: dict[str, tuple[str, str, str]] = {
+    PAUSE_PLAN_CHECKPOINT: ("plan", "plan checkpoint", "magenta"),
+    PAUSE_STORY_CHECKPOINT: ("story", "story checkpoint", "cyan"),
+    PAUSE_SPEC_APPROVAL: ("spec", "spec-approval gate", "yellow"),
+    PAUSE_EPIC_BOUNDARY: ("epic", "epic gate", "yellow"),
+    PAUSE_STORY_GATE: ("gate", "story gate", "yellow"),
+    PAUSE_ESCALATION: ("esc", "escalation", "bold red"),
+}
+
+
+def pause_tag(stage: str) -> Text:
+    """Compact colored tag for a paused run in the runs table ('' when not
+    paused / unknown stage renders the raw stage)."""
+    if not stage:
+        return Text("")
+    tag, _label, style = _PAUSE_BADGES.get(stage, (stage, stage, "yellow"))
+    return Text(tag, style=style)
+
+
+def pause_label(stage: str) -> tuple[str, str]:
+    """(full label, rich style) for a pause stage, for the run-header badge."""
+    _tag, label, style = _PAUSE_BADGES.get(stage, (stage, stage, "yellow"))
+    return label, style
 
 
 class RunHeader(Static):
@@ -115,10 +155,14 @@ class RunHeader(Static):
         if status == data.PAUSED:
             text.append("\n⏸ paused", style="bold yellow")
             if state.paused_stage:
-                text.append(f" ({state.paused_stage})", style="yellow")
+                label, badge_style = pause_label(state.paused_stage)
+                text.append("  ")
+                text.append(f"[{label}]", style=f"bold {badge_style}")
             if state.paused_reason:
                 text.append(f" — {state.paused_reason}", style="yellow")
-            text.append("  · press e to resume", style="dim")
+            # p opens the stage-appropriate review viewer; e resumes; R resolves
+            # an escalation (the header only hints the common paths).
+            text.append("\n  press p to review · e to resume", style="dim")
         elif status == data.CRASHED:
             text.append(
                 "\n✖ engine crashed — see crash.txt · press e to resume",
@@ -326,6 +370,104 @@ class SprintTree(Tree[str]):
                 for key, child_label in zip(child_keys, child_labels):
                     node.add_leaf(child_label, data=key)
                 self._epic_child_keys[num] = child_keys
+
+
+# ------------------------------------------------------------- stories table
+
+# Story on-disk state (stories.state_label) -> glyph + style. The label may be a
+# `sentinel:<kind>` composite, so lookups key on the token before ':'.
+STORY_GLYPHS = {
+    "pending": "·",
+    "draft": "◦",
+    "ready-for-dev": "○",
+    "in-progress": "▶",
+    "in-review": "◆",
+    "done": "✓",
+    "blocked": "✖",
+    "ambiguous": "⚠",
+    "sentinel": "⚠",
+}
+
+STORY_STYLES = {
+    "pending": "dim",
+    "draft": "dim",
+    "ready-for-dev": "cyan",
+    "in-progress": "cyan",
+    "in-review": "magenta",
+    "done": "green",
+    "blocked": "bold red",
+    "ambiguous": "bold red",
+    "sentinel": "bold red",
+}
+
+
+def story_state_cell(label: str) -> Text:
+    key = label.split(":", 1)[0]
+    return Text(f"{STORY_GLYPHS.get(key, '?')} {label}", style=STORY_STYLES.get(key, "dim"))
+
+
+def story_checkpoint_cell(spec_checkpoint: bool, done_checkpoint: bool) -> Text:
+    """Independent spec/done checkpoint markers as one compact cell: `S` (plan
+    review before code, magenta), `D` (review after commit, cyan), dim `·` for an
+    unset slot so the two stay positionally readable."""
+    text = Text()
+    text.append("S" if spec_checkpoint else "·", style="magenta" if spec_checkpoint else "dim")
+    text.append("D" if done_checkpoint else "·", style="cyan" if done_checkpoint else "dim")
+    return text
+
+
+class StoriesTable(DataTable):
+    """The stories-mode board — one row per stories.yaml entry with its live
+    on-disk state, replacing the sprint tree when a stories-mode run is selected.
+
+    Reconciles in place each rescan tick (stable row key = story id): the id set
+    is stable within a run, so existing rows only get cell updates, keeping the
+    cursor. Rebuilds only when the id set/order actually changes (a between-runs
+    Story Breakdown re-derive)."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.cursor_type = "row"
+        self.zebra_stripes = True
+        self._row_ids: list[str] | None = None  # None: placeholder/empty shown
+
+    def on_mount(self) -> None:
+        self.add_column("state", key="state", width=15)
+        self.add_column("id", key="id", width=8)
+        self.add_column("✓", key="chk", width=2)
+        self.add_column("title", key="title")
+
+    def _placeholder(self, label: str) -> None:
+        self.clear()
+        self.add_row(Text(label, style="dim"), "", "", "")
+        self._row_ids = None
+
+    def update_stories(self, rows: list[StoryRow] | None) -> None:
+        if rows is None:
+            self._placeholder("stories board unavailable")
+            return
+        if not rows:
+            self._placeholder("no stories")
+            return
+        ids = [r.id for r in rows]
+        if self._row_ids != ids:
+            self.clear()
+            for r in rows:
+                self.add_row(
+                    story_state_cell(r.label),
+                    r.id,
+                    story_checkpoint_cell(r.spec_checkpoint, r.done_checkpoint),
+                    _short(r.title, 48),
+                    key=r.id,
+                )
+            self._row_ids = ids
+            return
+        for r in rows:
+            self.update_cell(r.id, "state", story_state_cell(r.label))
+            self.update_cell(
+                r.id, "chk", story_checkpoint_cell(r.spec_checkpoint, r.done_checkpoint)
+            )
+            self.update_cell(r.id, "title", _short(r.title, 48))
 
 
 # ------------------------------------------------------------ deferred work

--- a/tests/test_stories_e2e.py
+++ b/tests/test_stories_e2e.py
@@ -1,0 +1,274 @@
+"""Deterministic full-CLI sandbox E2E for stories mode (folder+id dispatch).
+
+Drives the REAL `bmad-loop run/resolve/resume` binaries through REAL tmux with a
+scripted fake `claude` wired in as a custom profile — no LLM, no cost, fully
+reproducible. The fake fakes both the CLI and its Stop hook (it writes the
+SessionStart/Stop event files itself), so no `bmad-loop init` is needed; it
+leaves the id-keyed story spec on disk and the `GenericDevAdapter` synthesizes
+the result from it (`_stories_result_json`, keyed on `BMAD_LOOP_SPEC_FOLDER`).
+
+The fake routes on the story spec's frontmatter status, like `bmad-dev-auto`
+step-01: no spec / `ready-for-dev` → implement to `done`; `BMAD_LOOP_PLAN_HALT`
+→ halt at `ready-for-dev` (plan-checkpoint leg); a `.block-<id>` marker → write a
+`blocked` spec (a CRITICAL escalation). This exercises the CLI wiring the mock
+adapter bypasses: arg parsing, prompt render, hook-signal completion, the
+stories read-back, git commit, and the resolve/resume dance.
+
+Covers, through the real binary: (1) two-story happy path, (2) `spec_checkpoint`
+two-leg plan-halt + resume, (4) blocked → resolve → re-dispatch. Scenarios
+(3) `done_checkpoint`, (5) worktree isolation, and (6) sprint-mode regression are
+covered deterministically at the engine level in test_stories_engine.py /
+test_engine.py; here we prove the end-to-end CLI stack.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+HAVE_TMUX = sys.platform != "win32" and shutil.which("tmux") is not None
+pytestmark = pytest.mark.skipif(not HAVE_TMUX, reason="stories E2E needs real tmux")
+
+# The fake CLI: reads the story id + spec folder from the session env (as the real
+# folder+id adapter does), writes the id-keyed story spec BEFORE the Stop event so
+# the adapter's read-back finds a terminal spec, and stays alive until the engine
+# kills its window. Routes on the existing spec status so one script drives a fresh
+# dispatch, a plan-halt leg, its post-checkpoint implement leg, and a blocked halt.
+FAKE_CLI = r"""#!/usr/bin/env bash
+set -e
+rd="$BMAD_LOOP_RUN_DIR"; tid="$BMAD_LOOP_TASK_ID"
+story="$BMAD_LOOP_STORY_KEY"; folder="$BMAD_LOOP_SPEC_FOLDER"
+ts=$(date +%s%N)
+mkdir -p "$rd/events"
+printf '{"ts": %s, "event": "SessionStart", "task_id": "%s", "session_id": "fake-1"}' \
+    "$ts" "$tid" > "$rd/events/$ts-$tid-SessionStart.json"
+
+sdir="$folder/stories"
+mkdir -p "$sdir"
+spec="$sdir/$story-slug.md"
+existing=$(ls "$sdir/$story"-*.md 2>/dev/null | head -1 || true)
+status=""
+[ -n "$existing" ] && status=$(sed -n 's/^status:[[:space:]]*//p' "$existing" | head -1 | tr -d "'\" ")
+baseline=$(git rev-parse HEAD)
+
+write_done() {
+    echo "impl for $story" >> src.txt
+    printf -- '---\ntitle: %s\nstatus: done\nbaseline_commit: %s\n---\n\n# %s\nimplemented.\n' \
+        "$story" "$baseline" "$story" > "$spec"
+}
+write_planned() {
+    printf -- '---\ntitle: %s\nstatus: ready-for-dev\nbaseline_commit: %s\n---\n\n# %s\nplanned.\n' \
+        "$story" "$baseline" "$story" > "$spec"
+}
+write_blocked() {
+    printf -- '---\ntitle: %s\nstatus: blocked\nbaseline_commit: %s\n---\n\n# %s\n\n## Auto Run Result\n\n- Status: blocked\n\nNeeds a human decision.\n' \
+        "$story" "$baseline" "$story" > "$spec"
+}
+
+if [ "$status" = "ready-for-dev" ] || [ "$status" = "in-progress" ] || [ "$status" = "draft" ]; then
+    write_done                       # re-dispatch after a plan-checkpoint or a re-arm
+elif [ -n "$BMAD_LOOP_PLAN_HALT" ]; then
+    write_planned                    # spec_checkpoint leg 1: halt after planning
+elif [ -f "$folder/.block-$story" ]; then
+    write_blocked                    # poisoned story: first dispatch blocks
+else
+    write_done                       # normal fresh dispatch
+fi
+
+ts2=$(( ts + 1 ))
+printf '{"ts": %s, "event": "Stop", "task_id": "%s", "session_id": "fake-1"}' \
+    "$ts2" "$tid" > "$rd/events/$ts2-$tid-Stop.json"
+sleep 30
+"""
+
+PROFILE_TOML = """\
+name = "fakestories"
+binary = "{binary}"
+bypass_args = []
+usage_parser = "none"
+skill_tree = ".claude/skills"
+
+[hooks]
+dialect = "claude-settings-json"
+config_path = ".claude/settings.json"
+events = {{ SessionStart = "SessionStart", Stop = "Stop" }}
+"""
+
+SPEC_FOLDER = "_bmad-output/epic-1"
+CLI = [sys.executable, "-m", "bmad_loop.cli"]
+
+
+def _git(root: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(root), *args], check=True, capture_output=True, text=True)
+
+
+def _entry(story_id: str, **over) -> dict:
+    d = {"id": story_id, "title": f"Story {story_id}", "description": "does a thing"}
+    d.update(over)
+    return d
+
+
+def _scaffold(root: Path, entries: list[dict]) -> None:
+    """A committed, clean sandbox: git repo, BMAD config + artifact dirs, the
+    base-skill stubs the stories preflight requires (incl. the folder+id dispatch
+    probe), a stories.yaml + SPEC.md, the fake-CLI profile, and a stories-mode
+    policy — everything committed so the run-start worktree_clean gate passes."""
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "src.txt").write_text("original\n", encoding="utf-8")
+    (root / ".gitignore").write_text(".bmad-loop/runs/\n", encoding="utf-8")
+
+    cfg = root / "_bmad" / "bmm"
+    cfg.mkdir(parents=True)
+    (cfg / "config.yaml").write_text(
+        "implementation_artifacts: '{project-root}/_bmad-output/implementation-artifacts'\n"
+        "planning_artifacts: '{project-root}/_bmad-output/planning-artifacts'\n",
+        encoding="utf-8",
+    )
+    for sub in ("implementation-artifacts", "planning-artifacts"):
+        (root / "_bmad-output" / sub).mkdir(parents=True, exist_ok=True)
+        (root / "_bmad-output" / sub / ".keep").write_text("", encoding="utf-8")
+
+    # base skills (DEV_BASE_SKILLS) + the folder+id dispatch content probe
+    skills = root / ".claude" / "skills"
+    dev = skills / "bmad-dev-auto"
+    dev.mkdir(parents=True)
+    (dev / "SKILL.md").write_text("# bmad-dev-auto\n", encoding="utf-8")
+    (dev / "step-04-review.md").write_text("x\n", encoding="utf-8")
+    (dev / "step-01-clarify-and-route.md").write_text(
+        "This is a **folder+id dispatch** router.\n", encoding="utf-8"
+    )
+    for hunter in ("bmad-review-adversarial-general", "bmad-review-edge-case-hunter"):
+        (skills / hunter).mkdir(parents=True)
+        (skills / hunter / "SKILL.md").write_text(f"# {hunter}\n", encoding="utf-8")
+
+    folder = root / SPEC_FOLDER
+    (folder / "stories").mkdir(parents=True)
+    (folder / "SPEC.md").write_text("---\ntitle: Epic 1\n---\n# Epic 1\n", encoding="utf-8")
+    (folder / "stories.yaml").write_text(yaml.safe_dump(entries, sort_keys=False), encoding="utf-8")
+
+    fake = root / ".bmad-loop" / "fake-cli.sh"
+    fake.parent.mkdir(parents=True, exist_ok=True)
+    fake.write_text(FAKE_CLI, encoding="utf-8")
+    os.chmod(fake, 0o755)
+    profiles = root / ".bmad-loop" / "profiles"
+    profiles.mkdir(parents=True)
+    (profiles / "fakestories.toml").write_text(
+        PROFILE_TOML.format(binary=str(fake)), encoding="utf-8"
+    )
+    (root / ".bmad-loop" / "policy.toml").write_text(
+        '[adapter]\nname = "fakestories"\n\n'
+        "[review]\nenabled = false\n\n"
+        f'[stories]\nsource = "stories"\nspec_folder = "{SPEC_FOLDER}"\n',
+        encoding="utf-8",
+    )
+
+    _git(root, "init", "-q", "-b", "main")
+    _git(root, "config", "user.email", "e2e@test")
+    _git(root, "config", "user.name", "e2e")
+    _git(root, "config", "core.fsync", "none")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-q", "-m", "sandbox")
+
+
+def _run(root: Path, *args: str, timeout: float = 150) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [*CLI, args[0], "--project", str(root), *args[1:]],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        cwd=str(root),
+    )
+
+
+def _status(root: Path, story_id: str) -> str:
+    spec = root / SPEC_FOLDER / "stories" / f"{story_id}-slug.md"
+    if not spec.is_file():
+        return "pending"
+    for line in spec.read_text(encoding="utf-8").splitlines():
+        if line.startswith("status:"):
+            return line.split(":", 1)[1].strip().strip("'\"")
+    return "?"
+
+
+def _commit_count(root: Path) -> int:
+    out = subprocess.run(
+        ["git", "-C", str(root), "rev-list", "--count", "HEAD"],
+        capture_output=True,
+        text=True,
+    )
+    return int(out.stdout.strip())
+
+
+def _run_id(root: Path) -> str:
+    runs = sorted((root / ".bmad-loop" / "runs").iterdir())
+    assert runs, "no run dir created"
+    return runs[-1].name
+
+
+def test_e2e_two_story_happy_path(tmp_path):
+    root = tmp_path / "sbx"
+    _scaffold(root, [_entry("1"), _entry("2")])
+    base = _commit_count(root)
+
+    proc = _run(root, "run")
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+    assert _status(root, "1") == "done"
+    assert _status(root, "2") == "done"
+    # one squashed story commit per story above the sandbox baseline
+    assert _commit_count(root) == base + 2
+
+
+def test_e2e_spec_checkpoint_two_leg(tmp_path):
+    root = tmp_path / "sbx"
+    _scaffold(root, [_entry("1", spec_checkpoint=True)])
+    base = _commit_count(root)
+
+    # leg 1: dispatch halts after planning → run pauses at the plan checkpoint
+    proc = _run(root, "run")
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+    assert _status(root, "1") == "ready-for-dev"  # planned, not implemented
+    assert _commit_count(root) == base  # no commit yet
+
+    run_id = _run_id(root)
+    st = _run(root, "status", run_id)
+    assert "plan-checkpoint" in st.stdout.lower() or "paused" in st.stdout.lower()
+
+    # leg 2: resume re-dispatches straight to implementation → done + commit
+    resume = _run(root, "resume", run_id)
+    assert resume.returncode == 0, resume.stderr or resume.stdout
+    assert _status(root, "1") == "done"
+    assert _commit_count(root) == base + 1
+
+
+def test_e2e_blocked_resolve_redispatch(tmp_path):
+    root = tmp_path / "sbx"
+    _scaffold(root, [_entry("1"), _entry("2")])
+    (root / SPEC_FOLDER / ".block-1").write_text("", encoding="utf-8")  # story 1 poisoned
+    _git(root, "add", "-A")
+    _git(root, "commit", "-q", "-m", "poison story 1")
+    base = _commit_count(root)
+
+    # story 1 blocks → run pauses at the escalation (story 2 not leapfrogged)
+    proc = _run(root, "run")
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+    assert _status(root, "1") == "blocked"
+    assert _status(root, "2") == "pending"
+    run_id = _run_id(root)
+
+    # resolve (non-interactive) re-arms blocked → ready-for-dev + strips the halt
+    resolve = _run(root, "resolve", run_id, "--no-interactive", "--no-resume")
+    assert resolve.returncode == 0, resolve.stderr or resolve.stdout
+    assert _status(root, "1") == "ready-for-dev"
+
+    # resume re-dispatches story 1 to done and continues to story 2
+    resume = _run(root, "resume", run_id)
+    assert resume.returncode == 0, resume.stderr or resume.stdout
+    assert _status(root, "1") == "done"
+    assert _status(root, "2") == "done"
+    assert _commit_count(root) == base + 2

--- a/tests/test_stories_e2e.py
+++ b/tests/test_stories_e2e.py
@@ -15,10 +15,12 @@ adapter bypasses: arg parsing, prompt render, hook-signal completion, the
 stories read-back, git commit, and the resolve/resume dance.
 
 Covers, through the real binary: (1) two-story happy path, (2) `spec_checkpoint`
-two-leg plan-halt + resume, (4) blocked → resolve → re-dispatch. Scenarios
-(3) `done_checkpoint`, (5) worktree isolation, and (6) sprint-mode regression are
-covered deterministically at the engine level in test_stories_engine.py /
-test_engine.py; here we prove the end-to-end CLI stack.
+two-leg plan-halt + resume, (4) blocked → resolve → re-dispatch, and (6)
+sprint-mode regression (the new folder+id-capable dev skill installed, yet a
+plain sprint run drives dev → verify → commit → sprint-status advance untouched
+by the stories wiring). Scenarios (3) `done_checkpoint` and (5) worktree
+isolation are covered deterministically at the engine level in
+test_stories_engine.py; here we prove the end-to-end CLI stack.
 """
 
 from __future__ import annotations
@@ -48,6 +50,24 @@ ts=$(date +%s%N)
 mkdir -p "$rd/events"
 printf '{"ts": %s, "event": "SessionStart", "task_id": "%s", "session_id": "fake-1"}' \
     "$ts" "$tid" > "$rd/events/$ts-$tid-SessionStart.json"
+baseline=$(git rev-parse HEAD)
+
+# SPRINT mode (no BMAD_LOOP_SPEC_FOLDER in env): the folder+id-capable skill is
+# installed, but a plain sprint run must still work. Write the result artifact
+# the orchestrator scans by mtime under implementation-artifacts, make a real
+# code change, and Stop — the orchestrator (not the skill) advances sprint-status.
+if [ -z "$folder" ]; then
+    impl="_bmad-output/implementation-artifacts"
+    mkdir -p "$impl"
+    echo "impl for $story" >> src.txt
+    printf -- '---\ntitle: %s\nstatus: done\nbaseline_commit: %s\n---\n\n## Intent\n\nx\n\n## Auto Run Result\n\n- Status: done\n\nSummary: sprint.\n' \
+        "$story" "$baseline" > "$impl/spec-$story.md"
+    ts2=$(( ts + 1 ))
+    printf '{"ts": %s, "event": "Stop", "task_id": "%s", "session_id": "fake-1"}' \
+        "$ts2" "$tid" > "$rd/events/$ts2-$tid-Stop.json"
+    sleep 30
+    exit 0
+fi
 
 sdir="$folder/stories"
 mkdir -p "$sdir"
@@ -55,7 +75,6 @@ spec="$sdir/$story-slug.md"
 existing=$(ls "$sdir/$story"-*.md 2>/dev/null | head -1 || true)
 status=""
 [ -n "$existing" ] && status=$(sed -n 's/^status:[[:space:]]*//p' "$existing" | head -1 | tr -d "'\" ")
-baseline=$(git rev-parse HEAD)
 
 write_done() {
     echo "impl for $story" >> src.txt
@@ -176,6 +195,86 @@ def _scaffold(root: Path, entries: list[dict]) -> None:
     _git(root, "commit", "-q", "-m", "sandbox")
 
 
+def _scaffold_sprint(root: Path, story_key: str) -> None:
+    """A committed, clean SPRINT-mode sandbox carrying the SAME new folder+id-
+    capable bmad-dev-auto skill stub as `_scaffold` (with the folder+id dispatch
+    probe content) — the regression point: installing that skill must not disturb
+    the default sprint path. sprint-status.yaml holds one ready-for-dev story; the
+    policy has NO [stories] section, so the run is plain sprint mode."""
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "src.txt").write_text("original\n", encoding="utf-8")
+    (root / ".gitignore").write_text(".bmad-loop/runs/\n", encoding="utf-8")
+
+    cfg = root / "_bmad" / "bmm"
+    cfg.mkdir(parents=True)
+    (cfg / "config.yaml").write_text(
+        "implementation_artifacts: '{project-root}/_bmad-output/implementation-artifacts'\n"
+        "planning_artifacts: '{project-root}/_bmad-output/planning-artifacts'\n",
+        encoding="utf-8",
+    )
+    impl = root / "_bmad-output" / "implementation-artifacts"
+    for sub in ("implementation-artifacts", "planning-artifacts"):
+        (root / "_bmad-output" / sub).mkdir(parents=True, exist_ok=True)
+        (root / "_bmad-output" / sub / ".keep").write_text("", encoding="utf-8")
+
+    # the SAME new folder+id-capable skill stub the stories scaffold installs
+    skills = root / ".claude" / "skills"
+    dev = skills / "bmad-dev-auto"
+    dev.mkdir(parents=True)
+    (dev / "SKILL.md").write_text("# bmad-dev-auto\n", encoding="utf-8")
+    (dev / "step-04-review.md").write_text("x\n", encoding="utf-8")
+    (dev / "step-01-clarify-and-route.md").write_text(
+        "This is a **folder+id dispatch** router.\n", encoding="utf-8"
+    )
+    for hunter in ("bmad-review-adversarial-general", "bmad-review-edge-case-hunter"):
+        (skills / hunter).mkdir(parents=True)
+        (skills / hunter / "SKILL.md").write_text(f"# {hunter}\n", encoding="utf-8")
+
+    sprint = {
+        "generated": "01-06-2026 10:00",
+        "last_updated": "01-06-2026 10:00",
+        "project": "sandbox",
+        "project_key": "NOKEY",
+        "tracking_system": "file-system",
+        "development_status": {story_key: "ready-for-dev"},
+    }
+    (impl / "sprint-status.yaml").write_text(
+        yaml.safe_dump(sprint, sort_keys=False), encoding="utf-8"
+    )
+
+    fake = root / ".bmad-loop" / "fake-cli.sh"
+    fake.parent.mkdir(parents=True, exist_ok=True)
+    fake.write_text(FAKE_CLI, encoding="utf-8")
+    os.chmod(fake, 0o755)
+    profiles = root / ".bmad-loop" / "profiles"
+    profiles.mkdir(parents=True)
+    (profiles / "fakestories.toml").write_text(
+        PROFILE_TOML.format(binary=str(fake)), encoding="utf-8"
+    )
+    (root / ".bmad-loop" / "policy.toml").write_text(
+        '[adapter]\nname = "fakestories"\n\n'
+        "[review]\nenabled = false\n\n"
+        '[gates]\nmode = "none"\n',
+        encoding="utf-8",
+    )
+
+    _git(root, "init", "-q", "-b", "main")
+    _git(root, "config", "user.email", "e2e@test")
+    _git(root, "config", "user.name", "e2e")
+    _git(root, "config", "core.fsync", "none")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-q", "-m", "sandbox")
+
+
+def _sprint_status(root: Path, story_key: str) -> str:
+    doc = yaml.safe_load(
+        (root / "_bmad-output" / "implementation-artifacts" / "sprint-status.yaml").read_text(
+            encoding="utf-8"
+        )
+    )
+    return doc.get("development_status", {}).get(story_key, "?")
+
+
 def _run(root: Path, *args: str, timeout: float = 150) -> subprocess.CompletedProcess:
     return subprocess.run(
         [*CLI, args[0], "--project", str(root), *args[1:]],
@@ -276,3 +375,20 @@ def test_e2e_blocked_resolve_redispatch(tmp_path):
     assert _status(root, "1") == "done"
     assert _status(root, "2") == "done"
     assert _commit_count(root) == base + 2
+
+
+def test_e2e_sprint_mode_regression(tmp_path):
+    # Scenario 6 (audit MAJOR-2): the new folder+id-capable bmad-dev-auto skill is
+    # installed, but this is a plain SPRINT-mode run. It must drive dev → verify →
+    # commit and let the orchestrator advance sprint-status to done through the
+    # real CLI — unaffected by the stories wiring (the adapter's
+    # BMAD_LOOP_SPEC_FOLDER read-back branch, the per-session env exports, etc.).
+    root = tmp_path / "sbx"
+    story = "1-1-thing"
+    _scaffold_sprint(root, story)
+    base = _commit_count(root)
+
+    proc = _run(root, "run")
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+    assert _sprint_status(root, story) == "done"
+    assert _commit_count(root) == base + 1

--- a/tests/test_stories_e2e.py
+++ b/tests/test_stories_e2e.py
@@ -237,7 +237,11 @@ def test_e2e_spec_checkpoint_two_leg(tmp_path):
 
     run_id = _run_id(root)
     st = _run(root, "status", run_id)
-    assert "plan-checkpoint" in st.stdout.lower() or "paused" in st.stdout.lower()
+    # deterministic status line: `PAUSED (plan-checkpoint) — …` — assert BOTH the
+    # paused state and the specific stage, not either-or (a weak `or` would pass on
+    # any paused run regardless of stage).
+    out = st.stdout.lower()
+    assert "paused" in out and "plan-checkpoint" in out
 
     # leg 2: resume re-dispatches straight to implementation → done + commit
     resume = _run(root, "resume", run_id)

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -17,11 +17,14 @@ from rich.text import Text
 from textual.geometry import Offset
 from textual.selection import Selection
 from textual.widgets import (
+    Button,
     Checkbox,
     DataTable,
     Input,
     OptionList,
     RichLog,
+    Select,
+    Static,
     TabbedContent,
 )
 
@@ -36,8 +39,11 @@ from bmad_loop.tui.screens.modals import (
     ConfirmResumeModal,
     DecisionModal,
     DeferredEntryModal,
+    EscalationModal,
+    SpecReviewModal,
     StartRunModal,
     StartSweepModal,
+    StoryCheckpointModal,
     TextOutputModal,
 )
 from bmad_loop.tui.widgets import (
@@ -47,7 +53,12 @@ from bmad_loop.tui.widgets import (
     RunHeader,
     SelectableRichLog,
     SprintTree,
+    StoriesTable,
     journal_line,
+    pause_label,
+    pause_tag,
+    story_checkpoint_cell,
+    story_state_cell,
 )
 
 
@@ -61,9 +72,12 @@ def make_run(
     tasks: dict[str, StoryTask] | None = None,
     paused_stage: str | None = None,
     paused_reason: str | None = None,
+    paused_story_key: str | None = None,
     crashed: bool = False,
     crash_error: str | None = None,
     policy_snapshot: dict | None = None,
+    source: str = "sprint-status",
+    spec_folder: str = "",
 ) -> Path:
     run_dir = root / RUNS_DIR / run_id
     state = RunState(
@@ -75,9 +89,12 @@ def make_run(
         tasks=tasks or {},
         paused_stage=paused_stage,
         paused_reason=paused_reason,
+        paused_story_key=paused_story_key,
         crashed=crashed,
         crash_error=crash_error,
         policy_snapshot=policy_snapshot or {},
+        source=source,
+        spec_folder=spec_folder,
     )
     save_state(run_dir, state)
     if alive:
@@ -889,8 +906,10 @@ async def test_start_run_modal_launches(project, monkeypatch):
     calls = {}
     monkeypatch.setattr(launch, "tmux_available", lambda: True)
 
-    def fake_start(proj, run_id, *, epic, story, max_stories):
-        calls.update(project=proj, run_id=run_id, epic=epic, story=story, max_stories=max_stories)
+    def fake_start(proj, run_id, *, spec=None, epic, story, max_stories):
+        calls.update(
+            project=proj, run_id=run_id, spec=spec, epic=epic, story=story, max_stories=max_stories
+        )
 
     monkeypatch.setattr(launch, "start_run_detached", fake_start)
     app = BmadLoopApp(project.project)
@@ -1396,3 +1415,381 @@ async def test_resolve_refused_when_not_escalation(project, monkeypatch):
         await pilot.press("R")
         await until(pilot, lambda: any("escalation" in m for m in notifications(app)))
     assert launched == []  # warned, never launched
+
+
+# ------------------------------------------------- stories mode: board + badges
+
+
+def test_pause_tag_and_label_render():
+    assert pause_tag("plan-checkpoint").plain == "plan"
+    assert pause_tag("story-checkpoint").plain == "story"
+    assert pause_tag("escalation").plain == "esc"
+    assert pause_tag("").plain == ""  # not paused → no tag
+    label, style = pause_label("escalation")
+    assert label == "escalation" and "red" in style
+
+
+def test_story_cells_render():
+    assert story_state_cell("done").plain == "✓ done"
+    assert story_state_cell("sentinel:unresolved").plain.startswith("⚠")
+    assert story_checkpoint_cell(True, False).plain == "S·"
+    assert story_checkpoint_cell(False, True).plain == "·D"
+    assert story_checkpoint_cell(True, True).plain == "SD"
+    assert story_checkpoint_cell(False, False).plain == "··"
+
+
+def _write_stories_fixture(root: Path) -> None:
+    import yaml
+
+    folder = root / "epic-1"
+    (folder / "stories").mkdir(parents=True)
+    (folder / "SPEC.md").write_text("# Epic 1\n", encoding="utf-8")
+    (folder / "stories.yaml").write_text(
+        yaml.safe_dump(
+            [
+                {"id": "1", "title": "First story", "description": "d", "spec_checkpoint": True},
+                {"id": "2", "title": "Second story", "description": "d"},
+            ],
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    (folder / "stories" / "1-slug.md").write_text("---\nstatus: done\n---\n", encoding="utf-8")
+
+
+async def test_stories_mode_run_shows_board_and_attention(project):
+    root = project.project
+    _write_stories_fixture(root)
+    make_run(
+        root,
+        "20260611-100000-aaaa",
+        source="stories",
+        spec_folder="epic-1",
+        paused_stage="plan-checkpoint",
+        paused_reason="plan checkpoint for 2",
+    )
+    app = BmadLoopApp(root)
+    async with app.run_test() as pilot:
+        await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
+        screen = dashboard(app)
+        await until(pilot, lambda: screen.selected_run_id == "20260611-100000-aaaa")
+        stories_table = screen.query_one("#stories-table", StoriesTable)
+        sprint_tree = screen.query_one("#sprint-tree", SprintTree)
+        # the stories board replaces the sprint tree for a stories-mode run
+        await until(pilot, lambda: stories_table.display and not sprint_tree.display)
+        await until(pilot, lambda: stories_table.row_count == 2)
+        # global attention indicator + per-run pause badge
+        runs = screen.query_one("#runs", DataTable)
+        assert "need attention" in str(runs.border_title)
+        note = runs.get_cell("20260611-100000-aaaa", "note")
+        assert note.plain == "plan"
+
+
+async def test_sprint_mode_run_keeps_sprint_tree(project):
+    root = project.project
+    install_bmad_config(project)
+    write_sprint(project, {"epic-1": "in-progress", "1-1-a": "ready-for-dev"})
+    make_run(root, "20260611-100000-aaaa", finished=True)
+    app = BmadLoopApp(root)
+    async with app.run_test() as pilot:
+        await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
+        screen = dashboard(app)
+        await until(pilot, lambda: screen.selected_run_id == "20260611-100000-aaaa")
+        stories_table = screen.query_one("#stories-table", StoriesTable)
+        sprint_tree = screen.query_one("#sprint-tree", SprintTree)
+        await until(pilot, lambda: sprint_tree.display and not stories_table.display)
+
+
+# ---------------------------------------------------- HITL pause review viewers
+
+
+def _stories_paused_run(
+    root: Path,
+    *,
+    stage: str,
+    story_key: str = "1",
+    spec_status: str = "ready-for-dev",
+    spec_checkpoint: bool = True,
+    done_checkpoint: bool = False,
+    commit_sha: str = "",
+    blocked_result: str = "",
+    sentinel: bool = False,
+) -> tuple[Path, Path]:
+    """A stories-mode run paused at `stage`, with the id-keyed story spec on disk
+    and a StoryTask pointing at it. Returns (run_dir, spec_path)."""
+    import yaml
+
+    folder = root / "epic-1"
+    (folder / "stories").mkdir(parents=True, exist_ok=True)
+    (folder / "SPEC.md").write_text("# Epic 1\n", encoding="utf-8")
+    (folder / "stories.yaml").write_text(
+        yaml.safe_dump(
+            [
+                {
+                    "id": story_key,
+                    "title": f"Story {story_key}",
+                    "description": "does a thing",
+                    "spec_checkpoint": spec_checkpoint,
+                    "done_checkpoint": done_checkpoint,
+                }
+            ],
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    slug = "unresolved" if sentinel else "slug"
+    spec = folder / "stories" / f"{story_key}-{slug}.md"
+    body = f"---\nstatus: {spec_status}\n---\n\n# plan for {story_key}\n"
+    if blocked_result:
+        body += f"\n## Auto Run Result\n\n- Status: blocked\n\n{blocked_result}\n"
+    spec.write_text(body, encoding="utf-8")
+    task = StoryTask(story_key=story_key, epic=0, phase=Phase.DEV_VERIFY)
+    task.spec_file = str(spec)
+    if commit_sha:
+        task.commit_sha = commit_sha
+    run_dir = make_run(
+        root,
+        "20260611-100000-aaaa",
+        source="stories",
+        spec_folder="epic-1",
+        paused_stage=stage,
+        paused_reason=f"{stage} for {story_key}",
+        paused_story_key=story_key,
+        tasks={story_key: task},
+    )
+    return run_dir, spec
+
+
+async def _open_review(app, pilot, modal_type):
+    await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
+    await until(pilot, lambda: dashboard(app).selected_run_id is not None)
+    await pilot.press("p")
+    await until(pilot, lambda: isinstance(app.screen, modal_type))
+
+
+async def test_plan_checkpoint_approve_resumes(project, monkeypatch):
+    calls: list[str] = []
+    monkeypatch.setattr(launch, "tmux_available", lambda: True)
+    monkeypatch.setattr(launch, "resume_detached", lambda proj, rid: calls.append(rid))
+    monkeypatch.setattr(data, "liveness", lambda run_dir: "dead")
+    _stories_paused_run(project.project, stage="plan-checkpoint")
+    app = BmadLoopApp(project.project)
+    async with app.run_test() as pilot:
+        await _open_review(app, pilot, SpecReviewModal)
+        await pilot.click(await ready(pilot, "#act-approve"))
+        await until(pilot, lambda: calls == ["20260611-100000-aaaa"])
+
+
+async def test_plan_checkpoint_replan_resets_and_resumes(project, monkeypatch):
+    from bmad_loop import devcontract
+
+    calls: list[str] = []
+    resets: list[tuple] = []
+    strips: list[Path] = []
+    monkeypatch.setattr(launch, "tmux_available", lambda: True)
+    monkeypatch.setattr(launch, "resume_detached", lambda proj, rid: calls.append(rid))
+    monkeypatch.setattr(data, "liveness", lambda run_dir: "dead")
+    monkeypatch.setattr(
+        devcontract, "reset_spec_status", lambda p, s: resets.append((p, s)) or True
+    )
+    monkeypatch.setattr(devcontract, "strip_auto_run_result", lambda p: strips.append(p) or True)
+    _run_dir, spec = _stories_paused_run(project.project, stage="plan-checkpoint")
+    app = BmadLoopApp(project.project)
+    async with app.run_test() as pilot:
+        await _open_review(app, pilot, SpecReviewModal)
+        await pilot.click(await ready(pilot, "#act-replan"))
+        await until(pilot, lambda: calls == ["20260611-100000-aaaa"])
+        assert resets == [(spec, "draft")]
+        assert strips == [spec]
+
+
+async def test_story_checkpoint_continue_resumes(project, monkeypatch):
+    calls: list[str] = []
+    monkeypatch.setattr(launch, "tmux_available", lambda: True)
+    monkeypatch.setattr(launch, "resume_detached", lambda proj, rid: calls.append(rid))
+    monkeypatch.setattr(data, "liveness", lambda run_dir: "dead")
+    _stories_paused_run(
+        project.project,
+        stage="story-checkpoint",
+        spec_status="done",
+        spec_checkpoint=False,
+        done_checkpoint=True,
+        commit_sha="abc1234def5678",
+    )
+    app = BmadLoopApp(project.project)
+    async with app.run_test() as pilot:
+        await _open_review(app, pilot, StoryCheckpointModal)
+        await pilot.click(await ready(pilot, "#act-continue"))
+        await until(pilot, lambda: calls == ["20260611-100000-aaaa"])
+
+
+async def test_story_checkpoint_stop_marks_stopped(project, monkeypatch):
+    from bmad_loop import runs
+
+    stops: list[Path] = []
+    monkeypatch.setattr(launch, "tmux_available", lambda: True)
+    monkeypatch.setattr(data, "liveness", lambda run_dir: "dead")
+    monkeypatch.setattr(runs, "stop_run", lambda rd: stops.append(rd) or True)
+    monkeypatch.setattr(launch, "kill_ctl_window", lambda rid: None)
+    _stories_paused_run(
+        project.project,
+        stage="story-checkpoint",
+        spec_status="done",
+        spec_checkpoint=False,
+        done_checkpoint=True,
+    )
+    app = BmadLoopApp(project.project)
+    async with app.run_test() as pilot:
+        await _open_review(app, pilot, StoryCheckpointModal)
+        await pilot.click(await ready(pilot, "#act-stop"))
+        await until(pilot, lambda: len(stops) == 1)
+
+
+async def test_escalation_rearm_resumes_when_resolution_ready(project, monkeypatch):
+    from bmad_loop import resolve, runs
+
+    calls: list[str] = []
+    rearms: list[str] = []
+    monkeypatch.setattr(launch, "tmux_available", lambda: True)
+    monkeypatch.setattr(launch, "resume_detached", lambda proj, rid: calls.append(rid))
+    monkeypatch.setattr(data, "liveness", lambda run_dir: "dead")
+    monkeypatch.setattr(
+        runs, "rearm_escalation", lambda rd, sk: rearms.append(sk) or "ready-for-dev"
+    )
+    run_dir, _spec = _stories_paused_run(
+        project.project,
+        stage="escalation",
+        spec_status="blocked",
+        spec_checkpoint=False,
+        blocked_result="Blocked: needs a human decision on the auth scheme.",
+    )
+    marker = resolve.resolution_path(run_dir, "1")
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text("{}", encoding="utf-8")
+    app = BmadLoopApp(project.project)
+    async with app.run_test() as pilot:
+        await _open_review(app, pilot, EscalationModal)
+        # story context + blocking condition were resolved from stories.yaml + the spec
+        assert app.screen._description == "does a thing"
+        assert "Auto Run Result" in app.screen._blocking
+        await pilot.click(await ready(pilot, "#act-rearm"))
+        await until(pilot, lambda: rearms == ["1"] and calls == ["20260611-100000-aaaa"])
+
+
+async def test_escalation_rearm_disabled_without_resolution(project, monkeypatch):
+    monkeypatch.setattr(data, "liveness", lambda run_dir: "dead")
+    _stories_paused_run(
+        project.project,
+        stage="escalation",
+        spec_status="blocked",
+        spec_checkpoint=False,
+        blocked_result="Blocked.",
+    )
+    app = BmadLoopApp(project.project)
+    async with app.run_test() as pilot:
+        await _open_review(app, pilot, EscalationModal)
+        await ready(pilot, "#act-rearm")
+        assert app.screen.query_one("#act-rearm", Button).disabled
+
+
+async def test_gate_pause_resume(project, monkeypatch):
+    calls: list[str] = []
+    monkeypatch.setattr(launch, "tmux_available", lambda: True)
+    monkeypatch.setattr(launch, "resume_detached", lambda proj, rid: calls.append(rid))
+    monkeypatch.setattr(data, "liveness", lambda run_dir: "dead")
+    spec = project.project / "spec-1-1-a.md"
+    spec.write_text("---\nstatus: ready-for-dev\n---\n# finalized spec\n", encoding="utf-8")
+    task = StoryTask(story_key="1-1-a", epic=1, phase=Phase.DEV_VERIFY)
+    task.spec_file = str(spec)
+    make_run(
+        project.project,
+        "20260611-100000-aaaa",
+        paused_stage="spec-approval",
+        paused_reason="awaiting spec approval",
+        paused_story_key="1-1-a",
+        tasks={"1-1-a": task},
+    )
+    app = BmadLoopApp(project.project)
+    async with app.run_test() as pilot:
+        await _open_review(app, pilot, SpecReviewModal)
+        await pilot.click(await ready(pilot, "#act-resume"))
+        await until(pilot, lambda: calls == ["20260611-100000-aaaa"])
+
+
+async def test_start_run_modal_stories_source_launches(project, monkeypatch):
+    calls: dict = {}
+    monkeypatch.setattr(launch, "tmux_available", lambda: True)
+
+    def fake_start(proj, run_id, *, spec=None, epic, story, max_stories):
+        calls.update(spec=spec, epic=epic, story=story)
+
+    monkeypatch.setattr(launch, "start_run_detached", fake_start)
+    app = BmadLoopApp(project.project)
+    async with app.run_test() as pilot:
+        await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
+        await pilot.press("r")
+        await until(pilot, lambda: isinstance(app.screen, StartRunModal))
+        await ready(pilot, "#ok")
+        app.screen.query_one("#source", Select).value = "stories"
+        app.screen.query_one("#spec-folder", Input).value = "epic-1"
+        await pilot.pause()
+        await pilot.click("#ok")
+        await until(pilot, lambda: bool(calls))
+        assert calls["spec"] == "epic-1"
+
+
+async def test_start_run_modal_stories_preview_validates(project, monkeypatch):
+    # action_start_run bails on _tmux_missing() before it can push the modal, and
+    # the Windows CI matrix has no tmux on PATH — every StartRunModal test stubs
+    # this out so the modal opens (its absence here was the all-Windows timeout).
+    monkeypatch.setattr(launch, "tmux_available", lambda: True)
+    _write_stories_fixture(project.project)  # epic-1 with two stories, 1 done
+    app = BmadLoopApp(project.project)
+    async with app.run_test() as pilot:
+        await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
+        await pilot.press("r")
+        await until(pilot, lambda: isinstance(app.screen, StartRunModal))
+        await ready(pilot, "#preview-body")
+        modal = app.screen
+        body = modal.query_one("#preview-body", Static)
+
+        # Switch to stories mode with a spec folder. A programmatic reactive
+        # `.value` set posts its Changed from outside the app's message pump, so
+        # invoke the same handler the framework routes to directly — the preview
+        # projection is asserted synchronously, with no dependence on async Changed
+        # delivery, and the on_input_changed/on_select_changed routing is covered.
+        modal.query_one("#source", Select).value = "stories"
+        spec_input = modal.query_one("#spec-folder", Input)
+        spec_input.value = "epic-1"
+        modal.on_input_changed(Input.Changed(spec_input, "epic-1"))
+        rendered = str(body.render())
+        assert "2 stories" in rendered
+        # checkpoint markers + live disk state surfaced in the preview
+        assert "(done)" in rendered  # story 1's on-disk spec status
+        assert "[spec]" in rendered  # story 1's spec_checkpoint marker
+
+        # a Changed from an unrelated input is ignored (route guard), and the
+        # source select drives the preview back to the sprint-mode default.
+        modal.on_input_changed(Input.Changed(modal.query_one("#epic", Input), "9"))
+        assert "2 stories" in str(body.render())
+        source = modal.query_one("#source", Select)
+        source.value = "sprint-status"
+        modal.on_select_changed(Select.Changed(source, "sprint-status"))
+        assert "sprint mode" in str(body.render())
+
+
+async def test_start_run_modal_stories_source_blank_folder_errors(project, monkeypatch):
+    calls: list = []
+    monkeypatch.setattr(launch, "tmux_available", lambda: True)
+    monkeypatch.setattr(launch, "start_run_detached", lambda *a, **kw: calls.append(a))
+    app = BmadLoopApp(project.project)
+    async with app.run_test() as pilot:
+        await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
+        await pilot.press("r")
+        await until(pilot, lambda: isinstance(app.screen, StartRunModal))
+        await ready(pilot, "#ok")
+        app.screen.query_one("#source", Select).value = "stories"  # no spec folder
+        await pilot.pause()
+        await pilot.click("#ok")
+        await until(pilot, lambda: any("needs a spec folder" in m for m in notifications(app)))
+        assert not calls

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1512,6 +1512,7 @@ def _stories_paused_run(
     spec_checkpoint: bool = True,
     done_checkpoint: bool = False,
     commit_sha: str = "",
+    review_cycle: int = 0,
     blocked_result: str = "",
     sentinel: bool = False,
 ) -> tuple[Path, Path]:
@@ -1545,6 +1546,7 @@ def _stories_paused_run(
     spec.write_text(body, encoding="utf-8")
     task = StoryTask(story_key=story_key, epic=0, phase=Phase.DEV_VERIFY)
     task.spec_file = str(spec)
+    task.review_cycle = review_cycle
     if commit_sha:
         task.commit_sha = commit_sha
     run_dir = make_run(
@@ -1643,6 +1645,37 @@ async def test_story_checkpoint_stop_marks_stopped(project, monkeypatch):
         await _open_review(app, pilot, StoryCheckpointModal)
         await pilot.click(await ready(pilot, "#act-stop"))
         await until(pilot, lambda: len(stops) == 1)
+
+
+def test_checkpoint_gate_line_pluralization():
+    # The gate line is derived, not hardcoded — and pluralizes the real cycle count.
+    f = BmadLoopApp._checkpoint_gate_line
+    assert f(0) == "verify + review gates passed · no follow-up review cycles"
+    assert f(1) == "verify + review gates passed · 1 follow-up review cycle"
+    assert f(3) == "verify + review gates passed · 3 follow-up review cycles"
+
+
+async def test_story_checkpoint_card_surfaces_real_review_cycles(project, monkeypatch):
+    # audit item 13: the card's gate line must reflect the task's real
+    # review_cycle, never the old blanket "verification passed" string.
+    monkeypatch.setattr(launch, "tmux_available", lambda: True)
+    monkeypatch.setattr(data, "liveness", lambda run_dir: "dead")
+    _stories_paused_run(
+        project.project,
+        stage="story-checkpoint",
+        spec_status="done",
+        spec_checkpoint=False,
+        done_checkpoint=True,
+        commit_sha="abc1234def5678",
+        review_cycle=2,
+    )
+    app = BmadLoopApp(project.project)
+    async with app.run_test() as pilot:
+        await _open_review(app, pilot, StoryCheckpointModal)
+        line = app.screen._verify_line
+        assert "verify + review gates passed" in line
+        assert "2 follow-up review cycles" in line
+        assert "verification passed" not in line
 
 
 async def test_escalation_rearm_resumes_when_resolution_ready(project, monkeypatch):

--- a/tests/test_tui_data.py
+++ b/tests/test_tui_data.py
@@ -746,6 +746,63 @@ def test_sprint_overview_unavailable(tmp_path, project):
     assert data.sprint_overview(project.project) is None
 
 
+# ------------------------------------------------- stories mode: pause + board
+
+
+def test_discover_runs_reports_pause_stage(tmp_path):
+    from bmad_loop.model import PAUSE_PLAN_CHECKPOINT
+
+    make_run(
+        tmp_path,
+        "20260101-000000-aaaa",
+        paused_reason="plan checkpoint for 1",
+        paused_stage=PAUSE_PLAN_CHECKPOINT,
+    )
+    info = data.discover_runs(tmp_path)[0]
+    assert info.status == data.PAUSED
+    assert info.paused_stage == PAUSE_PLAN_CHECKPOINT
+
+
+def test_discover_runs_pause_stage_blank_when_not_paused(tmp_path):
+    # a finished run keeps its last paused_stage in state; it must not badge.
+    make_run(tmp_path, "20260101-000000-aaaa", finished=True, paused_stage="plan-checkpoint")
+    info = data.discover_runs(tmp_path)[0]
+    assert info.status == data.FINISHED
+    assert info.paused_stage == ""
+
+
+def _write_stories(folder: Path, entries: list[dict]) -> None:
+    import yaml
+
+    (folder / "stories").mkdir(parents=True, exist_ok=True)
+    (folder / "stories.yaml").write_text(yaml.safe_dump(entries, sort_keys=False))
+
+
+def test_stories_overview_reads_board(tmp_path):
+    folder = tmp_path / "epic-1"
+    _write_stories(
+        folder,
+        [
+            {"id": "1", "title": "First", "description": "d", "spec_checkpoint": True},
+            {"id": "2", "title": "Second", "description": "d", "done_checkpoint": True},
+        ],
+    )
+    (folder / "stories" / "1-slug.md").write_text("---\nstatus: done\n---\n", encoding="utf-8")
+    rows = data.stories_overview(tmp_path, "epic-1")
+    assert rows is not None
+    assert [(r.id, r.label) for r in rows] == [("1", "done"), ("2", "pending")]
+    assert rows[0].spec_checkpoint and rows[1].done_checkpoint
+
+
+def test_stories_overview_none_when_unavailable(tmp_path):
+    assert data.stories_overview(tmp_path, "") is None  # no folder pinned
+    assert data.stories_overview(tmp_path, "missing") is None  # no stories.yaml
+    bad = tmp_path / "bad"
+    bad.mkdir()
+    (bad / "stories.yaml").write_text("not: a list\n", encoding="utf-8")
+    assert data.stories_overview(tmp_path, "bad") is None  # invalid manifest, no raise
+
+
 # ------------------------------------------------------------- deferred work
 
 

--- a/tests/test_tui_launch.py
+++ b/tests/test_tui_launch.py
@@ -118,6 +118,23 @@ def test_start_run_detached_argv(fake_run, tmp_path: Path):
     assert "detach-client" in shell
 
 
+def test_start_run_detached_argv_stories(fake_run, tmp_path: Path):
+    launch.start_run_detached(tmp_path, "RID", spec="_bmad-output/epic-1")
+    shell = fake_run.by_verb("new-window")[0][-1]
+    assert (
+        expected_cli(
+            "run",
+            "--project",
+            str(tmp_path),
+            "--run-id",
+            "RID",
+            "--spec",
+            "_bmad-output/epic-1",
+        )
+        in shell
+    )
+
+
 def test_start_run_omits_blank_filters(fake_run, tmp_path: Path):
     launch.start_run_detached(tmp_path, "RID")
     shell = fake_run.by_verb("new-window")[0][-1]


### PR DESCRIPTION
Phase 4 of the spec-to-loop / stories-mode work: the **TUI human-in-the-loop surface, the prose docs, and the full sandbox E2E matrix**. **Stacked on #77** — base is `feat/spec-to-loop-stories-phase2`, not `main`. Review/merge #65 → #77 → this, in order.

## Why this is split from #77

The original single Phase-4 commit bundled the presentation layer with shared infrastructure the Phase-2/3 code already depends on. That infrastructure — `stories.resolve_spec_folder` + the `story_rows` / `StoryRow` / `state_label` status projection, and the mode-aware `bmad-loop status` + `run --dry-run` refactor onto `story_rows` — was moved down onto **#77** (the code that calls it: `validate`, the resolve context, the engine folder render). This branch keeps only what is genuinely the read/observe surface plus the E2E tests, so each PR reviews as one honest scope.

## TUI (every action calls the same CLI code paths — no duplicated logic)

- Stories board replaces the sprint tree for a stories-mode run (state glyph, id, independent spec/done checkpoint cell, title); per-run pause-kind badge + a global "⚑ N need attention" count on the runs table.
- `p` opens the stage-appropriate viewer: plan-checkpoint spec review (Approve & resume / Request replan), story-checkpoint summary card (Continue / Stop), escalation with story context + blocking condition + sentinel indicator (Resolve / Re-arm & resume), and a gate spec viewer the spec-approval/epic pauses reuse.
- Start-run modal gains a source select (prefilled from `[stories]`) + spec-folder input with a live schedule preview.
- Wave-1b item 10 (the parts targeting Phase-4 code): `_do_replan` checks liveness **before** mutating the spec and honors the `reset_spec_status` bool (MINOR-D); `_sentinel_kind` guards a race-window `OSError` (NOTE-9).

## Docs

README dual-flow section + command/keybinding updates, `docs/FEATURES.md`, `docs/tui-guide.md` HITL pages, CHANGELOG `[Unreleased]`, and the "per-epic gates are inert in stories mode" note (README + FEATURES).

## E2E matrix — honest coverage map

`tests/test_stories_e2e.py` drives the **real** `run/resume/resolve` binaries through **real tmux** with a scripted fake `claude` (no LLM, deterministic):

- **Full sandbox CLI E2E:** (1) two-story happy path, (2) `spec_checkpoint` two-leg plan-halt + resume, (4) blocked → resolve → re-dispatch, **(6) sprint-mode regression** — the new folder+id-capable dev skill installed, yet a plain sprint run drives dev → verify → commit → sprint-status advance untouched by the stories wiring.
- **Engine-level (deterministic, documented as such in `test_stories_engine.py`):** (3) `done_checkpoint`, (5) worktree isolation.

This corrects the original Phase-4 commit's "all six scenarios covered" overclaim: scenario 6 previously existed only as a preflight-function unit test on stub markers (audit MAJOR-2); it is now a real sandbox run.

## Session-4 fixes carried here

- **Story-checkpoint card no longer hardcodes "✓ verification passed"** (audit: it was a constant, not read from real state). The task model persists no per-command verify output, so the card now derives its gate line from real task state — the verify + review gates the commit cleared, plus the recorded follow-up review-cycle count — and falls back to "no commit recorded" rather than assert an outcome it cannot back.

## Tests

TUI key-press / modal tests (stories board, the `p` viewers, start-run preview), `test_tui_data` / `test_tui_launch`, the E2E matrix above, and the new story-checkpoint-card unit + modal tests. Full suite green; `trunk check` (no filter) clean. (The 2 local `test_module_skills_sync[bmad-loop-setup]` failures are pre-existing gitignored-workspace drift and skip on CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
