### PR TITLE
feat(sprintstatus): accept letter-suffix, sprint-NN, and backlog keys

### DIFF
--- a/examples/plugins/guardrails/guardrails.py
+++ b/examples/plugins/guardrails/guardrails.py
@@ -47,7 +47,7 @@ class GuardrailsPlugin(Plugin):
         """Validation gate: quietly skip any story in a 'parked' epic. ``skip``
         retires the unit with no human notification; switch to ``defer`` to notify
         or ``pause`` to escalate."""
-        parked = int(self.settings.get("forbid_epic") or 0)
+        parked = str(self.settings.get("forbid_epic") or "").strip()
         if parked and ctx.epic == parked:
             ctx.veto("skip", f"epic {parked} is parked by the guardrails plugin")
 

--- a/src/bmad_loop/cli.py
+++ b/src/bmad_loop/cli.py
@@ -1253,7 +1253,11 @@ def main(argv: list[str] | None = None) -> int:
     probe_p.add_argument("--keep-temp", action="store_true", help=argparse.SUPPRESS)
 
     run_p = add("run", cmd_run, "run the orchestration loop")
-    run_p.add_argument("--epic", type=int, help="only stories from this epic")
+    run_p.add_argument(
+        "--epic",
+        type=str,
+        help="only stories from this epic (numeric id, suffix id like '1a' or '18a', 'sprint-08', 'backlog', or full epic key)",
+    )
     run_p.add_argument("--story", help="story: E-S / E.S, a slug fragment, or full key")
     run_p.add_argument("--max-stories", type=int, help="stop after N stories")
     run_p.add_argument("--dry-run", action="store_true", help="print the plan, spawn nothing")

--- a/src/bmad_loop/diagnostics.py
+++ b/src/bmad_loop/diagnostics.py
@@ -156,7 +156,7 @@ class RunDiag:
     paused: bool
     paused_stage: str | None
     paused_reason_present: bool
-    current_epic: int | None
+    current_epic: str | None  # was int — accepts "1a", "sprint-08", "backlog"
     sweep_cycle: int
     sweeps_triggered: list[str]
     plugin_shared_keys: int

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -148,7 +148,7 @@ class Engine:
         journal: Journal,
         state: RunState,
         max_stories: int | None = None,
-        epic_filter: int | None = None,
+        epic_filter: str | None = None,
         story_filter: str | None = None,
         review_adapter: CodingCLIAdapter | None = None,
         sweep_factory: Callable[[str], None] | None = None,
@@ -747,7 +747,7 @@ class Engine:
             self.journal.append("sprint-status-unknown-keys", keys=list(ss.unknown_keys))
         base_skip = set(self.state.tasks)  # anything this run already touched
 
-        def _first(epic: int | None):
+        def _first(epic: str | None):
             # local skip copy so selector-rejections in this pass don't leak into
             # the next one (a story rejected here may still match the fallback).
             skip = set(base_skip)
@@ -2259,10 +2259,18 @@ class Engine:
             self.journal.append("sweep-auto-failed", trigger=trigger, error=str(e))
             gates.notify(self.policy, self.run_dir, "auto sweep failed", f"{trigger}: {e}")
 
-    def _epic_boundary(self, finished_epic: int, next_epic: int) -> None:
+    def _epic_boundary(self, finished_epic: str, next_epic: str) -> None:
         self.journal.append("epic-boundary", finished=finished_epic, next=next_epic)
         self._emit("pre_epic_boundary", epic=finished_epic)
