### PR TITLE
feat(tui): mux.backend dropdown + close the dev.skill settings-parity gap

### DIFF
--- a/src/bmad_loop/data/settings/core.toml
+++ b/src/bmad_loop/data/settings/core.toml
@@ -365,10 +365,11 @@ description = "cap to 15fps + disable animations — fixes repaint tearing/garba
 [[section]]
 name = "mux"
 description = "terminal-multiplexer backend (machine-specific — policy.toml is gitignored)"
+# options are injected at build-registry time from detect_multiplexers() (plus any
+# already-forced value), since registered backends are a runtime fact, not an enum.
 [[section.field]]
 key = "backend"
-kind = "str"
+kind = "select"
 default_ref = "MuxPolicy.backend"
-placeholder = "auto: env var > this key > platform default > first available match"
 label = "backend"
-description = "force a registered transport backend by name (see `bmad-loop mux`) — BMAD_LOOP_MUX_BACKEND outranks it · takes effect on the next bmad-loop invocation"
+description = "force a registered transport backend by name (see `bmad-loop mux`); leave blank to auto-select — BMAD_LOOP_MUX_BACKEND outranks it · takes effect on the next bmad-loop invocation"

--- a/src/bmad_loop/settings_schema.py
+++ b/src/bmad_loop/settings_schema.py
@@ -28,7 +28,7 @@ back into this module's internals.
 from __future__ import annotations
 
 import tomllib
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from importlib import resources
 from pathlib import Path
 from typing import Any
@@ -216,6 +216,33 @@ def _plugin_fields(name: str, specs: tuple[PluginSettingSpec, ...]) -> tuple[Set
     )
 
 
+def _inject_mux_backends(sections: tuple[SectionSpec, ...], policy: Any) -> tuple[SectionSpec, ...]:
+    """Populate the ``mux.backend`` select with the backends registered on THIS host.
+
+    Registered backends are a runtime fact (not a policy enum set), so the option
+    list is built per screen-open from ``detect_multiplexers()`` rather than baked
+    into ``core.toml``. Any value already present in policy is unioned in, so a
+    backend forced via ``bmad-loop mux set --force <name>`` on a host where it is not
+    registered is never silently dropped when the settings screen saves (a blank
+    Select would collect to ``None`` = delete the key). The empty string (auto-select)
+    stays the implicit blank choice and is not listed."""
+    from .adapters.multiplexer import detect_multiplexers
+
+    current = getattr(getattr(policy, "mux", None), "backend", "") or ""
+    names = [info.name for info in detect_multiplexers()]
+    options = tuple(name for name in dict.fromkeys([*names, current]) if name)
+    out: list[SectionSpec] = []
+    for section in sections:
+        if section.name != "mux":
+            out.append(section)
+            continue
+        fields = tuple(
+            replace(f, options=options) if f.key == "backend" else f for f in section.fields
+        )
+        out.append(replace(section, fields=fields))
+    return tuple(out)
+
+
 def build_registry(project: Path | None = None, policy: Any = None) -> SettingsRegistry:
     """Core schema, plus a PluginInfo for every *discovered* plugin.
 
@@ -226,7 +253,7 @@ def build_registry(project: Path | None = None, policy: Any = None) -> SettingsR
     (the screen greys them until enabled), so ``plugin_schemas`` covers every
     plugin that contributes settings, making each ``[plugins.<name>]`` table
     typed on save regardless of toggle state."""
-    sections = load_core_schema()
+    sections = _inject_mux_backends(load_core_schema(), policy)
     enabled = set(getattr(getattr(policy, "plugins", None), "enabled", ()) or ())
     manifests = load_plugins(project)
     plugins: list[PluginInfo] = []

--- a/src/bmad_loop/tui/screens/settings_screen.py
+++ b/src/bmad_loop/tui/screens/settings_screen.py
@@ -186,7 +186,7 @@ class SettingsScreen(Screen[None]):
             if spec.kind == "select":
                 yield Select(
                     [(o, o) for o in spec.options],
-                    prompt=f"default: {spec.default}",
+                    prompt=f"default: {spec.default or 'auto'}",
                     value=str(raw) if raw in spec.options else Select.NULL,
                     id=spec.widget_id,
                 )

