### PR TITLE
fix(verify): baseline-untracked subtraction + skill's baseline key in the shared gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,22 @@ breaking changes may land in a minor release.
 
 ### Fixed
 
+- **Baseline-era untracked residue no longer vacuously satisfies the proof-of-work gate.**
+  `has_changes_since` counted every untracked file. After an intent-gap halt the saved patch is
+  untracked residue under the artifact dirs every reset deliberately protects, so a from-scratch
+  re-arm — which never learns the patch's path — let a re-driven session that produced nothing but a
+  spec status flip pass the gate on that file's mere presence, and `finalize_commit`'s `add -A` swept
+  it into the story commit. The gate now subtracts the task's `baseline_untracked` snapshot. A `None`
+  snapshot (a pre-upgrade run) still counts every untracked file — deliberately the opposite of
+  `attempt_dirty`'s ignore-all, because a proof-of-work gate has to fail open toward "work happened".
+  (closes #88)
+- **The baseline-match verify gate was dead code for generic dev sessions.** The gate read the spec's
+  `baseline_commit` and skipped itself when that key was absent — but `bmad-dev-auto` stamps
+  `baseline_revision`; `baseline_commit` exists only in the orchestrator's synthesized `result.json`.
+  In production the check never fired, so a spec claiming a stale or foreign baseline sailed through.
+  The gate now reads either key, the idiom `devcontract` already used. The test fixture stamps
+  `baseline_revision` like the real skill does, so it can no longer fabricate the key that hid this.
+  (closes #89)
 - **Unit keys with git-ref-illegal characters no longer break worktree runs.** `unit_branch_name`
   built `bmad-loop/<run_id>/<unit_key>` from the raw ids, so a key or `--run-id` carrying `:`, `..`,
   `@{`, a space or a trailing `.lock` cleared the (already-sanitized) worktree dir only to die at

--- a/src/bmad_loop/verify.py
+++ b/src/bmad_loop/verify.py
@@ -138,7 +138,13 @@ def same_commit(a: str, b: str) -> bool:
     return a.startswith(b) or b.startswith(a)
 
 
-def has_changes_since(repo: Path, baseline: str, exclude: tuple[str, ...] = ()) -> bool:
+def has_changes_since(
+    repo: Path,
+    baseline: str,
+    exclude: tuple[str, ...] = (),
+    *,
+    baseline_untracked: list[str] | None = None,
+) -> bool:
     """True if tracked changes since baseline OR untracked files exist.
 
     `exclude` is repo-relative posix dir prefixes whose changes don't count —
@@ -146,11 +152,27 @@ def has_changes_since(repo: Path, baseline: str, exclude: tuple[str, ...] = ()) 
     BMAD artifact folders (see `artifact_relpaths`), so a session that only
     rewrites its own spec (e.g. the frontmatter-status reconcile) under those
     folders doesn't register as real implementation work. Mirrors
-    `attempt_dirty`'s exclusion. Default `()` keeps the unscoped behavior."""
+    `attempt_dirty`'s exclusion. Default `()` keeps the unscoped behavior.
+
+    `baseline_untracked` is the untracked-file snapshot taken when the baseline
+    was recorded; when given, those files already existed before the session ran
+    and are subtracted, so pre-session residue (e.g. an earlier halt's saved
+    intent-gap patch, which `_protected_relpaths` shields from every reset) can
+    never masquerade as this session's work.
+
+    `None` means count EVERY untracked file — deliberately the *opposite* of
+    `attempt_dirty`'s `None` = ignore-all, and not an oversight. The two gates
+    fail open in opposite directions: a proof-of-work gate must fail open toward
+    "work happened" (a pre-snapshot run must not have its gate silently
+    weakened into never seeing new files), while a rollback gate must fail open
+    toward "nothing to remove" (never delete a file it cannot prove this attempt
+    created). Keep it that way."""
     rc, _ = _git(repo, "diff", "--quiet", baseline, "--", ".", *_exclude_specs(exclude))
     if rc != 0:
         return True
     created = untracked_files(repo)
+    if baseline_untracked is not None:
+        created -= set(baseline_untracked)
     created = {p for p in created if not _path_under_any(p, exclude)}
     return bool(created)
 
@@ -1091,7 +1113,13 @@ def _verify_shared_gates(
             f"spec status is {status!r}, expected {expected_status!r}: {spec_path}"
         )
 
-    claimed_baseline = str(fm.get("baseline_commit", "")).strip()
+    # The generic bmad-dev-auto skill stamps `baseline_revision`, never
+    # `baseline_commit` — that name exists only in the result.json devcontract
+    # synthesizes, which this gate does not consult (it re-reads frontmatter).
+    # An absent key skips the check below, so reading `baseline_commit` alone
+    # made this gate dead code for every generic-skill session. Read both, the
+    # same idiom as `devcontract.synthesize_result`.
+    claimed_baseline = str(fm.get("baseline_commit", fm.get("baseline_revision", ""))).strip()
     if task.baseline_commit and claimed_baseline not in ("", "NO_VCS"):
         if not same_commit(claimed_baseline, task.baseline_commit):
             return VerifyOutcome.retry(
@@ -1101,7 +1129,12 @@ def _verify_shared_gates(
 
     if proof_exclude is not None and task.baseline_commit:
         try:
-            if not has_changes_since(paths.project, task.baseline_commit, exclude=proof_exclude):
+            if not has_changes_since(
+                paths.project,
+                task.baseline_commit,
+                exclude=proof_exclude,
+                baseline_untracked=task.baseline_untracked,
+            ):
                 return VerifyOutcome.retry("no changes in worktree since baseline commit")
         except GitError as e:
             return VerifyOutcome.escalate(str(e))

--- a/src/bmad_loop/verify.py
+++ b/src/bmad_loop/verify.py
@@ -1123,7 +1123,7 @@ def _verify_shared_gates(
     if task.baseline_commit and claimed_baseline not in ("", "NO_VCS"):
         if not same_commit(claimed_baseline, task.baseline_commit):
             return VerifyOutcome.retry(
-                f"spec baseline_commit {claimed_baseline[:12]} does not match "
+                f"spec baseline {claimed_baseline[:12]} does not match "
                 f"orchestrator-recorded baseline {task.baseline_commit[:12]}"
             )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -183,9 +183,14 @@ def set_sprint(paths: ProjectPaths, key: str, status: str) -> None:
 
 
 def write_spec(path: Path, status: str, baseline: str, *, prose_status: str | None = None) -> None:
+    """Write a spec the way the real bmad-dev-auto skill does. The skill's step-03
+    stamps `baseline_revision` and NEVER `baseline_commit` (that name exists only
+    in the orchestrator's synthesized result.json), so this fixture stamps the
+    same key — a reader that only knows `baseline_commit` must fail a test here,
+    not sail through production (issue #89)."""
     body = (
         f"---\ntitle: 'test'\ntype: 'feature'\nstatus: '{status}'\n"
-        f"baseline_commit: '{baseline}'\n---\n\n## Intent\n\ntest spec\n"
+        f"baseline_revision: '{baseline}'\n---\n\n## Intent\n\ntest spec\n"
     )
     if prose_status is not None:
         # mirror bmad-dev-auto's terminal finalize: it appends a `## Auto Run
@@ -291,8 +296,11 @@ def review_effect(
 
 
 def _spec_baseline(path: Path) -> str:
+    """Read back whichever baseline key a spec carries: `write_spec` stamps
+    `baseline_revision` like the real skill, but hand-rolled fixture specs (and
+    re-arm's re-stamp) may carry either."""
     for line in path.read_text().splitlines():
-        if line.startswith("baseline_commit:"):
+        if line.startswith(("baseline_commit:", "baseline_revision:")):
             return line.split(":", 1)[1].strip().strip("'\"")
     return ""
 

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1092,6 +1092,36 @@ def test_has_changes_since_excludes_artifact_only_edit(project):
     )
 
 
+def test_has_changes_since_subtracts_baseline_untracked(project):
+    """Untracked files already on disk when the baseline snapshot was taken are
+    not this session's work. `None` deliberately keeps counting all of them —
+    the opposite of `attempt_dirty`'s ignore-all — so a pre-snapshot run's
+    proof-of-work gate is never silently weakened."""
+    baseline = verify.rev_parse_head(project.project)
+    (project.project / "residue.txt").write_text("left by an earlier halt\n")
+
+    assert verify.has_changes_since(project.project, baseline) is True
+    assert verify.has_changes_since(project.project, baseline, baseline_untracked=None) is True
+    assert (
+        verify.has_changes_since(project.project, baseline, baseline_untracked=["residue.txt"])
+        is False
+    )
+
+    # a file created after the snapshot is this session's
+    (project.project / "fresh.txt").write_text("this session\n")
+    assert (
+        verify.has_changes_since(project.project, baseline, baseline_untracked=["residue.txt"])
+        is True
+    )
+    # and a tracked edit counts regardless of how complete the snapshot is
+    (project.project / "fresh.txt").unlink()
+    (project.project / "src.txt").write_text("real\n")
+    assert (
+        verify.has_changes_since(project.project, baseline, baseline_untracked=["residue.txt"])
+        is True
+    )
+
+
 def test_verify_dev_exclude_relpaths_is_file_granular(project):
     """Unlike artifact_relpaths (whole-folder), this excludes only the
     sprint-status ledger and the session's own claimed spec file — sibling
@@ -1143,6 +1173,63 @@ def test_verify_dev_latched_restore_patch_is_not_proof_of_work(project):
     task.restore_patch = str(patch)
     out = verify.verify_dev(task, project, dev_result(sp))
     assert not out.ok and "no changes" in out.reason
+
+
+def test_verify_dev_baseline_era_untracked_is_not_proof_of_work(project):
+    """#88: the from-scratch case the T4 latch exclusion cannot reach. After an
+    intent-gap halt the saved patch is untracked residue under the protected
+    artifact dirs, and a from-scratch re-arm (`restore_patch=None`) never learns
+    its path — but the re-arm's snapshot captured it. Subtracting
+    `baseline_untracked` is the only mechanical close: a re-driven session that
+    produced nothing but a status flip must not pass the gate on that residue."""
+    write_sprint(project, {"1-1-a": "review"})
+    sp = spec_path(project, "1-1-a")
+    write_spec(sp, "in-review", "NO_VCS")
+    git(project.project, "add", "-A")
+    git(project.project, "commit", "-q", "-m", "baseline")
+    task = make_task(project)
+    residue = project.implementation_artifacts / "attempt.patch"
+    residue.write_text("stale intent-gap diff\n", encoding="utf-8")
+    rel = residue.relative_to(project.project).as_posix()
+
+    # no latch (from-scratch re-arm) — only the snapshot can rule the residue out
+    assert task.restore_patch is None
+    task.baseline_untracked = [rel]
+    out = verify.verify_dev(task, project, dev_result(sp))
+    assert not out.ok and "no changes" in out.reason
+
+    # None (a pre-snapshot run) still counts every untracked file: the gate fails
+    # open toward "work happened", never toward a silently disabled gate
+    task.baseline_untracked = None
+    assert verify.verify_dev(task, project, dev_result(sp)).ok
+
+    # real work passes with the snapshot in place
+    task.baseline_untracked = [rel]
+    (project.project / "src.txt").write_text("real work\n")
+    assert verify.verify_dev(task, project, dev_result(sp)).ok
+
+
+def test_verify_dev_baseline_gate_reads_the_skills_baseline_revision_key(project):
+    """#89: the generic bmad-dev-auto skill's step-03 stamps `baseline_revision`;
+    `baseline_commit` exists only in the orchestrator's synthesized result.json.
+    Reading just the latter made the baseline-match gate dead code in production
+    (an absent key skips the check), so a spec claiming a foreign baseline sailed
+    through. Masked for years by fixtures that stamped the key the skill never
+    writes."""
+    write_sprint(project, {"1-1-a": "review"})
+    task = make_task(project)
+    sp = spec_path(project, "1-1-a")
+
+    write_spec(sp, "in-review", "0" * 40)  # a foreign baseline, skill-style key
+    body = sp.read_text()
+    assert "baseline_revision:" in body and "baseline_commit:" not in body
+    out = verify.verify_dev(task, project, dev_result(sp))
+    assert not out.ok and "does not match" in out.reason
+
+    # matching baseline + real work → the gate passes
+    write_spec(sp, "in-review", task.baseline_commit)
+    (project.project / "src.txt").write_text("real work\n")
+    assert verify.verify_dev(task, project, dev_result(sp)).ok
 
 
 def test_verify_dev_exclude_relpaths_normalizes_dotdot_segments(project):


### PR DESCRIPTION
Closes #88, Closes #89

Both bugs were surfaced by the **PR #86 final review** (the intent-gap/patch-restore audit), where each was adversarially verified against `main` and filed rather than folded into that PR — they are pre-existing, not regressions from #86. They land together because both fixes are in the same ~15-line block: `_verify_shared_gates`, the workflow-tag / expected-status / baseline-match / proof-of-work gates shared verbatim by `verify_dev`, `verify_dev_bundle` and `verify_dev_stories`.

### #88 — the proof-of-work gate now subtracts the baseline snapshot

`has_changes_since` counted **every** untracked file and never subtracted `baseline_untracked` (contrast `attempt_dirty` directly below it, which does). After any intent-gap halt the saved patch is untracked residue under `implementation_artifacts`, which `_protected_relpaths` shields from every reset. #86's T4 fix excludes the *latched* patch by path, but a **from-scratch** re-arm (`restore_patch=None` — the common "the attempted reading was wrong" case) has no latch and never learns the path. A re-driven session that produced zero code changes but flipped the spec status passed the gate on the patch file's mere presence, and `finalize_commit`'s `add -A` then swept it into the story commit.

`has_changes_since` gains a keyword-only `baseline_untracked`, subtracted when non-None; the sole production caller passes `task.baseline_untracked`. Both snapshot writers (re-arm in `runs.py`, dispatch-time re-capture in `engine.py`) run while the patch is on disk, so it lands in the snapshot and stops counting.

**`None` deliberately keeps counting all untracked files** — the *opposite* of `attempt_dirty`'s `None` = ignore-all. Pinned in the docstring, because it reads like an inconsistency and isn't: the two gates fail open in opposite directions. A proof-of-work gate must fail open toward "work happened" (a pre-snapshot run must not have its gate silently weakened into never seeing new files); a rollback gate must fail open toward "nothing to remove" (never delete a file it cannot prove this attempt created).

### #89 — the baseline-match gate reads the key the skill actually writes

The gate read `fm.get("baseline_commit", "")` and **skips the whole check when the key is absent**. The generic `bmad-dev-auto` skill's step-03 stamps **`baseline_revision`**; `baseline_commit` exists only in the `result.json` `devcontract` synthesizes, which the gate does not consult (it re-reads frontmatter directly). Net: in production the baseline-match gate never fired for generic-skill sessions, and a spec claiming a stale or foreign baseline sailed through.

The gate now reads both keys via the exact idiom already in `devcontract.synthesize_result`. It composes with #86's review-F2 re-stamp (re-arm rewrites `baseline_revision`), so patch-restore re-drives stay consistent by construction.

**Fixture honesty.** The bug was masked because `conftest.write_spec` emitted `baseline_commit:` — fabricating precisely the key the real skill never writes, which made the gate look alive under test. `write_spec` now stamps `baseline_revision` like the skill, and `_spec_baseline` reads either key. This is the load-bearing part: with the fixture honest but the reader unfixed, the two **pre-existing** tests `test_verify_dev_lying_baseline` and `test_verify_dev_stories_lying_baseline` fail — they had been passing vacuously. No other suite breakage surfaced, so no spec stamps both keys.

### Tests

- `has_changes_since`: snapshot subtraction, `None` counts everything, post-snapshot file counts, tracked edit counts regardless of snapshot.
- Gate level, #88: baseline-era untracked residue + a bare status flip → `retry("no changes…")` with no latch in play; `baseline_untracked=None` → still passes (the fallback pinned); real work still passes with the snapshot in place.
- Gate level, #89: a spec carrying only a *mismatched* `baseline_revision` fires the gate (zero coverage before — this was the masked path); a matching one passes.

Mutation-checked: reverting either source fix fails exactly the corresponding new tests (plus the two now-honest pre-existing ones).

### Verification

`.venv/bin/python -m pytest` — 1930 passed, 1 skipped. Full `trunk check` (no filter) clean.

### Follow-up ordering note

Per the bundling plan, **#91(d) must land after this**: it rewrites the exact `has_changes_since` call this PR modifies (renaming `proof_exclude` → `extra_exclude` and deriving the restore-patch exclusion inside the gate). The `baseline_untracked=task.baseline_untracked` argument added here has to survive that refactor verbatim.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed verification so pre-existing untracked files no longer count as new work in baseline checks.
  * Improved baseline matching to recognize both revision-style and commit-style baseline fields, reducing false failures in dev verification.
  * Tightened proof-of-work checks so leftover untracked artifacts are handled correctly.

* **Documentation**
  * Updated the changelog with the latest fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->