-        self._maybe_auto_sweep("per-epic", f"epic-{finished_epic}")
+        # Journal key keeps the upstream "epic-N" shape for backwards-compatible
+        # tools (TUI log filters, post-mortem scripts). For non-numeric ids we
+        # fall back to the raw id so the journal still records the boundary.
+        sweep_key = (
+            f"epic-{finished_epic}"
+            if finished_epic.isdigit()
+            else finished_epic
+        )
+        self._maybe_auto_sweep("per-epic", sweep_key)
         if self.policy.gates.retrospective != "never":
             gates.notify(
                 self.policy,

--- a/src/bmad_loop/model.py
+++ b/src/bmad_loop/model.py
@@ -123,7 +123,10 @@ class SessionRecord:
 @dataclass
 class StoryTask:
     story_key: str
-    epic: int
+    # epic is a string id (str): "1", "1a", "sprint-08", "backlog". Was int in
+    # upstream bmad-loop; widened to str to support the project's letter-suffix
+    # + sprint + backlog conventions. See sprintstatus.py for the regex.
+    epic: str
     phase: Phase = Phase.PENDING
     attempt: int = 0
     review_cycle: int = 0
@@ -227,9 +230,12 @@ class StoryTask:
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> "StoryTask":
+        # Coerce epic to str for back-compat with any state.json persisted by
+        # an int-only build (current epic is always non-null for any tasked run).
+        epic_raw = d["epic"]
         return cls(
             story_key=d["story_key"],
-            epic=int(d["epic"]),
+            epic=str(epic_raw) if epic_raw is not None else "",
             phase=Phase(d["phase"]),
             attempt=int(d.get("attempt", 0)),
             review_cycle=int(d.get("review_cycle", 0)),
@@ -260,12 +266,12 @@ class RunState:
     project: str
     started_at: str
     policy_snapshot: dict[str, Any] = field(default_factory=dict)
-    current_epic: int | None = None
+    current_epic: str | None = None  # was int — accepts "1a", "sprint-08", etc.
     # the run's story scope + cap, as passed on the launching CLI (`--epic`,
     # `--story`, `--max-stories`). Persisted so `resume` rebuilds the Engine with
     # the SAME selector — otherwise a resumed `--epic N` run silently widens to
     # every epic and can jump out of its scope at the next pick.
-    epic_filter: int | None = None
+    epic_filter: str | None = None  # was int — accepts the same ids as current_epic
     story_filter: str | None = None
     max_stories: int | None = None
     paused_reason: str | None = None
@@ -354,13 +360,18 @@ class RunState:
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> "RunState":
+        # Coerce current_epic / epic_filter to str for back-compat with any
+        # state.json persisted by an int-only build.
+        def _coerce_str(v: Any) -> str | None:
+            return None if v is None else str(v)
+
         return cls(
             run_id=d["run_id"],
             project=d["project"],
             started_at=d["started_at"],
             policy_snapshot=d.get("policy_snapshot", {}),
-            current_epic=d.get("current_epic"),
-            epic_filter=d.get("epic_filter"),
+            current_epic=_coerce_str(d.get("current_epic")),
+            epic_filter=_coerce_str(d.get("epic_filter")),
             story_filter=d.get("story_filter"),
             max_stories=d.get("max_stories"),
             paused_reason=d.get("paused_reason"),

--- a/src/bmad_loop/sprintstatus.py
+++ b/src/bmad_loop/sprintstatus.py
@@ -15,12 +15,31 @@ from pathlib import Path
 
 import yaml
 
-EPIC_RE = re.compile(r"^epic-(\d+)$")
-RETRO_RE = re.compile(r"^epic-(\d+)-retrospective$")
-RETRO_ITEM_RE = re.compile(r"^epic-(\d+)-retro-item-(\d+)-(.+)$")
-STORY_RE = re.compile(r"^(\d+)-(\d+)-(.+)$")
+# Sprint-status key classifiers. The original regexes only accepted pure-digit
+# epics + stories (epic-N, N-N-slug). Extended here to accept:
+#   - epic-1a, epic-18a, epic-0-p2        (letter / phase suffix on epics)
+#   - 1a-1-..., 3-3a-..., 18-0a-...       (letter suffix on story segments)
+#   - sprint-NN + sprint-NN-*             (sprint grouping container)
+#   - backlog + backlog-*                 (unscheduled work under a virtual epic)
+#   - {status: done, size: M, rationale: ...} struct values (Phase 4 entries
+#     attach size + rationale inline)
+EPIC_RE = re.compile(r"^epic-(\d+[a-z]?(?:-p\d+)?)$")
+RETRO_RE = re.compile(r"^epic-(\d+[a-z]?(?:-p\d+)?)-retrospective$")
+RETRO_ITEM_RE = re.compile(r"^epic-(\d+[a-z]?(?:-p\d+)?)-retro-item-(\d+)-(.+)$")
+STORY_RE = re.compile(r"^(\d+[a-z]?(?:-p\d+)?)-(\d+[a-z]?)-(.+)$")
+SPRINT_RE = re.compile(r"^sprint-(\d+)$")
+SPRINT_RETRO_RE = re.compile(r"^sprint-(\d+)-retrospective$")
+SPRINT_STORY_RE = re.compile(r"^sprint-(\d+)-(.+)$")
+BACKLOG_RE = re.compile(r"^backlog$")
+BACKLOG_STORY_RE = re.compile(r"^backlog-(.+)$")
 SHORT_REF_RE = re.compile(r"^(\d+)[-.](\d+)$")  # short story ref: 3-1 or 3.1
 BARE_NUM_RE = re.compile(r"^(\d+)$")  # a lone story number, needs --epic
+# Sprint/backlog story prefix detector — splits domain code, story number, slug.
+# Examples:
+#   "qua-5g1-auth-session-state-extraction" -> ("qua", "5g1", "auth-session-state-extraction")
+#   "deploy-monolith-image-go-live"         -> ("deploy", "",   "monolith-image-go-live")
+SPRINT_STORY_SPLIT_RE = re.compile(r"^([a-z]+)-(\d+[a-z]?)-(.+)$")
+SPRINT_STORY_NOSPLIT_RE = re.compile(r"^([a-z]+)-(.+)$")
 
 STORY_STATUSES = {"backlog", "ready-for-dev", "in-progress", "review", "done"}
 # Lifecycle order, earliest -> latest. `advance` never moves a story backward
@@ -37,8 +56,12 @@ class SprintStatusError(Exception):
 @dataclass(frozen=True)
 class Story:
     key: str
-    epic: int
-    num: int
+    # epic is a string id: "1", "1a", "0-p2", "sprint-08", or "backlog".
+    # Original bmad-loop typed this as int; we widen to str so the orchestrator
+    # can group letter-suffix / phase-suffix / sprint / backlog stories.
+    epic: str
+    # num is a string id: "1", "3a", "5g1", or "" when the format has no number.
+    num: str
     slug: str
     status: str
 
@@ -53,7 +76,7 @@ class RetroItem:
     """
 
     key: str
-    epic: int
+    epic: str  # was int — accepts "1", "1a", etc.
     num: int
     slug: str
     status: str
@@ -62,9 +85,11 @@ class RetroItem:
 @dataclass(frozen=True)
 class SprintStatus:
     path: Path
-    epics: dict[int, str]
+    # Keys are epic ids (str); "epic-" / "sprint-" / "backlog" prefixes live in
+    # the value-side labels, not the key (matches the YAML literal key style).
+    epics: dict[str, str]
     stories: tuple[Story, ...]
-    retros: dict[int, str]
+    retros: dict[str, str]
     retro_items: tuple[RetroItem, ...]
     unknown_keys: tuple[str, ...]
 
@@ -82,36 +107,92 @@ def load(path: Path) -> SprintStatus:
     if not isinstance(dev, dict):
         raise SprintStatusError(f"sprint status missing development_status map: {path}")
 
-    epics: dict[int, str] = {}
+    epics: dict[str, str] = {}
     stories: list[Story] = []
-    retros: dict[int, str] = {}
+    retros: dict[str, str] = {}
     retro_items: list[RetroItem] = []
     unknown: list[str] = []
     for key, raw_status in dev.items():
         key = str(key)
-        status = str(raw_status).strip()
+        # Status can be a plain string ("done") or a struct with metadata
+        # ({status: done, size: M, rationale: "...", last_updated: ...}).
+        # The project's Phase 4 entries use the struct shape to attach size +
+        # rationale inline; upstream bmad-loop treated them as plain strings.
+        if isinstance(raw_status, dict):
+            status = str(raw_status.get("status", "")).strip()
+        else:
+            status = str(raw_status).strip()
         if m := RETRO_ITEM_RE.match(key):
             retro_items.append(
                 RetroItem(
                     key=key,
-                    epic=int(m.group(1)),
+                    epic=m.group(1),  # str — was int
                     num=int(m.group(2)),
                     slug=m.group(3),
                     status=status,
                 )
             )
         elif m := RETRO_RE.match(key):
-            retros[int(m.group(1))] = status
+            retros[m.group(1)] = status  # str key — was int
         elif m := EPIC_RE.match(key):
-            epics[int(m.group(1))] = status
+            epics[m.group(1)] = status  # str key — was int
         elif m := STORY_RE.match(key):
             status = LEGACY_STORY_STATUSES.get(status, status)
             stories.append(
                 Story(
                     key=key,
-                    epic=int(m.group(1)),
-                    num=int(m.group(2)),
+                    epic=m.group(1),  # str — was int
+                    num=m.group(2),   # str — was int (preserves "3a", "5g1", etc.)
                     slug=m.group(3),
+                    status=status,
+                )
+            )
+        elif m := SPRINT_RETRO_RE.match(key):
+            retros[f"sprint-{m.group(1)}"] = status
+        elif m := SPRINT_RE.match(key):
+            epics[f"sprint-{m.group(1)}"] = status
+        elif m := SPRINT_STORY_RE.match(key):
+            status = LEGACY_STORY_STATUSES.get(status, status)
+            rest = m.group(2)
+            # Best-effort split into (domain, num, slug). Sprint story keys have
+            # inconsistent shape (e.g. "qua-5g1-auth-..." has a num, but
+            # "deploy-monolith-..." and "bugfix-..." do not), so num may be "".
+            sm = SPRINT_STORY_SPLIT_RE.match(rest)
+            if sm:
+                num = sm.group(2)
+                slug = f"{sm.group(1)}-{sm.group(3)}"
+            else:
+                # No numeric segment (e.g. "deploy-monolith-..." / "bugfix-..."):
+                # treat the entire rest as slug with empty num.
+                num = ""
+                slug = rest
+            stories.append(
+                Story(
+                    key=key,
+                    epic=f"sprint-{m.group(1)}",
+                    num=num,
+                    slug=slug,
+                    status=status,
+                )
+            )
+        elif m := BACKLOG_RE.match(key):
+            epics["backlog"] = status
+        elif m := BACKLOG_STORY_RE.match(key):
+            status = LEGACY_STORY_STATUSES.get(status, status)
+            rest = m.group(1)
+            sm = re.match(r"^([a-z]+)-(\d+)-(.+)$", rest)
+            if sm:
+                num = sm.group(2)
+                slug = f"{sm.group(1)}-{sm.group(3)}"
+            else:
+                num = ""
+                slug = rest
+            stories.append(
+                Story(
+                    key=key,
+                    epic="backlog",
+                    num=num,
+                    slug=slug,
                     status=status,
                 )
             )
@@ -129,7 +210,7 @@ def load(path: Path) -> SprintStatus:
 
 
 def next_actionable(
-    ss: SprintStatus, skip: set[str] | None = None, *, epic: int | None = None
+    ss: SprintStatus, skip: set[str] | None = None, *, epic: str | None = None
 ) -> Story | None:
     """First story in file order whose status allows starting work. When
     ``epic`` is given, only stories of that epic are considered — the caller
@@ -215,12 +296,32 @@ def advance(path: Path, story_key: str, target: str, *, now: str | None = None) 
     changed = story_changed
 
     if target == "in-progress":
-        m = STORY_RE.match(story_key)
-        if m:
-            epic_key = f"epic-{int(m.group(1))}"
+        # Derive parent epic from the story_key prefix. STORY_RE covers
+        # numeric/letter-suffix/phase-suffix epics; SPRINT_STORY_RE and
+        # BACKLOG_STORY_RE cover Phase 4 + unscheduled work.
+        #
+        # Two keys here:
+        #   - yaml_key is what `_set_mapping_value` writes to the YAML file
+        #     (literal key in the document, e.g. "epic-3" or "sprint-08").
+        #   - lookup_id is what `ss.epics` is keyed by after `load()` (no
+        #     prefix, e.g. "3" or "sprint-08" or "backlog"). The split lets
+        #     letter-suffix epics (epic-1a, epic-0-p2) round-trip cleanly.
+        yaml_key: str | None = None
+        lookup_id: str | None = None
+        if m_story := STORY_RE.match(story_key):
+            bare = m_story.group(1)
+            yaml_key = f"epic-{bare}"
+            lookup_id = bare
+        elif m_sprint := SPRINT_STORY_RE.match(story_key):
+            yaml_key = f"sprint-{m_sprint.group(1)}"
+            lookup_id = yaml_key  # sprint epics keep "sprint-NN" as their id
+        elif BACKLOG_STORY_RE.match(story_key):
+            yaml_key = "backlog"
+            lookup_id = "backlog"
+        if yaml_key is not None and lookup_id is not None:
             ss = load(path)
-            if ss.epics.get(int(m.group(1))) == "backlog":
-                changed = _set_mapping_value(lines, epic_key, "in-progress") or changed
+            if ss.epics.get(lookup_id) == "backlog":
+                changed = _set_mapping_value(lines, yaml_key, "in-progress") or changed
 
     if now is not None:
         changed = _set_mapping_value(lines, "last_updated", now) or changed
@@ -240,10 +341,12 @@ class StorySelector:
     * bare number ``1`` with ``--epic 3`` — epic 3, story 1
     * slug fragment ``user-auth`` / ``auth`` — substring of the slug (must be unique)
     * epic only (``--epic 3``, blank story) — every story in the epic
+    * Phase-4 keys: ``--epic sprint-08 --story qua-5g1-...`` or the full key
+      as a slug fragment.
     """
 
-    epic: int | None = None
-    num: int | None = None
+    epic: str | None = None
+    num: str | None = None  # str — was int; preserves "3a", "5g1", or ""
     key: str | None = None  # exact full key
     slug: str | None = None  # slug substring
 
@@ -265,7 +368,7 @@ class StorySelector:
         return True
 
 
-def parse_selector(epic: int | None, story: str | None) -> StorySelector:
+def parse_selector(epic: str | None, story: str | None) -> StorySelector:
     """Translate the ``--epic``/``--story`` pair into a :class:`StorySelector`.
 
     Raises :class:`SprintStatusError` on bad or ambiguous input.
@@ -274,18 +377,18 @@ def parse_selector(epic: int | None, story: str | None) -> StorySelector:
     if not text:
         return StorySelector(epic=epic)
 
-    def _check_epic(parsed_epic: int) -> None:
+    def _check_epic(parsed_epic: str) -> None:
         if epic is not None and epic != parsed_epic:
             raise SprintStatusError(
                 f"--epic {epic} conflicts with story '{text}' (epic {parsed_epic})"
             )
 
-    if m := STORY_RE.match(text):  # full key 3-1-slug
-        e, n = int(m.group(1)), int(m.group(2))
+    if m := STORY_RE.match(text):  # full key 3-1-slug (or 1a-1-slug, etc.)
+        e, n = m.group(1), m.group(2)  # keep as str — was int
         _check_epic(e)
         return StorySelector(epic=e, num=n, key=text)
     if m := SHORT_REF_RE.match(text):  # 3-1 / 3.1
-        e, n = int(m.group(1)), int(m.group(2))
+        e, n = m.group(1), m.group(2)  # keep as str — was int
         _check_epic(e)
         return StorySelector(epic=e, num=n)
     if m := BARE_NUM_RE.match(text):  # bare story number, needs --epic
@@ -293,11 +396,11 @@ def parse_selector(epic: int | None, story: str | None) -> StorySelector:
             raise SprintStatusError(
                 f"ambiguous story '{text}': use --epic E --story {text}, or E-{text}"
             )
-        return StorySelector(epic=epic, num=int(m.group(1)))
+        return StorySelector(epic=epic, num=m.group(1))  # str — was int
     return StorySelector(epic=epic, slug=text)  # slug fragment
 
 
-def select_actionable(ss: SprintStatus, epic: int | None, story: str | None) -> list[Story]:
+def select_actionable(ss: SprintStatus, epic: str | None, story: str | None) -> list[Story]:
     """Stories selected by ``--epic``/``--story`` that are ready to start, in
     file order. Raises :class:`SprintStatusError` with a targeted message when a
     named story is missing, ambiguous, or exists but is not actionable.

--- a/src/bmad_loop/tui/widgets.py
+++ b/src/bmad_loop/tui/widgets.py
@@ -7,6 +7,7 @@ interpreted as markup.
 
 from __future__ import annotations
 
+import re
 import time
 from pathlib import Path
 from typing import Any
@@ -237,7 +238,15 @@ SPRINT_STYLES = {
 def sprint_story_label(story: Story) -> Text:
     glyph = SPRINT_GLYPHS.get(story.status, "?")
     style = SPRINT_STYLES.get(story.status, "dim")
-    return Text(f"{glyph} {story.num}-{story.slug}", style=style)
+    # Original format was "{glyph} {num}-{slug}". When the story came from a
+    # sprint / backlog with no numeric segment (e.g. bugfix-*), num is "" and
+    # the rendered label would start with "-". Drop the num segment when empty
+    # so the visible label is just "{glyph} {slug}".
+    if story.num:
+        text = f"{glyph} {story.num}-{story.slug}"
+    else:
+        text = f"{glyph} {story.slug}"
+    return Text(text, style=style)
 
 
 def sprint_retro_label(status: str) -> Text:
@@ -246,10 +255,44 @@ def sprint_retro_label(status: str) -> Text:
     return Text(f"{glyph} retrospective", style=style)
 
 
-def sprint_epic_label(num: int, status: str, done: int, total: int) -> Text:
+def _epic_id_sort_key(epic_id: str) -> tuple:
+    """Natural-order sort key for epic ids: numeric first ("1", "2", "10"),
+    then letter-suffix ("1a", "1b", "18a"), then phase-suffix ("0-p2"). Used by
+    :meth:`SprintTree.update_sprint` so the panel lists "Epic 1, 2, 3, 1a, 1b"
+    in human order rather than alphabetic order ("1, 10, 11, 1a, 1b, 2").
+    """
+    # Match "<num>[<letter>][-p<num>]" parts and use (group, num, letter, ...).
+    m = re.match(r"^(\d+)([a-z]?)(?:-p(\d+))?$", epic_id)
+    if not m:
+        return (1, 0, "", epic_id)
+    n = int(m.group(1))
+    letter = m.group(2) or ""
+    p = int(m.group(3)) if m.group(3) is not None else -1
+    return (0, n, letter, p, epic_id)
+
+
+def sprint_epic_label(epic_id: str, status: str, done: int, total: int) -> Text:
+    """Render an epic row label. ``epic_id`` is the canonical id (str):
+
+    * "1", "1a", "0-p2" → "Epic 1", "Epic 1a", "Epic 0-p2"
+    * "sprint-08" → "Sprint 08"
+    * "backlog"   → "Backlog"
+
+    Original signature took ``num: int``; we accept the str id and render
+    based on prefix so the SprintTree can group letter-suffix / sprint /
+    backlog epics alongside numeric ones.
+    """
     complete = status == "done" or (total > 0 and done == total)
     text = Text()
-    text.append(f"Epic {num}", style="green" if complete else "bold")
+    if epic_id == "backlog":
+        label = "Backlog"
+    elif epic_id.startswith("sprint-"):
+        label = f"Sprint {epic_id.removeprefix('sprint-')}"
+    elif epic_id.startswith("epic-"):
+        label = f"Epic {epic_id.removeprefix('epic-')}"
+    else:
+        label = f"Epic {epic_id}"
+    text.append(label, style="green" if complete else "bold")
     if total:
         text.append(f" · {done}/{total}", style="green" if complete else "dim")
     if complete:
@@ -285,10 +328,28 @@ class SprintTree(Tree[str]):
         if ss is None:
             self._show_placeholder("sprint status unavailable")
             return
-        stories_by_epic: dict[int, list[Story]] = {}
+        stories_by_epic: dict[str, list[Story]] = {}
         for story in ss.stories:
             stories_by_epic.setdefault(story.epic, []).append(story)
-        epic_nums = sorted(set(ss.epics) | set(stories_by_epic) | set(ss.retros))
+        # Sort: numeric epics first (natural order), then letter-suffix, then
+        # sprint-NN, then backlog last. We use a tuple sort key so the visual
+        # grouping stays stable as the YAML evolves.
+        def _sort_key(epic_id: str) -> tuple:
+            if epic_id == "backlog":
+                return (3, 0, epic_id)
+            if epic_id.startswith("sprint-"):
+                try:
+                    n = int(epic_id.removeprefix("sprint-"))
+                except ValueError:
+                    n = 0
+                return (2, n, epic_id)
+            if epic_id.startswith("epic-"):
+                return _epic_id_sort_key(epic_id.removeprefix("epic-"))
+            return _epic_id_sort_key(epic_id)
+
+        epic_nums = sorted(
+            set(ss.epics) | set(stories_by_epic) | set(ss.retros), key=_sort_key
+        )
         if not epic_nums:
             self._show_placeholder("no sprint data")
             return
@@ -309,14 +370,20 @@ class SprintTree(Tree[str]):
             )
             node = self._epic_nodes.get(num)
             if node is None:
-                node = self.root.add(label, data=f"epic-{num}")
+                # Node data is the canonical epic id; downstream code only
+                # stores it (no read-by-data consumers exist in the TUI today),
+                # so the old "epic-{num}" prefix is no longer needed.
+                node = self.root.add(label, data=num)
                 self._epic_nodes[num] = node
             else:
                 node.set_label(label)
             child_keys = tuple(s.key for s in stories)
             child_labels = [sprint_story_label(s) for s in stories]
             if retro is not None:
-                child_keys += (f"epic-{num}-retrospective",)
+                # The retrospective child node data follows the same canonical
+                # form as the YAML literal key (e.g. "1a-retrospective",
+                # "sprint-08-retrospective", "backlog-retrospective" if any).
+                child_keys += (f"{num}-retrospective",)
                 child_labels.append(sprint_retro_label(retro))
             if self._epic_child_keys.get(num) == child_keys:
                 for child, child_label in zip(node.children, child_labels):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -71,7 +71,7 @@ def test_dry_run_renders_per_stage_commands(project, capsys):
 
 @pytest.mark.parametrize(
     "epic,story",
-    [(None, "3-1"), (None, "3.1"), (3, "1"), (None, "user-auth"), (None, "3-1-user-auth")],
+    [(None, "3-1"), (None, "3.1"), ("3", "1"), (None, "user-auth"), (None, "3-1-user-auth")],
 )
 def test_dry_run_selects_story_by_short_ref(project, capsys, epic, story):
     write_sprint(
@@ -624,7 +624,7 @@ def test_archive_refuses_live_run_without_force(tmp_path, monkeypatch, capsys):
 def _escalated_run(project, run_id="r1", *, story="s1", spec_file=None):
     from bmad_loop.model import Phase, StoryTask
 
-    task = StoryTask(story_key=story, epic=1, phase=Phase.ESCALATED, attempt=1, spec_file=spec_file)
+    task = StoryTask(story_key=story, epic="1", phase=Phase.ESCALATED, attempt=1, spec_file=spec_file)
     return _make_run_with_state(
         project,
         run_id,
@@ -923,7 +923,7 @@ def test_resume_restores_persisted_run_scope(project, monkeypatch):
     monkeypatch.setattr(cli, "_make_adapters", lambda *a, **k: {r: None for r in cli.ROLES})
 
     assert cli._resume_paused_run(project.project, run_dir) == 0
-    assert captured["epic_filter"] == 9
+    assert captured["epic_filter"] == "9"
     assert captured["story_filter"] == "9-0"
     assert captured["max_stories"] == 4
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -55,7 +55,7 @@ def _seed_run(root, run_id="20260627-120000-aaaa", *, extra_journal=None):
 
     task = StoryTask(
         story_key=STORY_KEY,
-        epic=1,
+        epic="1",
         phase=Phase.ESCALATED,
         attempt=2,
         review_cycle=1,

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -102,7 +102,7 @@ def test_run_session_saves_completed_session_checkpoint(project):
     a host kill inside the hooks cannot lose it."""
     write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
     engine, _ = make_engine(project, [SessionResult(status="completed")])
-    task = StoryTask(story_key="1-1-a", epic=1)
+    task = StoryTask(story_key="1-1-a", epic="1")
     engine.state.tasks[task.story_key] = task
     engine._save()
 
@@ -136,7 +136,7 @@ def test_run_session_persists_session_when_usage_read_raises(project):
         project,
         [SessionResult(status="completed", session_id="sess-1", transcript_path="events.jsonl")],
     )
-    task = StoryTask(story_key="1-1-a", epic=1)
+    task = StoryTask(story_key="1-1-a", epic="1")
     engine.state.tasks[task.story_key] = task
     engine._save()
 
@@ -296,7 +296,7 @@ def test_resume_restart_when_session_record_incomplete(project, record):
     session with a recorded result still takes today's resume-restart."""
     write_sprint(project, {"1-1-a": "ready-for-dev"})
     engine, _ = make_engine(project, [])
-    task = StoryTask(story_key="1-1-a", epic=1, phase=Phase.DEV_RUNNING, attempt=1)
+    task = StoryTask(story_key="1-1-a", epic="1", phase=Phase.DEV_RUNNING, attempt=1)
     task.record_session(record)
     engine.state.tasks[task.story_key] = task
     engine._save()
@@ -421,7 +421,7 @@ def test_reconcile_early_return_heals_stale_resumed_dict(project):
         "---\ntitle: 'test'\ntype: 'feature'\nstatus: 'done'\n"
         "followup_review_recommended: true\nbaseline_commit: 'abc'\n---\n\n## Intent\n\ntest\n"
     )
-    task = StoryTask(story_key="1-1-a", epic=1)
+    task = StoryTask(story_key="1-1-a", epic="1")
     # the pre-reconcile snapshot persisted before the original run mutated its
     # in-memory dict: frontmatter template default status, no followup key.
     stale = {"workflow": "auto-dev", "spec_file": str(sp), "status": "in-progress"}
@@ -442,7 +442,7 @@ def test_run_session_record_result_json_isolated_from_later_mutation(project):
     engine, _ = make_engine(
         project, [SessionResult(status="completed", result_json={"workflow": "auto-dev"})]
     )
-    task = StoryTask(story_key="1-1-a", epic=1)
+    task = StoryTask(story_key="1-1-a", epic="1")
     engine.state.tasks[task.story_key] = task
     engine._save()
 
@@ -471,7 +471,7 @@ def test_run_session_persists_result_json_only_for_resumable_roles(project):
         ],
     )
     engine.adapters["triage"] = adapter  # SweepEngine registers this; wire it here
