### PR TITLE
unity plugin: prevent editor modal-dialog stalls (scene auto-save guard, rollback quiesce, dialog probe)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ breaking changes may land in a minor release.
 
 ### Added
 
+- **Unity modal-dialog guards (`[plugins.unity]`).** A chronically-dirty Unity scene raises modal
+  Editor dialogs ("scene changed on disk", "save changes before closing") that freeze the MCP
+  dispatch loop and stall the whole run. The bundled Unity plugin now defends in depth: it seeds an
+  editor-only `SceneAutoSaveGuard` into the project (`install_scene_guard`, default on), quiesces
+  the Editor around a failed-attempt rollback so `git reset --hard` can't leave a stale scene open
+  (`quiesce_on_rollback`, default on), and appends the scene-save discipline (from a shipped
+  `unity_facts.md`) to every dev/review prompt so the agent saves at the boundaries that would
+  otherwise trip a modal. As a last-resort observability net, an opt-in **detect-only** probe
+  (`dialog_probe`, default off) watches — via xdotool, X11/Linux only — for those dialogs and
+  _reports_ any it sees (a JSONL record, an `ATTENTION` line, and a best-effort `notify-send`); it
+  never clicks or keys anything, no-ops where there is no X display, and self-reaps when the engine
+  exits (`dialog_probe_interval_sec`, `dialog_probe_notify`).
+
 - **Follow-up-review damping (`limits.max_followup_reviews`, default 1).** Bounds how many extra
   review rounds a story is granted _solely_ because a completed round finalized `status: done` yet
   still set `followup_review_recommended: true`. Once spent, the next such round force-converges —

