### PR TITLE
fix: preserve seed file modes + pause on verify env faults (rc 126/127)

### DIFF
--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -1845,6 +1845,14 @@ class Engine:
         if not outcome.ok and outcome.fixable and self._fix_phase(task, outcome.reason):
             outcome = self._verify_review(task)
         if not outcome.ok:
+            # same event kind as the review-enabled loop so journal consumers
+            # see the structured env_fault flag on this path too
+            self.journal.append(
+                "review-verify-failed",
+                story_key=task.story_key,
+                reason=outcome.reason,
+                env_fault=outcome.env_fault,
+            )
             if not outcome.retryable:
                 # escalate-grade failure (environment fault, git error): a
                 # defer would just replay it on the next story — pause the run

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -1585,6 +1585,7 @@ class Engine:
                 session_status=result.status,
                 action=str(decision.action),
                 reason=decision.reason,
+                env_fault=bool(outcome is not None and outcome.env_fault),
             )
             self._save()
             if decision.action == Action.PROCEED:
@@ -1772,7 +1773,13 @@ class Engine:
                     "review-verify-failed",
                     story_key=task.story_key,
                     reason=outcome.reason,
+                    env_fault=outcome.env_fault,
                 )
+                if not outcome.retryable:
+                    # escalate-grade failure (environment fault, git error): a
+                    # repair session cannot fix it and another review cycle
+                    # would replay it — pause the run instead of burning budget
+                    self._escalate(task, outcome.reason)
                 if outcome.fixable and task.review_cycle < self.policy.limits.max_review_cycles:
                     # failing verify commands are dev work, not review work: a
                     # re-review of the same tree cannot make them pass. Repair
@@ -1838,6 +1845,10 @@ class Engine:
         if not outcome.ok and outcome.fixable and self._fix_phase(task, outcome.reason):
             outcome = self._verify_review(task)
         if not outcome.ok:
+            if not outcome.retryable:
+                # escalate-grade failure (environment fault, git error): a
+                # defer would just replay it on the next story — pause the run
+                self._escalate(task, outcome.reason)
             self._defer(task, f"verify failed with review disabled: {outcome.reason}")
             return
         self._commit(task)
@@ -2451,7 +2462,13 @@ class Engine:
                 attempt=task.attempt,
                 session_status=result.status,
                 ok=ok,
+                env_fault=bool(outcome is not None and outcome.env_fault),
             )
+            if outcome is not None and not outcome.ok and not outcome.retryable:
+                # escalate-grade failure (environment fault): another repair
+                # session cannot fix the run environment — stop spending the
+                # dev budget and pause for a human instead
+                self._escalate(task, outcome.reason)
             self._save()
             if ok:
                 return True

--- a/src/bmad_loop/install.py
+++ b/src/bmad_loop/install.py
@@ -330,7 +330,12 @@ def _copy_traversable(src, dst: Path) -> None:
         dst.mkdir(parents=True, exist_ok=True)
         for child in src.iterdir():
             _copy_traversable(child, dst / child.name)
+    elif isinstance(src, Path):
+        # real filesystem source (worktree seeds, non-zip package data): copy2
+        # preserves the mode so a seeded vendor/bin/* keeps +x (issue #126)
+        shutil.copy2(src, dst)
     else:
+        # zip-imported Traversable exposes no stat: content-only copy
         dst.write_bytes(src.read_bytes())
 
 

--- a/src/bmad_loop/verify.py
+++ b/src/bmad_loop/verify.py
@@ -61,6 +61,10 @@ class VerifyOutcome:
     # fixable failures carry concrete evidence (failing command output) that a
     # feedback-driven repair session can act on; non-fixable retries start over
     fixable: bool = False
+    # the failure is the run environment's, not the story's (verify command
+    # not found / not executable): no repair session can fix it and every
+    # story shares the same commands, so it must never charge attempt budgets
+    env_fault: bool = False
 
     @classmethod
     def passed(cls) -> "VerifyOutcome":
@@ -71,8 +75,10 @@ class VerifyOutcome:
         return cls(ok=False, reason=reason, fixable=fixable)
 
     @classmethod