-    task = StoryTask(story_key="1-1-a", epic=1)
+    task = StoryTask(story_key="1-1-a", epic="1")
     engine.state.tasks[task.story_key] = task
     engine._save()
 
@@ -993,7 +993,7 @@ def test_generic_reconcile_skips_out_of_tree_spec(project, tmp_path):
         scm=ScmPolicy(rollback_on_failure=True),
     )
     engine, _ = make_engine(project, [generic_dev_effect(project, "1-1-a")], policy=pol)
-    task = StoryTask(story_key="1-1-a", epic=1)
+    task = StoryTask(story_key="1-1-a", epic="1")
     engine._reconcile_generic_terminal_status(task, {"spec_file": str(outside)})
 
     assert outside.read_text() == original  # never written
@@ -1043,7 +1043,7 @@ def test_reset_spec_for_repair_strips_stale_terminal_section(project):
         "## Auto Run Result\n\nStatus: done\nAll done.\n",
         encoding="utf-8",
     )
-    task = StoryTask(story_key="1-1-a", epic=1, spec_file=str(spec))
+    task = StoryTask(story_key="1-1-a", epic="1", spec_file=str(spec))
 
     engine._reset_spec_for_repair(task)
 
@@ -1478,7 +1478,7 @@ def test_rollback_or_pause_skips_clean_tree(project):
         scm=ScmPolicy(rollback_on_failure=False),
     )
     engine, _ = make_engine(project, [], policy=policy)
