### PR TITLE
fix(tui): guard raiser-side multiplexer calls in action handlers

### DIFF
--- a/src/bmad_loop/tui/app.py
+++ b/src/bmad_loop/tui/app.py
@@ -932,8 +932,11 @@ class BmadLoopApp(App[None]):
         try:
             windows = launch.prune_ctl_windows(self.project)
         except MultiplexerError as e:
+            # prune_sessions already killed the agent sessions above; surface the
+            # ctl-window failure but keep reporting that completed work (and the
+            # unknown-pid warning) rather than swallowing it on an early return.
             self.call_from_thread(self.notify, str(e), severity="error")
-            return
+            windows = []
         if unknown:
             self.call_from_thread(
                 self.notify,

--- a/src/bmad_loop/tui/app.py
+++ b/src/bmad_loop/tui/app.py
@@ -13,6 +13,7 @@ import subprocess
 import time
 from collections.abc import Callable
 from pathlib import Path
+from typing import TypeVar
 
 from rich.text import Text
 from textual import work
@@ -60,6 +61,9 @@ def _engine_possibly_live(run_dir: Path) -> bool:
     # whose pid exists but is unreadable). A legacy pid-less run's 'unknown' just
     # means no session was found — it must not flag every old finished run.
     return live == "unknown" and runs.read_pid(run_dir) is not None
+
+
+_T = TypeVar("_T")
 
 
 class BmadLoopApp(App[None]):
@@ -153,6 +157,21 @@ class BmadLoopApp(App[None]):
             return False
         self.notify("multiplexer backend unavailable — launch/attach disabled", severity="error")
         return True
+
+    def _mux_guarded(self, probe: Callable[[], _T]) -> tuple[bool, _T | None]:
+        """Run a raiser-side multiplexer *read* probe from a foreground action
+        handler, converting a transport failure into an error toast. Returns
+        (ok, value); when ok is False a MultiplexerError was caught and toasted
+        and the handler must abort — a backend hiccup after the availability
+        pre-gate fails the action soft instead of crashing the TUI. Foreground
+        only: worker threads marshal notify() via call_from_thread (see
+        _cleanup_sessions_worker), and launch-layer failures convert to
+        LaunchError (see launch._ensure_ctl_session)."""
+        try:
+            return True, probe()
+        except MultiplexerError as e:
+            self.notify(str(e), severity="error")
+            return False, None
 
     def _guarded(self, go: Callable[[], None]) -> None:
         """Pre-launch guard mirroring the CLI: clean worktree required, plus a
@@ -353,7 +372,9 @@ class BmadLoopApp(App[None]):
             return
         session = runs.session_name(run_id)
         window = launch.ctl_window(run_id)
-        agent_live = launch.session_exists(session)
+        ok, agent_live = self._mux_guarded(lambda: launch.session_exists(session))
+        if not ok:
+            return
         # A sweep blocked on a decision prompt has no agent session — the
         # human answers in the orchestrator's ctl window. Otherwise prefer the
         # live agent session, falling back to the ctl window between sessions.
@@ -378,10 +399,8 @@ class BmadLoopApp(App[None]):
         self._attach_to_target(target)
 
     def _attach_to_target(self, target: str, return_window: str | None = None) -> None:
-        try:
-            argv = runs.attach_target_argv(target)
-        except MultiplexerError as e:
-            self.notify(str(e), severity="error")
+        ok, argv = self._mux_guarded(lambda: runs.attach_target_argv(target))
+        if not ok:
             return
         # Backend-honest inside-the-multiplexer probe (current_pane_id() is None
         # outside): inside, attach_target_argv returned the fire-and-forget
@@ -907,7 +926,14 @@ class BmadLoopApp(App[None]):
         # killed and unknown come from prune_sessions' single partition sample,
         # so the warning below only ever names sessions that were actually pruned
         killed, _live, unknown = runs.prune_sessions(self.project)
-        windows = launch.prune_ctl_windows(self.project)
+        # prune_ctl_windows probes has_session on the shared ctl session, a
+        # raiser-side call; on a worker thread the toast must be marshalled, and
+        # notify() must not be called directly (see _mux_guarded — foreground only).
+        try:
+            windows = launch.prune_ctl_windows(self.project)
+        except MultiplexerError as e:
+            self.call_from_thread(self.notify, str(e), severity="error")
+            return
         if unknown:
             self.call_from_thread(
                 self.notify,

--- a/src/bmad_loop/tui/launch.py
+++ b/src/bmad_loop/tui/launch.py
@@ -245,12 +245,16 @@ def prune_ctl_windows(project: Path) -> list[str]:
 
 def _ensure_ctl_session(project: Path) -> None:
     mux = get_multiplexer()
-    if mux.has_session(CTL_SESSION):
-        return
+    # has_session is raiser-side (a server-backed backend can fail the probe after
+    # the availability pre-gate). Keep it inside the try so a transport failure
+    # converts to LaunchError, which the TUI launch/resume/resolve handlers already
+    # catch — otherwise the raw MultiplexerError slips past them and crashes the app.
     try:
+        if mux.has_session(CTL_SESSION):
+            return
         mux.new_session(CTL_SESSION, project)
     except MultiplexerError as e:
-        raise LaunchError(f"multiplexer new-session failed: {e}") from e
+        raise LaunchError(f"multiplexer ctl-session setup failed: {e}") from e
 
 
 def cli_argv(*tail: str) -> list[str]:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1187,12 +1187,14 @@ async def test_cleanup_unknown_sessions_notifies(project, monkeypatch):
 async def test_cleanup_sessions_mux_error_notifies(project, monkeypatch):
     # prune_ctl_windows probes has_session on the shared ctl session (raiser-side),
     # so it can raise on a server-backed backend. The worker must marshal the error
-    # to a toast via call_from_thread and return, not crash on an unhandled worker
-    # exception. (prune_sessions is stubbed benign — only sentinel-side seam calls.)
+    # to a toast via call_from_thread without crashing on an unhandled worker
+    # exception — AND, because prune_sessions already killed the agent sessions
+    # before prune_ctl_windows ran, it must still report that completed work (the
+    # "removed N session(s)" summary and the unknown-pid warning), not swallow it.
     from bmad_loop import runs
 
     monkeypatch.setattr(launch, "mux_available", lambda: True)
-    monkeypatch.setattr(runs, "prune_sessions", lambda _p: ([], [], set()))
+    monkeypatch.setattr(runs, "prune_sessions", lambda _p: (["odd-1"], [], {"odd-1"}))
 
     def boom(_p):
         raise MultiplexerError("ctl window probe unreachable")
@@ -1208,6 +1210,10 @@ async def test_cleanup_sessions_mux_error_notifies(project, monkeypatch):
         await until(
             pilot, lambda: any("ctl window probe unreachable" in m for m in notifications(app))
         )
+        # the ctl-window failure is surfaced, but the session pruning that already
+        # completed is still reported — not swallowed by an early return
+        await until(pilot, lambda: any("unverifiable engine pid" in m for m in notifications(app)))
+        assert any("removed 1 session(s)" in m for m in notifications(app))
         assert isinstance(app.screen, DashboardScreen)  # worker failed soft, no crash
 
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1184,6 +1184,33 @@ async def test_cleanup_unknown_sessions_notifies(project, monkeypatch):
         assert any("removed 1 session(s)" in m for m in notifications(app))
 
 
+async def test_cleanup_sessions_mux_error_notifies(project, monkeypatch):
+    # prune_ctl_windows probes has_session on the shared ctl session (raiser-side),
+    # so it can raise on a server-backed backend. The worker must marshal the error
+    # to a toast via call_from_thread and return, not crash on an unhandled worker
+    # exception. (prune_sessions is stubbed benign — only sentinel-side seam calls.)
+    from bmad_loop import runs
+
+    monkeypatch.setattr(launch, "mux_available", lambda: True)
+    monkeypatch.setattr(runs, "prune_sessions", lambda _p: ([], [], set()))
+
+    def boom(_p):
+        raise MultiplexerError("ctl window probe unreachable")
+
+    monkeypatch.setattr(launch, "prune_ctl_windows", boom)
+    make_run(project.project, "20260611-100000-aaaa")
+    app = BmadLoopApp(project.project)
+    async with app.run_test() as pilot:
+        await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
+        await pilot.press("c")
+        await until(pilot, lambda: isinstance(app.screen, ConfirmModal))
+        await pilot.click(await ready(pilot, "#ok"))
+        await until(
+            pilot, lambda: any("ctl window probe unreachable" in m for m in notifications(app))
+        )
+        assert isinstance(app.screen, DashboardScreen)  # worker failed soft, no crash
+
+
 async def test_resume_finished_run_refused(project, monkeypatch):
     monkeypatch.setattr(launch, "mux_available", lambda: True)
     make_run(project.project, "20260611-100000-aaaa", finished=True)
@@ -1243,6 +1270,30 @@ async def test_attach_multiplexer_error_notifies(project, monkeypatch):
         await pilot.press("a")
         await until(
             pilot, lambda: any("backend server not reachable" in m for m in notifications(app))
+        )
+        assert isinstance(app.screen, DashboardScreen)  # the action failed soft
+
+
+async def test_attach_session_probe_error_notifies(project, monkeypatch):
+    # session_exists probes has_session, a raiser-side call: on a server-backed
+    # backend it can raise after the availability pre-gate (server unreachable /
+    # torn down in between). action_attach routes it through _mux_guarded, so the
+    # TUI toasts the error and aborts the attach instead of crashing the app.
+    monkeypatch.setattr(launch, "mux_available", lambda: True)
+    monkeypatch.setattr(launch, "ctl_window", lambda run_id: None)
+
+    def boom(_session):
+        raise MultiplexerError("session probe unreachable")
+
+    monkeypatch.setattr(launch, "session_exists", boom)
+    make_run(project.project, "20260611-100000-aaaa")
+    app = BmadLoopApp(project.project)
+    async with app.run_test() as pilot:
+        await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
+        await until(pilot, lambda: dashboard(app).selected_run_id is not None)
+        await pilot.press("a")
+        await until(
+            pilot, lambda: any("session probe unreachable" in m for m in notifications(app))
         )
         assert isinstance(app.screen, DashboardScreen)  # the action failed soft
 

--- a/tests/test_tui_launch.py
+++ b/tests/test_tui_launch.py
@@ -203,6 +203,22 @@ def test_new_window_failure_raises(monkeypatch, tmp_path: Path):
         launch.start_run_detached(tmp_path, "RID")
 
 
+def test_ensure_ctl_session_probe_failure_raises_launch_error(monkeypatch, tmp_path: Path):
+    # has_session is raiser-side: a transport failure (timeout / missing binary) on
+    # the ctl-session probe must convert to LaunchError so the TUI's launch/resume/
+    # resolve handlers (which catch LaunchError) surface a toast instead of crashing
+    # on the raw MultiplexerError that would otherwise slip past their except clause.
+    def failing_run(argv, **kwargs):
+        if argv[1] == "has-session":
+            raise OSError("backend server not reachable")
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(tmux_base.subprocess, "run", failing_run)
+    monkeypatch.setattr(tmux_base.shutil, "which", lambda name: f"/usr/bin/{name}")
+    with pytest.raises(launch.LaunchError, match="ctl-session setup failed"):
+        launch.start_run_detached(tmp_path, "RID")
+
+
 def test_session_exists(monkeypatch):
     fake = FakeRun(has_session_rc=0)
     monkeypatch.setattr(tmux_base.subprocess, "run", fake)


### PR DESCRIPTION
## Summary

Closes #143. Any **raiser-side** multiplexer seam call (one that raises `MultiplexerError` on a transport failure — `has_session` and friends) made from a Textual action handler with no `try/except` propagates out of the handler and **crashes the whole TUI**. Commit `8ed66e8` fixed one instance (`attach_target_argv` in `_attach_to_target`); this PR closes the rest of the class.

Auditing every handler, **only calls routing to `has_session`** were both unguarded and reachable. The other raiser-side methods are already guarded (`attach_target_argv`; `new_*` → `LaunchError`), contract-sentinel-side (`available`, `list_windows`, `current_pane_id`, `select_window`, `kill_window`, `target`, …), or not reached from the TUI at all (`send_text`, `list_window_ids`, `window_alive` — engine/probe only). The dashboard poll's `has_session` was already guarded (`tui/data.py`).

## Three fix sites, three contexts

| Fix | Site | Change |
|-----|------|--------|
| **A** | `launch._ensure_ctl_session` | `has_session` sat **outside** the existing `try`, so its `MultiplexerError` escaped as-is and slipped past the launch/resume/resolve handlers' `except launch.LaunchError`. Moved inside the `try` → converts to `LaunchError`, hardening six handlers with **zero `app.py` change**. |
| **B** | `action_attach` (the issue's named line ~356) | The `session_exists` probe now routes through a new `_mux_guarded` helper that toasts the error and aborts the attach. |
| **C** | `_cleanup_sessions_worker` | `prune_ctl_windows` (probes `has_session` on the shared ctl session) is guarded on the worker thread with a `call_from_thread` toast + return. |

### `_mux_guarded` helper

A new `BmadLoopApp._mux_guarded(probe) -> (ok, value)` unifies the **foreground** convention: it backs both the new `action_attach` guard and the refactored `_attach_to_target` guard (behavior unchanged — the existing `test_attach_multiplexer_error_notifies` still passes). Fix A (LaunchError conversion, launch layer) and Fix C (worker `call_from_thread`) stay inline where the helper can't apply — Textual forbids `call_from_thread` from the main thread, so no single helper covers both.

## Out of scope

The CLI `cmd_attach` path (`cli.py` → `launch.attach_plan` → `session_exists`) is also unguarded, but this issue is TUI-scoped ("crashes the whole TUI"); a one-shot CLI surfacing a traceback + nonzero exit is a lesser problem. A tidy follow-up could mirror how `cmd_mux` already handles `MultiplexerError`.

## Tests

One behavioral test per fix, modeled on existing idioms:
- **A** — `test_ensure_ctl_session_probe_failure_raises_launch_error` (mirrors `test_new_window_failure_raises`): a `has-session` transport failure converts to `LaunchError`.
- **B** — `test_attach_session_probe_error_notifies` (mirrors `test_attach_multiplexer_error_notifies`): a raising `session_exists` yields a toast and a soft-failed attach, app stays on the dashboard.
- **C** — `test_cleanup_sessions_mux_error_notifies`: a raising `prune_ctl_windows` in the worker yields a toast, no crash.

## Verification

- Full suite: **2262 passed, 1 skipped**.
- `ruff` clean, `trunk check` clean.

Depends on #136/#137/#141/#142 (all merged).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when connecting to or managing terminal sessions.
  * The dashboard now displays helpful notifications instead of crashing when session operations fail.
  * Launch failures during terminal session setup are reported consistently.
  * Background session cleanup now fails gracefully while keeping the interface responsive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->