--- a/docs/game-engine-mcp-guide.md
+++ b/docs/game-engine-mcp-guide.md
@@ -111,7 +111,7 @@ These compose with the `[scm]` worktree seeds (`seed_adapter_defaults`,
 
 ## Full env-var reference (Unity plugin)
 
-The five `[plugins.unity]` keys are the operator-facing settings (editable in the TUI
+The twelve `[plugins.unity]` keys are the operator-facing settings (editable in the TUI
 under the Unity plugin's section). Everything below is a **script-level knob** with a
 built-in default. The plugin builds the helper scripts' environment from `os.environ`
 (then overlays the identity + settings vars below), so **override a knob by exporting it
@@ -124,11 +124,15 @@ export BMAD_LOOP_UNITY_LIBRARY_SEED_MODE="copy"   # e.g. force a deep copy off-C
 bmad-loop run …
 ```
 
-**Always injected by the plugin** (identity from the run context + the five settings; do
-not set by hand): `BMAD_LOOP_REPO_ROOT`, `BMAD_LOOP_WORKTREE`, `BMAD_LOOP_RUN_DIR`,
-`BMAD_LOOP_STORY_KEY`, `BMAD_LOOP_ENGINE_MCP`, `BMAD_LOOP_ENGINE_EDITOR_MODE`,
-`BMAD_LOOP_ENGINE_READY_TIMEOUT`, `BMAD_LOOP_ENGINE_READY_GRACE`, `BMAD_LOOP_UNITY_PATH`,
-and `BMAD_LOOP_ENGINE_AGENTS` (the dev + review CLI ids, for per-worktree MCP routing).
+**Always injected by the plugin** (identity from the run context + the resolved
+settings; do not set by hand): `BMAD_LOOP_REPO_ROOT`, `BMAD_LOOP_WORKTREE`,
+`BMAD_LOOP_RUN_DIR`, `BMAD_LOOP_STORY_KEY`, `BMAD_LOOP_ENGINE_MCP`,
+`BMAD_LOOP_ENGINE_EDITOR_MODE`, `BMAD_LOOP_ENGINE_READY_TIMEOUT`,
+`BMAD_LOOP_ENGINE_READY_GRACE`, `BMAD_LOOP_UNITY_PATH`, `BMAD_LOOP_CLEAN_TMP`,
+`BMAD_LOOP_UNITY_INSTALL_SCENE_GUARD`, `BMAD_LOOP_UNITY_SCENE_GUARD_DIR`,
+`BMAD_LOOP_UNITY_DIALOG_PROBE`, `BMAD_LOOP_UNITY_DIALOG_PROBE_INTERVAL_SEC`,
+`BMAD_LOOP_UNITY_DIALOG_PROBE_NOTIFY`, and `BMAD_LOOP_ENGINE_AGENTS` (the dev + review
+CLI ids, for per-worktree MCP routing).
 
 ### Readiness gate (`unity_ready.py`)
 
@@ -183,6 +187,48 @@ IvanMurzak MCP downloads per-project, so CoplayDev is skipped.
 | ---------------------------- | ------- | --------------------------------------------------- |
 | `BMAD_LOOP_CLEAN_TMP`        | `1`     | `0` disables the post-run /tmp + log cleanup.       |
 | `BMAD_LOOP_UNITY_LOG_CAP_MB` | `5`     | Truncate `ai-editor-logs.txt` once it exceeds this. |
+
+### Scene-guard seeding (`unity_seed_assets.py`)
+
+Copies the `SceneAutoSaveGuard` editor script into the project so a chronically-dirty
+scene never raises the run-stalling modal dialogs (see the plugin guide's
+[modal-dialog section](game-engine-plugin-guide.md#preventing-editor-modal-dialog-stalls-unity)).
+Seeded before the Editor's first import (at `pre_worktree_setup` in `per_worktree`
+mode, at `pre_ready_gate` in shared mode); the seeded guard is committed into the
+consumer project by story-finalize's `git add -A`.
+
+| Variable                              | Default                  | Effect                                                              |
+| ------------------------------------- | ------------------------ | ------------------------------------------------------------------- |
+| `BMAD_LOOP_UNITY_INSTALL_SCENE_GUARD` | `1`                      | `0` skips seeding entirely (mirrors `install_scene_guard = false`). |
+| `BMAD_LOOP_UNITY_SCENE_GUARD_DIR`     | `Assets/BmadLoop/Editor` | Project-relative install dir; must live under the asset root.       |
+
+### Rollback quiesce (`unity_quiesce.py`)
+
+Saves + closes open scenes before a failed-attempt rollback's `git reset --hard`
+(`pre` phase) and refreshes assets after (`post` phase), so the reset can't leave a
+tracked `.unity` open under the Editor. IvanMurzak-only; best-effort, never blocks the
+rollback (per-call `--timeout` + a subprocess kill + the plugin's overall
+`quiesce_timeout_sec`).
+
+| Variable                               | Default         | Effect                                                      |
+| -------------------------------------- | --------------- | ----------------------------------------------------------- |
+| `BMAD_LOOP_QUIESCE_PHASE`              | `pre`           | `pre` \| `post` — set by the plugin per hook.               |
+| `BMAD_LOOP_UNITY_QUIESCE_CALL_TIMEOUT` | `15000`         | Per-CLI-call budget, ms (assets-refresh floors at `45000`). |
+| `UNITY_MCP_CLI`                        | `unity-mcp-cli` | IvanMurzak CLI binary.                                      |
+
+### Detect-only dialog probe (`unity_dialog_probe.py`)
+
+Opt-in (`dialog_probe = true`), X11/Linux-only. Watches xdotool for a visible Unity
+modal dialog and **reports** it (JSONL + `ATTENTION` + `notify-send`) — it never clicks
+or keys anything. No-op where `DISPLAY` is unset or `xdotool`/`notify-send` is absent;
+self-reaps when the engine pid dies.
+
+| Variable                                    | Default | Effect                                                           |
+| ------------------------------------------- | ------- | ---------------------------------------------------------------- |
+| `BMAD_LOOP_UNITY_DIALOG_PROBE`              | `0`     | `1` enables the launch (mirrors `dialog_probe = true`).          |
+| `BMAD_LOOP_UNITY_DIALOG_PROBE_INTERVAL_SEC` | `5`     | Poll interval seconds (min 1).                                   |
+| `BMAD_LOOP_UNITY_DIALOG_PROBE_NOTIFY`       | `1`     | `0` suppresses the desktop `notify-send` (JSONL/ATTENTION stay). |
+| `BMAD_LOOP_UNITY_DIALOG_PROBE_CLASS`        | `Unity` | xdotool WM_CLASS regex for the Editor's windows.                 |
 
 ## Dev-control HTTP bridge (upstream, dev-only — not wired)
 

--- a/docs/game-engine-plugin-guide.md
+++ b/docs/game-engine-plugin-guide.md
@@ -271,6 +271,13 @@ That dirty state is what makes the Editor raise:
 2. **"Do you want to save the changes you made…?"** — pops on Editor quit with a
    dirty scene, e.g. when a `per_worktree` Editor is torn down.
 
+> **Clean scenes are not safe from dialog 1.** Live verification on Unity 6.5.2
+> showed the "changed on disk" dialog can pop for a **clean** open scene too — and
+> even after dismissal the Editor could stay hard-wedged. Keeping scenes saved
+> (layer 1) is therefore necessary but **not sufficient** on the rollback path;
+> the quiesce's scene-close (layer 2), which leaves no tracked scene open during
+> the reset, is the real protection there.
+
 ### 1. `SceneAutoSaveGuard` (seeded editor script)
 
 `unity_seed_assets.py` copies an editor-only C# guard —
@@ -281,7 +288,8 @@ mode, at `pre_ready_gate` in shared mode where setup never runs). The guard fixe
 the **root cause**: it debounce-saves any loaded, on-disk scene ~5 s after it goes
 dirty, and on quit it saves pathed scenes (discarding an unsaveable _untitled_
 scene by swapping in a fresh empty one, since saving it would itself pop a "Save
-As" modal). An operator can toggle it live from the Editor's **`BmadLoop` menu**
+As" modal). The quit hook is `EditorApplication.wantsToQuit`; a hard
+`EditorApplication.Exit` bypasses it (along with every other quit handler). An operator can toggle it live from the Editor's **`BmadLoop` menu**
 ("Scene Auto-Save Guard" on/off, "Save Open Scenes Now"); the toggle persists in
 `EditorPrefs`, default **on**.
 
@@ -308,7 +316,9 @@ the Editor is already unresponsive it fails fast and the quiesce is skipped, at 
 cost of one call timeout rather than the whole budget. Every call carries both the
 CLI's own `--timeout` and a subprocess-level kill, and the plugin hard-kills the
 whole helper past `quiesce_timeout_sec` — so a wedged Editor can **never stall the
-rollback**. Disable with `quiesce_on_rollback = false`.
+rollback**. The quiesce logs to stderr and writes no journal events of its own —
+the rollback's journal marker remains `rollback-auto`. Disable with
+`quiesce_on_rollback = false`.
 
 ### 3. Prompt-fact injection (`pre_session`)
 
@@ -338,7 +348,10 @@ argv-scan backstop. Tune with `dialog_probe_interval_sec` and
 > live Linux Editor build and kept broad on purpose; detection is advisory, so a
 > miss degrades to the pre-existing behavior (a human notices the frozen run),
 > never worse. Override `BMAD_LOOP_UNITY_DIALOG_PROBE_CLASS` or the phrase list in a
-> project-local plugin copy if your build differs.
+> project-local plugin copy if your build differs. Detection **is** verified on
+> XWayland — but synthetic input (xdotool/ydotool) is unreliable there, one more
+> reason the probe only reports: dismissing a detected dialog must stay a human
+> action.
 
 ## Platform behavior (Linux fast paths, Windows fallbacks)
 

--- a/docs/game-engine-plugin-guide.md
+++ b/docs/game-engine-plugin-guide.md
@@ -63,19 +63,24 @@ An engine binds the orchestrator's **per-story stages** that surround a unit's
 worktree and sessions. The relevant ones (full list in the
 [stage reference](plugin-authoring-guide.md#stage-reference)):
 
-| Stage                   | shared mode                       | per_worktree mode                                                                                                                 |
-| ----------------------- | --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `pre_worktree_setup`    | not run                           | per unit, right after the worktree is cut — make it a usable project + launch its Editor                                          |
-| `pre_ready_gate`        | once, before the first session    | per unit, after setup, before the agent runs — block until Editor + MCP are ready                                                 |
-| (agent dev/review)      | drives the operator's live Editor | drives the worktree's managed Editor                                                                                              |
-| `pre_worktree_teardown` | not run                           | per unit, on completion **and** on pause/escalation — quit the Editor + clean up                                                  |
-| `post_run`              | once, on clean finish             | once, on clean finish — reclaim per-run scratch (the Unity plugin clears the MCP server's `/tmp` zips + truncates its editor log) |
+| Stage                            | shared mode                                                  | per_worktree mode                                                                                                                 |
+| -------------------------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
+| `pre_worktree_setup`             | not run                                                      | per unit, right after the worktree is cut — make it a usable project + launch its Editor                                          |
+| `pre_ready_gate`                 | once, before the first session                               | per unit, after setup, before the agent runs — block until Editor + MCP are ready                                                 |
+| (agent dev/review)               | drives the operator's live Editor                            | drives the worktree's managed Editor                                                                                              |
+| `pre_worktree_teardown`          | not run                                                      | per unit, on completion **and** on pause/escalation — quit the Editor + clean up                                                  |
+| `pre_rollback` / `post_rollback` | per failed attempt, around the rollback's `git reset --hard` | same — quiesce the Editor (save + close open scenes) before the reset rewrites tracked files under it, refresh assets after       |
+| `post_run`                       | once, on clean finish                                        | once, on clean finish — reclaim per-run scratch (the Unity plugin clears the MCP server's `/tmp` zips + truncates its editor log) |
 
 A **blocking** hook at `pre_ready_gate` or `pre_worktree_setup` whose command
 exits non-zero **defers the unit** — bmad-loop never starts a session against a
-half-open Editor. `pre_worktree_teardown` is **observe-only** for veto purposes
-(a veto can't un-tear-down) but the command still **runs** — best-effort, even
-when a unit pauses or escalates, so a managed Editor never outlives its worktree.
+half-open Editor. `pre_worktree_teardown`, `pre_rollback`, and `post_rollback` are
+**observe-only** for veto purposes (a veto can't un-tear-down or un-reset) but the
+command still **runs** — best-effort, even when a unit pauses or escalates, so a
+managed Editor never outlives its worktree and a rollback is never stalled by a
+wedged Editor. The Unity plugin uses `pre_rollback` to save + close open scenes
+before the reset, so a shared Editor holding a dirty scene never raises the
+run-freezing "scene changed on disk" modal.
 
 You can implement these as **declarative** `[hooks.<stage>]` shell commands (the
 smallest thing that works), or as an **in-process** `[python]` module when you need

--- a/docs/game-engine-plugin-guide.md
+++ b/docs/game-engine-plugin-guide.md
@@ -211,16 +211,28 @@ module (see the [authoring guide](plugin-authoring-guide.md#in-process-hooks)).
 
 The canonical example lives at `src/bmad_loop/data/plugins/unity/`:
 
-- `plugin.toml` — a `[python]` module + five `[[settings]]` (`editor_mode`, `mcp`,
-  `unity_path`, `ready_timeout_sec`, `ready_grace_sec`) + `seed_globs =
-[".claude/skills/*"]`.
+- `plugin.toml` — a `[python]` module + twelve `[[settings]]` (`editor_mode`, `mcp`,
+  `unity_path`, `ready_timeout_sec`, `ready_grace_sec`, plus the modal-dialog knobs
+  `install_scene_guard`, `scene_guard_dir`, `quiesce_on_rollback`,
+  `quiesce_timeout_sec`, `dialog_probe`, `dialog_probe_interval_sec`,
+  `dialog_probe_notify`) + `seed_globs = [".claude/skills/*"]`.
 - `unity_plugin.py` — the in-process brain: the readiness gate
   (`on_pre_ready_gate`), `per_worktree` Editor setup/teardown, MCP agent routing,
-  Library priming, and the `editor_mode`↔`scm.isolation` coupling validation.
+  Library priming, the `editor_mode`↔`scm.isolation` coupling validation, and the
+  modal-dialog defense (scene-guard seeding, rollback quiesce, prompt-fact
+  injection, and the detached detect-only probe — see the next section).
 - `unity_ready.py` — readiness gate script (branches on `BMAD_LOOP_ENGINE_MCP`).
 - `unity_setup.py` — `per_worktree` Library priming, `.mcp.json` write, Custom-mode
   pin, and Editor launch.
-- `unity_teardown.py` — Editor quit + MCP-server reap + symlink-Library cleanup.
+- `unity_teardown.py` — Editor quit + MCP-server reap + symlink-Library cleanup +
+  dialog-probe reap.
+- `unity_seed_assets.py` + `unity_assets/` — seed the `SceneAutoSaveGuard` editor
+  script (with fixed-GUID `.meta` files) into the project.
+- `unity_quiesce.py` — save + close open scenes before a rollback's `git reset
+--hard`, refresh assets after.
+- `unity_facts.md` — the scene-save discipline appended to every dev/review prompt.
+- `unity_dialog_probe.py` — the detached, detect-only modal-dialog watcher (X11
+  only, opt-in).
 
 > **Tuning long PlayMode dev sessions.** The readiness knobs above
 > (`ready_timeout_sec` / `ready_grace_sec`) gate Editor _startup_, not dev-session
@@ -235,6 +247,98 @@ Each script's module docstring documents every env knob it reads — the
 authoritative source if a default ever changes. The [Game Engine MCP guide](game-engine-mcp-guide.md)
 distills those into a single reference table and explains the IvanMurzak vs
 CoplayDev differences.
+
+## Preventing Editor modal-dialog stalls (Unity)
+
+A live Unity Editor can raise a **modal dialog** — a window that blocks
+`EditorApplication.update`, the pump the Unity-MCP plugin uses to dispatch every
+tool call. While it is up, all MCP calls time out and the run wedges. The bundled
+Unity plugin defends against the two that a bmad-loop run can trip, **in depth**,
+so no single failure lets one appear. All four layers are best-effort and none can
+block or veto the run.
+
+### The two dialogs, and why they open
+
+The **root cause** is that Unity-MCP GameObject tools
+(`com.ivanmurzak.unity.mcp`) call `MarkSceneDirty` but **never save**, so a
+project driven by the shared Editor accumulates a chronically **dirty** open scene.
+That dirty state is what makes the Editor raise:
+
+1. **"Scene '…' has been changed on disk. Reload the scene?"** — pops when git or
+   an agent rewrites the open scene's `.unity` file underneath the Editor. A
+   failed-attempt rollback does exactly this: `git reset --hard` rewrites the
+   tracked scene file the Editor still holds dirty in memory.
+2. **"Do you want to save the changes you made…?"** — pops on Editor quit with a
+   dirty scene, e.g. when a `per_worktree` Editor is torn down.
+
+### 1. `SceneAutoSaveGuard` (seeded editor script)
+
+`unity_seed_assets.py` copies an editor-only C# guard —
+`Assets/BmadLoop/Editor/SceneAutoSaveGuard.cs` plus its asmdef, with
+pre-generated fixed-GUID `.meta` files — into the project, so the Editor's very
+first import already sees it (seeded at `pre_worktree_setup` in `per_worktree`
+mode, at `pre_ready_gate` in shared mode where setup never runs). The guard fixes
+the **root cause**: it debounce-saves any loaded, on-disk scene ~5 s after it goes
+dirty, and on quit it saves pathed scenes (discarding an unsaveable _untitled_
+scene by swapping in a fresh empty one, since saving it would itself pop a "Save
+As" modal). An operator can toggle it live from the Editor's **`BmadLoop` menu**
+("Scene Auto-Save Guard" on/off, "Save Open Scenes Now"); the toggle persists in
+`EditorPrefs`, default **on**.
+
+Seeding is idempotent + version-aware (a `bmad-loop-scene-guard-version` header
+gates reinstall), never rewrites a file it didn't ship, and a missing `Assets/`
+tree is a graceful skip. Because it happens **pre-baseline**, the run's rollback
+never treats the guard as a created-this-unit file and never reclaims it — and
+**story-finalize's `git add -A` commits the seeded guard into the consumer
+project**. That is intended: the guard travels with the repo, so any Editor that
+later opens the project is protected. Disable with `install_scene_guard = false`;
+relocate with `scene_guard_dir`.
+
+### 2. Rollback quiesce (`pre_rollback` / `post_rollback`)
+
+The seeded guard cannot help a scene that goes dirty _during_ a failed attempt
+that is about to be rolled back, so the plugin also **quiesces the Editor around
+the reset**. At `pre_rollback` (before `verify.safe_rollback` runs `git reset
+--hard`) `unity_quiesce.py` saves every open scene, then opens a fresh empty
+untitled scene so **no tracked `.unity` file is open** when the reset rewrites it —
+closing the "changed on disk" dialog's window before it can open. At
+`post_rollback` it refreshes assets so the Editor drops its stale in-memory copies
+and re-imports the reverted tree. The first call doubles as a **wedge probe**: if
+the Editor is already unresponsive it fails fast and the quiesce is skipped, at the
+cost of one call timeout rather than the whole budget. Every call carries both the
+CLI's own `--timeout` and a subprocess-level kill, and the plugin hard-kills the
+whole helper past `quiesce_timeout_sec` — so a wedged Editor can **never stall the
+rollback**. Disable with `quiesce_on_rollback = false`.
+
+### 3. Prompt-fact injection (`pre_session`)
+
+At `pre_session` the plugin appends the scene-save discipline (shipped as
+`unity_facts.md`) to every non-empty dev/review prompt, so the agent itself saves
+dirty scenes at the boundaries that would otherwise trip a modal — a prompt-only
+nudge that complements the automatic guard. A project-local plugin-dir copy of
+`unity_facts.md` overrides the shipped text.
+
+### 4. Detect-only dialog probe (opt-in, `dialog_probe`, default off)
+
+The last-resort **observability** net for a modal the first three layers didn't
+prevent. When `dialog_probe = true`, the plugin launches a detached
+`unity_dialog_probe.py` (shared mode: at `pre_run`; `per_worktree`: per unit at
+`pre_worktree_setup`) that polls **xdotool** for a visible Unity-owned window whose
+title matches a known dialog phrase and, on a fresh detection, **reports it and
+nothing more** — a JSONL record (`<run_dir>/unity-dialog-probe.jsonl`), an
+`ATTENTION` line, and a best-effort `notify-send`. **It never clicks, keys, or
+closes any window**; clicking a Unity dialog blind could discard work. It is
+**X11/Linux only** (a no-op where `DISPLAY` is unset or `xdotool` is absent, so
+Windows/macOS fall straight through), self-reaps when the engine pid dies, and is
+reaped at `post_run` / worktree teardown via a pid-file handle plus a `/proc`
+argv-scan backstop. Tune with `dialog_probe_interval_sec` and
+`dialog_probe_notify`.
+
+> The exact dialog titles and the `Unity` window class are **unverified** against a
+> live Linux Editor build and kept broad on purpose; detection is advisory, so a
+> miss degrades to the pre-existing behavior (a human notices the frozen run),
+> never worse. Override `BMAD_LOOP_UNITY_DIALOG_PROBE_CLASS` or the phrase list in a
+> project-local plugin copy if your build differs.
 
 ## Platform behavior (Linux fast paths, Windows fallbacks)
 

--- a/docs/plugin-authoring-guide.md
+++ b/docs/plugin-authoring-guide.md
@@ -374,14 +374,15 @@ there.
 
 ### Story / unit
 
-| Stage                                              | When                                  | Mutable surface                                    |
-| -------------------------------------------------- | ------------------------------------- | -------------------------------------------------- |
-| `pre_story` / `post_story`                         | around one story                      | veto (`pre_`)                                      |
-| `pre_worktree_setup` / `post_worktree_setup`       | around isolated-worktree provisioning | —                                                  |
-| `pre_ready_gate` / `post_ready_gate`               | around the engine-ready gate          | veto (`pre_`)                                      |
-| `pre_worktree_teardown` / `post_worktree_teardown` | around teardown (in a `finally`)      | **observe-only** — a veto here cannot un-tear-down |
-| `pre_integrate`                                    | before integrating a finished unit    | —                                                  |
-| `pre_merge` / `post_merge`                         | around the local branch merge         | —                                                  |
+| Stage                                              | When                                                                              | Mutable surface                                       |
+| -------------------------------------------------- | --------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| `pre_story` / `post_story`                         | around one story                                                                  | veto (`pre_`)                                         |
+| `pre_worktree_setup` / `post_worktree_setup`       | around isolated-worktree provisioning                                             | —                                                     |
+| `pre_ready_gate` / `post_ready_gate`               | around the engine-ready gate                                                      | veto (`pre_`)                                         |
+| `pre_worktree_teardown` / `post_worktree_teardown` | around teardown (in a `finally`)                                                  | **observe-only** — a veto here cannot un-tear-down    |
+| `pre_rollback` / `post_rollback`                   | around a failed attempt's `git reset --hard` (only when a rollback actually runs) | **observe-only** — a veto here cannot block the reset |
+| `pre_integrate`                                    | before integrating a finished unit                                                | —                                                     |
+| `pre_merge` / `post_merge`                         | around the local branch merge                                                     | —                                                     |
 
 ### Dev
 

--- a/src/bmad_loop/data/plugins/unity/plugin.toml
+++ b/src/bmad_loop/data/plugins/unity/plugin.toml
@@ -43,6 +43,9 @@ seed_globs = [".claude/skills/*"]
 # quiesces the Editor around a failed-attempt rollback (pre_rollback /
 # post_rollback) so a git reset --hard can't leave a shared Editor showing a
 # run-freezing scene-changed-on-disk modal — best effort, never blocks the reset.
+# On pre_session it appends the scene-save discipline (unity_facts.md) to every
+# dev/review prompt, and (when dialog_probe is on) it launches + reaps a detached,
+# DETECT-ONLY modal-dialog probe (pre_run / post_run / pre_worktree_setup).
 [python]
 module = "unity_plugin.py"
 class = "UnityPlugin"
@@ -113,3 +116,25 @@ default = 60
 min = 1
 label = "Rollback quiesce timeout (sec)"
 help = "overall budget for the pre/post-rollback quiesce helper; the loop hard-kills it past this so a wedged Editor can never stall a rollback"
+
+[[settings]]
+key = "dialog_probe"
+type = "bool"
+default = false
+label = "Detect-only modal-dialog probe"
+help = "launch a detached, DETECT-ONLY probe (unity_dialog_probe.py) that watches — via xdotool, X11/Linux only — for the run-freezing Unity modal dialogs and REPORTS them (JSONL + ATTENTION + notify-send). It never clicks or keys anything; it is the last-resort observability net for a modal the scene guard + prompt facts did not prevent. No-op where DISPLAY is unset or xdotool is absent (Windows/macOS out of scope). Off by default."
+
+[[settings]]
+key = "dialog_probe_interval_sec"
+type = "int"
+default = 5
+min = 1
+label = "Dialog probe poll interval (sec)"
+help = "how often the dialog probe polls xdotool for a visible Unity modal dialog"
+
+[[settings]]
+key = "dialog_probe_notify"
+type = "bool"
+default = true
+label = "Dialog probe desktop notification"
+help = "on a fresh detection, also fire a best-effort notify-send desktop notification (guarded by shutil.which); the JSONL + ATTENTION records are written regardless"

--- a/src/bmad_loop/data/plugins/unity/plugin.toml
+++ b/src/bmad_loop/data/plugins/unity/plugin.toml
@@ -15,6 +15,15 @@
 #
 # Override per project by copying this dir to .bmad-loop/plugins/unity/ and
 # editing it (the project-local copy wins, and its dir becomes {scripts}).
+#
+# Scene auto-save guard: Unity-MCP GameObject tools mark scenes dirty but never
+# save, so a shared editor's scene sits chronically dirty — and that dirty state
+# is what raises the two run-stalling modal dialogs (scene-changed-on-disk reload,
+# and save-before-quit), which freeze the MCP dispatch loop. This plugin seeds an
+# editor-only auto-save guard (Assets/BmadLoop/Editor/, from unity_assets/) into
+# the project so no such modal ever appears. The seeded guard is committed into
+# the consumer project by story-finalize's `git add -A` — that is intended (the
+# guard travels with the repo). Disable with install_scene_guard = false.
 
 [plugin]
 name = "unity"
@@ -72,3 +81,17 @@ type = "int"
 default = -1
 label = "Readiness grace (sec)"
 help = "seconds to wait before the first readiness probe (-1 = auto: per_worktree waits for a cold Editor, shared does not)"
+
+[[settings]]
+key = "install_scene_guard"
+type = "bool"
+default = true
+label = "Install scene auto-save guard"
+help = "seed an editor-only auto-save guard into the project so chronically-dirty scenes never raise the run-stalling scene-changed-on-disk / save-before-quit modal dialogs. The seeded guard is committed into the consumer project by story-finalize's git add -A (intended). false disables seeding."
+
+[[settings]]
+key = "scene_guard_dir"
+type = "str"
+default = "Assets/BmadLoop/Editor"
+label = "Scene guard install dir"
+help = "project-relative dir the scene auto-save guard is seeded into (must live under the project's asset root, e.g. Assets/)"

--- a/src/bmad_loop/data/plugins/unity/plugin.toml
+++ b/src/bmad_loop/data/plugins/unity/plugin.toml
@@ -39,7 +39,10 @@ seed_globs = [".claude/skills/*"]
 # Editor setup/teardown, MCP agent routing, Library priming, and the
 # editor_mode<->scm.isolation coupling validation. It hooks the engine's
 # lifecycle stages (pre_ready_gate / pre_worktree_setup / pre_worktree_teardown)
-# and vetoes (defers) the unit when the Editor can't be made ready.
+# and vetoes (defers) the unit when the Editor can't be made ready. It also
+# quiesces the Editor around a failed-attempt rollback (pre_rollback /
+# post_rollback) so a git reset --hard can't leave a shared Editor showing a
+# run-freezing scene-changed-on-disk modal — best effort, never blocks the reset.
 [python]
 module = "unity_plugin.py"
 class = "UnityPlugin"
@@ -95,3 +98,18 @@ type = "str"
 default = "Assets/BmadLoop/Editor"
 label = "Scene guard install dir"
 help = "project-relative dir the scene auto-save guard is seeded into (must live under the project's asset root, e.g. Assets/)"
+
+[[settings]]
+key = "quiesce_on_rollback"
+type = "bool"
+default = true
+label = "Quiesce Editor before rollback"
+help = "save open scenes + open an empty untitled scene via the MCP CLI before git reset, refresh assets after; best-effort, never blocks the rollback"
+
+[[settings]]
+key = "quiesce_timeout_sec"
+type = "int"
+default = 60
+min = 1
+label = "Rollback quiesce timeout (sec)"
+help = "overall budget for the pre/post-rollback quiesce helper; the loop hard-kills it past this so a wedged Editor can never stall a rollback"

--- a/src/bmad_loop/data/plugins/unity/unity_assets/BmadLoop.Unity.Editor.asmdef
+++ b/src/bmad_loop/data/plugins/unity/unity_assets/BmadLoop.Unity.Editor.asmdef
@@ -1,0 +1,16 @@
+{
+    "name": "BmadLoop.Unity.Editor",
+    "rootNamespace": "BmadLoop.Unity.Editor",
+    "references": [],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": false,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/src/bmad_loop/data/plugins/unity/unity_assets/BmadLoop.Unity.Editor.asmdef.meta
+++ b/src/bmad_loop/data/plugins/unity/unity_assets/BmadLoop.Unity.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d3183d5c02f900e680aa4d788779cd91
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/bmad_loop/data/plugins/unity/unity_assets/SceneAutoSaveGuard.cs
+++ b/src/bmad_loop/data/plugins/unity/unity_assets/SceneAutoSaveGuard.cs
@@ -1,0 +1,221 @@
+// bmad-loop-scene-guard-version: 1.0.0
+//
+// Scene auto-save guard for bmad-loop-driven Unity projects.
+//
+// Unity-MCP GameObject tools (com.ivanmurzak.unity.mcp) call MarkSceneDirty and
+// never save, so a project driven by the shared editor accumulates a chronically
+// dirty scene. That dirty state is what makes Unity raise the two run-stalling
+// modal dialogs:
+//   * "Scene '<name>' has been changed on disk. Reload the scene?" — pops when git
+//     or an agent rewrites the open dirty scene's .unity file on disk;
+//   * "Do you want to save the changes you made ...?" — pops on editor quit.
+// A modal dialog freezes EditorApplication.update, which the MCP plugin uses to
+// dispatch tool calls, so every subsequent MCP call times out and the run stalls.
+//
+// This guard fixes the root cause: it keeps loaded, on-disk scenes clean by
+// debounce-saving them shortly after they go dirty, and on quit it saves (or, for
+// an unsaveable untitled scene, discards) so no modal ever appears. Untitled scenes
+// are never saved automatically — that would pop a "Save As" modal, exactly what we
+// are avoiding.
+//
+// bmad-loop seeds this file into consumer projects; story-finalize's `git add -A`
+// then commits it into the project — that is intended (the guard travels with the
+// repo so any editor opening it is protected). Toggle it from the BmadLoop menu.
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace BmadLoop.Unity.Editor
+{
+    [InitializeOnLoad]
+    internal static class SceneAutoSaveGuard
+    {
+        // EditorPrefs toggle (default ON) + its two menu items.
+        private const string EnabledPref = "BmadLoop.SceneAutoSaveGuard.Enabled";
+        private const string EnabledMenu = "BmadLoop/Scene Auto-Save Guard";
+        private const string SaveNowMenu = "BmadLoop/Save Open Scenes Now";
+
+        // Debounce window: each sceneDirtied event pushes the deadline out this far,
+        // so a burst of MCP edits collapses into a single save once they settle.
+        private const double DebounceSeconds = 5.0;
+
+        // The timeSinceStartup deadline for the pending save; < 0 means "nothing
+        // pending" — the cheap early-out the per-frame update handler checks first.
+        private static double s_dueAt = -1.0;
+
+        static SceneAutoSaveGuard()
+        {
+            EditorSceneManager.sceneDirtied += OnSceneDirtied;
+            EditorApplication.update += OnUpdate;
+            EditorApplication.wantsToQuit += OnWantsToQuit;
+            EditorApplication.quitting += OnQuitting;
+            // A scene can already be dirty from before this domain reload — an MCP
+            // tool dirtied it, then a recompile reloaded the domain and reset our
+            // pending state. Arm immediately so that dirty scene still gets flushed.
+            if (HasDirtyPathedScene())
+            {
+                Arm();
+            }
+        }
+
+        private static bool Enabled => EditorPrefs.GetBool(EnabledPref, true);
+
+        private static void Arm()
+        {
+            s_dueAt = EditorApplication.timeSinceStartup + DebounceSeconds;
+        }
+
+        private static void OnSceneDirtied(Scene scene)
+        {
+            Arm();
+        }
+
+        private static void OnUpdate()
+        {
+            // Cheap early-out: nothing pending is the overwhelmingly common case, so
+            // this handler must cost next to nothing when idle.
+            if (s_dueAt < 0.0)
+            {
+                return;
+            }
+            if (EditorApplication.timeSinceStartup < s_dueAt)
+            {
+                return;
+            }
+            if (!Enabled)
+            {
+                s_dueAt = -1.0; // toggled off while a save was pending — drop it
+                return;
+            }
+            // Never save mid-transition: entering/exiting play mode, compiling,
+            // importing/refreshing assets, building a player, or editing a prefab in
+            // isolation (the open scenes aren't the active editing target then).
+            // Re-arm and try again on a later frame.
+            if (EditorApplication.isPlayingOrWillChangePlaymode
+                || EditorApplication.isCompiling
+                || EditorApplication.isUpdating
+                || BuildPipeline.isBuildingPlayer
+                || PrefabStageUtility.GetCurrentPrefabStage() != null)
+            {
+                Arm();
+                return;
+            }
+            s_dueAt = -1.0;
+            SaveDirtyPathedScenes("auto-saved");
+        }
+
+        private static bool OnWantsToQuit()
+        {
+            // Even with the guard off, never block the quit — that would defeat the
+            // whole point (a frozen editor). Just don't touch the scenes.
+            if (Enabled)
+            {
+                SaveDirtyPathedScenes("auto-saved");
+                // A dirty *untitled* scene has no path to save to; leaving it would
+                // pop the "save changes before quitting?" modal we exist to prevent.
+                // Discard it by swapping in a fresh empty single scene.
+                string discarded = DirtyUntitledSceneNames();
+                if (discarded.Length > 0)
+                {
+                    Debug.LogWarning(
+                        "[SceneAutoSaveGuard] discarding unsaved untitled scene(s) on quit: "
+                            + discarded);
+                    EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+                }
+            }
+            // ALWAYS allow the quit to proceed.
+            return true;
+        }
+
+        private static void OnQuitting()
+        {
+            // Backstop: wantsToQuit already saved, but another handler in the quit
+            // chain may have re-dirtied a pathed scene after it. Save once more.
+            if (Enabled)
+            {
+                SaveDirtyPathedScenes("auto-saved");
+            }
+        }
+
+        [MenuItem(EnabledMenu, priority = 200)]
+        private static void ToggleEnabled()
+        {
+            bool now = !Enabled;
+            EditorPrefs.SetBool(EnabledPref, now);
+            Menu.SetChecked(EnabledMenu, now);
+            if (!now)
+            {
+                s_dueAt = -1.0; // cancel any pending save when the guard is disabled
+            }
+        }
+
+        [MenuItem(EnabledMenu, validate = true)]
+        private static bool ToggleEnabledValidate()
+        {
+            // Reflect the persisted toggle in the menu's checkmark each time it opens.
+            Menu.SetChecked(EnabledMenu, Enabled);
+            return true;
+        }
+
+        [MenuItem(SaveNowMenu, priority = 201)]
+        private static void SaveOpenScenesNow()
+        {
+            s_dueAt = -1.0; // immediate flush, bypassing the debounce
+            SaveDirtyPathedScenes("auto-saved");
+        }
+
+        private static bool HasDirtyPathedScene()
+        {
+            for (int i = 0; i < SceneManager.sceneCount; i++)
+            {
+                Scene scene = SceneManager.GetSceneAt(i);
+                if (scene.isDirty && !string.IsNullOrEmpty(scene.path))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        // Save every loaded scene that is dirty and has a path on disk. Untitled
+        // scenes (empty path) are always skipped so we never trigger a "Save As"
+        // modal. Returns the number saved; logs the paths when at least one saved.
+        private static int SaveDirtyPathedScenes(string verb)
+        {
+            var saved = new List<string>();
+            for (int i = 0; i < SceneManager.sceneCount; i++)
+            {
+                Scene scene = SceneManager.GetSceneAt(i);
+                if (scene.isDirty
+                    && !string.IsNullOrEmpty(scene.path)
+                    && EditorSceneManager.SaveScene(scene))
+                {
+                    saved.Add(scene.path);
+                }
+            }
+            if (saved.Count > 0)
+            {
+                Debug.Log(
+                    "[SceneAutoSaveGuard] " + verb + " " + saved.Count + " scene(s): "
+                        + string.Join(", ", saved));
+            }
+            return saved.Count;
+        }
+
+        private static string DirtyUntitledSceneNames()
+        {
+            var names = new List<string>();
+            for (int i = 0; i < SceneManager.sceneCount; i++)
+            {
+                Scene scene = SceneManager.GetSceneAt(i);
+                if (scene.isDirty && string.IsNullOrEmpty(scene.path))
+                {
+                    names.Add(string.IsNullOrEmpty(scene.name) ? "<untitled>" : scene.name);
+                }
+            }
+            return string.Join(", ", names);
+        }
+    }
+}

--- a/src/bmad_loop/data/plugins/unity/unity_assets/SceneAutoSaveGuard.cs.meta
+++ b/src/bmad_loop/data/plugins/unity/unity_assets/SceneAutoSaveGuard.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 03213cb31364059c331c65ce16ba3356
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/bmad_loop/data/plugins/unity/unity_assets/_folders/BmadLoop.meta
+++ b/src/bmad_loop/data/plugins/unity/unity_assets/_folders/BmadLoop.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9f46d91abc0bd668334c07a3ce41e1d2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/bmad_loop/data/plugins/unity/unity_assets/_folders/Editor.meta
+++ b/src/bmad_loop/data/plugins/unity/unity_assets/_folders/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3edfe262bc470b24adffcffcbeb3ff11
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/src/bmad_loop/data/plugins/unity/unity_dialog_probe.py
+++ b/src/bmad_loop/data/plugins/unity/unity_dialog_probe.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Detached, DETECT-ONLY Unity modal-dialog probe for the bmad-loop Unity plugin.
+
+Unity on Linux is an X11 (or XWayland) client, so its run-freezing modal dialogs —
+"scene(s) have been modified" (reload / save-before-close), "conflicting scene
+changes" — are ordinary X windows. This probe polls xdotool for a *visible*
+Unity-owned window whose title matches one of those dialogs and, when it finds one,
+**reports it and nothing more**: it NEVER clicks, keys, activates, or closes any
+window. The scene-guard (auto-save) and the injected prompt facts are what *prevent*
+the modals; this is the last-resort observability net that tells a human one slipped
+through and is now freezing the MCP dispatch loop.
+
+Report on a fresh detection (deduped per window id, per probe lifetime):
+  1. a JSONL line to ``<run_dir>/unity-dialog-probe.jsonl`` — ``{ts, window, title}``;
+  2. a line to ``<run_dir>/ATTENTION`` in the same format as ``gates.notify``;
+  3. a best-effort ``notify-send`` desktop notification (guarded by ``shutil.which``,
+     gated by ``BMAD_LOOP_UNITY_DIALOG_PROBE_NOTIFY``), mirroring ``gates.notify``.
+
+Lifecycle: launched detached by ``UnityPlugin`` (shared mode: at ``pre_run``;
+per_worktree: at ``pre_worktree_setup``) with the project/worktree path in argv, so
+``unity_teardown.py``'s ``/proc`` argv scan can find + reap it. It also writes its own
+``<run_dir>/unity-dialog-probe.pid`` (pid + start-time identity, via
+``runs.write_named_pid``) as the primary reap handle. Self-reaping backstop: it polls
+``<run_dir>/engine.pid`` liveness (``runs.engine_alive`` — the same identity-checked
+logic the CLI uses) and exits when the engine dies, so an un-reaped probe can never
+outlive its run.
+
+Stdlib only, plus bmad-loop's own dep-free process/pid helpers (no third-party deps).
+No-op clean exit (0) when there is nothing to watch: ``DISPLAY`` unset, ``xdotool``
+absent, or ``BMAD_LOOP_RUN_DIR`` unset (Windows/macOS fall out here — out of scope).
+
+Env (injected by the engine plugin):
+  BMAD_LOOP_RUN_DIR                          run dir for outputs + engine.pid liveness
+  BMAD_LOOP_UNITY_DIALOG_PROBE_INTERVAL_SEC  poll interval seconds     (default 5, min 1)
+  BMAD_LOOP_UNITY_DIALOG_PROBE_NOTIFY        1/0 desktop notify        (default 1)
+  BMAD_LOOP_UNITY_DIALOG_PROBE_CLASS         xdotool WM_CLASS regex    (default Unity)
+
+NOTE: the exact dialog titles + the "Unity" window class are UNVERIFIED against a live
+Linux Editor build — they are best-effort heuristics. Detection is advisory; a miss
+degrades to the pre-existing behavior (a human notices the frozen run), never worse.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+# bmad-loop's own dep-free liveness/pid helpers (run under sys.executable, so the
+# package is importable — same contract unity_teardown.py relies on for process_host).
+from bmad_loop.runs import engine_alive, write_named_pid
+
+PROBE_PID_FILE = "unity-dialog-probe.pid"
+PROBE_JSONL = "unity-dialog-probe.jsonl"
+ATTENTION_FILE = "ATTENTION"
+_TITLE = "Unity modal dialog detected"
+
+# Case-insensitive substrings identifying a run-freezing Unity modal dialog by its
+# window title. UNVERIFIED against a live Editor — kept broad + advisory on purpose.
+_DIALOG_PATTERNS = (
+    "changed on disk",
+    "save changes before",
+    "conflicting scene changes",
+    "scene(s) have been modified",
+    "reload the following",
+    "do you want to save",
+    "unapplied import settings",
+)
+
+# Set by the SIGTERM/SIGINT handler so a polite teardown ends the loop promptly.
+_stop = False
+
+
+def _truthy(value: str | None, default: bool) -> bool:
+    if value is None or value.strip() == "":
+        return default
+    return value.strip().lower() in ("1", "true", "yes", "on")
+
+
+def _install_signals() -> None:
+    """Break the poll loop on SIGTERM/SIGINT so the plugin's polite reap suffices."""
+
+    def _handler(_signum, _frame):
+        global _stop
+        _stop = True
+
+    for name in ("SIGTERM", "SIGINT"):
+        sig = getattr(signal, name, None)
+        if sig is not None:
+            try:
+                signal.signal(sig, _handler)
+            except (ValueError, OSError):  # pragma: no cover - not the main thread, etc.
+                pass
+
+
+def _interval() -> float:
+    try:
+        return max(1.0, float(os.environ.get("BMAD_LOOP_UNITY_DIALOG_PROBE_INTERVAL_SEC", "5")))
+    except (TypeError, ValueError):
+        return 5.0
+
+
+def _run_xdotool(args: list[str], timeout: float = 10.0) -> subprocess.CompletedProcess:
+    return subprocess.run(["xdotool", *args], capture_output=True, text=True, timeout=timeout)
+
+
+def _unity_window_ids(run) -> list[str]:
+    """Ids of *visible* Unity-owned windows (xdotool search by WM_CLASS regex).
+    xdotool exits non-zero when nothing matches — that is the normal "no dialog"
+    case, not an error. Any launch failure degrades to an empty list."""
+    cls = os.environ.get("BMAD_LOOP_UNITY_DIALOG_PROBE_CLASS", "Unity")
+    try:
+        proc = run(["search", "--onlyvisible", "--class", cls])
+    except (subprocess.SubprocessError, OSError):
+        return []
+    if proc.returncode != 0:
+        return []
+    return [line.strip() for line in proc.stdout.splitlines() if line.strip().isdigit()]
+
+
+def _window_name(run, wid: str) -> str:
+    try:
+        proc = run(["getwindowname", wid])
+    except (subprocess.SubprocessError, OSError):
+        return ""
+    return proc.stdout.strip() if proc.returncode == 0 else ""
+
+
+def _matches_dialog(name: str) -> bool:
+    low = name.lower()
+    return any(pattern in low for pattern in _DIALOG_PATTERNS)
+
+
+def _scan_for_dialogs(run) -> list[tuple[str, str]]:
+    """(window id, title) for every visible Unity window whose title matches a known
+    modal-dialog phrase. ``run`` is an injectable xdotool runner (for testing)."""
+    hits: list[tuple[str, str]] = []
+    for wid in _unity_window_ids(run):
+        name = _window_name(run, wid)
+        if name and _matches_dialog(name):
+            hits.append((wid, name))
+    return hits
+
+
+def _report(run_dir: Path, wid: str, name: str, *, notify: bool) -> None:
+    """Record one fresh detection: JSONL + ATTENTION + (best-effort) notify-send.
+    Every sink is independently guarded — a filesystem or notify failure never stops
+    the others, and never raises."""
+    ts = time.strftime("%Y-%m-%dT%H:%M:%S")
+    try:
+        with (run_dir / PROBE_JSONL).open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps({"ts": ts, "window": wid, "title": name}) + "\n")
+    except OSError:
+        pass
+    # ATTENTION line: identical shape to gates.notify's file sink.
+    stamp = time.strftime("%Y-%m-%d %H:%M:%S")
+    message = f"window {wid}: {name}"
+    try:
+        with (run_dir / ATTENTION_FILE).open("a", encoding="utf-8") as fh:
+            fh.write(f"[{stamp}] {_TITLE}: {message}\n")
+    except OSError:
+        pass
+    # portability: notify-send is Linux-only; the shutil.which guard makes this a
+    # no-op where it is absent (mirrors gates.notify).
+    if notify and shutil.which("notify-send"):
+        try:
+            subprocess.run(
+                ["notify-send", "--app-name=bmad-loop", _TITLE, message],
+                timeout=10,
+                capture_output=True,
+            )
+        except (subprocess.SubprocessError, OSError):
+            pass  # desktop notification is best-effort
+
+
+def _scan_once(run, run_dir: Path, seen: set[str], *, notify: bool) -> int:
+    """One scan+report pass. Reports only window ids not already in ``seen`` (dedupe
+    repeat detections of the same dialog). Returns the count of NEW reports."""
+    reported = 0
+    for wid, name in _scan_for_dialogs(run):
+        if wid in seen:
+            continue
+        seen.add(wid)
+        _report(run_dir, wid, name, notify=notify)
+        reported += 1
+    return reported
+
+
+def _sleep_until_next_poll(interval: float, run_dir: Path) -> None:
+    """Sleep ``interval`` in ~1s slices so a SIGTERM or a dead engine is noticed
+    within about a second regardless of how long the poll interval is."""
+    slept = 0.0
+    while not _stop and slept < interval and engine_alive(run_dir):
+        time.sleep(min(1.0, interval - slept))
+        slept += 1.0
+
+
+def main() -> int:
+    if not os.environ.get("DISPLAY"):
+        print("unity_dialog_probe: DISPLAY unset; nothing to probe (exit 0)", file=sys.stderr)
+        return 0
+    if shutil.which("xdotool") is None:
+        print("unity_dialog_probe: xdotool not on PATH; nothing to probe (exit 0)", file=sys.stderr)
+        return 0
+    rd = (os.environ.get("BMAD_LOOP_RUN_DIR") or "").strip()
+    if not rd:
+        # Without a run dir we have nowhere to report AND no engine pid to shadow —
+        # refuse rather than loop forever as an orphan.
+        print(
+            "unity_dialog_probe: BMAD_LOOP_RUN_DIR unset; refusing to run with no "
+            "engine to shadow (exit 0)",
+            file=sys.stderr,
+        )
+        return 0
+
+    run_dir = Path(rd)
+    interval = _interval()
+    notify = _truthy(os.environ.get("BMAD_LOOP_UNITY_DIALOG_PROBE_NOTIFY"), True)
+    _install_signals()
+    # primary reap handle: our own pid + start-time identity (mirrors runs.write_pid).
+    try:
+        write_named_pid(run_dir / PROBE_PID_FILE, os.getpid())
+    except OSError:
+        pass
+
+    seen: set[str] = set()
+    while not _stop and engine_alive(run_dir):
+        _scan_once(_run_xdotool, run_dir, seen, notify=notify)
+        _sleep_until_next_poll(interval, run_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/bmad_loop/data/plugins/unity/unity_facts.md
+++ b/src/bmad_loop/data/plugins/unity/unity_facts.md
@@ -1,0 +1,17 @@
+## Unity scene-save discipline (bmad-loop)
+
+You are driving a live Unity Editor over MCP. Unity-MCP scene-mutating tools mark
+scenes dirty but never save them, and a dirty or unsaved-on-quit scene raises modal
+Editor dialogs ("scene changed on disk", "save changes before closing") that freeze
+the Editor and every subsequent MCP call. Follow these rules:
+
+- After any scene-mutating MCP batch (`gameobject-*`, `*component*`, `tilemap-*`,
+  `cinemachine-*`, prefab instantiate), call `scene-save` for **each modified open
+  scene** BEFORE any of: running tests (`tests-run` aborts on dirty scenes), any
+  `git` command, entering play mode (`editor-application-set-state`), or ending the
+  session.
+- Never rewrite an open scene's `.unity`/`.prefab` on disk directly — prefer the MCP
+  tools. If a disk edit is unavoidable: `scene-save` first, make the edit, then
+  `assets-refresh`.
+- A `SceneAutoSaveGuard` auto-saves dirty scenes after ~5s idle, but do **not** rely
+  on it for ordering — call `scene-save` explicitly at the boundaries above.

--- a/src/bmad_loop/data/plugins/unity/unity_plugin.py
+++ b/src/bmad_loop/data/plugins/unity/unity_plugin.py
@@ -7,6 +7,11 @@ top of the generic plugin framework:
     report ready before any session runs, in both editor modes;
   * **per_worktree setup/teardown** (``on_pre_worktree_setup`` /
     ``on_pre_worktree_teardown``) launch and reap a managed Editor per worktree;
+  * a **rollback quiesce** (``on_pre_rollback`` / ``on_post_rollback``) saves +
+    closes open scenes before ``verify.safe_rollback`` runs ``git reset --hard``,
+    then refreshes assets after — so the reset can't rewrite a tracked ``.unity``
+    file under a shared Editor and raise a run-freezing modal dialog. Best effort:
+    a wedged Editor is skipped (fast) and the rollback always proceeds;
   * a failure **vetoes (defers)** the unit through the bus — the engine's generic
     ``_vetoed`` routing turns that into a deferral + notification, with no
     Unity-specific branch in the loop;
@@ -51,6 +56,10 @@ _TEARDOWN_TIMEOUT = 120
 # scene-guard seeding is a handful of small file copies; bound it small so a wedged
 # filesystem can't eat into the readiness budget (it never vetoes either way).
 _SEED_TIMEOUT = 60
+# fallback overall budget for the rollback quiesce helper if quiesce_timeout_sec is
+# unreadable. The helper's own per-call timeouts are the primary no-deadlock guard;
+# this is the outer kill so a wedged Editor can never stall a rollback either way.
+_QUIESCE_TIMEOUT = 60
 
 
 class UnityPlugin(Plugin):
@@ -126,6 +135,23 @@ class UnityPlugin(Plugin):
             return
         self._run_script("unity_teardown.py", ctx, timeout=_TEARDOWN_TIMEOUT)
 
+    def on_pre_rollback(self, ctx) -> None:
+        """Quiesce the Editor before ``verify.safe_rollback`` runs ``git reset
+        --hard``: save every open scene, then open an empty untitled scene so no
+        tracked ``.unity`` file is open when the reset rewrites it. Without this a
+        shared Editor holding a dirty scene raises a modal "scene changed on disk —
+        Reload/Cancel" dialog that freezes ``EditorApplication.update`` and every
+        Unity-MCP dispatch. Best effort — a wedged Editor is detected fast and
+        skipped, and the rc is ignored: a failed quiesce must never block the
+        rollback."""
+        self._quiesce("pre", ctx)
+
+    def on_post_rollback(self, ctx) -> None:
+        """After the reset rewrote the tracked tree, tell the Editor to re-import
+        so it sees the reverted assets rather than its stale in-memory copies. Best
+        effort — same never-veto contract as ``on_pre_rollback``."""
+        self._quiesce("post", ctx)
+
     def on_post_run(self, ctx) -> None:
         """Run finished cleanly: reclaim the IvanMurzak MCP server's /tmp scratch
         (downloaded server zips) and truncate its unbounded editor log. Best
@@ -148,6 +174,32 @@ class UnityPlugin(Plugin):
 
     def _install_scene_guard(self) -> bool:
         return bool(self.settings.get("install_scene_guard", True))
+
+    def _quiesce_on_rollback(self) -> bool:
+        return bool(self.settings.get("quiesce_on_rollback", True))
+
+    def _quiesce_timeout(self) -> int:
+        try:
+            return max(1, int(self.settings.get("quiesce_timeout_sec", _QUIESCE_TIMEOUT)))
+        except (TypeError, ValueError):
+            return _QUIESCE_TIMEOUT
+
+    def _quiesce(self, phase: str, ctx) -> None:
+        """Run the rollback quiesce helper for ``phase`` ("pre" | "post"). Skipped
+        when disabled or when the MCP isn't the IvanMurzak CLI (the only server the
+        helper drives). Best effort: the rc is ignored (the helper's exit codes are
+        advisory) and a failure never vetoes — this is observe-only, called from the
+        engine's ``pre_rollback`` / ``post_rollback`` stages which forbid a veto."""
+        if not self._quiesce_on_rollback():
+            return
+        if str(self.settings.get("mcp", "ivanmurzak")) != "ivanmurzak":
+            return
+        self._run_script(
+            "unity_quiesce.py",
+            ctx,
+            timeout=self._quiesce_timeout(),
+            extra_env={"BMAD_LOOP_QUIESCE_PHASE": phase},
+        )
 
     def _seed_scene_guard(self, ctx) -> None:
         """Seed the scene auto-save guard into the project so a chronically-dirty
@@ -197,12 +249,18 @@ class UnityPlugin(Plugin):
             env["BMAD_LOOP_ENGINE_AGENTS"] = ",".join(ctx.agents)
         return env
 
-    def _run_script(self, name: str, ctx, *, timeout: int) -> tuple[int, str]:
+    def _run_script(
+        self, name: str, ctx, *, timeout: int, extra_env: dict[str, str] | None = None
+    ) -> tuple[int, str]:
         """Run one helper script with the engine env, returning (rc, output-tail).
-        Never raises: a launch failure / timeout maps to a non-zero rc so the
-        readiness gate defers rather than crashing the run."""
+        ``extra_env`` is merged over ``engine_env(ctx)`` for per-call knobs the base
+        contract doesn't carry (e.g. the quiesce phase). Never raises: a launch
+        failure / timeout maps to a non-zero rc so the readiness gate defers rather
+        than crashing the run."""
         script = Path(self.manifest.scripts_dir) / name
         env = self.engine_env(ctx)
+        if extra_env:
+            env.update(extra_env)
         cwd = ctx.worktree or ctx.repo_root or None
         try:
             proc = subprocess.run(  # nosec B603 - operator-enabled engine plugin script

--- a/src/bmad_loop/data/plugins/unity/unity_plugin.py
+++ b/src/bmad_loop/data/plugins/unity/unity_plugin.py
@@ -17,6 +17,15 @@ top of the generic plugin framework:
     Unity-specific branch in the loop;
   * **MCP agent routing** reads ``ctx.agents`` (the dev + review CLIs in the
     worktree) so every agent's MCP config is pointed at the worktree's Editor;
+  * **prompt-fact injection** (``on_pre_session``) appends the Unity scene-save
+    discipline (from the shipped ``unity_facts.md``) to every dev/review session
+    prompt, so the agent saves dirty scenes at the boundaries that would otherwise
+    raise the run-freezing modals — a plugin-only change, no engine edit;
+  * a **detect-only dialog probe** (``on_pre_run`` / ``on_post_run`` /
+    ``on_pre_worktree_setup``) launches a detached ``unity_dialog_probe.py`` that
+    watches (via xdotool, X11 only) for the modal dialogs and *reports* them
+    (JSONL + ATTENTION + notify-send) — it never clicks or keys anything. It is the
+    last-resort observability net for a modal the guard + facts didn't prevent;
   * **editor_mode↔scm.isolation coupling** is validated in ``validate`` at startup
     (it moved out of core ``policy.loads`` — a flat per-key schema can't express a
     cross-section coupling).
@@ -41,15 +50,20 @@ The seeded guard is committed into the consumer project by story-finalize's
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from pathlib import Path
 from typing import Any
 
 from bmad_loop.plugins.model import Plugin, PluginError
+from bmad_loop.process_host import get_process_host
 
 # editor modes this plugin supports; the operator picks one via [plugins.unity].
 EDITOR_MODES = ("shared", "per_worktree")
+# the detached detect-only modal-dialog probe + its pid-file reap handle.
+_DIALOG_PROBE_SCRIPT = "unity_dialog_probe.py"
+_DIALOG_PROBE_PID_FILE = "unity-dialog-probe.pid"
 # best-effort teardown bound so a hung Editor-quit can't stall the loop for the
 # full readiness budget on every unit (was Engine._ENGINE_TEARDOWN_TIMEOUT).
 _TEARDOWN_TIMEOUT = 120
@@ -123,6 +137,10 @@ class UnityPlugin(Plugin):
         # Seed the scene guard BEFORE unity_setup launches the Editor, so the
         # Editor's very first import already sees it. Best effort — never vetoes.
         self._seed_scene_guard(ctx)
+        # Launch this unit's detect-only dialog probe (scoped to the worktree path
+        # so teardown's argv scan can find it) before the Editor comes up, so it is
+        # already watching. Best effort — a launch failure never blocks setup.
+        self._start_dialog_probe(ctx, ctx.worktree or "")
         rc, tail = self._run_script("unity_setup.py", ctx, timeout=self._ready_timeout())
         if rc != 0:
             ctx.veto("defer", f"Unity worktree setup failed (rc={rc}): {tail}".rstrip())
@@ -152,12 +170,40 @@ class UnityPlugin(Plugin):
         effort — same never-veto contract as ``on_pre_rollback``."""
         self._quiesce("post", ctx)
 
+    def on_pre_session(self, ctx) -> None:
+        """Append the Unity scene-save discipline to every dev/review session prompt
+        so the agent saves dirty scenes at the boundaries that raise the run-freezing
+        modals. Only the whitelisted ``proposed_prompt`` is mutated, and only when
+        it is non-empty — a fast-path emit with no prompt is left untouched. The
+        facts text ships as ``unity_facts.md`` next to the helper scripts; a
+        project-local plugin-dir copy overrides it (the loader points ``scripts_dir``
+        at the override)."""
+        if not ctx.proposed_prompt:
+            return
+        facts = self._session_facts()
+        if facts:
+            ctx.proposed_prompt = ctx.proposed_prompt + "\n\n" + facts
+
+    def on_pre_run(self, ctx) -> None:
+        """Run start: sweep a stale dialog probe recorded in this run dir (a resume
+        re-enters with the same run dir + a re-stamped engine pid, so a prior probe
+        would otherwise linger until its next self-reap poll), then in shared mode
+        launch a fresh detect-only probe that shadows the live Editor for the whole
+        run. per_worktree launches its probe per unit at ``pre_worktree_setup``."""
+        self._reap_dialog_probe(ctx)
+        if self._editor_mode() == "shared":
+            self._start_dialog_probe(ctx, ctx.repo_root or "")
+
     def on_post_run(self, ctx) -> None:
-        """Run finished cleanly: reclaim the IvanMurzak MCP server's /tmp scratch
-        (downloaded server zips) and truncate its unbounded editor log. Best
-        effort — observe-only, runs once per run in both editor modes, after the
-        loop so it never races an in-flight setup-mcp download. CoplayDev uses a
-        shared server with no per-project /tmp download, so it is skipped."""
+        """Run finished cleanly: reap the shared-mode dialog probe (per_worktree
+        probes are reaped at worktree teardown; the reap is idempotent + mode-
+        agnostic so it is safe here in both modes), then reclaim the IvanMurzak MCP
+        server's /tmp scratch (downloaded server zips) and truncate its unbounded
+        editor log. Best effort — observe-only, runs once per run in both editor
+        modes, after the loop so it never races an in-flight setup-mcp download.
+        CoplayDev uses a shared server with no per-project /tmp download, so the
+        cleanup is skipped."""
+        self._reap_dialog_probe(ctx)
         if not self._clean_tmp:
             return
         if str(self.settings.get("mcp", "ivanmurzak")) != "ivanmurzak":
@@ -214,13 +260,98 @@ class UnityPlugin(Plugin):
         if rc != 0:
             sys.stderr.write(f"unity: scene-guard seeding failed (rc={rc}): {tail}".rstrip() + "\n")
 
+    def _session_facts(self) -> str:
+        """The Unity operating facts appended to every session prompt, read once from
+        the shipped (or project-overridden) ``unity_facts.md``. Cached on the
+        instance; a missing/unreadable file degrades to no injection."""
+        cached = getattr(self, "_facts_text", None)
+        if cached is not None:
+            return cached
+        try:
+            text = (
+                (Path(self.manifest.scripts_dir) / "unity_facts.md")
+                .read_text(encoding="utf-8")
+                .strip()
+            )
+        except OSError:
+            text = ""
+        self._facts_text = text
+        return text
+
+    # ----------------------------------------------------- detect-only dialog probe
+
+    def _dialog_probe(self) -> bool:
+        return bool(self.settings.get("dialog_probe", False))
+
+    def _dialog_probe_interval(self) -> int:
+        try:
+            return max(1, int(self.settings.get("dialog_probe_interval_sec", 5)))
+        except (TypeError, ValueError):
+            return 5
+
+    def _dialog_probe_notify(self) -> bool:
+        return bool(self.settings.get("dialog_probe_notify", True))
+
+    def _probe_pid_path(self, ctx) -> Path | None:
+        return Path(ctx.run_dir) / _DIALOG_PROBE_PID_FILE if ctx.run_dir else None
+
+    def _start_dialog_probe(self, ctx, scan_path: str) -> None:
+        """Launch the detached detect-only dialog probe (only when enabled). Reaps
+        any probe recorded in this run dir first so a re-entry never leaves two
+        running. The probe self-reaps when the engine pid dies, so a leak is bounded
+        regardless. ``scan_path`` (the worktree in per_worktree mode, the repo root
+        in shared) is passed in argv so teardown's argv scan can find the process —
+        its exe basename is ``python``, invisible to the Editor sweep. Best effort:
+        a launch failure is logged, never blocks the caller."""
+        if not self._dialog_probe():
+            return
+        self._reap_dialog_probe(ctx)  # never run two
+        script = Path(self.manifest.scripts_dir) / _DIALOG_PROBE_SCRIPT
+        # detach so the probe outlives this hook (mirrors unity_setup's Editor launch)
+        detach: dict[str, Any] = {"start_new_session": True}  # portability: POSIX detach kwarg
+        if sys.platform == "win32":  # pragma: no cover - probe is X11/Linux-only
+            detach = {"creationflags": getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)}
+        try:
+            subprocess.Popen(  # nosec B603 - operator-enabled engine plugin script
+                [sys.executable, str(script), scan_path],
+                cwd=ctx.worktree or ctx.repo_root or None,
+                env=self.engine_env(ctx),
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                **detach,
+            )
+        except OSError as e:
+            sys.stderr.write(f"unity: dialog-probe launch failed: {e}\n")
+
+    def _reap_dialog_probe(self, ctx) -> None:
+        """Terminate a dialog probe recorded in this run dir's pid file, identity-
+        guarded so a kernel-recycled pid is never signalled. Best effort + idempotent:
+        a missing/stale handle is a no-op. The probe handles SIGTERM by exiting its
+        loop, so a polite terminate suffices; the run-end teardown / self-reap poll
+        are the backstops."""
+        path = self._probe_pid_path(ctx)
+        if path is None:
+            return
+        from bmad_loop import runs  # noqa: PLC0415 - lazy: keep import cost off the hot path
+
+        pid, identity = runs.read_named_pid_identity(path)
+        if pid is not None:
+            host = get_process_host()
+            if host.alive_and_ours(pid, identity):
+                try:
+                    host.terminate(pid)
+                except OSError:
+                    pass
+        try:
+            path.unlink()
+        except OSError:
+            pass
+
     def engine_env(self, ctx) -> dict[str, str]:
         """The ``BMAD_LOOP_*`` environment the helper scripts read — identity +
         worktree from the context, the Editor knobs from this plugin's settings,
         and the MCP agent ids from ``ctx.agents`` (dev + review CLIs). Identical
         to the contract the bespoke ``Engine._run_engine_hook`` used to inject."""
-        import os
-
         worktree = ctx.worktree or ctx.repo_root or ""
         env = dict(os.environ)
         env.update(
@@ -239,6 +370,9 @@ class UnityPlugin(Plugin):
                 "BMAD_LOOP_UNITY_SCENE_GUARD_DIR": str(
                     self.settings.get("scene_guard_dir", "Assets/BmadLoop/Editor")
                 ),
+                "BMAD_LOOP_UNITY_DIALOG_PROBE": "1" if self._dialog_probe() else "0",
+                "BMAD_LOOP_UNITY_DIALOG_PROBE_INTERVAL_SEC": str(self._dialog_probe_interval()),
+                "BMAD_LOOP_UNITY_DIALOG_PROBE_NOTIFY": "1" if self._dialog_probe_notify() else "0",
             }
         )
         # Tell the per_worktree setup which agent MCP configs to point at the

--- a/src/bmad_loop/data/plugins/unity/unity_plugin.py
+++ b/src/bmad_loop/data/plugins/unity/unity_plugin.py
@@ -20,6 +20,18 @@ The helper scripts (``unity_ready.py`` / ``unity_setup.py`` / ``unity_teardown.p
 are unchanged; they read the same ``BMAD_LOOP_*`` environment this module injects,
 so the env contract a Unity operator relies on is identical to the engine layer it
 replaces.
+
+A newer helper, ``unity_seed_assets.py``, seeds a **scene auto-save guard** into
+the project (see ``unity_assets/``). Unity-MCP GameObject tools mark scenes dirty
+but never save, so a shared editor's scene sits chronically dirty — the state that
+raises the two run-stalling modal dialogs (scene-changed-on-disk reload, and
+save-before-quit) that freeze the MCP dispatch loop. The guard is seeded *before*
+the Editor's first import in both modes (at ``pre_worktree_setup`` in per_worktree
+mode, ahead of ``unity_setup.py``; at ``pre_ready_gate`` in shared mode, where
+``unity_setup.py`` never runs). Seeding is best-effort — a failure is logged, never
+vetoes — and happens pre-baseline, so ``verify.safe_rollback`` never reclaims it.
+The seeded guard is committed into the consumer project by story-finalize's
+``git add -A`` — intended.
 """
 
 from __future__ import annotations
@@ -36,6 +48,9 @@ EDITOR_MODES = ("shared", "per_worktree")
 # best-effort teardown bound so a hung Editor-quit can't stall the loop for the
 # full readiness budget on every unit (was Engine._ENGINE_TEARDOWN_TIMEOUT).
 _TEARDOWN_TIMEOUT = 120
+# scene-guard seeding is a handful of small file copies; bound it small so a wedged
+# filesystem can't eat into the readiness budget (it never vetoes either way).
+_SEED_TIMEOUT = 60
 
 
 class UnityPlugin(Plugin):
@@ -80,7 +95,13 @@ class UnityPlugin(Plugin):
 
     def on_pre_ready_gate(self, ctx) -> None:
         """Block until the Editor + MCP report ready before a unit runs (both
-        modes). A non-zero exit vetoes (defers) the unit."""
+        modes). A non-zero exit vetoes (defers) the unit.
+
+        In shared mode ``unity_setup.py`` never runs (isolation=none has no
+        per_worktree setup stage), so this is where the scene guard is seeded —
+        before the readiness gate blocks on the live Editor."""
+        if self._editor_mode() == "shared":
+            self._seed_scene_guard(ctx)
         rc, tail = self._run_script("unity_ready.py", ctx, timeout=self._ready_timeout())
         if rc != 0:
             ctx.veto("defer", f"Unity Editor not ready (rc={rc}): {tail}".rstrip())
@@ -90,6 +111,9 @@ class UnityPlugin(Plugin):
         its managed Editor before the agent runs. A failure defers the unit."""
         if self._editor_mode() != "per_worktree":
             return
+        # Seed the scene guard BEFORE unity_setup launches the Editor, so the
+        # Editor's very first import already sees it. Best effort — never vetoes.
+        self._seed_scene_guard(ctx)
         rc, tail = self._run_script("unity_setup.py", ctx, timeout=self._ready_timeout())
         if rc != 0:
             ctx.veto("defer", f"Unity worktree setup failed (rc={rc}): {tail}".rstrip())
@@ -122,6 +146,22 @@ class UnityPlugin(Plugin):
         except (TypeError, ValueError):
             return 600
 
+    def _install_scene_guard(self) -> bool:
+        return bool(self.settings.get("install_scene_guard", True))
+
+    def _seed_scene_guard(self, ctx) -> None:
+        """Seed the scene auto-save guard into the project so a chronically-dirty
+        scene never raises the run-stalling modal dialogs (which freeze the MCP
+        dispatch loop). Skipped when ``install_scene_guard`` is off. Best effort:
+        the seeder never mutates tracked history and a failure is logged, never
+        vetoes — the guard is a convenience, and its absence must not defer a
+        unit."""
+        if not self._install_scene_guard():
+            return
+        rc, tail = self._run_script("unity_seed_assets.py", ctx, timeout=_SEED_TIMEOUT)
+        if rc != 0:
+            sys.stderr.write(f"unity: scene-guard seeding failed (rc={rc}): {tail}".rstrip() + "\n")
+
     def engine_env(self, ctx) -> dict[str, str]:
         """The ``BMAD_LOOP_*`` environment the helper scripts read — identity +
         worktree from the context, the Editor knobs from this plugin's settings,
@@ -143,6 +183,10 @@ class UnityPlugin(Plugin):
                 "BMAD_LOOP_ENGINE_READY_GRACE": str(self.settings.get("ready_grace_sec", -1)),
                 "BMAD_LOOP_UNITY_PATH": str(self.settings.get("unity_path", "")),
                 "BMAD_LOOP_CLEAN_TMP": "1" if self._clean_tmp else "0",
+                "BMAD_LOOP_UNITY_INSTALL_SCENE_GUARD": "1" if self._install_scene_guard() else "0",
+                "BMAD_LOOP_UNITY_SCENE_GUARD_DIR": str(
+                    self.settings.get("scene_guard_dir", "Assets/BmadLoop/Editor")
+                ),
             }
         )
         # Tell the per_worktree setup which agent MCP configs to point at the

--- a/src/bmad_loop/data/plugins/unity/unity_quiesce.py
+++ b/src/bmad_loop/data/plugins/unity/unity_quiesce.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Rollback quiesce for the bmad-loop Unity engine plugin.
+
+Called by ``UnityPlugin`` around a failed-attempt rollback, in two phases:
+
+  pre  (before ``verify.safe_rollback`` runs ``git reset --hard``): save every
+       open scene, then open an empty untitled scene so no tracked ``.unity`` file
+       is open when the reset rewrites it. A shared Editor holding a *dirty* scene
+       that the reset changes on disk raises a modal "scene changed on disk —
+       Reload/Cancel" dialog that freezes ``EditorApplication.update`` and every
+       Unity-MCP tool dispatch — this closes that window before it can open.
+  post (after the reset rewrote the tracked tree): refresh assets so the Editor
+       drops its stale in-memory copies and re-imports the reverted files.
+
+Only the IvanMurzak MCP CLI is driven (the plugin skips this script for any other
+MCP). Everything here is BEST EFFORT and never blocks the rollback:
+
+  * the pre phase opens with a ``scene-list-opened`` call that doubles as a wedge
+    probe — if the Editor is unresponsive (already showing a modal, or its update
+    loop is wedged) that call fails/hangs, and we skip immediately at the cost of
+    one call timeout rather than waiting out the whole quiesce budget;
+  * every subprocess call carries BOTH the CLI's own ``--timeout`` and a
+    subprocess-level ``timeout=`` kill, so a hung call can't deadlock;
+  * per-scene saves tolerate failures (an untitled scene throws — expected);
+  * exit codes are advisory: the plugin ignores the rc. The hard no-deadlock
+    guarantee is these per-call timeouts plus the plugin's overall
+    ``quiesce_timeout_sec`` kill of this whole process.
+
+Env knobs (all optional except the phase, which the plugin always sets):
+  BMAD_LOOP_QUIESCE_PHASE                   pre | post                (default pre)
+  BMAD_LOOP_WORKTREE                        project the Editor has open (falls back to REPO_ROOT)
+  BMAD_LOOP_REPO_ROOT                       main repo root
+  UNITY_MCP_CLI                             IvanMurzak CLI binary     (default unity-mcp-cli)
+  BMAD_LOOP_UNITY_QUIESCE_CALL_TIMEOUT      per-call budget, ms       (default 15000)
+
+NOTE: the exact IvanMurzak CLI tool names (``scene-list-opened`` / ``scene-save`` /
+``script-execute`` / ``assets-refresh``) and their ``--input`` schemas move between
+releases — verify against the version installed in your project and override the
+project-local plugin copy of this script if they differ. Because everything is
+best-effort, a name/schema mismatch degrades to "quiesce skipped", never a crash.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+# per-call subprocess kill = the CLI --timeout plus this margin, so the CLI gets a
+# chance to return its own clean "timed out" before we hard-kill the process.
+_SUBPROC_MARGIN_SEC = 5.0
+# default per-call CLI budget (ms) when BMAD_LOOP_UNITY_QUIESCE_CALL_TIMEOUT is unset.
+_DEFAULT_CALL_TIMEOUT_MS = 15000
+# assets-refresh re-imports the whole reverted tree and legitimately takes longer
+# than a scene op, so give it a wider floor than the per-call default.
+_REFRESH_CALL_TIMEOUT_MS = 45000
+
+# Transport/health phrases in the scene-list output that mean the Editor isn't
+# answering — the CLI returns rc 0 on a connection-refused, so the wedge probe can't
+# trust rc alone. These are deliberately NARROWER than unity_ready.py's marker set:
+# the probe's payload is a scene *list* whose contents are user data, so the generic
+# "error" / "not found" are excluded — a scene named "ErrorPopup.unity" must never
+# read as a dead Editor and silently skip the quiesce.
+_PROBE_ERROR_MARKERS = ("refused", "internal server error", "is null", "timed out")
+
+# C# executed via script-execute to close every open scene without a save prompt:
+# NewScene(EmptyScene, Single) replaces all open scenes with one fresh untitled
+# empty scene, which is not dirty — so no tracked scene is open during the reset.
+_QUIESCE_CSHARP = (
+    "using UnityEditor.SceneManagement; "
+    "public class BmadQuiesce { "
+    "public static string Main() { "
+    "EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single); "
+    'return "ok"; } }'
+)
+
+
+def _project() -> str:
+    return os.environ.get("BMAD_LOOP_WORKTREE") or os.environ.get("BMAD_LOOP_REPO_ROOT") or "."
+
+
+def _cli() -> str:
+    return os.environ.get("UNITY_MCP_CLI", "unity-mcp-cli")
+
+
+def _call_timeout_ms() -> int:
+    try:
+        return max(1000, int(os.environ.get("BMAD_LOOP_UNITY_QUIESCE_CALL_TIMEOUT", "")))
+    except ValueError:
+        return _DEFAULT_CALL_TIMEOUT_MS
+
+
+def _run_tool(
+    cli: str, tool: str, *, input_json: str | None = None, timeout_ms: int
+) -> tuple[int, str]:
+    """One ``run-tool`` round-trip. Carries the CLI ``--timeout`` and a subprocess
+    kill (``--timeout`` + margin). Returns (raw rc, output-tail); the caller decides
+    what the rc/output mean (the CLI's rc is unreliable — 0 on a connection-refused —
+    so the wedge probe also inspects the output). Never raises."""
+    cmd = [cli, "run-tool", tool, _project()]
+    if input_json is not None:
+        cmd += ["--input", input_json]
+    cmd += ["--timeout", str(timeout_ms)]
+    try:
+        proc = subprocess.run(
+            cmd,
+            timeout=timeout_ms / 1000.0 + _SUBPROC_MARGIN_SEC,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.TimeoutExpired:
+        return 1, f"run-tool {tool} timed out"
+    except OSError as exc:
+        return 1, str(exc)
+    return proc.returncode, (proc.stdout + proc.stderr).strip()[-500:]
+
+
+def _unresponsive(output: str) -> bool:
+    """True if the scene-list-opened output carries a transport/health phrase — the
+    Editor isn't answering — as opposed to a real (even empty) scene list. Only
+    transport-level phrases count, so a scene *named* with 'error' is never mistaken
+    for a dead Editor (see ``_PROBE_ERROR_MARKERS``)."""
+    low = output.lower()
+    return any(m in low for m in _PROBE_ERROR_MARKERS)
+
+
+def _parse_opened_scenes(output: str) -> list[str]:
+    """Best-effort extraction of open-scene names from ``scene-list-opened`` output.
+    The exact shape is version-specific, so accept the common ones (a JSON array of
+    strings, or of objects with a name-ish key, or an object wrapping such a list)
+    and return [] on anything unrecognised — step (c) closes every scene regardless,
+    so a miss here only skips the (optional) save, never the modal-avoidance."""
+    try:
+        data = json.loads(output)
+    except (ValueError, TypeError):
+        return []
+    return _scene_names_from(data)
+
+
+_NAME_KEYS = ("openedSceneName", "sceneName", "name", "path")
+_LIST_KEYS = ("scenes", "openedScenes", "result", "data", "value")
+
+
+def _scene_names_from(data: object) -> list[str]:
+    if isinstance(data, list):
+        names: list[str] = []
+        for item in data:
+            if isinstance(item, str) and item:
+                names.append(item)
+            elif isinstance(item, dict):
+                names.extend(_name_of(item))
+        return names
+    if isinstance(data, dict):
+        for key in _LIST_KEYS:
+            if isinstance(data.get(key), list):
+                return _scene_names_from(data[key])
+        return _name_of(data)  # a single-scene object
+    return []
+
+
+def _name_of(obj: dict) -> list[str]:
+    for key in _NAME_KEYS:
+        val = obj.get(key)
+        if isinstance(val, str) and val:
+            return [val]
+    return []
+
+
+def _quiesce_pre(cli: str) -> int:
+    call_ms = _call_timeout_ms()
+    # (a) list opened scenes — doubles as the wedge probe. A hard failure (rc!=0 /
+    # our timeout sentinel) or a transport-error payload (rc 0 on connection-refused)
+    # means the Editor is unresponsive; skip the whole quiesce now (cost ~ one call).
+    rc, out = _run_tool(cli, "scene-list-opened", timeout_ms=call_ms)
+    if rc != 0 or _unresponsive(out):
+        print("unity_quiesce: editor unresponsive; skipping quiesce", file=sys.stderr)
+        return 1
+    # (b) save each open scene so it isn't dirty when the reset rewrites it. Untitled
+    # scenes throw (no path) — expected; tolerate every per-scene failure.
+    for name in _parse_opened_scenes(out):
+        src, _ = _run_tool(
+            cli,
+            "scene-save",
+            input_json=json.dumps({"openedSceneName": name}),
+            timeout_ms=call_ms,
+        )
+        if src != 0:
+            print(f"unity_quiesce: scene-save {name!r} failed (tolerated)", file=sys.stderr)
+    # (c) close all scenes without a prompt by opening a fresh empty untitled scene,
+    # so no tracked scene is open during the reset. Advisory rc.
+    _run_tool(
+        cli,
+        "script-execute",
+        input_json=json.dumps({"code": _QUIESCE_CSHARP}),
+        timeout_ms=call_ms,
+    )
+    return 0
+
+
+def _quiesce_post(cli: str) -> int:
+    # refresh assets so the Editor re-imports the reverted tree. Give it the wider
+    # refresh floor; tolerate a timeout (the in-editor refresh continues on its own).
+    call_ms = max(_call_timeout_ms(), _REFRESH_CALL_TIMEOUT_MS)
+    rc, _ = _run_tool(cli, "assets-refresh", input_json="{}", timeout_ms=call_ms)
+    if rc != 0:
+        print(
+            "unity_quiesce: assets-refresh did not complete (refresh continues in-editor)",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+def main() -> int:
+    phase = (os.environ.get("BMAD_LOOP_QUIESCE_PHASE") or "pre").strip().lower()
+    cli = _cli()
+    if shutil.which(cli) is None:
+        print(
+            f"unity_quiesce: {cli!r} not found on PATH; skipping quiesce "
+            "(set UNITY_MCP_CLI or override the project-local plugin script)",
+            file=sys.stderr,
+        )
+        return 1
+    if phase == "post":
+        return _quiesce_post(cli)
+    return _quiesce_pre(cli)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/bmad_loop/data/plugins/unity/unity_quiesce.py
+++ b/src/bmad_loop/data/plugins/unity/unity_quiesce.py
@@ -139,7 +139,7 @@ def _parse_opened_scenes(output: str) -> list[str]:
     return _scene_names_from(data)
 
 
-_NAME_KEYS = ("openedSceneName", "sceneName", "name", "path")
+_NAME_KEYS = ("openedSceneName", "sceneName", "name", "Name", "path")
 _LIST_KEYS = ("scenes", "openedScenes", "result", "data", "value")
 
 
@@ -193,7 +193,9 @@ def _quiesce_pre(cli: str) -> int:
     _run_tool(
         cli,
         "script-execute",
-        input_json=json.dumps({"code": _QUIESCE_CSHARP}),
+        input_json=json.dumps(
+            {"csharpCode": _QUIESCE_CSHARP, "className": "BmadQuiesce", "methodName": "Main"}
+        ),
         timeout_ms=call_ms,
     )
     return 0

--- a/src/bmad_loop/data/plugins/unity/unity_seed_assets.py
+++ b/src/bmad_loop/data/plugins/unity/unity_seed_assets.py
@@ -40,7 +40,7 @@ import os
 import re
 import shutil
 import sys
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 
 # The guard's version header line, e.g. "// bmad-loop-scene-guard-version: 1.0.0".
 # The payload's value is the source of truth; a target with an older (or missing)
@@ -54,6 +54,20 @@ _GUARD_CS = "SceneAutoSaveGuard.cs"
 # the set copied into the install dir.
 _FOLDERS_SUBDIR = "_folders"
 _DEFAULT_GUARD_DIR = "Assets/BmadLoop/Editor"
+
+
+def _is_absolute(value: str) -> bool:
+    """True if ``value`` is rooted or drive-qualified in *either* POSIX or Windows
+    terms (mirrors ``bmad_loop.platform_util.is_absolute_path`` — this deployed
+    script is stdlib-only and cannot import core)."""
+    win = PureWindowsPath(value)
+    return PurePosixPath(value).is_absolute() or bool(win.drive or win.root)
+
+
+def _has_parent_ref(value: str) -> bool:
+    """True if ``value`` contains a ``..`` segment in *either* POSIX or Windows
+    terms (mirrors ``bmad_loop.platform_util.has_parent_ref``)."""
+    return ".." in PurePosixPath(value).parts or ".." in PureWindowsPath(value).parts
 
 
 def _truthy(value: str | None, default: bool) -> bool:
@@ -151,11 +165,14 @@ def main() -> int:
     payload_version = _read_version(guard_src)
 
     guard_dir = os.environ.get("BMAD_LOOP_UNITY_SCENE_GUARD_DIR", "").strip() or _DEFAULT_GUARD_DIR
-    target_dir = worktree / guard_dir
     rel = Path(guard_dir)
-    if not rel.parts:
+    # The install dir must stay inside the worktree: an absolute/drive-qualified
+    # path would make _install's relative_to() raise, and a ".." segment would
+    # let the copy escape the project tree.
+    if not rel.parts or _is_absolute(guard_dir) or _has_parent_ref(guard_dir):
         print(f"unity_seed_assets: invalid scene guard dir {guard_dir!r}", file=sys.stderr)
         return 2
+    target_dir = worktree / guard_dir
 
     # Only seed into a project whose asset root is actually checked out. A worktree
     # without it is not (yet) a Unity project, and scattering an Assets/ tree into

--- a/src/bmad_loop/data/plugins/unity/unity_seed_assets.py
+++ b/src/bmad_loop/data/plugins/unity/unity_seed_assets.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Seed the Unity scene auto-save guard into a bmad-loop-driven project.
+
+Unity-MCP GameObject tools mark a scene dirty but never save it, so a project
+driven by the shared editor accumulates a chronically dirty scene. That dirty
+state is what raises the two run-stalling modal dialogs ("scene changed on disk —
+reload?" when git/an agent rewrites the open .unity file, and "save changes before
+quitting?" on editor exit). A modal freezes ``EditorApplication.update`` — which
+the MCP plugin uses to dispatch tool calls — so every MCP call then times out.
+
+This helper copies an editor-only auto-save guard (``SceneAutoSaveGuard.cs`` + its
+asmdef, with pre-generated ``.meta`` files carrying fixed GUIDs) into the project's
+``Assets`` tree so the editor's very first import already sees it. It is invoked by
+the Unity plugin *before* ``unity_setup.py`` launches the per_worktree Editor, and
+at the readiness gate in shared mode (where ``unity_setup.py`` never runs).
+
+The install is idempotent and version-aware: it copies the payload only when the
+target ``.cs`` is absent or its ``bmad-loop-scene-guard-version`` header is older
+than the payload's. It never deletes or rewrites any file it did not ship, and a
+missing asset tree is a graceful skip (not every worktree is a Unity project yet).
+
+The seeded guard is committed into the consumer project by story-finalize's
+``git add -A`` — that is intended: the guard travels with the repo so any editor
+that opens the project is protected. Because seeding happens pre-baseline (before
+the unit's untracked-file baseline is snapshotted), ``verify.safe_rollback`` never
+treats it as a created-this-unit file and never deletes it.
+
+Env (injected by the Unity plugin):
+  BMAD_LOOP_WORKTREE                    project root (Assets = <worktree>/Assets)
+  BMAD_LOOP_UNITY_INSTALL_SCENE_GUARD   "1" (default) enables; "0"/false skips
+  BMAD_LOOP_UNITY_SCENE_GUARD_DIR       install dir  (default Assets/BmadLoop/Editor)
+
+Exit 0 = seeded, already-current, or a benign skip (disabled / no asset tree);
+non-zero = a real error (no worktree, unreadable payload, a failed copy).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import sys
+from pathlib import Path
+
+# The guard's version header line, e.g. "// bmad-loop-scene-guard-version: 1.0.0".
+# The payload's value is the source of truth; a target with an older (or missing)
+# value is reinstalled, a newer/equal one is left alone.
+_VERSION_RE = re.compile(r"bmad-loop-scene-guard-version:\s*([0-9]+(?:\.[0-9]+)*)")
+# The guard's canonical source file — its header carries the version, and its
+# presence/absence in the target decides a fresh install.
+_GUARD_CS = "SceneAutoSaveGuard.cs"
+# Payload subdir holding the parent-folder ``.meta`` files, keyed by folder name;
+# separated from the content files so "every file in the payload root" is exactly
+# the set copied into the install dir.
+_FOLDERS_SUBDIR = "_folders"
+_DEFAULT_GUARD_DIR = "Assets/BmadLoop/Editor"
+
+
+def _truthy(value: str | None, default: bool) -> bool:
+    if value is None or value.strip() == "":
+        return default
+    return value.strip().lower() in ("1", "true", "yes", "on")
+
+
+def _worktree() -> Path | None:
+    wt = os.environ.get("BMAD_LOOP_WORKTREE")
+    return Path(wt) if wt else None
+
+
+def _payload_dir() -> Path:
+    """The bundled ``unity_assets/`` payload, resolved relative to this script so it
+    travels with a project-local copy of the plugin too."""
+    return Path(__file__).resolve().parent / "unity_assets"
+
+
+def _parse_version(text: str) -> tuple[int, ...] | None:
+    """The ``bmad-loop-scene-guard-version`` tuple from a guard source, or None if
+    the header is absent (an absent/unrecognized header sorts as oldest)."""
+    match = _VERSION_RE.search(text)
+    if not match:
+        return None
+    return tuple(int(part) for part in match.group(1).split("."))
+
+
+def _read_version(cs_path: Path) -> tuple[int, ...] | None:
+    try:
+        return _parse_version(cs_path.read_text(encoding="utf-8", errors="replace"))
+    except OSError:
+        return None
+
+
+def _content_files(payload: Path) -> list[Path]:
+    """The payload files copied verbatim into the install dir: the guard source,
+    the asmdef, and their ``.meta`` companions (everything directly in the payload
+    root — the ``_folders`` subdir is handled separately)."""
+    return sorted(p for p in payload.iterdir() if p.is_file())
+
+
+def _ensure_dir_with_meta(directory: Path, payload: Path) -> None:
+    """Create ``directory`` if absent and, when the payload ships a matching
+    folder ``.meta`` (keyed by the folder's name), drop it beside the folder with
+    its fixed GUID. Never clobbers an existing folder meta — its GUID may already
+    be referenced by the project."""
+    directory.mkdir(parents=True, exist_ok=True)
+    folder_meta = payload / _FOLDERS_SUBDIR / f"{directory.name}.meta"
+    target_meta = directory.parent / f"{directory.name}.meta"
+    if folder_meta.is_file() and not target_meta.exists():
+        shutil.copy2(folder_meta, target_meta)
+
+
+def _install(worktree: Path, target_dir: Path, payload: Path) -> int:
+    """Copy the payload into ``target_dir``, creating each parent folder (with its
+    fixed-GUID meta) along the way. Returns 0 on success, non-zero on a real I/O
+    error."""
+    rel = target_dir.relative_to(worktree)
+    try:
+        # Create every path segment from the worktree down to the install dir,
+        # laying a fixed-GUID folder meta beside each that the payload ships one for
+        # (Assets itself has no payload meta — Unity owns it — so it is skipped).
+        current = worktree
+        for segment in rel.parts:
+            current = current / segment
+            _ensure_dir_with_meta(current, payload)
+        for src in _content_files(payload):
+            shutil.copy2(src, target_dir / src.name)
+    except OSError as exc:
+        print(f"unity_seed_assets: install failed: {exc}", file=sys.stderr)
+        return 1
+    print(
+        f"unity_seed_assets: seeded scene auto-save guard into {rel}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+def main() -> int:
+    if not _truthy(os.environ.get("BMAD_LOOP_UNITY_INSTALL_SCENE_GUARD"), True):
+        print("unity_seed_assets: scene guard disabled; skipping", file=sys.stderr)
+        return 0
+
+    worktree = _worktree()
+    if worktree is None:
+        print("unity_seed_assets: BMAD_LOOP_WORKTREE is not set", file=sys.stderr)
+        return 2
+
+    payload = _payload_dir()
+    guard_src = payload / _GUARD_CS
+    if not guard_src.is_file():
+        print(f"unity_seed_assets: payload guard missing at {guard_src}", file=sys.stderr)
+        return 2
+    payload_version = _read_version(guard_src)
+
+    guard_dir = os.environ.get("BMAD_LOOP_UNITY_SCENE_GUARD_DIR", "").strip() or _DEFAULT_GUARD_DIR
+    target_dir = worktree / guard_dir
+    rel = Path(guard_dir)
+    if not rel.parts:
+        print(f"unity_seed_assets: invalid scene guard dir {guard_dir!r}", file=sys.stderr)
+        return 2
+
+    # Only seed into a project whose asset root is actually checked out. A worktree
+    # without it is not (yet) a Unity project, and scattering an Assets/ tree into
+    # it would be wrong — a benign skip, never an error, never destructive.
+    asset_root = worktree / rel.parts[0]
+    if not asset_root.is_dir():
+        print(
+            f"unity_seed_assets: {rel.parts[0]}/ not present under the worktree; "
+            "nothing to seed",
+            file=sys.stderr,
+        )
+        return 0
+
+    target_cs = target_dir / _GUARD_CS
+    if target_cs.is_file():
+        target_version = _read_version(target_cs)
+        # An unreadable/absent header sorts as oldest, so a foreign or stale guard
+        # is refreshed; an equal-or-newer guard is left untouched (idempotent).
+        current = target_version or ()
+        incoming = payload_version or ()
+        if current >= incoming:
+            print(
+                "unity_seed_assets: scene guard already current "
+                f"({'.'.join(map(str, current)) or 'unversioned'}); nothing to do",
+                file=sys.stderr,
+            )
+            return 0
+
+    return _install(worktree, target_dir, payload)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/bmad_loop/data/plugins/unity/unity_teardown.py
+++ b/src/bmad_loop/data/plugins/unity/unity_teardown.py
@@ -16,7 +16,12 @@ stands (it does not re-defer a done/paused unit just because Editor-quit failed)
      NOT reap; a leaked server holds its port and poisons later runs (the plugin
      declines to start a fresh server when a stale one lingers in the name-keyed
      Library cache), so we sweep it up here too.
-  3. Drop the ``<worktree>/Library`` if setup left a *symlink* (the empty-cache
+  3. Reap this unit's detect-only dialog probe (``unity_dialog_probe.py``, launched
+     per-worktree at setup): terminate it via its pid-file handle, with a ``/proc``
+     argv-scan backstop (matched on the worktree path + the probe script name, since
+     its exe basename is ``python``). Best effort — a probe we cannot reap self-exits
+     when the engine pid dies, so it never fails the unit.
+  4. Drop the ``<worktree>/Library`` if setup left a *symlink* (the empty-cache
      fallback), leaving the persistent cache it pointed at intact for the next run.
      A real Library — the common case now that setup *primes* a warm reflink/CoW copy
      in — is left untouched; it is removed cheaply when bmad-loop deletes the worktree
@@ -28,6 +33,7 @@ here; for CoplayDev (shared :8080 server) override engine.worktree_teardown_cmd.
 
 Env (injected by the engine):
   BMAD_LOOP_WORKTREE     the worktree whose Editor to quit
+  BMAD_LOOP_RUN_DIR      run dir holding the dialog-probe pid-file handle
   BMAD_LOOP_ENGINE_MCP   ivanmurzak | coplaydev               (default ivanmurzak)
   UNITY_MCP_CLI          IvanMurzak CLI binary                (default unity-mcp-cli)
   BMAD_LOOP_UNITY_CLOSE_TIMEOUT  polite-quit seconds before --force (default 30)
@@ -68,9 +74,21 @@ def _worktree() -> Path | None:
     return Path(wt) if wt else None
 
 
+def _run_dir() -> Path | None:
+    rd = os.environ.get("BMAD_LOOP_RUN_DIR")
+    return Path(rd) if rd else None
+
+
 # Process basenames we reap when bound to the worktree path: the Unity Editor
 # binary and the local MCP HTTP server the plugin spawns as a child.
 _TARGET_BASENAMES = ("unity", "gamedev-mcp-server")
+
+# The detect-only dialog probe's pid-file handle + script basename. The probe's exe
+# basename is `python`, so it is INVISIBLE to the _TARGET_BASENAMES editor sweep (we
+# deliberately do not loosen those — a loosened editor match could kill the wrong
+# python); it gets its own argv-based matcher below.
+_DIALOG_PROBE_PID_FILE = "unity-dialog-probe.pid"
+_DIALOG_PROBE_SCRIPT_BASENAME = "unity_dialog_probe.py"
 
 
 def _exe_basename(entry: Path) -> str:
@@ -147,23 +165,13 @@ def _lingering_pids_psutil(worktree: Path) -> list[int]:
     return pids
 
 
-def _force_kill_lingering(worktree: Path) -> int:
-    """Best-effort SIGTERM→SIGKILL of any Editor or MCP server left running for this
-    worktree after ``close``. Returns the number of processes targeted."""
-    pids = _lingering_pids(worktree)
-    # exclude ourselves just in case (our own argv has the worktree path too)
-    pids = [p for p in pids if p != os.getpid()]
-    if not pids:
-        return 0
-    print(
-        f"unity_teardown: 'close' left {len(pids)} Unity process(es) for {worktree} "
-        f"running ({pids}); hard-killing",
-        file=sys.stderr,
-    )
+def _terminate_identity_guarded(pids: list[int]) -> None:
+    """SIGTERM → grace → identity-checked SIGKILL a confirmed pid list. Snapshots
+    each pid's identity *before* signalling so the force-kill escalation can never
+    land on a pid the kernel recycled to an unrelated process (mirrors runs.stop_run's
+    guard; force_kill's own contract requires confirmed identity). Shared by the
+    Editor/MCP sweep and the dialog-probe reap."""
     host = get_process_host()
-    # Snapshot identity before signalling so the force-kill escalation can never land
-    # on a pid the kernel recycled to an unrelated process (mirrors runs.stop_run's
-    # guard; force_kill's own contract requires confirmed identity).
     ident = {pid: host.identity(pid) for pid in pids}
     for pid in pids:
         try:
@@ -188,6 +196,87 @@ def _force_kill_lingering(worktree: Path) -> int:
             continue
         try:
             host.force_kill(pid)
+        except OSError:
+            pass
+
+
+def _force_kill_lingering(worktree: Path) -> int:
+    """Best-effort SIGTERM→SIGKILL of any Editor or MCP server left running for this
+    worktree after ``close``. Returns the number of processes targeted."""
+    pids = _lingering_pids(worktree)
+    # exclude ourselves just in case (our own argv has the worktree path too)
+    pids = [p for p in pids if p != os.getpid()]
+    if not pids:
+        return 0
+    print(
+        f"unity_teardown: 'close' left {len(pids)} Unity process(es) for {worktree} "
+        f"running ({pids}); hard-killing",
+        file=sys.stderr,
+    )
+    _terminate_identity_guarded(pids)
+    return len(pids)
+
+
+def _probe_argv_matches(argv: str, worktree: Path) -> bool:
+    """True when ``argv`` is THIS worktree's detached dialog probe: it references both
+    the worktree path and the probe script basename. Scoped to the worktree so we
+    never touch another unit's probe, and keyed on the script name because the exe
+    basename is ``python`` (not a target editor binary)."""
+    return _DIALOG_PROBE_SCRIPT_BASENAME in argv and str(worktree) in argv
+
+
+def _lingering_probe_pids(worktree: Path) -> list[int]:
+    """``/proc`` scan for the worktree's detached dialog probe (python argv match).
+    Backstop for the pid-file reap handle. Linux-only — the probe is X11/Linux-only,
+    and off-Linux the pid file is the sole handle (returns [] here)."""
+    if not sys.platform.startswith("linux"):
+        return []
+    pids: list[int] = []
+    for entry in Path("/proc").iterdir():  # portability: Linux-only /proc scan, guarded above
+        if not entry.name.isdigit():
+            continue
+        try:
+            argv = (
+                (entry / "cmdline").read_bytes().replace(b"\x00", b" ").decode("utf-8", "replace")
+            )
+        except OSError:
+            continue  # process gone or unreadable
+        if _probe_argv_matches(argv, worktree):
+            pids.append(int(entry.name))
+    return pids
+
+
+def _probe_pidfile_pids(run_dir: Path | None) -> list[int]:
+    """The dialog probe recorded in ``<run_dir>/unity-dialog-probe.pid``, iff it is
+    still alive AND still our probe (identity-checked). The primary reap handle."""
+    if run_dir is None:
+        return []
+    from bmad_loop.runs import read_named_pid_identity  # noqa: PLC0415 - lazy import
+
+    pid, identity = read_named_pid_identity(run_dir / _DIALOG_PROBE_PID_FILE)
+    if pid is None:
+        return []
+    return [pid] if get_process_host().alive_and_ours(pid, identity) else []
+
+
+def _reap_dialog_probe(worktree: Path, run_dir: Path | None) -> int:
+    """Terminate this unit's detect-only dialog probe. Primary handle is the pid file
+    (``<run_dir>/unity-dialog-probe.pid``); the ``/proc`` argv scan is a backstop for a
+    probe whose pid file is missing/stale. Identity-guarded escalation, same as the
+    Editor sweep. Best effort — never changes the unit outcome (a survivor self-exits
+    when the engine pid dies). Returns the count targeted."""
+    pids = set(_probe_pidfile_pids(run_dir)) | set(_lingering_probe_pids(worktree))
+    pids.discard(os.getpid())
+    if not pids:
+        return 0
+    print(
+        f"unity_teardown: reaping {len(pids)} dialog-probe process(es) {sorted(pids)}",
+        file=sys.stderr,
+    )
+    _terminate_identity_guarded(sorted(pids))
+    if run_dir is not None:
+        try:
+            (run_dir / _DIALOG_PROBE_PID_FILE).unlink()
         except OSError:
             pass
     return len(pids)
@@ -261,6 +350,10 @@ def main() -> int:
                 file=sys.stderr,
             )
             rc = rc or 1
+    # Reap this unit's detect-only dialog probe (pid-file handle + argv backstop).
+    # Best effort — a probe we cannot reap self-exits when the engine pid dies, so it
+    # never fails the unit (unlike a surviving Editor/server, which poisons later runs).
+    _reap_dialog_probe(worktree, _run_dir())
     _drop_library_symlink(worktree)
     return rc
 

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -853,6 +853,13 @@ class Engine:
                 baseline=task.baseline_commit or "",
                 note="reverting tracked changes + run-created untracked files",
             )
+            # Give a plugin (the Unity engine) a chance to quiesce before the reset
+            # rewrites tracked files under it — e.g. save + close open scenes so a
+            # git reset --hard can't leave a shared Editor showing a run-freezing
+            # "scene changed on disk" modal. Observe-only, like pre_worktree_teardown:
+            # the returned ctx is ignored and never routed through _vetoed — a failed
+            # quiesce must never block a rollback.
+            self._emit("pre_rollback", task)
             # A re-drive (resolved / mid-re-drive) is contractually pause-free, so it
             # preserves best-effort but never blocks; a plain rollback pauses rather
             # than reset past work it could not park.
@@ -863,6 +870,9 @@ class Engine:
             # failure); best-effort, never blocks.
             self._preserve_attempt_worktree(task)
             self._safe_reset(task, preserve=protected)
+            # Refresh the plugin's view of the now-reset tree (the Unity engine
+            # re-imports assets). Observe-only for the same reason as pre_rollback.
+            self._emit("post_rollback", task)
             return
         self._pause_for_manual_recovery(task, task.baseline_commit or "")
         return  # unreachable: _pause_for_manual_recovery always raises

--- a/src/bmad_loop/runs.py
+++ b/src/bmad_loop/runs.py
@@ -90,16 +90,24 @@ def latest_run_dir(project: Path) -> Path | None:
     return candidates[-1] if candidates else None
 
 
+def write_named_pid(pidfile: Path, pid: int) -> None:
+    """Record ``pid`` plus its identity to ``pidfile``, so a later liveness read can
+    tell our process from a stranger that inherited a reused pid (immediate on
+    Windows). One whitespace-delimited line: ``"<pid>"`` (legacy) or
+    ``"<pid> <identity>"``; the identity token is omitted when the platform can't
+    provide one. The parameterized form :func:`write_pid` builds on — reused for the
+    Unity dialog probe's own ``unity-dialog-probe.pid`` handle."""
+    identity = get_process_host().identity(pid)
+    line = f"{pid} {identity}" if identity is not None else str(pid)
+    pidfile.write_text(line, encoding="utf-8")
+
+
 def write_pid(run_dir: Path) -> None:
     """Record the engine pid plus its identity, so a later liveness read can tell
     our engine from a stranger that inherited a reused pid (immediate on Windows).
-    One whitespace-delimited line: ``"<pid>"`` (legacy) or ``"<pid> <identity>"``;
-    the identity token is omitted when the platform can't provide one. Never
-    deleted: a stale pid that reads as gone is the signal a run was interrupted."""
-    pid = os.getpid()
-    identity = get_process_host().identity(pid)
-    line = f"{pid} {identity}" if identity is not None else str(pid)
-    (run_dir / PID_FILE).write_text(line, encoding="utf-8")
+    Never deleted: a stale pid that reads as gone is the signal a run was
+    interrupted."""
+    write_named_pid(run_dir / PID_FILE, os.getpid())
 
 
 def session_name(run_id: str) -> str:
@@ -182,13 +190,20 @@ def read_pid(run_dir: Path) -> int | None:
 
 
 def read_pid_identity(run_dir: Path) -> tuple[int | None, float | None]:
-    """The recorded engine pid and its persisted identity. ``(None, None)`` when the
-    file is missing or the pid is unparseable; identity ``None`` for a legacy
+    """The recorded engine pid and its persisted identity, from ``<run_dir>/engine.pid``.
+    Thin wrapper over :func:`read_named_pid_identity` (which other pid files — the
+    Unity dialog probe's — reuse)."""
+    return read_named_pid_identity(run_dir / PID_FILE)
+
+
+def read_named_pid_identity(pidfile: Path) -> tuple[int | None, float | None]:
+    """The pid and its persisted identity recorded in ``pidfile``. ``(None, None)``
+    when the file is missing or the pid is unparseable; identity ``None`` for a legacy
     pid-only file (callers then degrade to a bare existence check). A malformed
     second token is not legacy: it returns an impossible identity so reuse guards
     fail closed. First token is the pid, an optional second token the identity float."""
     try:
-        tokens = (run_dir / PID_FILE).read_text(encoding="utf-8").split()
+        tokens = pidfile.read_text(encoding="utf-8").split()
     except OSError:
         return None, None
     if not tokens:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2464,6 +2464,75 @@ def test_rollback_preserves_committed_attempt_work(project):
     assert git(repo, "rev-parse", entry["ref"]).strip() == attempt_head  # reachable by name
 
 
+def test_rollback_emits_pre_and_post_around_reset(project):
+    """A plugin (the Unity engine) hooks pre_rollback / post_rollback so it can
+    quiesce a live Editor before the hard reset rewrites tracked files under it, and
+    refresh after. pre_rollback must fire while the attempt tree is still checked out
+    (HEAD == attempt); post_rollback only after the reset landed (HEAD == baseline)."""
+    policy = Policy(
+        gates=GatesPolicy(mode="none"),
+        notify=QUIET,
+        scm=ScmPolicy(rollback_on_failure=True),
+    )
+    engine, _ = make_engine(project, [], policy=policy)
+    repo = project.project
+    task = StoryTask(story_key="1-1-a", epic=1)
+    task.baseline_commit = rev_parse_head(repo)
+    task.baseline_untracked = []
+    (repo / "impl.txt").write_text("committed implementation\n")
+    git(repo, "add", "-A")
+    git(repo, "commit", "-q", "-m", "attempt work")
+    attempt_head = rev_parse_head(repo)
+
+    seen: list[tuple[str, str]] = []
+    original_emit = engine._emit
+
+    def spying_emit(stage, *args, **kwargs):
+        if stage in ("pre_rollback", "post_rollback"):
+            seen.append((stage, rev_parse_head(repo)))
+        return original_emit(stage, *args, **kwargs)
+
+    engine._emit = spying_emit
+    engine._rollback_or_pause(task)  # rollback ON: resets to baseline
+
+    assert rev_parse_head(repo) == task.baseline_commit
+    # pre fires before the reset (attempt tree still open), post after it landed
+    assert seen == [
+        ("pre_rollback", attempt_head),
+        ("post_rollback", task.baseline_commit),
+    ]
+
+
+def test_rollback_emits_are_observe_only(project):
+    """The rollback emits are observe-only, like pre_worktree_teardown: the returned
+    ctx is never routed through ``_vetoed``, so a failed Editor quiesce can never
+    block or pause the rollback."""
+    policy = Policy(
+        gates=GatesPolicy(mode="none"),
+        notify=QUIET,
+        scm=ScmPolicy(rollback_on_failure=True),
+    )
+    engine, _ = make_engine(project, [], policy=policy)
+    repo = project.project
+    task = StoryTask(story_key="1-1-a", epic=1)
+    task.baseline_commit = rev_parse_head(repo)
+    task.baseline_untracked = []
+    (repo / "src.txt").write_text("uncommitted tracked edit\n")
+
+    routed: list = []
+    original_vetoed = engine._vetoed
+
+    def spying_vetoed(ctx, t):
+        routed.append(ctx)
+        return original_vetoed(ctx, t)
+
+    engine._vetoed = spying_vetoed
+    engine._rollback_or_pause(task)  # must not raise / pause
+
+    assert rev_parse_head(repo) == task.baseline_commit  # reset still happened
+    assert routed == []  # the rollback emits were never handed to the veto router
+
+
 def test_rollback_preserves_uncommitted_attempt_worktree(project):
     """rollback_on_failure ON + an attempt that left work UNcommitted: before the
     hard reset (and its untracked cleanup) the engine parks the uncommitted diff —

--- a/tests/test_engine_plugin.py
+++ b/tests/test_engine_plugin.py
@@ -50,8 +50,32 @@ def test_builtin_unity_plugin_loads():
 
 def test_builtin_unity_plugin_ships_its_scripts():
     scripts = os.listdir(get_plugin("unity").scripts_dir)
-    for name in ("unity_plugin.py", "unity_ready.py", "unity_setup.py", "unity_teardown.py"):
+    for name in (
+        "unity_plugin.py",
+        "unity_ready.py",
+        "unity_setup.py",
+        "unity_teardown.py",
+        "unity_seed_assets.py",
+    ):
         assert name in scripts, name
+
+
+def test_builtin_unity_plugin_ships_scene_guard_payload():
+    """The scene auto-save guard payload (source + asmdef + fixed-GUID metas) ships
+    with the plugin so the seeder can copy it into consumer projects."""
+    payload = os.path.join(get_plugin("unity").scripts_dir, "unity_assets")
+    for name in (
+        "SceneAutoSaveGuard.cs",
+        "SceneAutoSaveGuard.cs.meta",
+        "BmadLoop.Unity.Editor.asmdef",
+        "BmadLoop.Unity.Editor.asmdef.meta",
+    ):
+        assert os.path.isfile(os.path.join(payload, name)), name
+    for name in ("BmadLoop.meta", "Editor.meta"):
+        assert os.path.isfile(os.path.join(payload, "_folders", name)), name
+    # the guard carries a machine-parseable version header (the seeder's contract)
+    with open(os.path.join(payload, "SceneAutoSaveGuard.cs"), encoding="utf-8") as fh:
+        assert "bmad-loop-scene-guard-version:" in fh.read()
 
 
 def test_builtin_unity_plugin_settings_schema():
@@ -63,11 +87,16 @@ def test_builtin_unity_plugin_settings_schema():
         "unity_path",
         "ready_timeout_sec",
         "ready_grace_sec",
+        "install_scene_guard",
+        "scene_guard_dir",
     }
     assert by_key["editor_mode"].type == "select"
     assert by_key["editor_mode"].options == ("shared", "per_worktree")
     assert by_key["editor_mode"].default == "shared"
     assert by_key["ready_timeout_sec"].default == 600
+    assert by_key["install_scene_guard"].type == "bool"
+    assert by_key["install_scene_guard"].default is True
+    assert by_key["scene_guard_dir"].default == "Assets/BmadLoop/Editor"
 
 
 def test_unity_is_trust_gated():
@@ -103,6 +132,8 @@ def _make_unity(settings, scripts_dir):
         "unity_path": "",
         "ready_timeout_sec": 600,
         "ready_grace_sec": -1,
+        "install_scene_guard": True,
+        "scene_guard_dir": "Assets/BmadLoop/Editor",
     }
     full.update(settings)
     return cls(manifest, full)
@@ -203,6 +234,117 @@ def test_engine_env_omits_agents_when_none(tmp_path):
     inst = _make_unity({}, tmp_path)
     env = inst.engine_env(_ctx("pre_ready_gate", tmp_path, agents=()))
     assert "BMAD_LOOP_ENGINE_AGENTS" not in env
+
+
+def test_engine_env_carries_scene_guard_settings(tmp_path):
+    on = _make_unity(
+        {"install_scene_guard": True, "scene_guard_dir": "Assets/Vendor/Editor"}, tmp_path
+    )
+    env = on.engine_env(_ctx("pre_ready_gate", tmp_path))
+    assert env["BMAD_LOOP_UNITY_INSTALL_SCENE_GUARD"] == "1"
+    assert env["BMAD_LOOP_UNITY_SCENE_GUARD_DIR"] == "Assets/Vendor/Editor"
+    off_env = _make_unity({"install_scene_guard": False}, tmp_path).engine_env(
+        _ctx("pre_ready_gate", tmp_path)
+    )
+    assert off_env["BMAD_LOOP_UNITY_INSTALL_SCENE_GUARD"] == "0"
+
+
+# ----------------------------------------- scene-guard seeding wired into the hooks
+
+
+def _real_unity(settings):
+    """A UnityPlugin whose {scripts} dir is the REAL bundled plugin dir, so its
+    hooks run the real unity_seed_assets.py against the ctx worktree."""
+    cls = _unity_plugin_module().UnityPlugin
+    manifest = PluginManifest(
+        name="unity", api_version=1, scripts_dir=get_plugin("unity").scripts_dir
+    )
+    full = {
+        "editor_mode": "shared",
+        "mcp": "ivanmurzak",
+        "unity_path": "",
+        "ready_timeout_sec": 600,
+        "ready_grace_sec": -1,
+        "install_scene_guard": True,
+        "scene_guard_dir": "Assets/BmadLoop/Editor",
+    }
+    full.update(settings)
+    return cls(manifest, full)
+
+
+def _worktree_ctx(stage, worktree):
+    return HookContext(
+        stage,
+        run_id="r",
+        story_key="1-1-a",
+        repo_root=str(worktree),
+        run_dir=str(worktree),
+        worktree=str(worktree),
+    )
+
+
+def test_seed_scene_guard_installs_via_plugin(tmp_path):
+    (tmp_path / "Assets").mkdir()
+    inst = _real_unity({"editor_mode": "per_worktree"})
+    inst._seed_scene_guard(_worktree_ctx("pre_worktree_setup", tmp_path))
+    guard = tmp_path / "Assets" / "BmadLoop" / "Editor" / "SceneAutoSaveGuard.cs"
+    assert guard.is_file()
+    assert "bmad-loop-scene-guard-version:" in guard.read_text()
+
+
+def test_seed_scene_guard_honours_custom_dir_setting(tmp_path):
+    (tmp_path / "Assets").mkdir()
+    inst = _real_unity({"scene_guard_dir": "Assets/Third/Editor"})
+    inst._seed_scene_guard(_worktree_ctx("pre_ready_gate", tmp_path))
+    assert (tmp_path / "Assets" / "Third" / "Editor" / "SceneAutoSaveGuard.cs").is_file()
+
+
+def test_seed_scene_guard_skipped_when_disabled(tmp_path):
+    (tmp_path / "Assets").mkdir()
+    inst = _real_unity({"install_scene_guard": False})
+    inst._seed_scene_guard(_worktree_ctx("pre_ready_gate", tmp_path))
+    assert not (tmp_path / "Assets" / "BmadLoop").exists()
+
+
+def test_seed_scene_guard_never_vetoes_on_failure(tmp_path, monkeypatch):
+    """A seeding failure is logged, never vetoes — the guard is a convenience, not a
+    gate. Point the seeder at a bogus interpreter path so _run_script returns rc!=0."""
+    inst = _real_unity({"editor_mode": "per_worktree"})
+    monkeypatch.setattr(inst, "_run_script", lambda *a, **k: (1, "boom"))
+    ctx = _worktree_ctx("pre_worktree_setup", tmp_path)
+    inst._seed_scene_guard(ctx)  # must not raise, must not veto
+    assert not ctx.vetoed
+
+
+def test_pre_worktree_setup_seeds_before_editor_launch(tmp_path, monkeypatch):
+    """In per_worktree mode the guard is seeded strictly BEFORE unity_setup.py
+    launches the Editor, so the Editor's first import already sees it. A setup
+    failure still vetoes (defers) — the seed does not swallow it."""
+    inst = _real_unity({"editor_mode": "per_worktree"})
+    order = []
+    monkeypatch.setattr(inst, "_seed_scene_guard", lambda ctx: order.append("seed"))
+
+    def fake_run(name, ctx, *, timeout):
+        order.append(name)
+        return (2, "no editor")
+
+    monkeypatch.setattr(inst, "_run_script", fake_run)
+    ctx = _worktree_ctx("pre_worktree_setup", tmp_path)
+    inst.on_pre_worktree_setup(ctx)
+    assert order == ["seed", "unity_setup.py"]  # seed runs first
+    assert ctx.resolved_veto().action == "defer"
+
+
+def test_pre_ready_gate_seeds_only_in_shared_mode(tmp_path, monkeypatch):
+    """The ready gate fires in both modes, but seeding here is a shared-mode-only
+    job (per_worktree already seeded at pre_worktree_setup)."""
+    for mode, expect_seed in (("shared", True), ("per_worktree", False)):
+        inst = _real_unity({"editor_mode": mode})
+        seeded = []
+        monkeypatch.setattr(inst, "_seed_scene_guard", lambda ctx: seeded.append(True))
+        monkeypatch.setattr(inst, "_run_script", lambda *a, **k: (0, ""))
+        inst.on_pre_ready_gate(_worktree_ctx("pre_ready_gate", tmp_path))
+        assert bool(seeded) is expect_seed, mode
 
 
 # --------------------------------------------------- editor_mode↔isolation coupling

--- a/tests/test_engine_plugin.py
+++ b/tests/test_engine_plugin.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import os
+import subprocess
 import sys
 import time
 
@@ -57,6 +58,8 @@ def test_builtin_unity_plugin_ships_its_scripts():
         "unity_teardown.py",
         "unity_seed_assets.py",
         "unity_quiesce.py",
+        "unity_dialog_probe.py",
+        "unity_facts.md",
     ):
         assert name in scripts, name
 
@@ -92,6 +95,9 @@ def test_builtin_unity_plugin_settings_schema():
         "scene_guard_dir",
         "quiesce_on_rollback",
         "quiesce_timeout_sec",
+        "dialog_probe",
+        "dialog_probe_interval_sec",
+        "dialog_probe_notify",
     }
     assert by_key["editor_mode"].type == "select"
     assert by_key["editor_mode"].options == ("shared", "per_worktree")
@@ -105,6 +111,14 @@ def test_builtin_unity_plugin_settings_schema():
     assert by_key["quiesce_timeout_sec"].type == "int"
     assert by_key["quiesce_timeout_sec"].default == 60
     assert by_key["quiesce_timeout_sec"].min == 1
+    # detect-only dialog probe: off by default, tunable interval + notify
+    assert by_key["dialog_probe"].type == "bool"
+    assert by_key["dialog_probe"].default is False
+    assert by_key["dialog_probe_interval_sec"].type == "int"
+    assert by_key["dialog_probe_interval_sec"].default == 5
+    assert by_key["dialog_probe_interval_sec"].min == 1
+    assert by_key["dialog_probe_notify"].type == "bool"
+    assert by_key["dialog_probe_notify"].default is True
 
 
 def test_unity_is_trust_gated():
@@ -144,6 +158,9 @@ def _make_unity(settings, scripts_dir):
         "scene_guard_dir": "Assets/BmadLoop/Editor",
         "quiesce_on_rollback": True,
         "quiesce_timeout_sec": 60,
+        "dialog_probe": False,
+        "dialog_probe_interval_sec": 5,
+        "dialog_probe_notify": True,
     }
     full.update(settings)
     return cls(manifest, full)
@@ -224,8 +241,9 @@ def test_rollback_hooks_run_quiesce_with_phase_and_timeout(tmp_path, monkeypatch
     monkeypatch.setattr(
         inst,
         "_run_script",
-        lambda name, ctx, *, timeout, extra_env=None: calls.append((name, timeout, extra_env))
-        or (0, ""),
+        lambda name, ctx, *, timeout, extra_env=None: (
+            calls.append((name, timeout, extra_env)) or (0, "")
+        ),
     )
     inst.on_pre_rollback(_ctx("pre_rollback", tmp_path))
     inst.on_post_rollback(_ctx("post_rollback", tmp_path))
@@ -270,7 +288,7 @@ def test_run_script_merges_extra_env(tmp_path):
     phase) reach the helper without polluting the base contract."""
     # a tiny helper that dumps the phase env var it received, so we can read it back
     (tmp_path / "echo_phase.py").write_text(
-        "import os, sys\n" "sys.stdout.write(os.environ.get('BMAD_LOOP_QUIESCE_PHASE', 'UNSET'))\n",
+        "import os, sys\nsys.stdout.write(os.environ.get('BMAD_LOOP_QUIESCE_PHASE', 'UNSET'))\n",
         encoding="utf-8",
     )
     inst = _make_unity({}, tmp_path)
@@ -351,6 +369,9 @@ def _real_unity(settings):
         "scene_guard_dir": "Assets/BmadLoop/Editor",
         "quiesce_on_rollback": True,
         "quiesce_timeout_sec": 60,
+        "dialog_probe": False,
+        "dialog_probe_interval_sec": 5,
+        "dialog_probe_notify": True,
     }
     full.update(settings)
     return cls(manifest, full)
@@ -429,6 +450,192 @@ def test_pre_ready_gate_seeds_only_in_shared_mode(tmp_path, monkeypatch):
         monkeypatch.setattr(inst, "_run_script", lambda *a, **k: (0, ""))
         inst.on_pre_ready_gate(_worktree_ctx("pre_ready_gate", tmp_path))
         assert bool(seeded) is expect_seed, mode
+
+
+# ------------------------------------------ prompt-fact injection (on_pre_session)
+
+
+def test_pre_session_appends_facts_to_nonempty_prompt():
+    """on_pre_session appends the shipped Unity scene-save facts to the whitelisted
+    proposed_prompt, preserving the original prompt as the prefix."""
+    inst = _real_unity({})  # real scripts_dir → real unity_facts.md
+    ctx = HookContext("pre_session", run_id="r", proposed_prompt="BASE PROMPT")
+    inst.on_pre_session(ctx)
+    assert ctx.proposed_prompt.startswith("BASE PROMPT\n\n")
+    assert "scene-save" in ctx.proposed_prompt  # a fact from unity_facts.md landed
+
+
+def test_pre_session_noop_when_prompt_empty():
+    """A fast-path emit with no prompt (None or "") is left untouched — nothing to
+    append onto, and we must never fabricate a prompt."""
+    inst = _real_unity({})
+    for empty in (None, ""):
+        ctx = HookContext("pre_session", run_id="r", proposed_prompt=empty)
+        inst.on_pre_session(ctx)
+        assert ctx.proposed_prompt == empty
+
+
+def test_pre_session_noop_when_facts_file_missing(tmp_path):
+    """A plugin dir with no unity_facts.md degrades to no injection (never crashes)."""
+    inst = _make_unity({}, tmp_path)  # tmp scripts dir ships no facts file
+    ctx = HookContext("pre_session", run_id="r", proposed_prompt="BASE")
+    inst.on_pre_session(ctx)
+    assert ctx.proposed_prompt == "BASE"
+
+
+# --------------------------------------------- detect-only dialog probe lifecycle
+
+
+class _ReapHost:
+    """Fake ProcessHost for the plugin-side probe reap: reports whether the recorded
+    pid is still ours and records any terminate."""
+
+    def __init__(self, ours=True):
+        self._ours = ours
+        self.terminated: list[int] = []
+
+    def alive_and_ours(self, pid, identity):
+        return self._ours
+
+    def terminate(self, pid):
+        self.terminated.append(pid)
+
+
+def test_engine_env_carries_dialog_probe_settings(tmp_path):
+    on = _make_unity(
+        {"dialog_probe": True, "dialog_probe_interval_sec": 9, "dialog_probe_notify": False},
+        tmp_path,
+    )
+    env = on.engine_env(_ctx("pre_run", tmp_path))
+    assert env["BMAD_LOOP_UNITY_DIALOG_PROBE"] == "1"
+    assert env["BMAD_LOOP_UNITY_DIALOG_PROBE_INTERVAL_SEC"] == "9"
+    assert env["BMAD_LOOP_UNITY_DIALOG_PROBE_NOTIFY"] == "0"
+    off = _make_unity({}, tmp_path).engine_env(_ctx("pre_run", tmp_path))
+    assert off["BMAD_LOOP_UNITY_DIALOG_PROBE"] == "0"  # off by default
+    assert off["BMAD_LOOP_UNITY_DIALOG_PROBE_NOTIFY"] == "1"  # notify defaults on
+
+
+def test_start_dialog_probe_launches_detached_with_scan_path(tmp_path, monkeypatch):
+    inst = _make_unity({"dialog_probe": True}, tmp_path)
+    calls = {}
+
+    class _FakePopen:
+        def __init__(self, argv, **kw):
+            calls["argv"] = argv
+            calls["kw"] = kw
+
+    monkeypatch.setattr(subprocess, "Popen", _FakePopen)
+    inst._start_dialog_probe(_ctx("pre_run", tmp_path), "/scan/here")
+    argv = calls["argv"]
+    assert argv[0] == sys.executable
+    assert argv[1].replace("\\", "/").endswith("unity_dialog_probe.py")
+    assert argv[2] == "/scan/here"  # the path teardown's argv scan keys on
+    assert calls["kw"]["env"]["BMAD_LOOP_UNITY_DIALOG_PROBE"] == "1"
+    if sys.platform == "win32":
+        assert "creationflags" in calls["kw"]
+    else:
+        assert calls["kw"].get("start_new_session") is True  # POSIX detach
+
+
+def test_start_dialog_probe_noop_when_disabled(tmp_path, monkeypatch):
+    inst = _make_unity({"dialog_probe": False}, tmp_path)  # off (the default)
+    launched = []
+    monkeypatch.setattr(subprocess, "Popen", lambda *a, **k: launched.append(a))
+    inst._start_dialog_probe(_ctx("pre_run", tmp_path), "/x")
+    assert launched == []
+
+
+def test_start_dialog_probe_reaps_prior_before_launch(tmp_path, monkeypatch):
+    """Starting a probe first reaps any recorded one so a re-entry never runs two."""
+    inst = _make_unity({"dialog_probe": True}, tmp_path)
+    order = []
+    monkeypatch.setattr(inst, "_reap_dialog_probe", lambda ctx: order.append("reap"))
+    monkeypatch.setattr(subprocess, "Popen", lambda *a, **k: order.append("launch") or object())
+    inst._start_dialog_probe(_ctx("pre_run", tmp_path), "/x")
+    assert order == ["reap", "launch"]
+
+
+def test_on_pre_run_starts_probe_only_in_shared_mode(tmp_path, monkeypatch):
+    for mode, expect in (("shared", True), ("per_worktree", False)):
+        inst = _make_unity({"dialog_probe": True, "editor_mode": mode}, tmp_path)
+        started, reaped = [], []
+        monkeypatch.setattr(inst, "_start_dialog_probe", lambda ctx, path: started.append(path))
+        monkeypatch.setattr(inst, "_reap_dialog_probe", lambda ctx: reaped.append(True))
+        inst.on_pre_run(_ctx("pre_run", tmp_path))
+        assert reaped == [True]  # stale-sweep runs in both modes
+        assert bool(started) is expect, mode
+        if expect:
+            assert started == [str(tmp_path)]  # shared probe scans the repo root
+
+
+def test_on_pre_worktree_setup_starts_probe_with_worktree_path(tmp_path, monkeypatch):
+    inst = _make_unity({"dialog_probe": True, "editor_mode": "per_worktree"}, tmp_path)
+    started = []
+    monkeypatch.setattr(inst, "_seed_scene_guard", lambda ctx: None)
+    monkeypatch.setattr(inst, "_start_dialog_probe", lambda ctx, path: started.append(path))
+    monkeypatch.setattr(inst, "_run_script", lambda *a, **k: (0, ""))
+    inst.on_pre_worktree_setup(_ctx("pre_worktree_setup", tmp_path))
+    assert started == [str(tmp_path)]  # per_worktree probe scans the worktree
+
+
+def test_on_post_run_reaps_probe(tmp_path, monkeypatch):
+    inst = _make_unity({}, tmp_path)
+    reaped = []
+    monkeypatch.setattr(inst, "_reap_dialog_probe", lambda ctx: reaped.append(True))
+    monkeypatch.setattr(inst, "_run_script", lambda *a, **k: (0, ""))
+    inst.on_post_run(_ctx("post_run", tmp_path))
+    assert reaped == [True]
+
+
+def test_reap_dialog_probe_terminates_recorded_pid(tmp_path, monkeypatch):
+    inst = _make_unity({}, tmp_path)
+    (tmp_path / "unity-dialog-probe.pid").write_text("424242 100.0", encoding="utf-8")
+    host = _ReapHost(ours=True)
+    monkeypatch.setitem(type(inst)._reap_dialog_probe.__globals__, "get_process_host", lambda: host)
+    inst._reap_dialog_probe(_ctx("post_run", tmp_path))
+    assert host.terminated == [424242]
+    assert not (tmp_path / "unity-dialog-probe.pid").exists()  # handle cleared
+
+
+def test_reap_dialog_probe_skips_signal_for_stale_handle(tmp_path, monkeypatch):
+    """A recorded pid that is no longer ours (dead / reused) is never signalled, but
+    its stale handle is still cleared."""
+    inst = _make_unity({}, tmp_path)
+    (tmp_path / "unity-dialog-probe.pid").write_text("424242 100.0", encoding="utf-8")
+    host = _ReapHost(ours=False)
+    monkeypatch.setitem(type(inst)._reap_dialog_probe.__globals__, "get_process_host", lambda: host)
+    inst._reap_dialog_probe(_ctx("post_run", tmp_path))
+    assert host.terminated == []
+    assert not (tmp_path / "unity-dialog-probe.pid").exists()
+
+
+def test_reap_dialog_probe_noop_without_pidfile(tmp_path):
+    """No recorded probe → a clean no-op (no crash, no signal)."""
+    inst = _make_unity({}, tmp_path)
+    inst._reap_dialog_probe(_ctx("post_run", tmp_path))  # must not raise
+
+
+# ------------------------------ dialog-probe reap matcher (unity_teardown scan)
+
+
+def test_probe_argv_matcher_needs_both_worktree_and_script():
+    mod = _load_unity_teardown()
+    from pathlib import Path as _P
+
+    wt = _P("/tmp/wt-abc")
+    script = mod._DIALOG_PROBE_SCRIPT_BASENAME
+    assert mod._probe_argv_matches(f"/usr/bin/python {script} {wt}", wt) is True
+    # an Editor referencing the worktree but NOT the probe script → never matched
+    assert mod._probe_argv_matches(f"/opt/Unity -projectPath {wt}", wt) is False
+    # another unit's probe (script present, different worktree) → not ours to reap
+    assert mod._probe_argv_matches(f"python {script} /tmp/other-wt", wt) is False
+
+
+def test_lingering_probe_pids_no_false_match(tmp_path):
+    """The runner is python but its argv is pytest, not the probe script → nothing
+    matches (and the scan never crashes on a path no process references)."""
+    mod = _load_unity_teardown()
+    assert mod._lingering_probe_pids(tmp_path) == []
 
 
 # --------------------------------------------------- editor_mode↔isolation coupling

--- a/tests/test_engine_plugin.py
+++ b/tests/test_engine_plugin.py
@@ -56,6 +56,7 @@ def test_builtin_unity_plugin_ships_its_scripts():
         "unity_setup.py",
         "unity_teardown.py",
         "unity_seed_assets.py",
+        "unity_quiesce.py",
     ):
         assert name in scripts, name
 
@@ -89,6 +90,8 @@ def test_builtin_unity_plugin_settings_schema():
         "ready_grace_sec",
         "install_scene_guard",
         "scene_guard_dir",
+        "quiesce_on_rollback",
+        "quiesce_timeout_sec",
     }
     assert by_key["editor_mode"].type == "select"
     assert by_key["editor_mode"].options == ("shared", "per_worktree")
@@ -97,6 +100,11 @@ def test_builtin_unity_plugin_settings_schema():
     assert by_key["install_scene_guard"].type == "bool"
     assert by_key["install_scene_guard"].default is True
     assert by_key["scene_guard_dir"].default == "Assets/BmadLoop/Editor"
+    assert by_key["quiesce_on_rollback"].type == "bool"
+    assert by_key["quiesce_on_rollback"].default is True
+    assert by_key["quiesce_timeout_sec"].type == "int"
+    assert by_key["quiesce_timeout_sec"].default == 60
+    assert by_key["quiesce_timeout_sec"].min == 1
 
 
 def test_unity_is_trust_gated():
@@ -134,6 +142,8 @@ def _make_unity(settings, scripts_dir):
         "ready_grace_sec": -1,
         "install_scene_guard": True,
         "scene_guard_dir": "Assets/BmadLoop/Editor",
+        "quiesce_on_rollback": True,
+        "quiesce_timeout_sec": 60,
     }
     full.update(settings)
     return cls(manifest, full)
@@ -203,6 +213,78 @@ def test_worktree_teardown_is_best_effort(tmp_path):
     assert not ctx.vetoed
 
 
+# --------------------------------------------------- rollback quiesce hooks
+
+
+def test_rollback_hooks_run_quiesce_with_phase_and_timeout(tmp_path, monkeypatch):
+    """pre/post_rollback shell the quiesce helper with the phase in the env and the
+    quiesce_timeout_sec as the overall kill budget."""
+    inst = _make_unity({"quiesce_timeout_sec": 42}, tmp_path)
+    calls = []
+    monkeypatch.setattr(
+        inst,
+        "_run_script",
+        lambda name, ctx, *, timeout, extra_env=None: calls.append((name, timeout, extra_env))
+        or (0, ""),
+    )
+    inst.on_pre_rollback(_ctx("pre_rollback", tmp_path))
+    inst.on_post_rollback(_ctx("post_rollback", tmp_path))
+    assert calls == [
+        ("unity_quiesce.py", 42, {"BMAD_LOOP_QUIESCE_PHASE": "pre"}),
+        ("unity_quiesce.py", 42, {"BMAD_LOOP_QUIESCE_PHASE": "post"}),
+    ]
+
+
+def test_rollback_hooks_skipped_when_disabled(tmp_path, monkeypatch):
+    inst = _make_unity({"quiesce_on_rollback": False}, tmp_path)
+    calls = []
+    monkeypatch.setattr(inst, "_run_script", lambda *a, **k: calls.append(a) or (0, ""))
+    inst.on_pre_rollback(_ctx("pre_rollback", tmp_path))
+    inst.on_post_rollback(_ctx("post_rollback", tmp_path))
+    assert calls == []  # quiesce did not run
+
+
+def test_rollback_hooks_skipped_for_non_ivanmurzak_mcp(tmp_path, monkeypatch):
+    """Only the IvanMurzak CLI is driven; CoplayDev has no quiesce helper here."""
+    inst = _make_unity({"mcp": "coplaydev"}, tmp_path)
+    calls = []
+    monkeypatch.setattr(inst, "_run_script", lambda *a, **k: calls.append(a) or (0, ""))
+    inst.on_pre_rollback(_ctx("pre_rollback", tmp_path))
+    inst.on_post_rollback(_ctx("post_rollback", tmp_path))
+    assert calls == []
+
+
+def test_rollback_hooks_never_veto_on_failure(tmp_path):
+    """The quiesce is best-effort — a failing (or missing) helper never vetoes; the
+    rollback stages forbid a veto anyway."""
+    # no unity_quiesce.py on disk -> _run_script returns rc!=0, must be swallowed
+    inst = _make_unity({}, tmp_path)
+    ctx = _ctx("pre_rollback", tmp_path)
+    inst.on_pre_rollback(ctx)
+    inst.on_post_rollback(_ctx("post_rollback", tmp_path))
+    assert not ctx.vetoed
+
+
+def test_run_script_merges_extra_env(tmp_path):
+    """_run_script layers extra_env over engine_env so per-call knobs (the quiesce
+    phase) reach the helper without polluting the base contract."""
+    # a tiny helper that dumps the phase env var it received, so we can read it back
+    (tmp_path / "echo_phase.py").write_text(
+        "import os, sys\n" "sys.stdout.write(os.environ.get('BMAD_LOOP_QUIESCE_PHASE', 'UNSET'))\n",
+        encoding="utf-8",
+    )
+    inst = _make_unity({}, tmp_path)
+    rc, out = inst._run_script(
+        "echo_phase.py",
+        _ctx("pre_rollback", tmp_path),
+        timeout=30,
+        extra_env={"BMAD_LOOP_QUIESCE_PHASE": "pre"},
+    )
+    assert rc == 0 and out == "pre"
+    # base engine_env is unchanged: without extra_env the var is absent
+    assert "BMAD_LOOP_QUIESCE_PHASE" not in inst.engine_env(_ctx("pre_rollback", tmp_path))
+
+
 # ------------------------------------------------------ UnityPlugin env contract
 
 
@@ -267,6 +349,8 @@ def _real_unity(settings):
         "ready_grace_sec": -1,
         "install_scene_guard": True,
         "scene_guard_dir": "Assets/BmadLoop/Editor",
+        "quiesce_on_rollback": True,
+        "quiesce_timeout_sec": 60,
     }
     full.update(settings)
     return cls(manifest, full)

--- a/tests/test_portability_guard.py
+++ b/tests/test_portability_guard.py
@@ -43,10 +43,12 @@ PATH_ALLOW = {
     "verify.py",
 }
 
-# The two detach helpers that legitimately request POSIX `start_new_session`.
+# The detach helpers that legitimately request POSIX `start_new_session` (each
+# branches on `sys.platform` for a Windows creationflags fallback).
 DETACH_ALLOW = {
     "platform_util.py",
     "data/plugins/unity/unity_setup.py",
+    "data/plugins/unity/unity_plugin.py",
 }
 
 # `os.kill(pid, 0)` is a read-only existence probe on POSIX but *destructive* on

--- a/tests/test_settings_schema.py
+++ b/tests/test_settings_schema.py
@@ -290,7 +290,15 @@ def test_unity_plugin_is_trust_gated_and_renders_settings():
     assert unity.trust_needed is True  # has [python] -> enabling grants trust
     assert unity.enabled is False
     keys = [f.key for f in unity.fields]
-    assert keys == ["editor_mode", "mcp", "unity_path", "ready_timeout_sec", "ready_grace_sec"]
+    assert keys == [
+        "editor_mode",
+        "mcp",
+        "unity_path",
+        "ready_timeout_sec",
+        "ready_grace_sec",
+        "install_scene_guard",
+        "scene_guard_dir",
+    ]
     editor_mode = next(f for f in unity.fields if f.key == "editor_mode")
     assert editor_mode.kind == "select"
     assert editor_mode.options == ("shared", "per_worktree")

--- a/tests/test_settings_schema.py
+++ b/tests/test_settings_schema.py
@@ -298,6 +298,8 @@ def test_unity_plugin_is_trust_gated_and_renders_settings():
         "ready_grace_sec",
         "install_scene_guard",
         "scene_guard_dir",
+        "quiesce_on_rollback",
+        "quiesce_timeout_sec",
     ]
     editor_mode = next(f for f in unity.fields if f.key == "editor_mode")
     assert editor_mode.kind == "select"

--- a/tests/test_settings_schema.py
+++ b/tests/test_settings_schema.py
@@ -300,6 +300,9 @@ def test_unity_plugin_is_trust_gated_and_renders_settings():
         "scene_guard_dir",
         "quiesce_on_rollback",
         "quiesce_timeout_sec",
+        "dialog_probe",
+        "dialog_probe_interval_sec",
+        "dialog_probe_notify",
     ]
     editor_mode = next(f for f in unity.fields if f.key == "editor_mode")
     assert editor_mode.kind == "select"

--- a/tests/test_unity_dialog_probe.py
+++ b/tests/test_unity_dialog_probe.py
@@ -1,0 +1,182 @@
+"""Unit tests for the detect-only Unity modal-dialog probe (``unity_dialog_probe.py``).
+
+The probe is launched detached by ``UnityPlugin`` to watch (via xdotool, X11 only)
+for the run-freezing Unity modal dialogs and REPORT them — it never clicks or keys
+anything. These drive its pure detection / report / dedupe functions with a stubbed
+xdotool runner (no real Editor or X server), and its ``main()`` no-op skips. The
+plugin-side lifecycle (launch at pre_run/pre_worktree_setup, reap at post_run /
+unity_teardown.py) lives in ``test_engine_plugin.py``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+
+from bmad_loop.plugins import get_plugin
+
+
+def _load_probe():
+    path = os.path.join(get_plugin("unity").scripts_dir, "unity_dialog_probe.py")
+    spec = importlib.util.spec_from_file_location("unity_dialog_probe_under_test", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class _FakeProc:
+    def __init__(self, returncode=0, stdout=""):
+        self.returncode = returncode
+        self.stdout = stdout
+
+
+def _make_run(windows):
+    """A stub xdotool runner. ``windows`` maps window id -> title: ``search`` returns
+    the ids (exit 1 when none, as real xdotool does), ``getwindowname`` the title."""
+
+    def run(args, timeout=10.0):
+        if args[0] == "search":
+            return _FakeProc(0 if windows else 1, "\n".join(windows))
+        if args[0] == "getwindowname":
+            return _FakeProc(0, windows.get(args[1], ""))
+        return _FakeProc(0, "")
+
+    return run
+
+
+# ------------------------------------------------------------------ detection
+
+
+def test_matches_dialog_is_case_insensitive_substring():
+    mod = _load_probe()
+    assert mod._matches_dialog("Scene(s) Have Been Modified")
+    assert mod._matches_dialog("Do you want to SAVE the changes?")
+    assert not mod._matches_dialog("MyGame - Main - PC, Mac & Linux - Unity 2022.3")
+
+
+def test_scan_only_flags_dialog_titled_windows():
+    """The main Editor window is ignored; only a window whose title matches a known
+    modal-dialog phrase is a hit."""
+    mod = _load_probe()
+    run = _make_run({"111": "MyGame - Main - Unity 2022", "222": "Scene(s) Have Been Modified"})
+    assert mod._scan_for_dialogs(run) == [("222", "Scene(s) Have Been Modified")]
+
+
+def test_scan_empty_when_no_unity_windows():
+    """xdotool exits non-zero when nothing matches — the normal 'no dialog' case,
+    not an error — so the scan is empty, never a crash."""
+    mod = _load_probe()
+    assert mod._scan_for_dialogs(_make_run({})) == []
+
+
+# --------------------------------------------------------------- report / dedupe
+
+
+def test_report_writes_jsonl_and_attention(tmp_path, monkeypatch):
+    mod = _load_probe()
+    monkeypatch.setattr(mod.shutil, "which", lambda _c: None)  # no notify-send present
+    mod._report(tmp_path, "999", "conflicting scene changes", notify=True)
+
+    rec = json.loads((tmp_path / mod.PROBE_JSONL).read_text(encoding="utf-8").strip())
+    assert rec["window"] == "999"
+    assert rec["title"] == "conflicting scene changes"
+    assert "ts" in rec
+    # ATTENTION line matches gates.notify's "[stamp] title: message" shape
+    att = (tmp_path / mod.ATTENTION_FILE).read_text(encoding="utf-8")
+    assert att.startswith("[")
+    assert "Unity modal dialog detected: window 999: conflicting scene changes" in att
+
+
+def test_report_notify_gating(tmp_path, monkeypatch):
+    mod = _load_probe()
+    called = []
+    monkeypatch.setattr(mod.shutil, "which", lambda _c: "/usr/bin/notify-send")
+    monkeypatch.setattr(mod.subprocess, "run", lambda *a, **k: called.append(a))
+    mod._report(tmp_path, "1", "changed on disk", notify=True)
+    assert called and called[0][0][0] == "notify-send"  # notify fired
+    called.clear()
+    mod._report(tmp_path, "2", "changed on disk", notify=False)
+    assert called == []  # notify disabled → JSONL/ATTENTION only, no desktop popup
+
+
+def test_scan_once_dedupes_repeat_detections(tmp_path):
+    mod = _load_probe()
+    run = _make_run({"222": "save changes before closing"})
+    seen: set[str] = set()
+    assert mod._scan_once(run, tmp_path, seen, notify=False) == 1
+    assert mod._scan_once(run, tmp_path, seen, notify=False) == 0  # same wid → no re-report
+    lines = (tmp_path / mod.PROBE_JSONL).read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 1  # exactly one record for the window
+
+
+def test_scan_once_reports_each_distinct_window(tmp_path):
+    mod = _load_probe()
+    run = _make_run(
+        {"1": "changed on disk", "2": "conflicting scene changes", "3": "unrelated editor"}
+    )
+    seen: set[str] = set()
+    assert mod._scan_once(run, tmp_path, seen, notify=False) == 2  # two dialogs, editor skipped
+    assert seen == {"1", "2"}
+
+
+# ----------------------------------------------------------------- main() skips
+
+
+def test_interval_default_floor_and_bad_value(monkeypatch):
+    mod = _load_probe()
+    monkeypatch.delenv("BMAD_LOOP_UNITY_DIALOG_PROBE_INTERVAL_SEC", raising=False)
+    assert mod._interval() == 5.0
+    monkeypatch.setenv("BMAD_LOOP_UNITY_DIALOG_PROBE_INTERVAL_SEC", "0")
+    assert mod._interval() == 1.0  # floored to the 1s minimum
+    monkeypatch.setenv("BMAD_LOOP_UNITY_DIALOG_PROBE_INTERVAL_SEC", "bogus")
+    assert mod._interval() == 5.0
+
+
+def test_main_noop_without_display(monkeypatch, capsys):
+    mod = _load_probe()
+    monkeypatch.delenv("DISPLAY", raising=False)
+    assert mod.main() == 0
+    assert "DISPLAY unset" in capsys.readouterr().err
+
+
+def test_main_noop_without_xdotool(monkeypatch):
+    mod = _load_probe()
+    monkeypatch.setenv("DISPLAY", ":0")
+    monkeypatch.setattr(mod.shutil, "which", lambda _c: None)
+    assert mod.main() == 0
+
+
+def test_main_noop_without_run_dir(monkeypatch, capsys):
+    mod = _load_probe()
+    monkeypatch.setenv("DISPLAY", ":0")
+    monkeypatch.setattr(mod.shutil, "which", lambda _c: "/usr/bin/xdotool")
+    monkeypatch.delenv("BMAD_LOOP_RUN_DIR", raising=False)
+    assert mod.main() == 0
+    assert "refusing to run" in capsys.readouterr().err
+
+
+def test_main_scans_once_then_exits_when_engine_dies(tmp_path, monkeypatch):
+    """The loop runs while the engine pid is alive, detects+reports a dialog, and
+    exits when engine_alive flips to False — leaving its pid-file reap handle."""
+    mod = _load_probe()
+    monkeypatch.setenv("DISPLAY", ":0")
+    monkeypatch.setenv("BMAD_LOOP_RUN_DIR", str(tmp_path))
+    monkeypatch.setattr(mod.shutil, "which", lambda c: "/usr/bin/" + c)
+    monkeypatch.setattr(mod.time, "sleep", lambda *_a: None)
+    alive = iter([True, False])  # alive for the first pass, dead thereafter
+    monkeypatch.setattr(mod, "engine_alive", lambda _rd: next(alive, False))
+
+    def fake_xdotool(args, timeout=10.0):
+        if args[0] == "search":
+            return _FakeProc(0, "555")
+        if args[0] == "getwindowname":
+            return _FakeProc(0, "Do you want to save the changes")
+        return _FakeProc(0, "")
+
+    monkeypatch.setattr(mod, "_run_xdotool", fake_xdotool)
+
+    assert mod.main() == 0
+    lines = (tmp_path / mod.PROBE_JSONL).read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 1  # detected + reported exactly once
+    assert (tmp_path / mod.PROBE_PID_FILE).exists()  # wrote its primary reap handle

--- a/tests/test_unity_quiesce.py
+++ b/tests/test_unity_quiesce.py
@@ -196,7 +196,7 @@ def test_pre_script_execute_carries_newscene_csharp(tmp_path, monkeypatch):
     seen = {}
 
     def capture(cmd):
-        seen["code"] = _input_of(cmd)["code"]
+        seen["input"] = _input_of(cmd)
         return _FakeProc(0, "ok")
 
     _stub_cli(
@@ -206,9 +206,15 @@ def test_pre_script_execute_carries_newscene_csharp(tmp_path, monkeypatch):
     )
 
     assert mod.main() == 0
+    # The IvanMurzak script-execute schema requires csharpCode (+ className/methodName);
+    # sending a bare "code" key makes the call fail silently and the modal-avoidance no-op.
+    assert "code" not in seen["input"]
     assert (
-        "EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single)" in seen["code"]
+        "EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single)"
+        in seen["input"]["csharpCode"]
     )
+    assert seen["input"]["className"] == "BmadQuiesce"
+    assert seen["input"]["methodName"] == "Main"
 
 
 # ----------------------------------------------------------------- post phase

--- a/tests/test_unity_quiesce.py
+++ b/tests/test_unity_quiesce.py
@@ -1,0 +1,280 @@
+"""Unit tests for the Unity rollback-quiesce helper (``unity_quiesce.py``).
+
+The helper is shelled out by ``UnityPlugin`` around a failed-attempt rollback: the
+``pre`` phase saves + closes open scenes before ``git reset --hard`` rewrites tracked
+``.unity`` files (so a shared Editor never raises the run-freezing "scene changed on
+disk" modal), and the ``post`` phase refreshes assets afterwards. These drive its
+``main()`` with a stubbed Unity-MCP CLI (monkeypatched ``subprocess.run`` + ``which``)
+so no real Editor is needed — the plugin-side wiring (env plumbing + the
+pre_rollback/post_rollback hooks that invoke it) lives in ``test_engine_plugin.py``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+
+from bmad_loop.plugins import get_plugin
+
+
+def _load_quiesce():
+    path = os.path.join(get_plugin("unity").scripts_dir, "unity_quiesce.py")
+    spec = importlib.util.spec_from_file_location("unity_quiesce_under_test", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class _FakeProc:
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _stub_cli(monkeypatch, mod, responses):
+    """Install a fake Unity-MCP CLI. ``responses`` maps a run-tool name to a
+    _FakeProc, a callable(cmd)->_FakeProc, or an Exception to raise. Returns the
+    list of tool names invoked, in order."""
+    tools: list[str] = []
+
+    def fake_run(cmd, **kwargs):
+        assert cmd[1] == "run-tool"
+        tool = cmd[2]
+        tools.append(tool)
+        resp = responses.get(tool, _FakeProc(0, "ok"))
+        if callable(resp) and not isinstance(resp, BaseException):
+            resp = resp(cmd)
+        if isinstance(resp, BaseException):
+            raise resp
+        return resp
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+    monkeypatch.setattr(mod.shutil, "which", lambda c: "/usr/bin/" + c)
+    return tools
+
+
+def _input_of(cmd):
+    """The JSON dict passed to a run-tool call via --input (or None)."""
+    if "--input" in cmd:
+        return json.loads(cmd[cmd.index("--input") + 1])
+    return None
+
+
+# ------------------------------------------------------------------ pre phase
+
+
+def test_pre_saves_each_open_scene_then_opens_empty(tmp_path, monkeypatch):
+    mod = _load_quiesce()
+    monkeypatch.setenv("BMAD_LOOP_QUIESCE_PHASE", "pre")
+    monkeypatch.setenv("BMAD_LOOP_WORKTREE", str(tmp_path))
+    saved = []
+
+    def record_save(cmd):
+        saved.append(_input_of(cmd)["openedSceneName"])
+        return _FakeProc(0, "ok")
+
+    tools = _stub_cli(
+        monkeypatch,
+        mod,
+        {
+            "scene-list-opened": _FakeProc(0, json.dumps(["Assets/Main.unity", "Assets/UI.unity"])),
+            "scene-save": record_save,
+        },
+    )
+
+    assert mod.main() == 0
+    # list (probe) → save each scene → close-all via script-execute, in that order
+    assert tools == ["scene-list-opened", "scene-save", "scene-save", "script-execute"]
+    assert saved == ["Assets/Main.unity", "Assets/UI.unity"]
+
+
+def test_pre_unresponsive_editor_exits_fast_without_further_calls(tmp_path, monkeypatch, capsys):
+    """The scene-list-opened probe failing means the Editor is wedged: skip the whole
+    quiesce immediately (exit 1), making no save / script-execute calls. The CLI
+    returns rc 0 on a connection-refused, so the transport-error payload — not the rc
+    — is what trips the skip here."""
+    mod = _load_quiesce()
+    monkeypatch.setenv("BMAD_LOOP_QUIESCE_PHASE", "pre")
+    monkeypatch.setenv("BMAD_LOOP_WORKTREE", str(tmp_path))
+    tools = _stub_cli(
+        monkeypatch,
+        mod,
+        {"scene-list-opened": _FakeProc(0, "Error: connection refused (localhost:8080)")},
+    )
+
+    assert mod.main() == 1
+    assert tools == ["scene-list-opened"]  # nothing after the probe
+    assert "editor unresponsive" in capsys.readouterr().err
+
+
+def test_pre_scene_named_error_is_not_treated_as_unresponsive(tmp_path, monkeypatch):
+    """A scene whose name/path contains 'error' must NOT read as a dead Editor — the
+    probe only skips on transport-level phrases, never on scene-list user data. The
+    quiesce proceeds: the scene is saved and the close-all still runs."""
+    mod = _load_quiesce()
+    monkeypatch.setenv("BMAD_LOOP_QUIESCE_PHASE", "pre")
+    monkeypatch.setenv("BMAD_LOOP_WORKTREE", str(tmp_path))
+    saved = []
+
+    def record_save(cmd):
+        saved.append(_input_of(cmd)["openedSceneName"])
+        return _FakeProc(0, "ok")
+
+    tools = _stub_cli(
+        monkeypatch,
+        mod,
+        {
+            "scene-list-opened": _FakeProc(0, json.dumps(["Assets/UI/ErrorPopup.unity"])),
+            "scene-save": record_save,
+        },
+    )
+
+    assert mod.main() == 0
+    assert tools == ["scene-list-opened", "scene-save", "script-execute"]
+    assert saved == ["Assets/UI/ErrorPopup.unity"]  # saved, not skipped
+
+
+def test_pre_probe_timeout_is_treated_as_unresponsive(tmp_path, monkeypatch):
+    """A hung probe (subprocess timeout) is a wedged Editor too — fast skip."""
+    mod = _load_quiesce()
+    monkeypatch.setenv("BMAD_LOOP_QUIESCE_PHASE", "pre")
+    monkeypatch.setenv("BMAD_LOOP_WORKTREE", str(tmp_path))
+    tools = _stub_cli(
+        monkeypatch,
+        mod,
+        {"scene-list-opened": subprocess.TimeoutExpired(cmd="scene-list-opened", timeout=15)},
+    )
+
+    assert mod.main() == 1
+    assert tools == ["scene-list-opened"]
+
+
+def test_pre_tolerates_per_scene_save_failure(tmp_path, monkeypatch, capsys):
+    """An individual scene-save failure (untitled scenes throw) is tolerated: the
+    other scenes still save and the close-all still runs. Overall success."""
+    mod = _load_quiesce()
+    monkeypatch.setenv("BMAD_LOOP_QUIESCE_PHASE", "pre")
+    monkeypatch.setenv("BMAD_LOOP_WORKTREE", str(tmp_path))
+
+    def flaky_save(cmd):
+        name = _input_of(cmd)["openedSceneName"]
+        return _FakeProc(1, "cannot save untitled") if name == "Untitled" else _FakeProc(0, "ok")
+
+    tools = _stub_cli(
+        monkeypatch,
+        mod,
+        {
+            "scene-list-opened": _FakeProc(0, json.dumps(["Untitled", "Assets/Main.unity"])),
+            "scene-save": flaky_save,
+        },
+    )
+
+    assert mod.main() == 0
+    assert tools == ["scene-list-opened", "scene-save", "scene-save", "script-execute"]
+    assert "scene-save 'Untitled' failed" in capsys.readouterr().err
+
+
+def test_pre_unparseable_scene_list_still_closes_all(tmp_path, monkeypatch):
+    """If the opened-scene list can't be parsed we skip the (optional) saves but the
+    close-all script-execute — the actual modal-avoidance — still runs."""
+    mod = _load_quiesce()
+    monkeypatch.setenv("BMAD_LOOP_QUIESCE_PHASE", "pre")
+    monkeypatch.setenv("BMAD_LOOP_WORKTREE", str(tmp_path))
+    tools = _stub_cli(monkeypatch, mod, {"scene-list-opened": _FakeProc(0, "not json at all")})
+
+    assert mod.main() == 0
+    assert tools == ["scene-list-opened", "script-execute"]  # no saves, close-all still runs
+
+
+def test_pre_script_execute_carries_newscene_csharp(tmp_path, monkeypatch):
+    mod = _load_quiesce()
+    monkeypatch.setenv("BMAD_LOOP_QUIESCE_PHASE", "pre")
+    monkeypatch.setenv("BMAD_LOOP_WORKTREE", str(tmp_path))
+    seen = {}
+
+    def capture(cmd):
+        seen["code"] = _input_of(cmd)["code"]
+        return _FakeProc(0, "ok")
+
+    _stub_cli(
+        monkeypatch,
+        mod,
+        {"scene-list-opened": _FakeProc(0, "[]"), "script-execute": capture},
+    )
+
+    assert mod.main() == 0
+    assert (
+        "EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single)" in seen["code"]
+    )
+
+
+# ----------------------------------------------------------------- post phase
+
+
+def test_post_refreshes_assets(tmp_path, monkeypatch):
+    mod = _load_quiesce()
+    monkeypatch.setenv("BMAD_LOOP_QUIESCE_PHASE", "post")
+    monkeypatch.setenv("BMAD_LOOP_WORKTREE", str(tmp_path))
+    refresh = {}
+
+    def capture(cmd):
+        refresh["input"] = _input_of(cmd)
+        # refresh gets the wider per-call floor (45s), passed as --timeout ms
+        refresh["timeout_ms"] = int(cmd[cmd.index("--timeout") + 1])
+        return _FakeProc(0, "ok")
+
+    tools = _stub_cli(monkeypatch, mod, {"assets-refresh": capture})
+
+    assert mod.main() == 0
+    assert tools == ["assets-refresh"]
+    assert refresh["input"] == {}
+    assert refresh["timeout_ms"] >= 45000
+
+
+def test_post_tolerates_refresh_timeout(tmp_path, monkeypatch, capsys):
+    """A refresh timeout is tolerated (exit 1 advisory): the in-editor refresh keeps
+    going on its own, and the plugin ignores the rc regardless."""
+    mod = _load_quiesce()
+    monkeypatch.setenv("BMAD_LOOP_QUIESCE_PHASE", "post")
+    monkeypatch.setenv("BMAD_LOOP_WORKTREE", str(tmp_path))
+    _stub_cli(
+        monkeypatch,
+        mod,
+        {"assets-refresh": subprocess.TimeoutExpired(cmd="assets-refresh", timeout=45)},
+    )
+
+    assert mod.main() == 1
+    assert "assets-refresh did not complete" in capsys.readouterr().err
+
+
+# --------------------------------------------------------------- cli resolution
+
+
+def test_missing_cli_skips_quiesce(tmp_path, monkeypatch, capsys):
+    mod = _load_quiesce()
+    monkeypatch.setenv("BMAD_LOOP_QUIESCE_PHASE", "pre")
+    monkeypatch.setenv("BMAD_LOOP_WORKTREE", str(tmp_path))
+    monkeypatch.setattr(mod.shutil, "which", lambda c: None)
+
+    assert mod.main() == 1
+    assert "not found on PATH" in capsys.readouterr().err
+
+
+def test_call_timeout_env_override(tmp_path, monkeypatch):
+    mod = _load_quiesce()
+    monkeypatch.setenv("BMAD_LOOP_QUIESCE_PHASE", "pre")
+    monkeypatch.setenv("BMAD_LOOP_WORKTREE", str(tmp_path))
+    monkeypatch.setenv("BMAD_LOOP_UNITY_QUIESCE_CALL_TIMEOUT", "8000")
+    seen = {}
+
+    def capture(cmd):
+        seen["ms"] = int(cmd[cmd.index("--timeout") + 1])
+        return _FakeProc(0, "[]")
+
+    _stub_cli(monkeypatch, mod, {"scene-list-opened": capture})
+
+    assert mod.main() == 0
+    assert seen["ms"] == 8000  # the per-call CLI --timeout honours the env override

--- a/tests/test_unity_scene_guard.py
+++ b/tests/test_unity_scene_guard.py
@@ -173,10 +173,46 @@ def test_seed_custom_dir_keys_folder_metas_by_name(tmp_path, monkeypatch):
     assert not (tmp_path / "Assets" / "Vendor.meta").exists()
 
 
+# ------------------------------------------------------------- invalid dirs
+
+
+def test_seed_rejects_absolute_guard_dir(tmp_path, monkeypatch):
+    mod = _load_seeder()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    worktree = tmp_path / "wt"
+    (worktree / "Assets").mkdir(parents=True)
+    _set_env(monkeypatch, worktree, guard_dir=str(outside / "Editor"))
+
+    assert mod.main() == 2  # a real error, not a crash (relative_to would raise)
+    assert not (outside / "Editor").exists()  # nothing written at the absolute target
+
+
+def test_seed_rejects_parent_traversal_guard_dir(tmp_path, monkeypatch):
+    mod = _load_seeder()
+    # the escape target's parent (tmp_path) exists, so an unguarded seeder would
+    # really create escaped/ out there — the mutate-check is meaningful
+    worktree = tmp_path / "wt"
+    (worktree / "Assets").mkdir(parents=True)
+    _set_env(monkeypatch, worktree, guard_dir="Assets/../../escaped/Editor")
+
+    assert mod.main() == 2
+    assert not (tmp_path / "escaped").exists()  # no write outside the worktree
+
+
+def test_seed_rejects_windows_flavored_escapes_on_any_platform(tmp_path, monkeypatch):
+    mod = _load_seeder()
+    (tmp_path / "Assets").mkdir()
+    for evil in ("C:\\evil", "C:evil", "\\evil", "..\\evil"):
+        _set_env(monkeypatch, tmp_path, guard_dir=evil)
+        assert mod.main() == 2, evil
+    assert not (tmp_path / "Assets" / "BmadLoop").exists()  # nothing seeded
+
+
 # ------------------------------------------------------------ version parsing
 
 
-def test_parse_version_tuple_and_missing(tmp_path, monkeypatch):
+def test_parse_version_tuple_and_missing():
     mod = _load_seeder()
     assert mod._parse_version("// bmad-loop-scene-guard-version: 1.2.3\n") == (1, 2, 3)
     assert mod._parse_version("no header here") is None

--- a/tests/test_unity_scene_guard.py
+++ b/tests/test_unity_scene_guard.py
@@ -1,0 +1,182 @@
+"""Unit tests for the Unity scene-guard seeder (``unity_seed_assets.py``).
+
+The seeder copies the bundled scene auto-save guard payload (``unity_assets/``:
+``SceneAutoSaveGuard.cs`` + its asmdef, with pre-generated fixed-GUID ``.meta``
+files) into a project's ``Assets`` tree so a chronically-dirty scene never raises
+the two run-stalling modal dialogs. These drive its ``main()`` end-to-end against a
+temp worktree, using the real bundled payload (so the version-header + GUID contract
+is exercised, not a stand-in).
+
+The plugin-side wiring (env plumbing + the pre_worktree_setup/pre_ready_gate hooks
+that invoke this seeder) lives in ``test_engine_plugin.py``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+
+from bmad_loop.plugins import get_plugin
+
+_GUARD_DIR = "Assets/BmadLoop/Editor"
+
+
+def _load_seeder():
+    path = os.path.join(get_plugin("unity").scripts_dir, "unity_seed_assets.py")
+    spec = importlib.util.spec_from_file_location("unity_seed_assets_under_test", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _payload(mod) -> Path:
+    return Path(mod.__file__).resolve().parent / "unity_assets"
+
+
+def _set_env(monkeypatch, worktree, *, install="1", guard_dir=None):
+    monkeypatch.setenv("BMAD_LOOP_WORKTREE", str(worktree))
+    monkeypatch.setenv("BMAD_LOOP_UNITY_INSTALL_SCENE_GUARD", install)
+    if guard_dir is None:
+        monkeypatch.delenv("BMAD_LOOP_UNITY_SCENE_GUARD_DIR", raising=False)
+    else:
+        monkeypatch.setenv("BMAD_LOOP_UNITY_SCENE_GUARD_DIR", guard_dir)
+
+
+# ---------------------------------------------------------------- fresh install
+
+
+def test_seed_fresh_install_lays_all_payload_files(tmp_path, monkeypatch):
+    mod = _load_seeder()
+    _set_env(monkeypatch, tmp_path)
+    (tmp_path / "Assets").mkdir()
+
+    assert mod.main() == 0
+
+    payload = _payload(mod)
+    editor = tmp_path / _GUARD_DIR
+    # content files land byte-identical to the payload (robust to a version bump)
+    for name in (
+        "SceneAutoSaveGuard.cs",
+        "SceneAutoSaveGuard.cs.meta",
+        "BmadLoop.Unity.Editor.asmdef",
+        "BmadLoop.Unity.Editor.asmdef.meta",
+    ):
+        assert (editor / name).read_bytes() == (payload / name).read_bytes(), name
+    # parent-folder metas carry the payload's fixed GUIDs (no per-worktree churn)
+    assert (tmp_path / "Assets" / "BmadLoop.meta").read_bytes() == (
+        payload / "_folders" / "BmadLoop.meta"
+    ).read_bytes()
+    assert (tmp_path / "Assets" / "BmadLoop" / "Editor.meta").read_bytes() == (
+        payload / "_folders" / "Editor.meta"
+    ).read_bytes()
+    # Unity owns Assets/ itself — the seeder never lays an Assets.meta over it
+    assert not (tmp_path / "Assets.meta").exists()
+
+
+# ------------------------------------------------------------------ idempotency
+
+
+def test_seed_idempotent_reinstall_is_noop(tmp_path, monkeypatch):
+    mod = _load_seeder()
+    _set_env(monkeypatch, tmp_path)
+    (tmp_path / "Assets").mkdir()
+    assert mod.main() == 0
+
+    # a local edit that keeps the (matching) version header must survive a re-run:
+    # an equal version is left untouched.
+    cs = tmp_path / _GUARD_DIR / "SceneAutoSaveGuard.cs"
+    cs.write_text(cs.read_text() + "\n// local edit marker\n", encoding="utf-8")
+
+    assert mod.main() == 0
+    assert "// local edit marker" in cs.read_text()  # not overwritten
+
+
+# --------------------------------------------------------------- version bump
+
+
+def test_seed_version_bump_reinstalls(tmp_path, monkeypatch):
+    mod = _load_seeder()
+    _set_env(monkeypatch, tmp_path)
+    editor = tmp_path / _GUARD_DIR
+    editor.mkdir(parents=True)
+    cs = editor / "SceneAutoSaveGuard.cs"
+    cs.write_text("// bmad-loop-scene-guard-version: 0.9.0\n// stale guard\n", encoding="utf-8")
+
+    assert mod.main() == 0
+
+    payload = _payload(mod)
+    assert "0.9.0" not in cs.read_text()  # the stale guard was replaced
+    assert cs.read_bytes() == (payload / "SceneAutoSaveGuard.cs").read_bytes()
+    # the reinstall also brought the meta companions along
+    assert (editor / "SceneAutoSaveGuard.cs.meta").is_file()
+    assert (editor / "BmadLoop.Unity.Editor.asmdef").is_file()
+
+
+def test_seed_newer_target_version_is_left_alone(tmp_path, monkeypatch):
+    mod = _load_seeder()
+    _set_env(monkeypatch, tmp_path)
+    editor = tmp_path / _GUARD_DIR
+    editor.mkdir(parents=True)
+    cs = editor / "SceneAutoSaveGuard.cs"
+    # a hypothetical future guard version must never be downgraded
+    cs.write_text("// bmad-loop-scene-guard-version: 99.0.0\n// future guard\n", encoding="utf-8")
+
+    assert mod.main() == 0
+    assert "99.0.0" in cs.read_text()  # untouched
+
+
+# ------------------------------------------------------------ graceful skips
+
+
+def test_seed_skips_when_no_asset_root(tmp_path, monkeypatch):
+    mod = _load_seeder()
+    _set_env(monkeypatch, tmp_path)  # no Assets/ created
+
+    assert mod.main() == 0  # benign skip, not an error
+    assert not (tmp_path / "Assets").exists()  # nothing scattered into a non-Unity tree
+
+
+def test_seed_disabled_via_env(tmp_path, monkeypatch):
+    mod = _load_seeder()
+    _set_env(monkeypatch, tmp_path, install="0")
+    (tmp_path / "Assets").mkdir()
+
+    assert mod.main() == 0
+    assert not (tmp_path / "Assets" / "BmadLoop").exists()  # seeding did not run
+
+
+def test_seed_errors_without_worktree(tmp_path, monkeypatch):
+    mod = _load_seeder()
+    monkeypatch.delenv("BMAD_LOOP_WORKTREE", raising=False)
+    monkeypatch.setenv("BMAD_LOOP_UNITY_INSTALL_SCENE_GUARD", "1")
+    assert mod.main() == 2  # a real error (no project to seed)
+
+
+# ---------------------------------------------------------------- custom dir
+
+
+def test_seed_custom_dir_keys_folder_metas_by_name(tmp_path, monkeypatch):
+    mod = _load_seeder()
+    _set_env(monkeypatch, tmp_path, guard_dir="Assets/Vendor/BmadLoop/Editor")
+    (tmp_path / "Assets").mkdir()
+
+    assert mod.main() == 0
+
+    editor = tmp_path / "Assets" / "Vendor" / "BmadLoop" / "Editor"
+    assert (editor / "SceneAutoSaveGuard.cs").is_file()
+    # the payload keys folder metas by folder NAME, so BmadLoop/ + Editor/ still get
+    # their fixed-GUID metas even under a custom parent...
+    assert (tmp_path / "Assets" / "Vendor" / "BmadLoop.meta").is_file()
+    assert (editor.parent / "Editor.meta").is_file()
+    # ...but Vendor/ has no payload meta, so Unity auto-generates that one (we ship none)
+    assert not (tmp_path / "Assets" / "Vendor.meta").exists()
+
+
+# ------------------------------------------------------------ version parsing
+
+
+def test_parse_version_tuple_and_missing(tmp_path, monkeypatch):
+    mod = _load_seeder()
+    assert mod._parse_version("// bmad-loop-scene-guard-version: 1.2.3\n") == (1, 2, 3)
+    assert mod._parse_version("no header here") is None


### PR DESCRIPTION
## What & why

A live Unity Editor raises **modal dialogs** that block `EditorApplication.update` — the pump the Unity-MCP plugin uses to dispatch every tool call. While a modal is up, all MCP calls time out and the whole bmad-loop run wedges. Two of them can be tripped by a normal run:

1. **"Scene '…' has been changed on disk. Reload the scene?"** — pops when git or an agent rewrites the open scene's `.unity` file underneath the Editor. A failed-attempt rollback does exactly this: `git reset --hard` rewrites the tracked scene the Editor still holds dirty.
2. **"Do you want to save the changes you made…?"** — pops on Editor quit with a dirty scene (e.g. a `per_worktree` Editor teardown).

**Root cause:** Unity-MCP GameObject tools (`com.ivanmurzak.unity.mcp`) call `MarkSceneDirty` but **never save**, so a project driven by the shared Editor accumulates a chronically dirty open scene — that dirty state is what raises the quit prompt and what makes the reload dialog destructive. (Live verification found the reload dialog can fire even for a **clean** open scene on Unity 6.5.2 — see the checklist below — which is why the quiesce closes scenes outright rather than merely saving them.)

The bundled Unity plugin now defends **in depth**, entirely inside the plugin (the only core change is two new observe-only lifecycle stages). No layer can block or veto a run.

## The four components

1. **Scene auto-save guard + seeder** (`unity_seed_assets.py` + `unity_assets/`). Seeds an editor-only `SceneAutoSaveGuard.cs` (with fixed-GUID `.meta` files) into `Assets/BmadLoop/Editor/` before the Editor's first import (at `pre_worktree_setup` in per_worktree mode; at `pre_ready_gate` in shared mode). The guard debounce-saves any dirty on-disk scene ~5 s after it goes dirty and saves-or-discards on quit, fixing the root cause. Toggle live from the Editor's **`BmadLoop` menu** (persists in `EditorPrefs`, default on). Seeding is idempotent + version-aware and never rewrites a file it didn't ship.
2. **Rollback quiesce** (engine `pre_rollback`/`post_rollback` emits + `unity_quiesce.py`). New **observe-only** engine stages fire around `_rollback_or_pause`'s `git reset --hard` (inside the reset branch only; the returned ctx is ignored and never routed through `_vetoed`). The plugin saves every open scene then opens an empty untitled scene so no tracked `.unity` is open during the reset, and refreshes assets after. The first call doubles as a wedge probe (fails fast on an unresponsive Editor); per-call `--timeout` + a subprocess kill + the overall `quiesce_timeout_sec` guarantee a wedged Editor can never stall the rollback.
3. **Prompt-fact injection** (`on_pre_session` + `unity_facts.md`). Appends the scene-save discipline to every non-empty dev/review prompt so the agent itself saves at the boundaries that would otherwise trip a modal.
4. **Detect-only dialog probe** (`unity_dialog_probe.py`, opt-in). A detached, X11/Linux-only watcher that polls xdotool for a visible Unity modal and **reports** it (JSONL + `ATTENTION` + best-effort `notify-send`) — it **never clicks, keys, or closes** any window. Launched at `pre_run` (shared) / `pre_worktree_setup` (per_worktree), reaped at `post_run` / worktree teardown via a pid-file handle + a `/proc` argv-scan backstop, and self-reaps when the engine pid dies. No-op where `DISPLAY`/`xdotool` is absent.

## Settings added (`[plugins.unity]`)

| Key | Type | Default | Effect |
| --- | --- | --- | --- |
| `install_scene_guard` | bool | `true` | Seed the scene auto-save guard into the project. |
| `scene_guard_dir` | str | `Assets/BmadLoop/Editor` | Project-relative install dir (must be under the asset root). |
| `quiesce_on_rollback` | bool | `true` | Save+close open scenes before a rollback's `git reset`, refresh after. |
| `quiesce_timeout_sec` | int | `60` | Outer kill budget for the quiesce helper. |
| `dialog_probe` | bool | `false` | Launch the detached detect-only modal probe (X11/xdotool only). |
| `dialog_probe_interval_sec` | int | `5` | Probe poll interval. |
| `dialog_probe_notify` | bool | `true` | Also fire a `notify-send` on a fresh detection (JSONL/ATTENTION always written). |

## Consumer-visible effects

- The seeded guard (`Assets/BmadLoop/Editor/SceneAutoSaveGuard.cs` + its asmdef + `.meta` files) is **committed into the consumer project** by story-finalize's `git add -A`. This is intended — the guard travels with the repo so any Editor that opens the project is protected. Seeding happens pre-baseline, so `verify.safe_rollback` never reclaims it. Disable with `install_scene_guard = false`.
- A new `BmadLoop` menu appears in the consumer's Editor (guard toggle + "Save Open Scenes Now").
- When `dialog_probe` is on, `<run_dir>/unity-dialog-probe.jsonl` and `ATTENTION` lines may be written.

## Live-editor verification checklist

Executed 2026-07-11 from a consumer project (Lights-Out; Unity 6.5.2, `unity-mcp-cli` 0.81.1, XWayland) — full results in [the verification comment](https://github.com/bmad-code-org/bmad-loop/pull/125#issuecomment-4949895208). It surfaced one required fix (`csharpCode`, landed in 49491bd) and two wrong expectations in this checklist, corrected below.

- [x] **Dirty-scene auto-save.** Dirty a saved scene via an MCP GameObject tool; after the debounce window, `[SceneAutoSaveGuard] auto-saved …` appears in the Editor log and the scene is clean.
- [x] **External rewrite of a clean open scene.** ~~The Editor reimports with **no** "changed on disk" modal.~~ **Finding:** on Unity 6.5.2 the modal fires **even for a clean scene** (and the Editor could hard-wedge after dismissal) — the guard's clean-scene invariant is necessary but not sufficient; the quiesce's scene-close is the real protection on the rollback path. Docs updated (7a3cbcd).
- [x] **Quit inside the debounce window → no prompt.** Verified via `OnWantsToQuit` directly (`allowQuit=True`, dirty scene saved) — `EditorApplication.Exit` is a hard exit that bypasses `wantsToQuit`, so it cannot exercise this path.
- [x] **Rollback with a dirtied scene → quiesce works.** After the `csharpCode` fix: rollback ran clean — no modal, window title → `Untitled` (scene-close ran), MCP live immediately, run finished. **Correction:** the quiesce writes no journal events; the marker is the `rollback-auto` journal entry plus the quiesce's stderr lines (the probe JSONL exists only when `dialog_probe` is on).
- [x] **`kill -STOP` the Editor → quiesce exits fast, rollback proceeds.** Wedge-probe failed fast in 15.07 s (CLI `--timeout`), ≪ the 60 s `quiesce_timeout_sec` budget; the rollback completed and the run was not stalled.

## Notes

- Only core change is the two observe-only `pre_rollback`/`post_rollback` emits in `engine.py` (inside the reset branch, ctx ignored). Everything else is plugin-local.
- Helper scripts are stdlib-only (plus bmad-loop's own dep-free pid/process helpers, run under `sys.executable`).
- The IvanMurzak CLI tool names/schemas and the xdotool dialog titles/window class are **unverified against a live build** and kept broad + best-effort on purpose; a mismatch degrades to "quiesce/detection skipped", never a crash. Override in a project-local plugin copy if your versions differ.
- Docs: `CHANGELOG.md`, `docs/game-engine-plugin-guide.md` (new modal-dialog section + updated stage tables), `docs/game-engine-mcp-guide.md` (new env-var tables), `docs/plugin-authoring-guide.md` (stage reference).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Unity scene auto-save guard to prevent dirty-scene modal stalls, including editor-only installation options.
  * Added optional detect-only modal-dialog monitoring that records JSONL, writes an attention file, and can send desktop notifications on supported Linux/X11.
  * Added rollback lifecycle hooks with a pre-quiesce phase and post-refresh behavior, with expanded configuration and documentation.
* **Bug Fixes**
  * Improved reaping/cleanup of Unity editor and monitoring processes during teardown.
* **Tests**
  * Added coverage for rollback hook emission, scene guarding, quiescing, dialog probing, settings schema, and cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