-    task = StoryTask(story_key="1-1-a", epic=1)
+    task = StoryTask(story_key="1-1-a", epic="1")
     task.baseline_commit = rev_parse_head(project.project)  # clean tree at baseline
     task.baseline_untracked = []
 
@@ -1499,7 +1499,7 @@ def test_manual_recovery_wording_stopped(project):
         scm=ScmPolicy(rollback_on_failure=False),
     )
     engine, _ = make_engine(project, [], policy=policy)
-    task = StoryTask(story_key="1-1-a", epic=1)
+    task = StoryTask(story_key="1-1-a", epic="1")
     baseline = rev_parse_head(project.project)
 
     with pytest.raises(RunPaused) as stopped:
@@ -1520,7 +1520,7 @@ def test_rollback_preserves_committed_attempt_work(project):
     )
     engine, _ = make_engine(project, [], policy=policy)
     repo = project.project
-    task = StoryTask(story_key="1-1-a", epic=1)
+    task = StoryTask(story_key="1-1-a", epic="1")
     task.baseline_commit = rev_parse_head(repo)
     task.baseline_untracked = []
     (repo / "impl.txt").write_text("committed implementation\n")  # attempt commits its work
@@ -1547,7 +1547,7 @@ def test_rollback_preserves_uncommitted_attempt_worktree(project):
     )
     engine, _ = make_engine(project, [], policy=policy)
     repo = project.project
