### PR TITLE
fix(adapters): disable Claude Code background tasks in the shipped profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,14 @@ breaking changes may land in a minor release.
 
 ### Fixed
 
+- **Claude sessions launch with `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1` (#109).** Claude Code
+  could bias a dev session toward backgrounding its implementation sub-agent despite the
+  bmad-dev-auto prompt ban; the session then ended its turn to await a completion notification,
+  and a harness exit at that turn boundary stranded the sub-agent with the story stuck
+  `in-progress` → manual-rollback pause. The shipped claude profile now forces subagents and bash
+  to run synchronously — the behavior the skill contract already requires. Opt out with a custom
+  profile in `.bmad-loop/profiles/`.
+
 - **Resume no longer discards a story that already passed its pre-commit gates.** A host death in
   the COMMITTING window (phase persisted before `finalize_commit` ran and the DONE save stamped
   `commit_sha`) matched no resume arm — there is no COMMITTING-keyed session record to replay — and

--- a/src/bmad_loop/data/profiles/claude.toml
+++ b/src/bmad_loop/data/profiles/claude.toml
@@ -22,8 +22,19 @@ seed_files = [
 # page. The classic renderer keeps output in native scrollback, so the capture
 # scrolls normally and the Log tab reconstructs the whole session. This env var
 # overrides any `tui` setting (user/project/local/seeded) per Claude Code docs.
+#
+# Disable background tasks (issue #109): Claude Code can bias a session toward
+# backgrounding Agent/bash work (run_in_background) despite the bmad-dev-auto
+# prompt ban on it. A session that ends its turn to await a background sub-agent
+# yields a result-less Stop — and if the CLI then exits, the in-process sub-agent
+# is stranded mid-implementation with the story stuck in-progress. The var forces
+# every subagent and bash call to run synchronously, which is the behavior the
+# skill contract already requires; bmad-loop has no background-completion
+# re-invocation, so nothing sanctioned is lost. To opt out, copy this profile
+# into .bmad-loop/profiles/ and drop the var.
 [env]
 CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN = "1"
+CLAUDE_CODE_DISABLE_BACKGROUND_TASKS = "1"
 
 [hooks]
 dialect = "claude-settings-json"

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -57,11 +57,15 @@ def test_builtin_profiles_load():
         assert profiles[name].stop_without_result_nudges is None
         assert profiles[name].subagent_stop_without_transcript is False
     # claude forces its classic (inline/scrollback) renderer so a pane capture is
-    # not collapsed to the final frame by the fullscreen alt-screen TUI; other
-    # profiles add no such env override
+    # not collapsed to the final frame by the fullscreen alt-screen TUI, and
+    # disables background tasks so a dev session cannot background its
+    # implementation sub-agent and strand it at turn end (#109); other profiles
+    # add no such env overrides
     assert profiles["claude"].env.get("CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN") == "1"
+    assert profiles["claude"].env.get("CLAUDE_CODE_DISABLE_BACKGROUND_TASKS") == "1"
     for name in ("codex", "gemini", "copilot"):
         assert "CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN" not in profiles[name].env
+        assert "CLAUDE_CODE_DISABLE_BACKGROUND_TASKS" not in profiles[name].env
 
 
 def test_usage_grace_and_nudges_default_when_unset(tmp_path):

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -63,7 +63,7 @@ def test_builtin_profiles_load():
     # add no such env overrides
     assert profiles["claude"].env.get("CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN") == "1"
     assert profiles["claude"].env.get("CLAUDE_CODE_DISABLE_BACKGROUND_TASKS") == "1"
-    for name in ("codex", "gemini", "copilot"):
+    for name in sorted(set(profiles) - {"claude"}):
         assert "CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN" not in profiles[name].env
         assert "CLAUDE_CODE_DISABLE_BACKGROUND_TASKS" not in profiles[name].env
 


### PR DESCRIPTION
Fixes #109

## Problem

Claude Code (≥ v2.1.x) can bias a dev session toward backgrounding its implementation `Agent` sub-agent (`run_in_background`) despite the explicit ban in `bmad-dev-auto`'s SKILL prompt — the reporter measured it at ~20% of sessions. The session then ends its turn to "await the completion notification", producing a result-less Stop.

## What the investigation found

The issue's original nudge-budget theory doesn't hold for dev sessions: `GenericDevAdapter` pins `stop_without_result_nudges` to 0, and a result-less Stop opens the 600s `dev_stall_grace_s` window with activity re-arm and refillable wake nudges — the orchestrator already waits correctly for a yield-to-await session **that stays alive**.

The actual killer in the reported trace (`Stop → SessionEnd` in 346ms): the claude process itself exited right after the yield-turn, taking the unguarded `"crashed"` branch in `wait_for_completion`. Since background subagents run in-process, the host exit strands the sub-agent mid-implementation — the story sticks at `in-progress`, the DEV_VERIFY gate demands `done`, and with `rollback_on_failure = false` the run pauses for manual rollback. No orchestrator-side waiting can rescue work whose host process is gone, so the fix is prevention at launch.

## Fix

Ship `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS = "1"` (Claude Code ≥ v2.1.4) in the claude profile's `[env]`. Subagents and bash then run synchronously — the behavior the skill contract already requires; bmad-loop has no background-completion re-invocation, so nothing sanctioned is lost. Profile env flows through `interactive_env`/`new_window`, covering dev/review/resolve/workflow sessions and worktree isolation with no adapter code changes.

- No regression to the Unity-plugin "await an external PlayMode run" pattern: that awaits an *external* process, untouched by this var; the grace/nudge machinery is unchanged.
- Opt-out escape hatch: copy the profile into `.bmad-loop/profiles/` and drop the var.

## Testing

- `tests/test_profile.py` asserts the claude profile carries the var and other built-ins don't.
- Full suite: 2131 passed, 1 skipped. `trunk check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Claude sessions now run subagents synchronously by default, reducing the risk of unfinished tasks when sessions end.
  * Users can opt out by creating a custom Claude profile.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->