-    def escalate(cls, reason: str, severity: str = "CRITICAL") -> "VerifyOutcome":
-        return cls(ok=False, reason=reason, severity=severity)
+    def escalate(
+        cls, reason: str, severity: str = "CRITICAL", env_fault: bool = False
+    ) -> "VerifyOutcome":
+        return cls(ok=False, reason=reason, severity=severity, env_fault=env_fault)
 
     @property
     def retryable(self) -> bool:
@@ -1393,6 +1399,14 @@ class CommandResult:
     output_tail: str
 
 
+# sh launcher convention (verify commands run shell=True): 126 = command found
+# but not executable, 127 = command not found. Both are environment faults —
+# deterministic for a given tree, unfixable by a repair session (issue #126:
+# seeded worktrees that lost +x burned dev attempts on no-op repairs). Windows
+# cmd signals these as 9009/1 instead, so it keeps the charged behavior.
+ENV_FAULT_RCS = frozenset({126, 127})
+
+
 def run_verify_commands(policy: Policy, cwd: Path) -> list[CommandResult]:
     results = []
     for command in policy.verify.commands:
@@ -1416,8 +1430,19 @@ def run_verify_commands(policy: Policy, cwd: Path) -> list[CommandResult]:
 
 def verify_commands_outcome(policy: Policy, cwd: Path) -> VerifyOutcome:
     """Run the policy's deterministic verify commands. Failures are fixable:
-    the captured output is concrete feedback a repair session can act on."""
+    the captured output is concrete feedback a repair session can act on —
+    except environment faults (ENV_FAULT_RCS), which escalate so the run
+    pauses for an environment fix instead of burning story budgets."""
     for result in run_verify_commands(policy, cwd):
+        if result.returncode in ENV_FAULT_RCS:
+            return VerifyOutcome.escalate(
+                f"verify environment fault (rc={result.returncode}): {result.command}\n"
+                "command not found / not executable — this is the run environment, "
+                "not the story; fix the environment, then re-arm the escalation "
+                "(the attempt budget resets on re-arm)\n"
+                f"{result.output_tail}",
+                env_fault=True,
+            )
         if result.returncode != 0:
             return VerifyOutcome.retry(
                 f"verify command failed (rc={result.returncode}): {result.command}\n"

--- a/src/bmad_loop/verify.py
+++ b/src/bmad_loop/verify.py
@@ -1432,8 +1432,12 @@ def verify_commands_outcome(policy: Policy, cwd: Path) -> VerifyOutcome:
     """Run the policy's deterministic verify commands. Failures are fixable:
     the captured output is concrete feedback a repair session can act on —
     except environment faults (ENV_FAULT_RCS), which escalate so the run
-    pauses for an environment fix instead of burning story budgets."""
-    for result in run_verify_commands(policy, cwd):
+    pauses for an environment fix instead of burning story budgets. An env
+    fault anywhere in the run wins over earlier ordinary failures: a repair
+    session dispatched for the ordinary failure would still run in the
+    broken environment."""
+    results = run_verify_commands(policy, cwd)
+    for result in results:
         if result.returncode in ENV_FAULT_RCS:
             return VerifyOutcome.escalate(
                 f"verify environment fault (rc={result.returncode}): {result.command}\n"
@@ -1443,6 +1447,7 @@ def verify_commands_outcome(policy: Policy, cwd: Path) -> VerifyOutcome:
                 f"{result.output_tail}",
                 env_fault=True,
             )
+    for result in results:
         if result.returncode != 0:
             return VerifyOutcome.retry(
                 f"verify command failed (rc={result.returncode}): {result.command}\n"

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -3763,6 +3763,8 @@ def test_skip_review_env_fault_escalates_not_defers(project):
     assert [s.role for s in adapter.sessions] == ["dev"]  # no fix session either
     assert engine.state.tasks["1-1-a"].phase == Phase.ESCALATED
     assert "rc=126" in engine.state.paused_reason
+    failed = [e for e in engine.journal.entries() if e["kind"] == "review-verify-failed"][-1]
+    assert failed["env_fault"] is True
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="sh env-fault exit codes (cmd reports 9009)")

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -3,6 +3,7 @@
 import os
 import re
 import signal
+import sys
 from pathlib import Path
 
 import pytest