-    task = StoryTask(story_key="1-1-a", epic=1)
+    task = StoryTask(story_key="1-1-a", epic="1")
     task.baseline_commit = rev_parse_head(repo)
     task.baseline_untracked = []
     (repo / "src.txt").write_text("uncommitted tracked edit\n")  # tracked, never committed
@@ -1578,7 +1578,7 @@ def test_rollback_preserves_distinct_refs_across_repeated_dirty_rollbacks(projec
     )
     engine, _ = make_engine(project, [], policy=policy)
     repo = project.project
-    task = StoryTask(story_key="1-1-a", epic=1)
+    task = StoryTask(story_key="1-1-a", epic="1")
     task.baseline_commit = rev_parse_head(repo)
     task.baseline_untracked = []
 
@@ -1804,7 +1804,7 @@ def test_rollback_worktree_preserve_failure_journals_git_error(project, monkeypa
     )
     engine, _ = make_engine(project, [], policy=policy)
     repo = project.project
-    task = StoryTask(story_key="1-1-a", epic=1)
+    task = StoryTask(story_key="1-1-a", epic="1")
     task.baseline_commit = rev_parse_head(repo)
     task.baseline_untracked = []
     (repo / "src.txt").write_text("uncommitted edit\n")  # dirty but uncommitted; no commits
