### PR TITLE
feat(tui): resizable dashboard panes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ breaking changes may land in a minor release.
 
 ### Added
 
+- **Resizable dashboard panes.** Every pane boundary is now adjustable by mouse-drag (divider
+  bars, which also carry the Sprint / Deferred Work headings) or a keyboard resize mode (`ctrl+w`,
+  then `←`/`→` for the sidebar, `↑`/`↓` for the active horizontal split, `Tab` to pick it, `Esc` to
+  exit). Sizes persist per-project to a new `[tui]` section in `policy.toml` and re-apply on the
+  next launch; untouched projects keep the previous fixed proportions.
+
 - **Dev-choosable multiplexer backend selection (#87).** `get_multiplexer()` now resolves by
   precedence — `BMAD_LOOP_MUX_BACKEND` env var → the new machine-scoped `[mux] backend` key in
   policy.toml → the platform default (win32: `psmux`, elsewhere: `tmux`) when installed → the first

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ A live, read-only dashboard over everything below — and a launcher for new run
 <img src="docs/images/dashboard.png" alt="Dashboard: runs table, run header with token totals, per-story phase table, sprint tree, deferred-work ledger, and the journal tab." width="880">
 </div>
 
-The left column stacks the **runs table** (newest auto-selected; a per-run pause badge tags paused runs by kind, and the title carries a global _⚑ N need attention_ count), an expandable **sprint tree** (epics → stories/retro, completed items checked green) — replaced by a **stories board** (id · live disk state · spec/done checkpoint markers · title) when the selected run is in stories mode — and the **deferred-work ledger** (severity colour-coded). The right column shows the selected run's **header** (status, epic, task counts, cost-weighted token total), a **per-story table** (phase · dev attempts · review cycles · tokens · commit/defer info), and tabs tailing the **journal**, the active session's **pane log**, and the **ATTENTION** file. On a paused run, **`p`** opens the stage-appropriate HITL viewer — a plan-checkpoint spec viewer (Approve & resume / Request replan), a story-checkpoint summary card (Continue / Stop), the escalation view with story context (Resolve / Re-arm & resume), or a gate spec viewer — each calling the exact code paths the CLI uses.
+The left column stacks the **runs table** (newest auto-selected; a per-run pause badge tags paused runs by kind, and the title carries a global _⚑ N need attention_ count), an expandable **sprint tree** (epics → stories/retro, completed items checked green) — replaced by a **stories board** (id · live disk state · spec/done checkpoint markers · title) when the selected run is in stories mode — and the **deferred-work ledger** (severity colour-coded). The right column shows the selected run's **header** (status, epic, task counts, cost-weighted token total), a **per-story table** (phase · dev attempts · review cycles · tokens · commit/defer info), and tabs tailing the **journal**, the active session's **pane log**, and the **ATTENTION** file. Every pane boundary is resizable — drag any divider bar or press **`ctrl+w`** for a keyboard resize mode; the sidebar width and pane heights persist per-project to `[tui]` in `policy.toml` (see the [TUI guide](docs/tui-guide.md#resizing-panes)). On a paused run, **`p`** opens the stage-appropriate HITL viewer — a plan-checkpoint spec viewer (Approve & resume / Request replan), a story-checkpoint summary card (Continue / Stop), the escalation view with story context (Resolve / Re-arm & resume), or a gate spec viewer — each calling the exact code paths the CLI uses.
 
 ### A sweep blocked on a human decision
 
@@ -151,6 +151,7 @@ Press **`g`** to edit `.bmad-loop/policy.toml` in a form grouped by section — 
 | `v`       | run `bmad-loop validate`, output in a modal                                                              |
 | `g`       | settings editor for `.bmad-loop/policy.toml`                                                             |
 | `y`       | copy the active Log/Attention pane to the clipboard                                                      |
+| `ctrl+w`  | enter/leave pane resize mode (arrows resize, `Tab` picks the boundary) — or drag any divider bar         |
 | `M` / `q` | toggle theme (light/dark mode) / quit                                                                    |
 
 **The TUI is an observer/launcher, never the engine.** Runs started with `r`/`s` are detached `bmad-loop` processes in windows of a dedicated tmux session (`bmad-loop-ctl`), so they survive a TUI exit or crash; the dashboard watches runs purely through the run-dir artifacts the engine writes atomically, so runs started from a plain shell show up identically. Launch and attach need tmux; the dashboard itself does not. Pid-based liveness is local-only — a run whose engine died shows `interrupted` (press `e`); runs on other hosts show `unknown`.
@@ -398,6 +399,12 @@ backend = ""               # "" = auto-select; else force a registered backend b
 
 [tui]
 low_frame_rate = false     # true = cap to 15fps + disable animations (= bmad-loop tui --low-frame-rate)
+# Persisted dashboard pane sizes (terminal cells). 0 = unset → default proportions;
+# the TUI writes these when you resize by mouse-drag or the Ctrl+W resize mode.
+# left_width = 0           # sidebar width, columns
+# runs_height = 0          # Runs pane height, rows
+# deferred_height = 0      # Deferred pane height, rows
+# tasks_height = 0         # Tasks table height, rows
 ```
 
 **Gate modes:** `none` runs everything unattended; `per-epic` (default) pauses at epic boundaries; `per-story-spec-approval` pauses after each spec is written so you approve it before implementation is reviewed.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -141,13 +141,14 @@ See [README.md](../README.md) for the narrative overview and [setup-guide.md](se
 ### Configuration (`.bmad-loop/policy.toml`)
 
 - Single policy file written by `init`, snapshotted at run start (applies to new runs and resumes; editable live from the TUI).
-- Sections: `[gates]`, `[limits]`, `[verify]`, `[notify]`, `[review]`, `[adapter]` (+ per-stage), `[sweep]`, `[scm]` (worktree isolation + merge-back), `[cleanup]` (run-dir retention + disk reclamation), `[plugins]` (trust allowlist + per-plugin `[plugins.<name>]` config — e.g. the opt-in game-engine layer via `[plugins.unity]`, off by default), `[tui]` (`low_frame_rate` for slow/SSH links).
+- Sections: `[gates]`, `[limits]`, `[verify]`, `[notify]`, `[review]`, `[adapter]` (+ per-stage), `[sweep]`, `[scm]` (worktree isolation + merge-back), `[cleanup]` (run-dir retention + disk reclamation), `[plugins]` (trust allowlist + per-plugin `[plugins.<name>]` config — e.g. the opt-in game-engine layer via `[plugins.unity]`, off by default), `[tui]` (`low_frame_rate` for slow/SSH links; persisted dashboard pane sizes).
 - Tunable limits: `max_review_cycles`, `max_dev_attempts`, `session_timeout_min`, `stop_without_result_nudges`, `dev_stall_grace_s`, `dev_stall_nudges`, `max_tokens_per_story`.
 
 ### TUI dashboard
 
 - Read-only observer + launcher (`bmad-loop tui`): runs table, expandable sprint tree (epics → stories/retro), severity-colored deferred-work ledger, per-story phase table (phase · dev attempts · review cycles · tokens · commit/defer), tabs tailing journal / pane log / `ATTENTION`.
 - Launch & manage from keys: start run/sweep (`r`/`s`), resume (`e`), resolve escalation (`R`), answer missed decisions (`d`), attach (`a`), cleanup (`c`), validate (`v`), settings editor (`g`), theme/mode toggle (`M`), quit (`q`).
+- Resizable panes: every boundary is drag-adjustable by mouse (the divider bars double as the Sprint / Deferred Work section headings) or a `ctrl+w` keyboard resize mode; sizes persist per-project to `[tui]` in `policy.toml` and re-apply on the next launch.
 - Survives TUI exit/crash: runs launched from the TUI are detached `bmad-loop` processes in a dedicated `bmad-loop-ctl` tmux session; the dashboard watches purely via run-dir artifacts, so shell-started runs appear identically.
 - Comment-preserving policy editor (`g`): grouped form, sections collapsed by default with one-line descriptions (`ctrl+e` toggles all), validated with the engine's own parser, unset keys show defaults as placeholders.
 

--- a/docs/tui-guide.md
+++ b/docs/tui-guide.md
@@ -82,11 +82,13 @@ captured and shown in a scrollable modal instead of spawned in tmux.
 
 ### Left column
 
-Three stacked panes; `tab` / `shift+tab` move focus between them. The sprint
-and deferred panes read project-level files maintained by LLM sessions
-(`sprint-status.yaml`, `deferred-work.md`), so both parse forgivingly: a
-missing or malformed file shows a dim placeholder instead of an error, and
-the pane recovers on the next poll once the file is readable again.
+Three stacked panes; `tab` / `shift+tab` move focus between them, and their
+heights (like the sidebar width) are resizable — see [Resizing
+panes](#resizing-panes). The sprint and deferred panes read project-level files
+maintained by LLM sessions (`sprint-status.yaml`, `deferred-work.md`), so both
+parse forgivingly: a missing or malformed file shows a dim placeholder instead
+of an error, and the pane recovers on the next poll once the file is readable
+again.
 
 #### Run list (top)
 
@@ -243,27 +245,46 @@ Journal kinds are styled by substring, first match wins:
 
 ## Key bindings
 
-| Key | Action                                                                     |
-| --- | -------------------------------------------------------------------------- |
-| `r` | start a run (modal)                                                        |
-| `s` | start a sweep (modal)                                                      |
-| `e` | resume the selected paused/interrupted run (confirm modal)                 |
-| `p` | review the selected paused run in the stage-appropriate HITL viewer        |
-| `R` | resolve a run paused at an escalation (interactive, then re-arm)           |
-| `d` | answer deferred-work decisions past sweeps left unanswered (modal walk)    |
-| `a` | attach to the selected run's live session or orchestrator window           |
-| `x` | stop the selected live run (confirm modal)                                 |
-| `D` | delete the selected run's directory (confirm modal)                        |
-| `A` | archive the selected run to `.bmad-loop/archive` (confirm modal)           |
-| `c` | clean up tmux sessions/windows for finished & stopped runs (confirm modal) |
-| `v` | run `bmad-loop validate`, output in a modal                                |
-| `g` | settings editor for `.bmad-loop/policy.toml`                               |
-| `M` | toggle theme (light/dark mode)                                             |
-| `y` | copy the active Log/Attention pane to the clipboard                        |
-| `q` | quit (running engines are unaffected)                                      |
+| Key      | Action                                                                     |
+| -------- | -------------------------------------------------------------------------- |
+| `r`      | start a run (modal)                                                        |
+| `s`      | start a sweep (modal)                                                      |
+| `e`      | resume the selected paused/interrupted run (confirm modal)                 |
+| `p`      | review the selected paused run in the stage-appropriate HITL viewer        |
+| `R`      | resolve a run paused at an escalation (interactive, then re-arm)           |
+| `d`      | answer deferred-work decisions past sweeps left unanswered (modal walk)    |
+| `a`      | attach to the selected run's live session or orchestrator window           |
+| `x`      | stop the selected live run (confirm modal)                                 |
+| `D`      | delete the selected run's directory (confirm modal)                        |
+| `A`      | archive the selected run to `.bmad-loop/archive` (confirm modal)           |
+| `c`      | clean up tmux sessions/windows for finished & stopped runs (confirm modal) |
+| `v`      | run `bmad-loop validate`, output in a modal                                |
+| `g`      | settings editor for `.bmad-loop/policy.toml`                               |
+| `M`      | toggle theme (light/dark mode)                                             |
+| `y`      | copy the active Log/Attention pane to the clipboard                        |
+| `ctrl+w` | enter/leave pane **resize mode** (see below)                               |
+| `q`      | quit (running engines are unaffected)                                      |
 
 In the settings editor: `ctrl+s` saves, `ctrl+e` expands/collapses all
 sections, `escape` goes back without saving. In any modal: `escape` cancels.
+
+### Resizing panes
+
+Every pane boundary is adjustable, by **mouse** or **keyboard**, and the sizes
+persist per-project to `[tui]` in `policy.toml` (re-applied on the next launch).
+
+- **Mouse** — drag any divider bar: the column split between the left sidebar and
+  the detail pane, the bars between the stacked left-column panes (they double as
+  the Sprint / Deferred Work section headings), and the bar between the Tasks
+  table and the Journal/Log/Attention tabs. Bars highlight on hover.
+- **Keyboard** — press `ctrl+w` to enter resize mode (the header shows a hint):
+  `←`/`→` widen or narrow the sidebar, `↑`/`↓` move the active horizontal
+  boundary, `Tab`/`Shift+Tab` pick which horizontal boundary is active, and
+  `Esc` (or `Enter`) leaves the mode. Outside resize mode the arrows and `Tab`
+  keep their usual navigation/focus behavior.
+
+To forget custom sizes, delete the `[tui]` size keys from `policy.toml` (or set
+them to `0`) — the panes return to their default proportions.
 
 ## Starting runs and sweeps (`r` / `s`)
 

--- a/src/bmad_loop/policy.py
+++ b/src/bmad_loop/policy.py
@@ -159,6 +159,15 @@ class TuiPolicy:
     # repaint tearing/garbage when driving the TUI over a slow/high-latency
     # link (SSH, Tailscale) where a 60fps update stream can't drain in time.
     low_frame_rate: bool = False
+    # Persisted dashboard pane geometry, in terminal cells. 0 = unset: the layout
+    # keeps its built-in default proportions (so a fresh project looks unchanged
+    # and only user-resized panes land in the file). The TUI writes these when a
+    # pane is resized by mouse-drag or the Ctrl+W resize mode, and seeds them back
+    # on the next launch. Per-project, since policy.toml is project-scoped.
+    left_width: int = 0  # sidebar (#left) width, columns
+    runs_height: int = 0  # Runs pane height, rows (top of the left column)
+    deferred_height: int = 0  # Deferred pane height, rows (bottom of the left column)
+    tasks_height: int = 0  # Tasks table height, rows (detail column)
 
 
 @dataclass(frozen=True)
@@ -412,6 +421,18 @@ def _opt_nudges(d: dict[str, Any], where: str) -> int | None:
     if value < 0:
         raise PolicyError(f"{where}.stop_without_result_nudges must be >= 0: got {value}")
     return value
+
+
+def _tui_dim(d: dict[str, Any], key: str) -> int:
+    """A persisted TUI pane dimension (cells). 0 = unset; negatives are rejected.
+    Strict like scm.max_parallel: a TOML bool or float would coerce silently and
+    corrupt the saved geometry, so require a real int."""
+    raw = d.get(key, 0)
+    if isinstance(raw, bool) or not isinstance(raw, int):
+        raise PolicyError(f"tui.{key} must be a non-negative integer: got {raw!r}")
+    if raw < 0:
+        raise PolicyError(f"tui.{key} must be >= 0: got {raw}")
+    return raw
 
 
 def _stage_adapter(adapter_d: dict[str, Any], key: str) -> StageAdapterPolicy:
@@ -699,7 +720,13 @@ def loads(text: str, plugin_schemas: dict[str, Any] | None = None) -> Policy:
         for name, raw_settings in plugin_settings.items():
             _validate_plugin_settings(name, raw_settings, plugin_schemas.get(name))
     plugins = PluginsPolicy(enabled=tuple(enabled), settings=plugin_settings)
-    tui = TuiPolicy(low_frame_rate=bool(tui_d.get("low_frame_rate", TuiPolicy.low_frame_rate)))
+    tui = TuiPolicy(
+        low_frame_rate=bool(tui_d.get("low_frame_rate", TuiPolicy.low_frame_rate)),
+        left_width=_tui_dim(tui_d, "left_width"),
+        runs_height=_tui_dim(tui_d, "runs_height"),
+        deferred_height=_tui_dim(tui_d, "deferred_height"),
+        tasks_height=_tui_dim(tui_d, "tasks_height"),
+    )
     mux = MuxPolicy(backend=str(mux_d.get("backend", MuxPolicy.backend)).strip())
     if mux.backend and not _MUX_NAME_RE.match(mux.backend):
         raise PolicyError(
@@ -901,6 +928,14 @@ enabled = []                 # e.g. ["unity", "my-lint-plugin"]
 # over slow/high-latency links (SSH, Tailscale). Equivalent to launching with
 # `bmad-loop tui --low-frame-rate`. Takes effect the next time the TUI starts.
 low_frame_rate = false
+# Persisted dashboard pane sizes, in terminal cells. 0 = unset (use the built-in
+# default proportions). The TUI writes these when you resize a pane by mouse-drag
+# or the Ctrl+W resize mode; they are re-applied on the next launch. Usually you
+# won't hand-edit these — resize in the TUI instead.
+# left_width = 0        # sidebar width, columns
+# runs_height = 0       # Runs pane height, rows
+# deferred_height = 0   # Deferred pane height, rows
+# tasks_height = 0      # Tasks table height, rows
 
 [mux]
 # Terminal-multiplexer backend for this machine (the transport axis — which

--- a/src/bmad_loop/tui/app.py
+++ b/src/bmad_loop/tui/app.py
@@ -68,29 +68,29 @@ class BmadLoopApp(App[None]):
     CSS = """
     #left {
         width: 34;
-        border-right: solid $primary-darken-2;
+        /* the divider to #detail is the draggable #split-main bar, not a border */
     }
     #runs {
         height: 2fr;
         min-height: 4;
         border-top: solid $primary-darken-2;
     }
-    #runs, #sprint-tree, #stories-table, #deferred {
+    #runs {
         border-title-color: $text;
         border-title-style: bold;
     }
     #sprint-tree, #stories-table {
+        /* the dividers above these panes are the draggable splitter bars, which
+           also carry the section title that used to ride the border-top */
         height: 3fr;
         min-height: 4;
-        border-top: solid $primary-darken-2;
     }
     #deferred {
         height: 2fr;
         min-height: 4;
         /* strip OptionList's default tall border + padding so the pane sits
-           flush with the runs table and sprint tree above it */
+           flush with the splitter bar above it */
         border: none;
-        border-top: solid $primary-darken-2;
         padding: 0;
         text-wrap: nowrap;
         text-overflow: ellipsis;

--- a/src/bmad_loop/tui/screens/dashboard.py
+++ b/src/bmad_loop/tui/screens/dashboard.py
@@ -174,11 +174,11 @@ class DashboardScreen(Screen[None]):
     def __init__(self, project: Path):
         super().__init__()
         self.project = project
-        # Persisted pane sizes to seed on first layout; a malformed policy file
-        # degrades to defaults rather than blocking the dashboard.
+        # Persisted pane sizes to seed on first layout; a malformed or unreadable
+        # policy file degrades to defaults rather than blocking the dashboard.
         try:
             self._tui_policy = policy_mod.load(project / policy_mod.POLICY_FILE).tui
-        except policy_mod.PolicyError:
+        except (policy_mod.PolicyError, OSError):
             self._tui_policy = policy_mod.TuiPolicy()
         self._seeded = False
         self._left_frozen = False  # Runs/Deferred switched to explicit heights
@@ -592,7 +592,9 @@ class DashboardScreen(Screen[None]):
         if not dirty and not path.is_file():
             return  # nothing customised and no file to update — don't create one
         try:
-            doc = PolicyDoc.load(path)
+            # A missing file starts empty, NOT from POLICY_TEMPLATE: a geometry
+            # save must not freeze every default setting into a fresh policy.toml.
+            doc = PolicyDoc.load(path, template_when_missing=False)
             doc.set("tui", "left_width", self.left_width if self.left_width > 0 else None)
             doc.set("tui", "runs_height", self.runs_height if self._left_frozen else None)
             doc.set("tui", "deferred_height", self.deferred_height if self._left_frozen else None)
@@ -600,6 +602,12 @@ class DashboardScreen(Screen[None]):
             doc.save(path)
         except (OSError, tomlkit.exceptions.TOMLKitError) as e:
             self.notify(f"could not save layout: {e}", severity="warning")
+
+    def on_unmount(self) -> None:
+        # Quitting mid-resize-mode would otherwise drop the new geometry: keyboard
+        # bumps persist only on mode exit, and `q` stays live inside the mode.
+        if self._resize_mode:
+            self._persist_geometry()
 
     # ---- keyboard resize mode -----------------------------------------------
 

--- a/src/bmad_loop/tui/screens/dashboard.py
+++ b/src/bmad_loop/tui/screens/dashboard.py
@@ -18,10 +18,11 @@ from pathlib import Path
 from typing import Any
 
 from rich.text import Text
-from textual import work
+from textual import events, work
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
+from textual.reactive import reactive
 from textual.screen import Screen
 from textual.widgets import (
     DataTable,
@@ -34,6 +35,7 @@ from textual.widgets import (
 )
 from textual.widgets.option_list import Option, OptionDoesNotExist
 
+from ... import policy as policy_mod
 from ... import sprintstatus, stories
 from ...model import RunState
 from ...runs import RUNS_DIR
@@ -43,12 +45,30 @@ from ..widgets import (
     JournalEntryOption,
     RunHeader,
     SelectableRichLog,
+    Splitter,
     SprintTree,
     StoriesTable,
     pause_tag,
     status_cell,
 )
 from .modals import DeferredEntryModal
+
+# Resizable-pane geometry, in terminal cells. The MIN_* floors keep a pane from
+# collapsing to nothing when a boundary is dragged or the terminal shrinks; they
+# mirror the `min-height: 4` backstops still in the CSS.
+_MIN_SIDEBAR = 20
+_MIN_DETAIL = 30
+_MIN_PANE = 4  # a stacked left-column pane (Runs / Deferred)
+_MIN_TASKS = 3
+_MIN_TABS = 5
+# The horizontal splitters cycled by Tab in resize mode, top to bottom.
+_HSPLITS = ("#split-runs", "#split-deferred", "#split-tasks")
+# Resize-mode actions gated off (key passes through to the focused widget) unless
+# the mode is active. Tab/Shift+Tab are intentionally absent: they stay live and
+# delegate to focus movement when not resizing.
+_RESIZE_ACTIONS = frozenset(
+    {"resize_up", "resize_down", "resize_left", "resize_right", "resize_done"}
+)
 
 # Keep at most this many parsed journal entries per run for active-task
 # tracking; the visible pane is bounded separately per widget.
@@ -130,11 +150,42 @@ class DashboardScreen(Screen[None]):
     BINDINGS = [
         Binding("escape", "unpin_log", "follow log", show=False),
         Binding("y", "copy_pane", "copy"),
+        Binding("ctrl+w", "resize_mode", "resize"),
+        # Priority so they beat the focused table/tree/list in resize mode;
+        # check_action() disables them (key passes through) when not resizing.
+        Binding("up", "resize_up", show=False, priority=True),
+        Binding("down", "resize_down", show=False, priority=True),
+        Binding("left", "resize_left", show=False, priority=True),
+        Binding("right", "resize_right", show=False, priority=True),
+        Binding("enter", "resize_done", show=False, priority=True),
+        # Tab stays live: it cycles the active boundary in resize mode and falls
+        # back to focus movement otherwise (see action_resize_cycle).
+        Binding("tab", "resize_cycle(1)", show=False, priority=True),
+        Binding("shift+tab", "resize_cycle(-1)", show=False, priority=True),
     ]
+
+    # Persisted pane geometry (cells); 0 = unset -> keep the CSS default. Seeded
+    # after first layout (and from policy) and mutated by drags / resize mode.
+    left_width: reactive[int] = reactive(0, init=False)
+    runs_height: reactive[int] = reactive(0, init=False)
+    deferred_height: reactive[int] = reactive(0, init=False)
+    tasks_height: reactive[int] = reactive(0, init=False)
 
     def __init__(self, project: Path):
         super().__init__()
         self.project = project
+        # Persisted pane sizes to seed on first layout; a malformed policy file
+        # degrades to defaults rather than blocking the dashboard.
+        try:
+            self._tui_policy = policy_mod.load(project / policy_mod.POLICY_FILE).tui
+        except policy_mod.PolicyError:
+            self._tui_policy = policy_mod.TuiPolicy()
+        self._seeded = False
+        self._left_frozen = False  # Runs/Deferred switched to explicit heights
+        self._detail_frozen = False  # Tasks switched to an explicit height
+        self._resize_mode = False
+        self._active_hsplit = 0  # index into _HSPLITS for Up/Down in resize mode
+        self._saved_subtitle = ""
         self._generation = 0
         self._ctx: _PollContext | None = None
         self._tick_count = 0
@@ -164,20 +215,43 @@ class DashboardScreen(Screen[None]):
         with Horizontal():
             with Vertical(id="left"):
                 runs = DataTable(id="runs", cursor_type="row")
-                runs.border_title = "Runs"
+                runs.border_title = "Runs"  # first pane: keeps its own titled border
                 yield runs
-                tree = SprintTree("sprint", id="sprint-tree")
-                tree.border_title = "Sprint"
-                yield tree
-                stories = StoriesTable(id="stories-table")
-                stories.border_title = "Stories"
-                yield stories
-                deferred = OptionList(id="deferred")
-                deferred.border_title = "Deferred Work"
-                yield deferred
+                # The section titles that used to ride each pane's border-top now
+                # ride the splitter bar above that pane (its border-top is dropped
+                # in CSS). split-runs' label tracks the sprint/stories toggle.
+                yield Splitter(
+                    horizontal=True,
+                    label="Sprint",
+                    apply=self._resize_runs,
+                    on_release=self._persist_geometry,
+                    id="split-runs",
+                )
+                yield SprintTree("sprint", id="sprint-tree")
+                yield StoriesTable(id="stories-table")
+                yield Splitter(
+                    horizontal=True,
+                    label="Deferred Work",
+                    apply=self._resize_deferred,
+                    on_release=self._persist_geometry,
+                    id="split-deferred",
+                )
+                yield OptionList(id="deferred")
+            yield Splitter(
+                horizontal=False,
+                apply=self._resize_left,
+                on_release=self._persist_geometry,
+                id="split-main",
+            )
             with Vertical(id="detail"):
                 yield RunHeader(id="runheader")
                 yield DataTable(id="tasks", cursor_type="row")
+                yield Splitter(
+                    horizontal=True,
+                    apply=self._resize_tasks,
+                    on_release=self._persist_geometry,
+                    id="split-tasks",
+                )
                 with TabbedContent(id="tabs"):
                     with TabPane("Journal", id="tab-journal"):
                         yield OptionList(id="journal")
@@ -209,6 +283,8 @@ class DashboardScreen(Screen[None]):
         self.query_one("#runheader", RunHeader).show_empty(self.project)
         self.set_interval(1.0, self._tick)
         self._tick()
+        # Seed pane geometry once the first layout has real sizes to read.
+        self.call_after_refresh(self._seed_geometry)
 
     # ------------------------------------------------------------- selection
 
@@ -317,6 +393,9 @@ class DashboardScreen(Screen[None]):
         log.scroll_to(y=max(0, target - viewport // 2), animate=False)
 
     def action_unpin_log(self) -> None:
+        if self._resize_mode:  # Escape leaves resize mode before it unpins the log
+            self._exit_resize_mode()
+            return
         if self._pin_task is None and self._pending_jump is None:
             return
         self._pin_task = None
@@ -343,6 +422,251 @@ class DashboardScreen(Screen[None]):
             return
         self.app.copy_to_clipboard(text)
         self.notify(f"copied {log_id.lstrip('#')} pane to clipboard")
+
+    # ------------------------------------------------------------ pane resizing
+    #
+    # Model: the pane on one side of a boundary carries an explicit cell size
+    # (owned by a reactive below); a designated neighbour stays `1fr` and absorbs
+    # slack, including terminal resizes. The sidebar (#left) is already fixed and
+    # #detail flexes. The left column freezes Runs/Deferred to explicit heights on
+    # first resize (the middle Sprint/Stories slot becomes the sole flex); the
+    # detail column freezes Tasks (the Tabs pane already flexes). Watchers clamp
+    # against live region sizes and write widget.styles; on_resize re-clamps.
+
+    def _seed_geometry(self) -> None:
+        """Apply persisted sizes once the first layout has real dimensions. With
+        nothing persisted the panes keep their CSS proportions untouched, so a
+        fresh project looks exactly as before."""
+        if self._seeded:
+            return
+        self._seeded = True
+        pol = self._tui_policy
+        if pol.left_width > 0:
+            self.left_width = pol.left_width
+        if pol.runs_height > 0 or pol.deferred_height > 0:
+            self._freeze_left()
+            if pol.runs_height > 0:
+                self.runs_height = pol.runs_height
+            if pol.deferred_height > 0:
+                self.deferred_height = pol.deferred_height
+        if pol.tasks_height > 0:
+            self._freeze_detail()
+            self.tasks_height = pol.tasks_height
+
+    def _freeze_left(self) -> None:
+        """Switch the left column to explicit Runs/Deferred heights with the
+        Sprint/Stories slot as the sole vertical flex. Idempotent."""
+        if self._left_frozen:
+            return
+        self._left_frozen = True
+        # Snapshot both current render heights before mutating anything: assigning
+        # one reactive fires its watcher, and _apply_left_heights must see both
+        # seeds (its 0-guard skips a half-seeded state). outer_size is the
+        # border-box height styles.height sets, so freezing is seamless even for
+        # #runs' titled border.
+        runs_seed = max(_MIN_PANE, self.query_one("#runs").outer_size.height)
+        deferred_seed = max(_MIN_PANE, self.query_one("#deferred").outer_size.height)
+        for wid in ("#sprint-tree", "#stories-table"):
+            self.query_one(wid).styles.height = "1fr"
+        if self.runs_height <= 0:
+            self.runs_height = runs_seed
+        if self.deferred_height <= 0:
+            self.deferred_height = deferred_seed
+        self._apply_left_heights()
+
+    def _freeze_detail(self) -> None:
+        """Switch Tasks to an explicit height (Tabs already flexes). Idempotent."""
+        if self._detail_frozen:
+            return
+        self._detail_frozen = True
+        tasks = self.query_one("#tasks", DataTable)
+        if self.tasks_height <= 0:
+            self.tasks_height = max(_MIN_TASKS, tasks.outer_size.height)
+        # The explicit height governs now; _apply_tasks_height also lifts the CSS
+        # `max-height: 35%` cap (setting the inline value to None would NOT — the
+        # stylesheet rule wins, silently re-clamping a taller Tasks pane).
+        self._apply_tasks_height()
+
+    # ---- appliers (clamp against live sizes, then write styles) --------------
+
+    def _apply_left_width(self) -> None:
+        if self.left_width <= 0:
+            return
+        total = self.size.width
+        if total <= 0:
+            return
+        hi = max(_MIN_SIDEBAR, total - _MIN_DETAIL - 1)  # -1 for the splitter column
+        val = max(_MIN_SIDEBAR, min(self.left_width, hi))
+        self.query_one("#left").styles.width = val
+        if val != self.left_width:
+            self.left_width = val  # snap the reactive to the clamped value
+
+    def _apply_left_heights(self) -> None:
+        if not self._left_frozen:
+            return
+        if self.runs_height <= 0 or self.deferred_height <= 0:
+            return  # mid-freeze: both seeds not in yet (see _freeze_left)
+        total = self.query_one("#left").size.height
+        if total <= 0:
+            return
+        # Reserve rows the two fixed panes cannot use: the two splitter bars, the
+        # Runs border-top, and the flex middle's minimum.
+        room = max(2 * _MIN_PANE, total - (2 + 1 + _MIN_PANE))
+        rh = max(_MIN_PANE, self.runs_height)
+        dh = max(_MIN_PANE, self.deferred_height)
+        if rh + dh > room:  # trim the deferred pane first, then runs
+            dh = max(_MIN_PANE, min(dh, room - _MIN_PANE))
+            rh = max(_MIN_PANE, min(rh, room - dh))
+        self.query_one("#runs").styles.height = rh
+        self.query_one("#deferred").styles.height = dh
+        if rh != self.runs_height:
+            self.runs_height = rh
+        if dh != self.deferred_height:
+            self.deferred_height = dh
+
+    def _apply_tasks_height(self) -> None:
+        if not self._detail_frozen or self.tasks_height <= 0:
+            return
+        total = self.query_one("#detail").size.height
+        if total <= 0:
+            return
+        header = self.query_one("#runheader").size.height
+        hi = max(_MIN_TASKS, total - header - 1 - _MIN_TABS)  # -1 for the splitter
+        val = max(_MIN_TASKS, min(self.tasks_height, hi))
+        tasks = self.query_one("#tasks")
+        tasks.styles.height = val
+        # Neutralize the stylesheet's `max-height: 35%` (the unfrozen default): an
+        # inline value >= the height is the only way to override it, since None
+        # falls back to the CSS rule and would re-clamp Tasks below `val`.
+        tasks.styles.max_height = val
+        if val != self.tasks_height:
+            self.tasks_height = val
+
+    def watch_left_width(self, _old: int, _new: int) -> None:
+        self._apply_left_width()
+
+    def watch_runs_height(self, _old: int, _new: int) -> None:
+        self._apply_left_heights()
+
+    def watch_deferred_height(self, _old: int, _new: int) -> None:
+        self._apply_left_heights()
+
+    def watch_tasks_height(self, _old: int, _new: int) -> None:
+        self._apply_tasks_height()
+
+    def on_resize(self, event: events.Resize) -> None:
+        # Re-clamp explicit sizes so a shrunk terminal can't push a fixed pane off
+        # screen; unfrozen dimensions are no-ops.
+        self._apply_left_width()
+        self._apply_left_heights()
+        self._apply_tasks_height()
+
+    # ---- drag targets (one per boundary; sign lives here) -------------------
+
+    def _resize_left(self, delta: int) -> None:
+        base = self.left_width if self.left_width > 0 else self.query_one("#left").size.width
+        self.left_width = base + delta  # +delta widens the sidebar
+
+    def _resize_runs(self, delta: int) -> None:
+        self._freeze_left()
+        self.runs_height = max(_MIN_PANE, self.runs_height + delta)  # down grows Runs
+
+    def _resize_deferred(self, delta: int) -> None:
+        self._freeze_left()
+        # The bar sits atop Deferred: moving it down grows Sprint / shrinks Deferred.
+        self.deferred_height = max(_MIN_PANE, self.deferred_height - delta)
+
+    def _resize_tasks(self, delta: int) -> None:
+        self._freeze_detail()
+        self.tasks_height = max(_MIN_TASKS, self.tasks_height + delta)  # down grows Tasks
+
+    def _persist_geometry(self) -> None:
+        """Write the current sizes to policy.toml (drag end / resize-mode exit).
+        Best-effort: a write or parse failure degrades to a toast, never a crash."""
+        import tomlkit.exceptions
+
+        from ..settings import PolicyDoc
+
+        path = self.project / policy_mod.POLICY_FILE
+        dirty = self.left_width > 0 or self._left_frozen or self._detail_frozen
+        if not dirty and not path.is_file():
+            return  # nothing customised and no file to update — don't create one
+        try:
+            doc = PolicyDoc.load(path)
+            doc.set("tui", "left_width", self.left_width if self.left_width > 0 else None)
+            doc.set("tui", "runs_height", self.runs_height if self._left_frozen else None)
+            doc.set("tui", "deferred_height", self.deferred_height if self._left_frozen else None)
+            doc.set("tui", "tasks_height", self.tasks_height if self._detail_frozen else None)
+            doc.save(path)
+        except (OSError, tomlkit.exceptions.TOMLKitError) as e:
+            self.notify(f"could not save layout: {e}", severity="warning")
+
+    # ---- keyboard resize mode -----------------------------------------------
+
+    def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
+        # The arrow/Enter resize bindings are priority so they beat the focused
+        # table/list while resizing; disable them otherwise so the key reaches the
+        # widget (Tab/Shift+Tab stay live — see action_resize_cycle).
+        if action in _RESIZE_ACTIONS and not self._resize_mode:
+            return False
+        return True
+
+    def action_resize_mode(self) -> None:
+        if self._resize_mode:
+            self._exit_resize_mode()
+        else:
+            self._enter_resize_mode()
+
+    def _enter_resize_mode(self) -> None:
+        self._resize_mode = True
+        self._active_hsplit = 0
+        self.query_one("#split-main", Splitter).add_class("-active")
+        self._highlight_active_hsplit()
+        self._saved_subtitle = self.app.sub_title
+        self.app.sub_title = "[RESIZE] ←/→ width · ↑/↓ height · Tab boundary · Esc done"
+
+    def _exit_resize_mode(self) -> None:
+        if not self._resize_mode:
+            return
+        self._resize_mode = False
+        for split in self.query(Splitter):
+            split.remove_class("-active")
+        self.app.sub_title = self._saved_subtitle or str(self.project)
+        self._persist_geometry()
+
+    def _highlight_active_hsplit(self) -> None:
+        for i, sid in enumerate(_HSPLITS):
+            self.query_one(sid, Splitter).set_class(i == self._active_hsplit, "-active")
+
+    def _active_hsplit_widget(self) -> Splitter:
+        return self.query_one(_HSPLITS[self._active_hsplit], Splitter)
+
+    def action_resize_cycle(self, direction: int) -> None:
+        # Tab stays bound always: cycle the active boundary while resizing, else
+        # fall back to the normal focus movement Tab would have done.
+        if not self._resize_mode:
+            if direction > 0:
+                self.app.action_focus_next()
+            else:
+                self.app.action_focus_previous()
+            return
+        self._active_hsplit = (self._active_hsplit + direction) % len(_HSPLITS)
+        self._highlight_active_hsplit()
+
+    def action_resize_left(self) -> None:
+        self.query_one("#split-main", Splitter).bump(-1)
+
+    def action_resize_right(self) -> None:
+        self.query_one("#split-main", Splitter).bump(1)
+
+    def action_resize_up(self) -> None:
+        self._active_hsplit_widget().bump(-1)
+
+    def action_resize_down(self) -> None:
+        self._active_hsplit_widget().bump(1)
+
+    def action_resize_done(self) -> None:
+        self._exit_resize_mode()
 
     # --------------------------------------------------------------- polling
 
@@ -611,6 +935,11 @@ class DashboardScreen(Screen[None]):
         stories_table = self.query_one("#stories-table", StoriesTable)
         sprint_tree.display = not snap.stories_mode
         stories_table.display = snap.stories_mode
+        # The splitter above this slot carries its section title; set_label already
+        # no-ops when the label is unchanged (this runs every poll tick).
+        self.query_one("#split-runs", Splitter).set_label(
+            "Stories" if snap.stories_mode else "Sprint"
+        )
         if snap.stories_mode:
             stories_table.update_stories(snap.stories)
 

--- a/src/bmad_loop/tui/settings.py
+++ b/src/bmad_loop/tui/settings.py
@@ -28,8 +28,15 @@ class PolicyDoc:
         self._doc = doc
 
     @classmethod
-    def load(cls, path: Path) -> PolicyDoc:
-        text = path.read_text(encoding="utf-8") if path.is_file() else policy_mod.POLICY_TEMPLATE
+    def load(cls, path: Path, *, template_when_missing: bool = True) -> PolicyDoc:
+        """``template_when_missing=False`` starts a missing file from an empty
+        document instead of POLICY_TEMPLATE — for callers that write a single
+        section (e.g. dashboard geometry) and must not materialise every
+        default setting into a fresh policy.toml."""
+        if path.is_file():
+            text = path.read_text(encoding="utf-8")
+        else:
+            text = policy_mod.POLICY_TEMPLATE if template_when_missing else ""
         return cls(tomlkit.parse(text))
 
     def _table(self, section: str, create: bool) -> Any | None:

--- a/src/bmad_loop/tui/widgets.py
+++ b/src/bmad_loop/tui/widgets.py
@@ -9,11 +9,16 @@ from __future__ import annotations
 
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
+from rich.segment import Segment
+from rich.style import Style
 from rich.table import Table
 from rich.text import Text
+from textual import events
 from textual.selection import Selection
+from textual.strip import Strip
+from textual.widget import Widget
 from textual.widgets import DataTable, RichLog, Static, Tree
 from textual.widgets.option_list import Option
 from textual.widgets.tree import TreeNode
@@ -521,3 +526,113 @@ class SelectableRichLog(RichLog):
 
     def selection_updated(self, selection: Selection | None) -> None:
         self.refresh()
+
+
+class Splitter(Widget):
+    """A draggable divider between two panes, drawn as a thin line so it reads
+    like the static border it replaces (not a filled bar). A ``horizontal``
+    splitter is a 1-row rule between vertically stacked panes (drag up/down); a
+    vertical one is a 1-column ``│`` line between side-by-side panes (drag
+    left/right). A horizontal splitter's ``label`` rides the rule as ``─ Sprint
+    ──`` so the section title that used to sit on the pane's ``border-top``
+    survives its removal.
+
+    The widget only measures a drag as a signed cell ``delta`` along its axis and
+    hands it to ``apply`` — the screen bakes in the sign and which reactive the
+    boundary moves. ``bump`` is the keyboard entry point (resize mode), so mouse
+    and keyboard drive the exact same code path. ``on_release`` fires once a drag
+    ends, for the screen to persist the new geometry.
+    """
+
+    DEFAULT_CSS = """
+    Splitter {
+        color: $primary-darken-2;  /* the line color; matches the old borders */
+        background: transparent;
+    }
+    Splitter.-vertical {
+        width: 1;
+        height: 1fr;
+    }
+    Splitter.-horizontal {
+        height: 1;
+        width: 1fr;
+    }
+    Splitter:hover, Splitter.-active, Splitter.-dragging {
+        color: $accent;  /* brighten the line while hovered / grabbed */
+    }
+    """
+
+    def __init__(
+        self,
+        *,
+        horizontal: bool,
+        apply: Callable[[int], None],
+        on_release: Callable[[], None],
+        label: str = "",
+        id: str | None = None,
+    ) -> None:
+        super().__init__(id=id)
+        self._horizontal = horizontal
+        self._apply = apply
+        self._on_release = on_release
+        self._label = label
+        self._last: int | None = None  # last drag coordinate; None = not dragging
+        self.add_class("-horizontal" if horizontal else "-vertical")
+        self.tooltip = "drag to resize (or Ctrl+W)"
+
+    @property
+    def label(self) -> str:
+        return self._label
+
+    def set_label(self, label: str) -> None:
+        if label != self._label:
+            self._label = label
+            self.refresh()
+
+    def render_line(self, y: int) -> Strip:
+        width = self.size.width
+        if width <= 0:
+            return Strip([])
+        base = self.rich_style
+        if not self._horizontal:
+            return Strip([Segment("│", base)], width)
+        if self._label:
+            # `─ Label ───…` — a left-set title on a box-drawing rule, echoing the
+            # old border-title. The label is bold so it reads as a heading.
+            head = f"─ {self._label} "[:width]
+            tail = "─" * max(0, width - len(head))
+            return Strip([Segment(head, base + Style(bold=True)), Segment(tail, base)], width)
+        return Strip([Segment("─" * width, base)], width)
+
+    def _coord(self, event: events.MouseEvent) -> int:
+        return event.screen_y if self._horizontal else event.screen_x
+
+    def on_mouse_down(self, event: events.MouseDown) -> None:
+        self._last = self._coord(event)
+        self.capture_mouse()
+        self.add_class("-dragging")
+        event.stop()
+
+    def on_mouse_move(self, event: events.MouseMove) -> None:
+        if self._last is None:
+            return  # hover, not a drag
+        pos = self._coord(event)
+        delta = pos - self._last
+        if delta:
+            self._last = pos
+            self._apply(delta)
+        event.stop()
+
+    def on_mouse_up(self, event: events.MouseUp) -> None:
+        if self._last is None:
+            return
+        self._last = None
+        self.release_mouse()
+        self.remove_class("-dragging")
+        self._on_release()
+        event.stop()
+
+    def bump(self, delta: int) -> None:
+        """Keyboard-driven nudge (resize mode). Persistence is handled by the
+        screen when the mode exits, so this does not call ``on_release``."""
+        self._apply(delta)

--- a/tests/test_settings_schema.py
+++ b/tests/test_settings_schema.py
@@ -92,6 +92,12 @@ HIDDEN = {
     ("adapter", "review"),  # rendered as the adapter.review section
     ("adapter", "triage"),  # rendered as the adapter.triage section
     ("dev", "skill"),  # internal dev-skill seam; DEV_SKILLS has one legal value, no UI knob
+    # Dashboard pane geometry — set by mouse-drag / the Ctrl+W resize mode, not a
+    # form field, so no settings-screen control.
+    ("tui", "left_width"),
+    ("tui", "runs_height"),
+    ("tui", "deferred_height"),
+    ("tui", "tasks_height"),
 }
 
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -8,6 +8,7 @@ bindings drive modals into tui.launch calls (monkeypatched — no real tmux)."""
 from __future__ import annotations
 
 import os
+import tomllib
 from pathlib import Path
 
 import pytest
@@ -2130,3 +2131,55 @@ async def test_split_runs_label_tracks_sprint_vs_stories(project):
         screen._apply_board(_Snapshot(generation=screen._generation, stories_mode=True, stories=[]))
         await pilot.pause()
         assert bar.label == "Stories"
+
+
+async def test_dashboard_survives_policy_read_oserror(project, monkeypatch):
+    """A transient read failure (permissions, race after the is_file check) while
+    loading policy at construction degrades to default geometry instead of
+    crashing the TUI at startup."""
+
+    def boom(path):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(policy_mod, "load", boom)
+    app = BmadLoopApp(project.project)
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = await _seeded(pilot, app)
+        assert screen._tui_policy == policy_mod.TuiPolicy()
+        assert screen.query_one("#left").size.width == 34  # CSS default, unseeded
+        assert not screen._left_frozen and not screen._detail_frozen
+
+
+async def test_first_geometry_save_writes_only_tui_keys(project):
+    """A geometry save on a project without policy.toml must create a minimal
+    [tui]-only file — not materialise POLICY_TEMPLATE, which would freeze every
+    default setting (gates, limits, ...) into the fresh file."""
+    root = project.project
+    policy_path = root / ".bmad-loop" / "policy.toml"
+    assert not policy_path.is_file()
+    app = BmadLoopApp(root)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _seeded(pilot, app)
+        await pilot.press("ctrl+w")
+        for _ in range(3):
+            await pilot.press("right")  # widen the sidebar only
+        await pilot.press("escape")  # exits resize mode -> persists
+        await pilot.pause()
+    doc = tomllib.loads(policy_path.read_text(encoding="utf-8"))
+    assert set(doc) == {"tui"}
+    assert doc["tui"] == {"left_width": 37}  # 34 + 3; untouched dims stay unset
+
+
+async def test_quit_in_resize_mode_persists_geometry(project):
+    """Quitting the app mid-resize-mode still persists the new geometry:
+    keyboard bumps only save on mode exit, and quit stays live in the mode."""
+    root = project.project
+    app = BmadLoopApp(root)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _seeded(pilot, app)
+        await pilot.press("ctrl+w")
+        for _ in range(4):
+            await pilot.press("right")
+        # Leave without Escape: shutdown unmounts the screen, which persists.
+    saved = policy_mod.load(root / ".bmad-loop" / "policy.toml").tui
+    assert saved.left_width == 38  # 34 + 4

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -14,6 +14,7 @@ import pytest
 from conftest import install_bmad_config, write_sprint
 from rich.console import Console
 from rich.text import Text
+from textual.events import MouseMove
 from textual.geometry import Offset
 from textual.selection import Selection
 from textual.widgets import (
@@ -28,12 +29,18 @@ from textual.widgets import (
     TabbedContent,
 )
 
+from bmad_loop import policy as policy_mod
 from bmad_loop.journal import Journal, save_state
 from bmad_loop.model import Phase, RunState, StoryTask, TokenUsage
 from bmad_loop.runs import RUNS_DIR
 from bmad_loop.tui import data, launch
 from bmad_loop.tui.app import BmadLoopApp
-from bmad_loop.tui.screens.dashboard import DashboardScreen, _Snapshot
+from bmad_loop.tui.screens.dashboard import (
+    _MIN_DETAIL,
+    _MIN_SIDEBAR,
+    DashboardScreen,
+    _Snapshot,
+)
 from bmad_loop.tui.screens.modals import (
     ConfirmModal,
     ConfirmResumeModal,
@@ -52,6 +59,7 @@ from bmad_loop.tui.widgets import (
     _JOURNAL_KIND_WIDTH,
     RunHeader,
     SelectableRichLog,
+    Splitter,
     SprintTree,
     StoriesTable,
     journal_line,
@@ -1895,3 +1903,230 @@ async def test_start_run_modal_stories_source_blank_folder_errors(project, monke
         await pilot.click("#ok")
         await until(pilot, lambda: any("needs a spec folder" in m for m in notifications(app)))
         assert not calls
+
+
+# --------------------------------------------------------------- pane resizing
+
+
+async def _seeded(pilot, app: BmadLoopApp) -> DashboardScreen:
+    """Mount the dashboard and wait for the first-layout geometry seed."""
+    await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
+    screen = dashboard(app)
+    await until(pilot, lambda: screen._seeded)
+    return screen
+
+
+async def _drag(pilot, selector: str, dx: int, dy: int) -> None:
+    """Mouse-drag a splitter by (dx, dy) cells: down on it, one move offset from
+    its own origin, then up. Capture routes the move to the splitter regardless."""
+    await pilot.mouse_down(selector)
+    await pilot._post_mouse_events([MouseMove], selector, offset=(dx, dy))
+    await pilot.mouse_up(selector)
+    await pilot.pause()
+
+
+async def test_resize_mode_widens_and_narrows_sidebar(project):
+    app = BmadLoopApp(project.project)
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = await _seeded(pilot, app)
+        left = screen.query_one("#left")
+        detail = screen.query_one("#detail")
+        w0, d0 = left.size.width, detail.size.width
+        await pilot.press("ctrl+w")
+        assert screen._resize_mode
+        for _ in range(5):
+            await pilot.press("right")
+        await pilot.pause()
+        assert left.size.width == w0 + 5
+        assert detail.size.width == d0 - 5  # #detail (1fr) absorbs the change
+        for _ in range(3):
+            await pilot.press("left")
+        await pilot.pause()
+        assert left.size.width == w0 + 2
+        await pilot.press("escape")
+        assert not screen._resize_mode
+
+
+async def test_resize_mode_grows_left_panes_and_cycles(project):
+    app = BmadLoopApp(project.project)
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = await _seeded(pilot, app)
+        runs = screen.query_one("#runs")
+        deferred = screen.query_one("#deferred")
+        r0, f0 = runs.size.height, deferred.size.height
+        await pilot.press("ctrl+w")
+        # Down on the Runs|Sprint boundary grows Runs; Sprint (the flex) shrinks.
+        for _ in range(3):
+            await pilot.press("down")
+        await pilot.pause()
+        assert screen._left_frozen
+        assert runs.size.height == r0 + 3
+        assert deferred.size.height == f0  # untouched boundary stays put
+        # Tab moves the active boundary to Sprint|Deferred; Up grows Deferred.
+        await pilot.press("tab")
+        assert screen._active_hsplit == 1
+        for _ in range(2):
+            await pilot.press("up")
+        await pilot.pause()
+        assert deferred.size.height == f0 + 2
+        assert runs.size.height == r0 + 3  # Runs boundary unaffected
+
+
+async def test_arrows_and_tab_untouched_outside_resize_mode(project):
+    root = project.project
+    make_run(root, "20260611-100000-aaaa", finished=True)
+    make_run(root, "20260611-110000-bbbb", finished=True)
+    app = BmadLoopApp(root)
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = await _seeded(pilot, app)
+        runs = screen.query_one("#runs", DataTable)
+        await until(pilot, lambda: runs.row_count == 2)
+        runs.focus()
+        await pilot.pause()
+        assert runs.cursor_row == 1  # newest auto-selected (bottom row)
+        await pilot.press("up")  # not resizing: arrow drives the table cursor
+        await pilot.pause()
+        assert runs.cursor_row == 0
+        assert screen.query_one("#left").size.width == 34  # geometry untouched
+        await pilot.press("tab")  # not resizing: tab moves focus
+        await pilot.pause()
+        assert screen.focused is not runs
+
+
+async def test_mouse_drag_resizes_sidebar_and_left_pane(project):
+    app = BmadLoopApp(project.project)
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = await _seeded(pilot, app)
+        w0 = screen.query_one("#left").size.width
+        await _drag(pilot, "#split-main", 6, 0)
+        assert screen.query_one("#left").size.width == w0 + 6
+        r0 = screen.query_one("#runs").size.height
+        await _drag(pilot, "#split-runs", 0, 2)  # drag the bar down: Runs grows
+        assert screen._left_frozen
+        assert screen.query_one("#runs").size.height == r0 + 2
+
+
+async def test_mouse_drag_resizes_tasks_and_tabs(project):
+    """The detail-column boundary: dragging #split-tasks grows Tasks and shrinks
+    the Tabs pane (which flexes). Regressed the whole boundary being unusable."""
+    app = BmadLoopApp(project.project)
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = await _seeded(pilot, app)
+        tasks = screen.query_one("#tasks", DataTable)
+        tabs = screen.query_one("#tabs", TabbedContent)
+        # First drag freezes the column and pins Tasks to an explicit height (an
+        # empty table's `auto` height sits below _MIN_TASKS, so the seed floors it
+        # rather than matching the rendered height — measure after it settles).
+        await _drag(pilot, "#split-tasks", 0, 2)
+        assert screen._detail_frozen
+        t0, b0 = tasks.size.height, tabs.size.height
+        await _drag(pilot, "#split-tasks", 0, 3)  # drag the bar down: Tasks grows
+        assert tasks.size.height == t0 + 3
+        assert tabs.size.height == b0 - 3  # #tabs (1fr) absorbs the change
+
+
+async def test_persisted_tall_tasks_height_survives_max_height_cap(project):
+    """Regression: a persisted tasks_height above the CSS `max-height: 35%`
+    default must render at full height, not be silently re-clamped to 35% —
+    which froze the boundary (story-maker: tasks_height=30, no run selected)."""
+    root = project.project
+    bmad = root / ".bmad-loop"
+    bmad.mkdir(parents=True, exist_ok=True)
+    # No run selected: the detail column is in its empty state, so the CSS 35%
+    # cap is the only thing that could clamp the persisted height.
+    (bmad / "policy.toml").write_text("[tui]\ntasks_height = 30\n", encoding="utf-8")
+    app = BmadLoopApp(root)
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = await _seeded(pilot, app)
+        await pilot.pause()
+        assert screen.selected_run_id is None
+        assert screen._detail_frozen
+        tasks = screen.query_one("#tasks", DataTable)
+        detail_h = screen.query_one("#detail").size.height
+        # The pane renders at the governed height, well past 35% of the column.
+        assert tasks.size.height == screen.tasks_height
+        assert tasks.size.height > 0.35 * detail_h
+        # And the boundary is live: dragging the bar up shrinks Tasks / grows Tabs.
+        tabs = screen.query_one("#tabs", TabbedContent)
+        b0 = tabs.size.height
+        await _drag(pilot, "#split-tasks", 0, -5)
+        assert tabs.size.height > b0
+
+
+async def test_sidebar_width_is_clamped(project):
+    app = BmadLoopApp(project.project)
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = await _seeded(pilot, app)
+        screen.left_width = 9999  # absurd: clamps to width - _MIN_DETAIL - splitter
+        await pilot.pause()
+        hi = 120 - _MIN_DETAIL - 1
+        assert screen.left_width == hi
+        assert screen.query_one("#left").size.width == hi
+        assert screen.query_one("#detail").size.width >= _MIN_DETAIL
+        screen.left_width = 1  # below the floor
+        await pilot.pause()
+        assert screen.left_width == _MIN_SIDEBAR
+
+
+async def test_geometry_persists_and_restores(project):
+    root = project.project
+    policy_path = root / ".bmad-loop" / "policy.toml"
+    assert not policy_path.is_file()
+    app = BmadLoopApp(root)
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = await _seeded(pilot, app)
+        await pilot.press("ctrl+w")
+        for _ in range(4):
+            await pilot.press("right")  # widen sidebar
+        for _ in range(2):
+            await pilot.press("down")  # grow Runs (freezes the left column)
+        await pilot.press("escape")  # exits resize mode -> persists
+        await pilot.pause()
+        want = (
+            screen.query_one("#left").size.width,
+            screen.query_one("#runs").size.height,
+            screen.query_one("#deferred").size.height,
+        )
+    assert policy_path.is_file()
+    saved = policy_mod.load(policy_path).tui
+    assert saved.left_width > 34 and saved.runs_height > 0 and saved.deferred_height > 0
+
+    # A fresh app in the same project restores the identical rendered geometry.
+    app2 = BmadLoopApp(root)
+    async with app2.run_test(size=(120, 40)) as pilot:
+        screen2 = await _seeded(pilot, app2)
+        got = (
+            screen2.query_one("#left").size.width,
+            screen2.query_one("#runs").size.height,
+            screen2.query_one("#deferred").size.height,
+        )
+    assert got == want
+
+
+async def test_untouched_layout_writes_nothing_and_keeps_defaults(project):
+    """No resize -> no policy file, panes at their CSS defaults, columns still
+    flex (unfrozen)."""
+    root = project.project
+    app = BmadLoopApp(root)
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = await _seeded(pilot, app)
+        assert screen.query_one("#left").size.width == 34
+        assert not screen._left_frozen and not screen._detail_frozen
+        # Entering and leaving resize mode with no change must not create a file.
+        await pilot.press("ctrl+w")
+        await pilot.press("escape")
+        await pilot.pause()
+    assert not (root / ".bmad-loop" / "policy.toml").is_file()
+
+
+async def test_split_runs_label_tracks_sprint_vs_stories(project):
+    """The splitter above the middle slot carries its section title, swapping
+    Sprint<->Stories with the selected run's board mode."""
+    app = BmadLoopApp(project.project)
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = await _seeded(pilot, app)
+        bar = screen.query_one("#split-runs", Splitter)
+        assert bar.label == "Sprint"
+        screen._apply_board(_Snapshot(generation=screen._generation, stories_mode=True, stories=[]))
+        await pilot.pause()
+        assert bar.label == "Stories"


### PR DESCRIPTION
## What

Makes every `bmad-loop tui` dashboard pane boundary resizable — by mouse-drag or a `Ctrl+W`
keyboard resize mode — with sizes persisted per-project to a new `[tui]` section in `policy.toml`.

## Why

The dashboard layout was fixed; a narrow sidebar or a short log pane couldn't be adjusted to fit
the run being watched. Untouched projects keep the previous proportions and write nothing.

## How

- New `Splitter` widget (thin-line divider, also carrying the Sprint / Deferred Work headings)
  drives both the mouse drag and the keyboard bump through one code path.
- "Dragged pane fixed, neighbour flexes" freeze model per column; geometry persisted to `[tui]`
  (`left_width` / `runs_height` / `deferred_height` / `tasks_height`, `0` = unset).
- Fixed the Tasks/Tabs boundary freezing solid: `styles.max_height = None` doesn't override the
  stylesheet's `#tasks { max-height: 35% }`, so a persisted `tasks_height` above 35% was silently
  re-clamped and the divider wouldn't drag; `_apply_tasks_height` now sets a concrete inline cap.

## Testing

Full suite green (2128 passed, 1 skipped) + `trunk check` clean. Added Pilot coverage for the
mouse/keyboard resize of all four boundaries, geometry persist/restore, and the max-height
regression. Note: ~280 of the +799 LOC are tests; one cohesive feature.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Dashboard panes can now be resized by dragging dividers or using keyboard resize mode (`Ctrl+W`).
  - Sidebar width and pane heights are saved per project and restored on the next launch.
  - Pane dimensions can be reset by clearing their saved values.

- **Documentation**
  - Updated the README, feature documentation, TUI guide, changelog, and configuration reference with resizing controls and persistence details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->