@@ -3676,6 +3677,136 @@ def test_verify_commands_never_pass_defers_at_dev(project):
     assert summary.deferred == 1 and summary.done == 0
     assert [s.role for s in adapter.sessions] == ["dev", "dev"]
     assert "Resume the autonomous" in adapter.sessions[1].prompt
+
+
+# --------------------------------------------------- verify env faults (issue #126)
+
+
+def test_verify_env_fault_pauses_dev_without_burning_budget(project):
+    """rc 127 at the dev gate is the run environment's fault, not the story's:
+    the run pauses at the first story instead of spending max_dev_attempts on
+    repair sessions that cannot fix the environment."""
+    write_sprint(project, {"1-1-a": "ready-for-dev"})
+    policy = Policy(
+        gates=GatesPolicy(mode="none"),
+        notify=QUIET,
+        verify=VerifyPolicy(commands=("exit 127",)),
+    )
+    # only one dev session scripted: a repair session must never be requested
+    engine, adapter = make_engine(project, [dev_effect(project, "1-1-a")], policy=policy)
+    summary = engine.run()
+
+    assert summary.paused and summary.escalated == 1 and summary.deferred == 0
+    assert [s.role for s in adapter.sessions] == ["dev"]
+    task = engine.state.tasks["1-1-a"]
+    assert task.phase == Phase.ESCALATED
+    assert task.attempt == 1  # budget untouched beyond the one real session
+    assert engine.state.paused_stage == PAUSE_ESCALATION
+    assert "rc=127" in engine.state.paused_reason
+    decision = [e for e in engine.journal.entries() if e["kind"] == "dev-decision"][-1]
+    assert decision["env_fault"] is True
+
+
+def _self_disarming_script(project, name="check.sh"):
+    """A verify script that passes once, then strips its own exec bit — the
+    next invocation dies rc=126 (the issue's seeded-worktree fault, exactly)."""
+    script = project.project / name
+    script.write_text(f'#!/bin/sh\nchmod 644 "{script}"\nexit 0\n', encoding="utf-8")
+    script.chmod(0o755)
+    return script
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="sh env-fault exit codes (cmd reports 9009)")
+def test_review_verify_env_fault_escalates_instead_of_fix_session(project):
+    """An env fault at the review gate pauses the run — no fix session is
+    dispatched and no review cycles are burned re-verifying a broken environment."""
+    write_sprint(project, {"1-1-a": "ready-for-dev"})
+    script = _self_disarming_script(project)
+    policy = Policy(
+        gates=GatesPolicy(mode="none"),
+        notify=QUIET,
+        verify=VerifyPolicy(commands=(f'"{script}"',)),
+    )
+    engine, adapter = make_engine(
+        project,
+        [dev_effect(project, "1-1-a"), review_effect(project, "1-1-a", clean=True)],
+        policy=policy,
+    )
+    summary = engine.run()
+
+    assert summary.paused and summary.escalated == 1 and summary.deferred == 0
+    assert [s.role for s in adapter.sessions] == ["dev", "review"]  # no fix session
+    assert engine.state.tasks["1-1-a"].phase == Phase.ESCALATED
+    assert "rc=126" in engine.state.paused_reason
+    failed = [e for e in engine.journal.entries() if e["kind"] == "review-verify-failed"][-1]
+    assert failed["env_fault"] is True
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="sh env-fault exit codes (cmd reports 9009)")
+def test_skip_review_env_fault_escalates_not_defers(project):
+    """review.enabled = false: an env fault at the commit gates pauses the run
+    instead of deferring the story as if its code were broken."""
+    from bmad_loop.policy import ReviewPolicy
+
+    write_sprint(project, {"1-1-a": "ready-for-dev"})
+    script = _self_disarming_script(project)
+    policy = Policy(
+        gates=GatesPolicy(mode="none"),
+        notify=QUIET,
+        review=ReviewPolicy(enabled=False),
+        verify=VerifyPolicy(commands=(f'"{script}"',)),
+    )
+    engine, adapter = make_engine(project, [dev_effect(project, "1-1-a")], policy=policy)
+    summary = engine.run()
+
+    assert summary.paused and summary.escalated == 1 and summary.deferred == 0
+    assert [s.role for s in adapter.sessions] == ["dev"]  # no fix session either
+    assert engine.state.tasks["1-1-a"].phase == Phase.ESCALATED
+    assert "rc=126" in engine.state.paused_reason
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="sh env-fault exit codes (cmd reports 9009)")
+def test_fix_phase_env_fault_escalates_instead_of_looping(project):
+    """An env fault surfacing mid-fix-loop stops the loop — the remaining dev
+    budget is not spent on repair sessions against an unfixable environment."""
+    write_sprint(project, {"1-1-a": "ready-for-dev"})
+    marker = project.project / "fixed.marker"
+    script = project.project / "check.sh"
+    script.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    script.chmod(0o755)
+
+    def dev_with_marker(spec):
+        marker.write_text("ok\n")
+        return dev_effect(project, "1-1-a")(spec)
+
+    def breaking_review(spec):
+        marker.unlink()  # ordinary fixable failure: routes to a fix session
+        return review_effect(project, "1-1-a", clean=True)(spec)
+
+    def env_breaking_fix(spec):
+        marker.write_text("ok\n")
+        script.chmod(0o644)  # the re-verify now dies rc=126 — env fault
+        return SessionResult(
+            status="completed", result_json={"workflow": "auto-dev", "escalations": []}
+        )
+
+    policy = Policy(
+        gates=GatesPolicy(mode="none"),
+        notify=QUIET,
+        verify=VerifyPolicy(commands=(_file_exists_cmd(marker), f'"{script}"')),
+        limits=LimitsPolicy(max_dev_attempts=3),  # budget left — must not be spent
+    )
+    engine, adapter = make_engine(
+        project, [dev_with_marker, breaking_review, env_breaking_fix], policy=policy
+    )
+    summary = engine.run()
+
+    assert summary.paused and summary.escalated == 1 and summary.deferred == 0
+    assert [s.role for s in adapter.sessions] == ["dev", "review", "dev"]  # one fix, then stop
+    assert engine.state.tasks["1-1-a"].phase == Phase.ESCALATED
+    assert "rc=126" in engine.state.paused_reason
+    fix = [e for e in engine.journal.entries() if e["kind"] == "fix-decision"][-1]
+    assert fix["env_fault"] is True
 
 
 def test_max_stories_limit(project):