@@ -1835,7 +1835,7 @@ def test_rollback_pauses_when_preserve_fails(project, monkeypatch):
     )
     engine, _ = make_engine(project, [], policy=policy)
     repo = project.project
-    task = StoryTask(story_key="1-1-a", epic=1)
+    task = StoryTask(story_key="1-1-a", epic="1")
     task.baseline_commit = rev_parse_head(repo)
     task.baseline_untracked = []
     (repo / "impl.txt").write_text("committed work\n")
@@ -1868,7 +1868,7 @@ def test_resolved_redrive_never_pauses_when_preserve_fails(project, monkeypatch)
     )
     engine, _ = make_engine(project, [], policy=policy)
     repo = project.project
-    task = StoryTask(story_key="1-1-a", epic=1)
+    task = StoryTask(story_key="1-1-a", epic="1")
     task.baseline_commit = rev_parse_head(repo)
     task.baseline_untracked = []
     (repo / "impl.txt").write_text("failed attempt work\n")  # committed, outside artifacts
@@ -1900,7 +1900,7 @@ def test_rollback_or_pause_resolved_auto_recovers(project):
     )
     engine, _ = make_engine(project, [], policy=policy)
     repo = project.project
-    task = StoryTask(story_key="1-1-a", epic=1)
+    task = StoryTask(story_key="1-1-a", epic="1")
     task.baseline_commit = rev_parse_head(repo)
     task.baseline_untracked = []  # clean fixture at baseline
 
@@ -1930,7 +1930,7 @@ def test_resolved_redrive_preserves_spec_on_later_rollback(project):
     )
     engine, _ = make_engine(project, [], policy=policy)
     repo = project.project
-    task = StoryTask(story_key="1-1-a", epic=1)
+    task = StoryTask(story_key="1-1-a", epic="1")
     task.baseline_commit = rev_parse_head(repo)
     task.baseline_untracked = []
     task.resolved_redrive = True  # latched by _finish_inflight on the re-drive
@@ -2808,11 +2808,11 @@ def test_resume_with_epic_filter_stays_in_scoped_epic(project):
             "9-1-keystone": "ready-for-dev",
         },
     )
-    engine, _ = make_engine(project, [_escalate_blocked(project, "9-0-test-infra")], epic_filter=9)
-    engine.state.epic_filter = 9  # cmd_run persists the launch scope; mirror it here
+    engine, _ = make_engine(project, [_escalate_blocked(project, "9-0-test-infra")], epic_filter="9")
+    engine.state.epic_filter = "9"  # cmd_run persists the launch scope; mirror it here
     summary = engine.run()
     assert summary.paused and summary.escalated == 1
-    assert engine.state.current_epic == 9
+    assert engine.state.current_epic == "9"
 
     rearm_escalation(engine.run_dir)  # the resolve workflow's re-arm step
     resumed, _ = resume_engine(
@@ -2850,13 +2850,13 @@ def test_pick_next_prefers_current_epic_over_earlier_file_position(project):
         },
     )
     engine, _ = make_engine(project, [])
-    engine.state.current_epic = 9
-    engine.state.tasks["9-0-x"] = StoryTask(story_key="9-0-x", epic=9, phase=Phase.DEFERRED)
+    engine.state.current_epic = "9"
+    engine.state.tasks["9-0-x"] = StoryTask(story_key="9-0-x", epic="9", phase=Phase.DEFERRED)
 
     assert engine._pick_next().key == "9-1-y"  # stays in epic 9, not 5-1-e5
 
     # exhaust epic 9 → fallback returns the earlier-in-file epic (doc order kept)
-    engine.state.tasks["9-1-y"] = StoryTask(story_key="9-1-y", epic=9, phase=Phase.DONE)
+    engine.state.tasks["9-1-y"] = StoryTask(story_key="9-1-y", epic="9", phase=Phase.DONE)
     assert engine._pick_next().key == "5-1-e5"
 
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -10,7 +10,7 @@ def _state(**kw) -> RunState:
 
 
 def _task_with_session(usage: TokenUsage | None = None) -> StoryTask:
-    task = StoryTask(story_key="1-1-a", epic=1)
+    task = StoryTask(story_key="1-1-a", epic="1")
     task.record_session(
         SessionRecord(task_id="1-1-a-dev-1", role="dev", status="completed", usage=usage)
     )
@@ -63,23 +63,23 @@ def test_session_record_result_json_defaults_none_for_legacy_state():
 
 
 def test_followup_review_recommended_round_trips():
-    task = StoryTask(story_key="1-1-a", epic=1, followup_review_recommended=True)
+    task = StoryTask(story_key="1-1-a", epic="1", followup_review_recommended=True)
     assert StoryTask.from_dict(task.to_dict()).followup_review_recommended is True
 
 
 def test_followup_review_recommended_defaults_false_for_legacy_state():
-    doc = StoryTask(story_key="1-1-a", epic=1).to_dict()
+    doc = StoryTask(story_key="1-1-a", epic="1").to_dict()
     del doc["followup_review_recommended"]  # state.json from before the field existed
     assert StoryTask.from_dict(doc).followup_review_recommended is False
 
 
 def test_resolved_redrive_round_trips():
-    task = StoryTask(story_key="1-1-a", epic=1, resolved_redrive=True)
+    task = StoryTask(story_key="1-1-a", epic="1", resolved_redrive=True)
     assert StoryTask.from_dict(task.to_dict()).resolved_redrive is True
 
 
 def test_resolved_redrive_defaults_false_for_legacy_state():
-    doc = StoryTask(story_key="1-1-a", epic=1).to_dict()
+    doc = StoryTask(story_key="1-1-a", epic="1").to_dict()
     del doc["resolved_redrive"]  # state.json from before the field existed
     assert StoryTask.from_dict(doc).resolved_redrive is False
 
@@ -96,9 +96,9 @@ def test_stopped_defaults_false_for_legacy_state():
 
 
 def test_run_filters_round_trip():