--- a/tests/test_settings_schema.py
+++ b/tests/test_settings_schema.py
@@ -26,10 +26,12 @@ from bmad_loop.policy import (
     SWEEP_AUTO_MODES,
     AdapterPolicy,
     CleanupPolicy,
+    DevPolicy,
     GatesPolicy,
     LimitsPolicy,
     MuxPolicy,
     NotifyPolicy,
+    PluginsPolicy,
     Policy,
     ReviewPolicy,
     ScmPolicy,
@@ -60,7 +62,13 @@ SECTION_DC = {
     "cleanup": CleanupPolicy,
     "tui": TuiPolicy,
     "mux": MuxPolicy,
+    "dev": DevPolicy,
 }
+
+# Policy dataclasses that are deliberately NOT a settings section. Plugins render
+# dynamically from their own manifests; Policy is the composed root. Every other
+# *Policy dataclass must appear in SECTION_DC (see test_every_policy_dataclass_is_classified).
+NON_SECTION_DC = {PluginsPolicy, Policy}
 
 # select fields whose options are an enum set.
 OPTIONS_ENUM = {
@@ -83,6 +91,7 @@ HIDDEN = {
     ("adapter", "dev"),  # rendered as the adapter.dev section
     ("adapter", "review"),  # rendered as the adapter.review section
     ("adapter", "triage"),  # rendered as the adapter.triage section
+    ("dev", "skill"),  # internal dev-skill seam; DEV_SKILLS has one legal value, no UI knob
 }
 
 
@@ -113,6 +122,27 @@ def test_select_options_match_enum_sets():
             assert f.options == expected, f"{f.section}.{f.key}"
 
 
+def test_mux_backend_is_a_dynamic_select():
+    """mux.backend is a dropdown populated at build time from the registered
+    backends (not an enum set, so it stays out of OPTIONS_ENUM). tmux is always
+    registered, and the default stays empty (== MuxPolicy.backend) so the blank
+    auto-select choice is intact and the defaults-sync test still holds."""
+    field = next(f for f in core_fields() if (f.section, f.key) == ("mux", "backend"))
+    assert field.kind == "select"
+    assert "tmux" in field.options
+    assert field.default == MuxPolicy.backend == ""
+
+
+def test_mux_backend_options_preserve_a_forced_value():
+    """A backend forced in policy that isn't registered on this host is still
+    offered, so an untouched save can't blank-and-delete it (a blank Select
+    collects to None = delete the key)."""
+    reg = build_registry(None, policy_mod.loads('[mux]\nbackend = "psmux"\n'))
+    field = next(f for f in reg.fields() if (f.section, f.key) == ("mux", "backend"))
+    assert "psmux" in field.options  # foreign forced value preserved
+    assert "tmux" in field.options  # plus the registered backend
+
+
 def test_every_core_spec_maps_to_a_real_policy_field():
     for f in core_fields():
         assert hasattr(SECTION_DC[f.section], f.key), f"{f.section}.{f.key} is not a policy field"
@@ -129,6 +159,20 @@ def test_every_policy_field_is_covered_by_exactly_one_spec():
             if key in HIDDEN:
                 continue
             assert key in covered, f"uncovered policy field {section}.{fld.name}"
+
+
+def test_every_policy_dataclass_is_classified():
+    """No policy dataclass can silently escape the editor contract: every *Policy
+    dataclass (and the composed root Policy) is either a settings section or
+    explicitly not one, so adding a new policy table forces a conscious editor
+    decision instead of leaving it unreachable and unchecked (as [dev] once was)."""
+    policy_dcs = {
+        obj
+        for name, obj in vars(policy_mod).items()
+        if isinstance(obj, type) and dataclasses.is_dataclass(obj) and name.endswith("Policy")
+    }
+    classified = set(SECTION_DC.values()) | NON_SECTION_DC
+    assert policy_dcs <= classified, f"unclassified policy dataclasses: {policy_dcs - classified}"
 
 
 # --------------------------------------------------------------- packaging

--- a/tests/test_tui_settings.py
+++ b/tests/test_tui_settings.py
@@ -231,6 +231,22 @@ async def test_settings_screen_blocks_invalid_value(project):
         assert (project.project / POLICY_FILE).read_text(encoding="utf-8") == POLICY_TEMPLATE
 
 
+async def test_settings_screen_mux_backend_select_roundtrip(project):
+    """The mux backend dropdown persists a chosen backend through the same save
+    path as every other field — a regression guard for the str->select change and
+    the runtime-injected options (assigning a value that isn't an offered option
+    raises, so this also asserts tmux is on the menu)."""
+    write_policy(project)
+    app = BmadLoopApp(project.project)
+    async with app.run_test(size=(100, 40)) as pilot:
+        screen = await open_settings(app, pilot)
+        screen.query_one("#mux-backend", Select).value = "tmux"
+        await pilot.press("ctrl+s")
+        await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
+        saved = policy_mod.loads((project.project / POLICY_FILE).read_text(encoding="utf-8"))
+        assert saved.mux.backend == "tmux"
+
+
 async def test_settings_screen_review_toggle_roundtrip(project):
     write_policy(project)
     app = BmadLoopApp(project.project)


### PR DESCRIPTION
## What

Two small hardening items for the TUI settings editor, surfaced while verifying that the post-0.8.1 tunables (`mux.backend`, `stories.source`, `stories.spec_folder`) are editable from the `g` screen. They **are** — and a parity test enforces it — so this PR only closes two edges, not a coverage hole.

## Changes

### 1. `mux.backend` is now a dropdown (`str` → `select`)
The field was free-text; it now offers the backends actually registered on this host. Registered backends are a **runtime** fact (`detect_multiplexers()`), not a policy enum, so the option list is injected in `build_registry(project, policy)` (per screen-open) rather than baked into `core.toml`.

**Data-loss guard:** a blank `Select` collects to `None` (delete key), so a backend force-set via `bmad-loop mux set --force <name>` that isn't registered here would be silently dropped on an untouched save. The current policy value is therefore **unioned into the options** so it stays selected and unchanged. Blank remains auto-select.

- `data/settings/core.toml`: `kind = "str"` → `"select"` (options runtime-injected; comment explains why).
- `settings_schema.py`: new `_inject_mux_backends()` helper; `build_registry` runs it over the core sections.
- `tui/screens/settings_screen.py`: 1-line polish — the select prompt reads `default: auto` for the empty default.

### 2. Close the `dev.skill` settings-parity gap (test-only)
`DevPolicy` was outside the test's `SECTION_DC`, so `[dev] skill` was neither editable nor caught by the completeness test — silently outside the contract. It's now in `SECTION_DC` + `HIDDEN` (single legal value `DEV_SKILLS = {"bmad-dev-auto"}`, no UI knob warranted), mirroring the existing hidden-field idiom. A new `test_every_policy_dataclass_is_classified` guard fails CI if any future `*Policy` dataclass is added without a conscious editor decision.

## Tests
- `test_mux_backend_is_a_dynamic_select`, `test_mux_backend_options_preserve_a_forced_value` (schema-level).
- `test_settings_screen_mux_backend_select_roundtrip` (Textual pilot: open `g` → set the dropdown → `ctrl+s` → assert `mux.backend` persisted to `policy.toml`).
- `test_every_policy_dataclass_is_classified` (contract guard).
- Existing sync tests unaffected: `mux.backend` stays out of `OPTIONS_ENUM` (dynamic, not an enum), default stays `""` (== `MuxPolicy.backend`).

## Verification
- Full suite green: **2118 passed, 1 skipped**.
- `trunk check` clean on all changed files.
- No behavior change outside the settings editor; no docs change needed (the field description already stands).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The Mux backend setting is now presented as a dropdown with locally available backend options.
  - A manually configured backend remains selectable even if it is not currently detected.
  - The settings screen displays “default: auto” when no backend is explicitly selected.

- **Bug Fixes**
  - Selecting and saving a Mux backend now correctly preserves the choice after reloading settings.

- **Tests**
  - Added coverage for dynamic backend options and settings round-trip behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->