--- a/tests/test_escalation.py
+++ b/tests/test_escalation.py
@@ -46,6 +46,16 @@ def test_noncompleted_session_reescalates_resolved_redrive():
     assert decide_dev(task, crashed, None, POLICY).action == Action.PAUSE
 
 
+def test_env_fault_outcome_pauses_even_with_budget_left():
+    """An environment-fault verify outcome (rc 126/127 → CRITICAL escalate)
+    pauses immediately — the attempt budget is never consulted for it."""
+    task = _task(attempt=1)  # 1 < 2 -> budget remains
+    env_fault = VerifyOutcome.escalate("verify environment fault (rc=127): pint", env_fault=True)
+    decision = decide_dev(task, COMPLETED, env_fault, POLICY)
+    assert decision.action == Action.PAUSE
+    assert "rc=127" in decision.reason
+
+
 def test_review_exhausted_defers_normal_story():
     task = _task(review_cycle=2)  # 2 == max_review_cycles
     crashed = SessionResult(status="crashed")

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,5 +1,8 @@
 import json
+import sys
+import zipfile
 
+import pytest
 from conftest import git
 
 from bmad_loop import verify
@@ -8,6 +11,7 @@ from bmad_loop.install import (
     BASE_SKILLS,
     LEGACY_MODULE_SKILLS,
     MODULE_SKILLS,
+    _copy_traversable,
     install_into,
     merge_hooks,
     missing_base_skills,
@@ -788,3 +792,48 @@ def test_provision_worktree_seed_globs_shielded_in_local_exclude(project, tmp_pa
     exclude = (repo / ".git" / "info" / "exclude").read_text(encoding="utf-8").splitlines()
     assert "/.claude/skills/tests-run" in exclude
     assert git(wt, "status", "--short", "--", ".claude/skills/tests-run") == ""
+
+
+# ----------------------------------------------------------------- seed file modes (issue #126)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX exec bits")
+def test_provision_worktree_seed_preserves_exec_bit(tmp_path):
+    """A seeded executable (vendor/bin/*) keeps +x in the worktree — a byte-only
+    copy would strip the mode and the first verify command dies rc=127."""
+    wt, repo = tmp_path / "wt", tmp_path / "repo"
+    tool = repo / "vendor" / "bin" / "tool"
+    tool.parent.mkdir(parents=True)
+    tool.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    tool.chmod(0o755)
+
+    provision_worktree(wt, [], repo, seed_files=["vendor/bin/tool"])
+
+    assert (wt / "vendor" / "bin" / "tool").stat().st_mode & 0o111
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX exec bits")
+def test_provision_worktree_seed_globs_preserve_exec_bit(tmp_path):
+    """Exec bits survive the recursive directory walk of a glob-seeded tree."""
+    wt, repo = tmp_path / "wt", tmp_path / "repo"
+    tool = repo / "node_modules" / ".bin" / "eslint"
+    tool.parent.mkdir(parents=True)
+    tool.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    tool.chmod(0o755)
+
+    provision_worktree(wt, [], repo, seed_globs=["node_modules/*"])
+
+    assert (wt / "node_modules" / ".bin" / "eslint").stat().st_mode & 0o111
+
+
+def test_copy_traversable_zip_source_copies_content(tmp_path):
+    """The zip-import fallback: a zipfile.Path source has no .stat(), so the
+    copy must stay content-only and not crash (the docstring's contract)."""
+    zf_path = tmp_path / "pkg.zip"
+    with zipfile.ZipFile(zf_path, "w") as zf:
+        zf.writestr("pkg/skill/SKILL.md", "tool")
+    dst = tmp_path / "out"
+
+    _copy_traversable(zipfile.Path(zf_path, "pkg/"), dst)
+
+    assert (dst / "skill" / "SKILL.md").read_text() == "tool"

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1,6 +1,7 @@
 import dataclasses
 import os
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -267,6 +268,50 @@ def test_verify_review_sprint_not_done(project):
     task.spec_file = str(sp)
     out = verify.verify_review(task, project, Policy())
     assert not out.ok and "sprint-status" in out.reason
+
+
+# --------------------------------------------------- verify command exit codes (issue #126)
+
+
+@pytest.mark.parametrize("rc", [126, 127])
+def test_verify_commands_env_fault_rc_escalates(tmp_path, rc):
+    """The shell's environment faults (126 = not executable, 127 = not found)
+    escalate instead of retrying: a repair session cannot fix the environment,
+    so they must never charge the story's attempt budget."""
+    policy = Policy(verify=VerifyPolicy(commands=(f"exit {rc}",)))
+    out = verify.verify_commands_outcome(policy, tmp_path)
+    assert not out.ok
+    assert out.severity == "CRITICAL"
+    assert out.env_fault
+    assert not out.retryable and not out.fixable
+    assert f"rc={rc}" in out.reason
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="cmd reports 9009, not 127")
+def test_verify_commands_missing_binary_is_env_fault(tmp_path):
+    """Realism check: an actual missing command yields sh's 127 → env fault."""
+    policy = Policy(verify=VerifyPolicy(commands=("definitely-not-a-real-cmd-126126",)))
+    out = verify.verify_commands_outcome(policy, tmp_path)
+    assert out.env_fault and "rc=127" in out.reason
+
+
+def test_verify_commands_rc1_stays_fixable_retry(tmp_path):
+    """Ordinary failures (tests failing) keep the fixable-retry classification."""
+    policy = Policy(verify=VerifyPolicy(commands=("exit 1",)))
+    out = verify.verify_commands_outcome(policy, tmp_path)
+    assert not out.ok and out.fixable and out.retryable and not out.env_fault
+
+
+def test_verify_commands_timeout_stays_charged(tmp_path, monkeypatch):
+    """A timeout is plausibly the story's own tests hanging — it keeps the
+    fixable-retry classification, not the env-fault escalate."""
+    monkeypatch.setattr(
+        verify,
+        "run_verify_commands",
+        lambda policy, cwd: [verify.CommandResult("pytest", -1, "timed out")],
+    )
+    out = verify.verify_commands_outcome(Policy(), tmp_path)
+    assert not out.ok and out.fixable and not out.env_fault
 
 
 def make_bundle_task(paths, dw_ids=("DW-1", "DW-2")):

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -295,6 +295,18 @@ def test_verify_commands_missing_binary_is_env_fault(tmp_path):
     assert out.env_fault and "rc=127" in out.reason
 
 
+def test_env_fault_takes_precedence_over_earlier_ordinary_failure(tmp_path):
+    """A mixed run must not classify by the first failure it sees: an env
+    fault later in the command list still escalates — a repair session
+    dispatched for the earlier rc=1 would run in the broken environment."""
+    policy = Policy(verify=VerifyPolicy(commands=("exit 1", "exit 127")))
+    out = verify.verify_commands_outcome(policy, tmp_path)
+    assert not out.ok
+    assert out.env_fault
+    assert not out.retryable and not out.fixable
+    assert "rc=127" in out.reason
+
+
 def test_verify_commands_rc1_stays_fixable_retry(tmp_path):
     """Ordinary failures (tests failing) keep the fixable-retry classification."""
     policy = Policy(verify=VerifyPolicy(commands=("exit 1",)))


### PR DESCRIPTION
Fixes #126.

## Problem

Both claims in #126 validated against HEAD:

1. `_copy_traversable` copied every seeded file via `dst.write_bytes(src.read_bytes())`, discarding file modes. Every `[scm] worktree_seed` / plugin `seed_globs` tree (e.g. `vendor/`, `node_modules/`) arrived in the worktree with non-executable binaries, and the first verify command died rc=127.
2. The engine collapsed verify exit codes to a boolean, so rc 126/127 (the shell's *found-but-not-executable* / *not-found* environment faults) was charged against `max_dev_attempts` exactly like broken story code — spawning no-op repair sessions and, on the reference run, falsely deferring a story.

## Fix

**Commit 1 — root cause.** Real-filesystem sources now copy via `shutil.copy2` (mode-preserving, matching every other copy site in the repo); the byte-only walk remains solely for zip-imported Traversables, which expose no `stat`. Seeded `vendor/bin/*` keep `+x`.

**Commit 2 — misclassification.** `verify_commands_outcome` classifies rc 126/127 as a CRITICAL escalate carrying a new `VerifyOutcome.env_fault` flag, so the run **pauses at the first environment fault** instead of burning story budgets. This deliberately diverges from the issue's "retry without decrementing" proposal: these rcs are deterministic for a given tree and shared by every story's verify commands, so uncharged retries either loop forever or replay the same wall on all N stories. The uncharged semantics land via existing machinery — `rearm_escalation` resets `task.attempt = 0`, so the story re-drives with a fresh budget once the environment is fixed. The review loop, skip-review path, and `_fix_phase` gain matching escalate branches (no fix sessions dispatched against an unfixable environment; also closes a latent hole where a shared-gate `GitError` escalate burned review cycles). Journal `dev-decision` / `review-verify-failed` / `fix-decision` events carry `env_fault`.

Out of scope, documented in-code: timeouts (rc -1) stay charged (a hang is plausibly the story's own tests); Windows `cmd` signals these faults as 9009/1 and keeps today's behavior.

The issue's shipped workarounds (`chmod +x vendor/bin/*` guard, `@php vendor/bin/...`) become unnecessary.

## Tests

- Seed exec-bit preservation (`seed_files` + `seed_globs`), plus a `zipfile.Path` fallback guard; the exec-bit tests fail on the old copy code.
- rc classification unit tests (126/127 escalate, rc 1 stays fixable retry, timeout stays charged, real missing binary yields 127).
- Engine scenarios: dev-gate rc 127 pauses with exactly one dev session and `attempt == 1`; review-gate rc 126 escalates with no fix session; skip-review rc 126 escalates instead of deferring; mid-fix-loop rc 126 stops the loop with budget left. All verified to fail without the fix.
- Full suite: 2223 passed. `trunk check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Treat environment-related verification failures (including missing/non-executable commands) as non-retryable and critical.
  - Runs now pause/escalate immediately instead of continuing through fix/repair loops or deferring to later review steps.
  - Environment-fault details are recorded consistently across development, review, and repair stages.
  - Seed provisioning now preserves executable permissions for seeded files and globbed content, including content copied from packaged sources.
- **Tests**
  - Added coverage for environment-fault escalation behavior and verify exit-code classification/precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->