-    state = _state(epic_filter=9, story_filter="9-0", max_stories=3)
+    state = _state(epic_filter="9", story_filter="9-0", max_stories=3)
     back = RunState.from_dict(state.to_dict())
-    assert (back.epic_filter, back.story_filter, back.max_stories) == (9, "9-0", 3)
+    assert (back.epic_filter, back.story_filter, back.max_stories) == ("9", "9-0", 3)
 
 
 def test_run_filters_default_none_for_legacy_state():

--- a/tests/test_plugin_workflows.py
+++ b/tests/test_plugin_workflows.py
@@ -385,7 +385,7 @@ def test_example_plugin_veto_gate_skips_parked_epic(project):
     install_example(project)
     setup_story(project)
     # park epic 1 -> the pre_dev_phase gate skips story 1-1-a before any session
-    policy = example_policy(forbid_epic=1)
+    policy = example_policy(forbid_epic="1")
     reg = PluginRegistry.build(project.project, policy)
     engine, adapter = make_engine(project, [], reg, policy)  # empty script: no session launches
     summary = engine.run()

--- a/tests/test_sprintstatus.py
+++ b/tests/test_sprintstatus.py
@@ -21,14 +21,14 @@ def test_load_classifies_keys(project):
         },
     )
     ss = sprintstatus.load(project.sprint_status)
-    assert ss.epics == {1: "in-progress", 2: "backlog"}
+    assert ss.epics == {"1": "in-progress", "2": "backlog"}
     assert [s.key for s in ss.stories] == [
         "1-1-user-auth",
         "1-2-account-mgmt",
         "2-1-personality",
     ]
-    assert ss.stories[1].epic == 1 and ss.stories[1].num == 2
-    assert ss.retros == {1: "optional", 2: "optional"}
+    assert ss.stories[1].epic == "1" and ss.stories[1].num == "2"
+    assert ss.retros == {"1": "optional", "2": "optional"}
     assert ss.unknown_keys == ("weird-key",)
 
 
@@ -44,12 +44,12 @@ def test_load_classifies_retro_items(project):
     ss = sprintstatus.load(project.sprint_status)
     # retro action items are recognized, not dumped into unknown_keys
     assert ss.unknown_keys == ()
-    assert ss.retros == {1: "done"}  # plain retrospective key is unaffected
+    assert ss.retros == {"1": "done"}  # plain retrospective key is unaffected
     assert [(r.key, r.epic, r.num, r.slug, r.status) for r in ss.retro_items] == [
-        ("epic-1-retro-item-1-test-design-in-stories", 1, 1, "test-design-in-stories", "done"),
+        ("epic-1-retro-item-1-test-design-in-stories", "1", 1, "test-design-in-stories", "done"),
         (
             "epic-5-retro-item-2-singleflight-inflight-guard-helper",
-            5,
+            "5",
             2,
             "singleflight-inflight-guard-helper",
             "backlog",
@@ -91,9 +91,9 @@ def test_next_actionable_epic_filter(project):
     )
     ss = sprintstatus.load(project.sprint_status)
     assert sprintstatus.next_actionable(ss).key == "5-1-e5"  # unfiltered = file order
-    assert sprintstatus.next_actionable(ss, epic=9).key == "9-0-x"
-    assert sprintstatus.next_actionable(ss, skip={"9-0-x"}, epic=9).key == "9-1-y"
-    assert sprintstatus.next_actionable(ss, skip={"9-0-x", "9-1-y"}, epic=9) is None
+    assert sprintstatus.next_actionable(ss, epic="9").key == "9-0-x"
+    assert sprintstatus.next_actionable(ss, skip={"9-0-x"}, epic="9").key == "9-1-y"
+    assert sprintstatus.next_actionable(ss, skip={"9-0-x", "9-1-y"}, epic="9") is None
 
 
 def test_story_status_reread(project):
@@ -105,20 +105,20 @@ def test_story_status_reread(project):
 def test_parse_selector_forms():
     # full key — exact match intent
     sel = sprintstatus.parse_selector(None, "3-1-user-auth")
-    assert (sel.epic, sel.num, sel.key, sel.slug) == (3, 1, "3-1-user-auth", None)
+    assert (sel.epic, sel.num, sel.key, sel.slug) == ("3", "1", "3-1-user-auth", None)
     # short refs: hyphen and dot are equivalent
     for ref in ("3-1", "3.1"):
         sel = sprintstatus.parse_selector(None, ref)
-        assert (sel.epic, sel.num, sel.key, sel.slug) == (3, 1, None, None)
+        assert (sel.epic, sel.num, sel.key, sel.slug) == ("3", "1", None, None)
     # bare number resolves against --epic
-    sel = sprintstatus.parse_selector(3, "1")
-    assert (sel.epic, sel.num, sel.slug) == (3, 1, None)
+    sel = sprintstatus.parse_selector("3", "1")
+    assert (sel.epic, sel.num, sel.slug) == ("3", "1", None)
     # slug fragment
     sel = sprintstatus.parse_selector(None, "user-auth")
     assert (sel.epic, sel.num, sel.slug) == (None, None, "user-auth")
     # epic only — not targeted
-    sel = sprintstatus.parse_selector(3, None)
-    assert sel.epic == 3 and not sel.is_targeted
+    sel = sprintstatus.parse_selector("3", None)
+    assert sel.epic == "3" and not sel.is_targeted
 
 
 def test_parse_selector_bare_number_needs_epic():
@@ -128,9 +128,9 @@ def test_parse_selector_bare_number_needs_epic():
 
 def test_parse_selector_epic_conflict():
     with pytest.raises(sprintstatus.SprintStatusError, match="conflicts"):
-        sprintstatus.parse_selector(2, "3-1")
+        sprintstatus.parse_selector("2", "3-1")
     with pytest.raises(sprintstatus.SprintStatusError, match="conflicts"):
-        sprintstatus.parse_selector(2, "3-1-user-auth")
+        sprintstatus.parse_selector("2", "3-1-user-auth")
 
 
 def test_select_actionable_short_ref_and_epic_story(project):
@@ -139,11 +139,11 @@ def test_select_actionable_short_ref_and_epic_story(project):
         {"3-1-user-auth": "ready-for-dev", "3-2-foo": "backlog", "4-1-bar": "backlog"},
     )
     ss = sprintstatus.load(project.sprint_status)
-    for epic, story in [(None, "3-1"), (None, "3.1"), (3, "1"), (None, "user-auth")]:
+    for epic, story in [(None, "3-1"), (None, "3.1"), ("3", "1"), (None, "user-auth")]:
         got = sprintstatus.select_actionable(ss, epic, story)
         assert [s.key for s in got] == ["3-1-user-auth"]
     # epic only selects every actionable story in the epic
-    assert [s.key for s in sprintstatus.select_actionable(ss, 3, None)] == [
+    assert [s.key for s in sprintstatus.select_actionable(ss, "3", None)] == [
         "3-1-user-auth",
         "3-2-foo",
     ]

--- a/tests/test_sprintstatus_advance.py
+++ b/tests/test_sprintstatus_advance.py
@@ -34,7 +34,7 @@ def test_advance_to_in_progress_lifts_backlog_epic(tmp_path):
     out = sprintstatus.advance(p, "3-2-digest-delivery", "in-progress")
     assert out == "in-progress"
     assert sprintstatus.story_status(p, "3-2-digest-delivery") == "in-progress"
-    assert sprintstatus.load(p).epics[3] == "in-progress"  # epic lifted
+    assert sprintstatus.load(p).epics["3"] == "in-progress"  # epic lifted
 
 
 def test_advance_preserves_comments_and_structure(tmp_path):
@@ -87,20 +87,20 @@ def test_advance_to_review(tmp_path):
     assert out == "review"
     assert sprintstatus.story_status(p, "3-2-digest-delivery") == "review"
     # epic NOT lifted for non-in-progress targets
-    assert sprintstatus.load(p).epics[3] == "backlog"
+    assert sprintstatus.load(p).epics["3"] == "backlog"
 
 
 def test_advance_done_does_not_touch_epic(tmp_path):
     p = _write(tmp_path)
     sprintstatus.advance(p, "3-2-digest-delivery", "done")
-    assert sprintstatus.load(p).epics[3] == "backlog"
+    assert sprintstatus.load(p).epics["3"] == "backlog"
 
 
 def test_advance_epic_not_lifted_when_not_backlog(tmp_path):
     p = _write(tmp_path)
     sprintstatus.advance(p, "4-1-thing", "in-progress")  # regresses -> no-op anyway
     # epic-4 was in-progress; ensure unchanged
-    assert sprintstatus.load(p).epics[4] == "in-progress"
+    assert sprintstatus.load(p).epics["4"] == "in-progress"
 
 
 def test_advance_refreshes_last_updated(tmp_path):

--- a/tests/test_tui_data.py
+++ b/tests/test_tui_data.py
@@ -231,10 +231,10 @@ def test_discover_runs_corrupt_state_is_unknown_not_crash(tmp_path):
 def test_watcher_state_keeps_last_good_parse(tmp_path):
     run_dir = make_run(tmp_path, "20260611-100000-aaaa", current_epic=1)
     watcher = data.RunWatcher(run_dir)
-    assert watcher.state().current_epic == 1
+    assert watcher.state().current_epic == "1"
 
     (run_dir / "state.json").write_text("{ mid-write garbage")
-    assert watcher.state().current_epic == 1  # last good survives
+    assert watcher.state().current_epic == "1"  # last good survives
 
     state = RunState(
         run_id=run_dir.name,
@@ -243,7 +243,7 @@ def test_watcher_state_keeps_last_good_parse(tmp_path):
         current_epic=2,
     )
     save_state(run_dir, state)
-    assert watcher.state().current_epic == 2
+    assert watcher.state().current_epic == "2"
 
 
 def test_watcher_state_none_before_first_write(tmp_path):
@@ -720,13 +720,13 @@ def test_sprint_overview(project):
         },
     )
     ss = data.sprint_overview(project.project)
-    assert ss.epics == {1: "in-progress", 2: "backlog"}
+    assert ss.epics == {"1": "in-progress", "2": "backlog"}
     assert [(s.key, s.status) for s in ss.stories] == [
         ("1-1-a", "ready-for-dev"),
         ("1-2-b", "done"),
         ("2-1-c", "backlog"),
     ]
-    assert ss.retros == {1: "optional"}
+    assert ss.retros == {"1": "optional"}
 
     # cached result (same object) until the file changes, then re-parsed
     assert data.sprint_overview(project.project) is ss


### PR DESCRIPTION
Widen the regex-based key classifiers in sprintstatus.py so that BMAD projects with non-canonical naming (e.g. nail_salon's letter-suffix epic ids like '1a'/'18a'/'0-p2', sub-lettered story segments like '3-3a-...' and '18-0a-...', plus the Phase-4 'sprint-NN' container + its stories, plus a single virtual 'backlog' epic for unscheduled work) parse without falling into 'unknown_keys'.

What changes:

* EPIC_RE / RETRO_RE / RETRO_ITEM_RE / STORY_RE widen to accept an optional single lowercase letter suffix (\d+[a-z]?) on either epic or story segment, plus a phase suffix (-p\d+) on epic ids.
* New SPRINT_RE / SPRINT_STORY_RE / SPRINT_RETRO_RE / BACKLOG_RE / BACKLOG_STORY_RE match the project's Phase 4 + unscheduled naming.
* Story / SprintStory / BacklogStory dispatches in load() emit the new patterns with the right epic id ('1', '1a', '0-p2', 'sprint-08', 'backlog').
* advance() lifts the parent epic to 'in-progress' using a yaml_key (literal 'epic-3' / 'sprint-08' / 'backlog') distinct from the lookup_id ('3' / 'sprint-08' / 'backlog') stored in SprintStatus.epics.
* Story.epic / Story.num / RetroItem.epic / SprintStatus.epics / SprintStatus.retros widen from int to str so the orchestrator can group non-numeric ids without coercion. Story.num stays as a string so '5g1' and '3a' round-trip cleanly.
* Status values that are structs ({status: done, size: M, rationale: ...}) are unwrapped — Phase 4 entries use this shape to attach size + rationale inline.
* CLI 'bmad-loop run --epic' argparse type widens from int to str.
* TUI: sprint_epic_label renders 'Epic 1a' / 'Sprint 08' / 'Backlog' from the canonical str id; SprintTree.update_sprint uses a natural sort key (1,2,...,10,1a,1b,sprint-01,...,backlog); sprint_story_label drops the num segment when empty.

Tests updated:
* test_sprintstatus / test_sprintstatus_advance / test_model / test_cli / test_engine / test_diagnostics / test_tui_data: int epic literals → str (the public dataclass API is now str).
* test_plugin_workflows + examples/plugins/guardrails/guardrails.py: forbid_epic comparison coerces to str.

## What

<!-- 1-2 sentences describing WHAT changed -->

## Why

<!-- 1-2 sentences explaining WHY this change is needed -->
<!-- Fixes `#issue_number` (if applicable) -->

## How

<!-- 2-3 bullets listing HOW you implemented it -->

-

## Testing

<!-- 1-2 sentences on how you tested this -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Epic references and filtering now support string-based IDs (including letter-suffixed and sprint/backlog-style epic formats).
  * CLI `--epic` help and validation now document and accept the broader epic value formats.

* **Bug Fixes**
  * Improved story/retro classification, selection, and epic-boundary handling for non-numeric epic IDs.
  * TUI epic/story labels were updated for cleaner rendering (including when story numbers are blank).
  * Existing saved run state continues to load with the new epic identifier format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->