### PR TITLE
fix: accept ancestor baselines for dw bundles; auto-recover unit worktrees on retry (#161)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,25 @@ PATH)`, the TUI notifies `multiplexer backend unavailable — launch/attach disa
 
 ### Fixed
 
+- **Deferred-work bundles that adopt an existing story spec pass the baseline gate (#161).** A
+  "follow-up review of story X" bundle is routed by `bmad-dev-auto` into that story's done
+  spec, whose `baseline_revision` is the story's original dev baseline — necessarily older
+  than the bundle's worktree cut, so the exact-match gate failed every such bundle after the
+  session had already done its work. The bundle gate now accepts a claimed baseline that is
+  an _ancestor_ of the orchestrator-recorded one (the session diffed a superset of the
+  unit's changes); diverged or unknown baselines still fail, any git fault in the probe
+  reads as not-an-ancestor, and sprint/stories modes keep the exact-match requirement.
+
+- **A failed attempt inside a unit worktree auto-recovers instead of pausing with in-place
+  instructions (#161).** The mid-drive dev retry was the only recovery path without an
+  isolation guard: with `rollback_on_failure = false` it paused the run with manual-recovery
+  instructions aimed at the operator's checkout — whose HEAD _is_ the baseline under
+  worktree isolation, while the commits sat on the unit branch, so following them literally
+  did nothing and invited a destructive reset of a tree the attempt never touched. A mounted
+  unit worktree is disposable: the attempt's commits are parked on `attempt-preserve/` refs
+  and the worktree resets regardless of the flag, which gates in-place (`isolation = "none"`)
+  recovery only. The remaining reachable pauses name their tree (`git -C "<root>" …`).
+
 - **A failed worktree teardown no longer crashes the run after the merge landed (#139).** When a
   process the just-ended session left running (e.g. pytest recreating `.pytest_cache`) makes
   `git worktree remove` fail with ENOTEMPTY, git still drops its admin entry, so the `force=True`

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -872,7 +872,16 @@ class Engine:
         if task.baseline_commit and not dirty:
             self.journal.append("rollback-skipped-clean", story_key=task.story_key)
             return
-        if resolved or self.policy.scm.rollback_on_failure:
+        # A mounted unit worktree is disposable by design: its branch never
+        # touches the operator's checkout and the attempt's work is parked on
+        # recovery refs before any reset. `scm.rollback_on_failure` gates
+        # *in-place* (isolation="none") recovery only — pausing here would emit
+        # main-checkout reset instructions for a tree the operator never works
+        # in (#161). Compared by path, not by policy: a worktree-mode call that
+        # reaches this method *outside* a mounted unit (e.g. resume with no
+        # worktree recorded) still targets the main checkout and must pause.
+        in_unit_worktree = self.workspace.root != self.paths.repo_root
+        if resolved or in_unit_worktree or self.policy.scm.rollback_on_failure:
             self.journal.append(
                 "rollback-auto",
                 story_key=task.story_key,
@@ -1096,11 +1105,18 @@ class Engine:
         escalation never reaches here — `_rollback_or_pause` auto-recovers that
         human-initiated re-drive regardless of `scm.rollback_on_failure`."""
         short = baseline[:12] or "<baseline_commit>"
+        # Name the tree every instruction targets. Usually the main checkout,
+        # but a preserve-failure pause can fire while a unit worktree is
+        # mounted — a bare "current HEAD" / `git reset --hard` there reads as
+        # the operator's own checkout (whose HEAD is typically *at* the
+        # baseline, making the quoted commit range empty) and invites a
+        # destructive reset of a tree the attempt never touched (#161).
+        root = self.workspace.root
         commits: list[str] = []
         if baseline:
             # advisory probe: a git fault here must not block the pause itself
             try:
-                commits = verify.commits_above(self.workspace.root, baseline)
+                commits = verify.commits_above(root, baseline)
             except verify.GitError:
                 commits = []
         if preserve_failed:
@@ -1110,12 +1126,12 @@ class Engine:
                 "baseline, but a recovery ref for those commits could not be created, "
                 "so the automatic rollback was refused rather than `reset --hard` "
                 "past (and discard) them. **Your commits are intact at the current "
-                "HEAD.**\n"
-                "  1. **Save them first** — e.g. `git branch my-rescue HEAD` (the "
-                f"commits are `{short}..HEAD`).\n"
+                f"HEAD of `{root}`.**\n"
+                f"  1. **Save them first** — e.g. `git -C {root} branch my-rescue "
+                f"HEAD` (the commits are `{short}..HEAD` there).\n"
                 "  2. Only once they are safe, discard the attempt if you want to: "
-                f"`git reset --hard {short}`, then review/remove leftover untracked "
-                "files.\n"
+                f"`git -C {root} reset --hard {short}`, then review/remove leftover "
+                "untracked files.\n"
                 f"Then run `bmad-loop resume {self.state.run_id}`."
             )
         elif commits:
@@ -1123,22 +1139,22 @@ class Engine:
                 "**ACTION REQUIRED — manual recovery needed (committed work present)**\n"
                 f"Story **{task.story_key}**'s attempt was stopped with auto-rollback "
                 "OFF, and it **committed work above its baseline**. **Your commits "
-                "are intact at the current HEAD.** They may already be integrated "
-                "or pushed to a remote — do NOT reset before checking.\n"
-                f"  1. **Save them first** — e.g. `git branch my-rescue HEAD` (the "
-                f"commits are `{short}..HEAD`).\n"
+                f"are intact at the current HEAD of `{root}`.** They may already be "
+                "integrated or pushed to a remote — do NOT reset before checking.\n"
+                f"  1. **Save them first** — e.g. `git -C {root} branch my-rescue "
+                f"HEAD` (the commits are `{short}..HEAD` there).\n"
                 "  2. Check whether they are already integrated (merged, pushed to "
                 "a remote, referenced by open PRs) before discarding anything.\n"
                 "  3. Only if you decide to discard the attempt: "
-                f"`git reset --hard {short}`, then review/remove leftover untracked "
-                "files.\n"
+                f"`git -C {root} reset --hard {short}`, then review/remove leftover "
+                "untracked files.\n"
                 f"Then run `bmad-loop resume {self.state.run_id}`."
             )
         else:
             why = (
                 f"Story **{task.story_key}**'s attempt was stopped and auto-rollback "
-                "is OFF, so the working tree was left exactly as-is for you to "
-                "inspect.\n"
+                f"is OFF, so the working tree at `{root}` was left exactly as-is "
+                "for you to inspect.\n"
             )
             notice = (
                 "**ACTION REQUIRED — manual rollback needed**\n"
@@ -1146,8 +1162,8 @@ class Engine:
                 "To discard this attempt yourself:\n"
                 "  1. **BACK UP any untracked files you want to keep** — the reset "
                 "below deletes uncommitted work.\n"
-                f"  2. `git reset --hard {short}` then review/remove leftover "
-                "untracked files.\n"
+                f"  2. `git -C {root} reset --hard {short}` then review/remove "
+                "leftover untracked files.\n"
                 "  3. **Restore the files you backed up in step 1.**\n"
                 f"Then run `bmad-loop resume {self.state.run_id}`. To let the "
                 "orchestrator do a safe automatic rollback next time, enable "

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -823,7 +823,7 @@ class Engine:
         return tuple(out)
 
     def _rollback_or_pause(self, task: StoryTask, *, cause: str = "stopped") -> None:
-        """Recover from an in-place attempt that won't proceed.
+        """Recover from an attempt that won't proceed.
 
         No-op when the tree is already at the attempt's baseline (nothing this
         attempt touched, ignoring orchestrator-owned artifact folders): neither a
@@ -841,11 +841,15 @@ class Engine:
         not read as a failed attempt) and preserved through every reset — so a
         later mid-re-drive retry/defer reset can't silently revert the correction.
 
-        Otherwise (a stopped/abandoned attempt) the flag governs: OFF (default)
-        leaves the working tree untouched and emits a bold manual-recovery notice
-        that pauses the run (stop-and-wait); ON does a clean reset to baseline.
-        Either way pre-existing untracked files are preserved; there is no blanket
-        ``git clean``."""
+        Otherwise (a stopped/abandoned attempt) recovery depends on where the
+        attempt ran. Inside a mounted unit worktree it always auto-recovers: the
+        worktree is disposable, the attempt's work is parked on preserve refs
+        before the reset, and ``scm.rollback_on_failure`` gates *in-place*
+        (isolation="none") recovery only (#161). In the main checkout the flag
+        governs: OFF (default) leaves the working tree untouched and emits a bold
+        manual-recovery notice that pauses the run (stop-and-wait); ON does a
+        clean reset to baseline. Either way pre-existing untracked files are
+        preserved; there is no blanket ``git clean``."""
         resolved = cause == "resolved"
         # preserve the corrected spec for the whole re-drive, not just the first
         # reset; the auto-recover (pause-vs-reset) decision below is unaffected.
@@ -1127,10 +1131,10 @@ class Engine:
                 "so the automatic rollback was refused rather than `reset --hard` "
                 "past (and discard) them. **Your commits are intact at the current "
                 f"HEAD of `{root}`.**\n"
-                f"  1. **Save them first** — e.g. `git -C {root} branch my-rescue "
+                f'  1. **Save them first** — e.g. `git -C "{root}" branch my-rescue '
                 f"HEAD` (the commits are `{short}..HEAD` there).\n"
                 "  2. Only once they are safe, discard the attempt if you want to: "
-                f"`git -C {root} reset --hard {short}`, then review/remove leftover "
+                f'`git -C "{root}" reset --hard {short}`, then review/remove leftover '
                 "untracked files.\n"
                 f"Then run `bmad-loop resume {self.state.run_id}`."
             )
@@ -1141,12 +1145,12 @@ class Engine:
                 "OFF, and it **committed work above its baseline**. **Your commits "
                 f"are intact at the current HEAD of `{root}`.** They may already be "
                 "integrated or pushed to a remote — do NOT reset before checking.\n"
-                f"  1. **Save them first** — e.g. `git -C {root} branch my-rescue "
+                f'  1. **Save them first** — e.g. `git -C "{root}" branch my-rescue '
                 f"HEAD` (the commits are `{short}..HEAD` there).\n"
                 "  2. Check whether they are already integrated (merged, pushed to "
                 "a remote, referenced by open PRs) before discarding anything.\n"
                 "  3. Only if you decide to discard the attempt: "
-                f"`git -C {root} reset --hard {short}`, then review/remove leftover "
+                f'`git -C "{root}" reset --hard {short}`, then review/remove leftover '
                 "untracked files.\n"
                 f"Then run `bmad-loop resume {self.state.run_id}`."
             )
@@ -1162,7 +1166,7 @@ class Engine:
                 "To discard this attempt yourself:\n"
                 "  1. **BACK UP any untracked files you want to keep** — the reset "
                 "below deletes uncommitted work.\n"
-                f"  2. `git -C {root} reset --hard {short}` then review/remove "
+                f'  2. `git -C "{root}" reset --hard {short}` then review/remove '
                 "leftover untracked files.\n"
                 "  3. **Restore the files you backed up in step 1.**\n"
                 f"Then run `bmad-loop resume {self.state.run_id}`. To let the "

--- a/src/bmad_loop/verify.py
+++ b/src/bmad_loop/verify.py
@@ -169,12 +169,13 @@ def same_commit(a: str, b: str) -> bool:
 def is_ancestor(repo: Path, ancestor: str, descendant: str) -> bool:
     """True when `ancestor` is an ancestor of (or equal to) `descendant`.
 
-    Any git failure — unknown ref, shallow history, not a repo — reads as
+    Any git failure — unknown ref, shallow history, not a repo, a timeout
+    (surfacing as GitError since `_run_git` translates it, #156) — reads as
     False: callers use this to *relax* a gate, so uncertainty must keep the
     gate strict."""
     try:
         code, _ = _git(repo, "merge-base", "--is-ancestor", ancestor, descendant)
-    except (OSError, subprocess.TimeoutExpired):
+    except (OSError, GitError):
         return False
     return code == 0
 

--- a/src/bmad_loop/verify.py
+++ b/src/bmad_loop/verify.py
@@ -166,6 +166,19 @@ def same_commit(a: str, b: str) -> bool:
     return a.startswith(b) or b.startswith(a)
 
 
+def is_ancestor(repo: Path, ancestor: str, descendant: str) -> bool:
+    """True when `ancestor` is an ancestor of (or equal to) `descendant`.
+
+    Any git failure — unknown ref, shallow history, not a repo — reads as
+    False: callers use this to *relax* a gate, so uncertainty must keep the
+    gate strict."""
+    try:
+        code, _ = _git(repo, "merge-base", "--is-ancestor", ancestor, descendant)
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return code == 0
+
+
 def has_changes_since(
     repo: Path,
     baseline: str,
@@ -1153,6 +1166,7 @@ def _verify_shared_gates(
     *,
     expected_status: str,
     extra_exclude: tuple[str, ...] | None,
+    allow_ancestor_baseline: bool = False,
 ) -> VerifyOutcome | None:
     """The workflow-tag, expected-status, baseline-match, and proof-of-work gates
     shared verbatim by :func:`verify_dev`, :func:`verify_dev_bundle`, and
@@ -1193,10 +1207,22 @@ def _verify_shared_gates(
     claimed_baseline = str(fm.get("baseline_commit", fm.get("baseline_revision", ""))).strip()
     if task.baseline_commit and claimed_baseline not in ("", "NO_VCS"):
         if not same_commit(claimed_baseline, task.baseline_commit):
-            return VerifyOutcome.retry(
-                f"spec baseline {claimed_baseline[:12]} does not match "
-                f"orchestrator-recorded baseline {task.baseline_commit[:12]}"
-            )
+            # A deferred-work bundle may legitimately adopt a pre-existing story
+            # spec: bmad-dev-auto routes a "follow-up review of story X" bundle
+            # into that story's done spec, whose baseline_revision is the
+            # story's original dev baseline — necessarily older than the unit
+            # worktree cut for the bundle (#161). An *ancestor* baseline means
+            # the session diffed from an earlier commit on the unit's own
+            # history (a superset of the unit's changes), which is sound; a
+            # diverged or unknown baseline still fails.
+            if not (
+                allow_ancestor_baseline
+                and is_ancestor(paths.project, claimed_baseline, task.baseline_commit)
+            ):
+                return VerifyOutcome.retry(
+                    f"spec baseline {claimed_baseline[:12]} does not match "
+                    f"orchestrator-recorded baseline {task.baseline_commit[:12]}"
+                )
 
     if extra_exclude is not None and task.baseline_commit:
         exclude = verify_dev_exclude_relpaths(paths, spec_path, task.restore_patch) + extra_exclude
@@ -1282,6 +1308,8 @@ def verify_dev_bundle(
         return VerifyOutcome.retry(f"claimed spec file does not exist: {spec_path}")
 
     # With review disabled, the dev session finalizes the bundle straight to done.
+    # allow_ancestor_baseline: a bundle that adopts a pre-existing story spec
+    # (follow-up review) carries that spec's older-but-ancestral baseline (#161).
     gate = _verify_shared_gates(
         spec_path,
         rj,
@@ -1289,6 +1317,7 @@ def verify_dev_bundle(
         paths,
         expected_status="in-review" if review_enabled else "done",
         extra_exclude=(),
+        allow_ancestor_baseline=True,
     )
     if gate is not None:
         return gate

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2944,7 +2944,7 @@ def test_manual_recovery_notice_names_committed_work(project):
     assert "intact" in reason
     assert "pushed" in reason
     # save-the-commits comes before any reset instruction
-    assert reason.index("git branch") < reason.index("reset --hard")
+    assert reason.index("branch my-rescue") < reason.index("reset --hard")
     manual = [e for e in engine.journal.entries() if e["kind"] == "rollback-manual-required"]
     assert manual and manual[-1]["commits"] == 1
 

--- a/tests/test_engine_worktree.py
+++ b/tests/test_engine_worktree.py
@@ -1373,3 +1373,60 @@ def test_spec_file_serialized_with_posix_separators():
     serialized = task.to_dict()["spec_file"]
     assert serialized == "_out/sub/spec.md"
     assert "\\" not in serialized
+
+
+# ------------------------------------------------- retry recovery (issue #161)
+
+
+def test_dev_retry_in_worktree_auto_recovers_instead_of_pausing(project):
+    """#161: a mid-drive dev retry inside a unit worktree must auto-recover the
+    disposable worktree (parking the attempt's commits on a preserve ref) even
+    with rollback_on_failure OFF — never pause with in-place manual-recovery
+    instructions aimed at the operator's checkout, which the attempt never
+    touched. rollback_on_failure gates isolation="none" recovery only."""
+    commit_sprint(project, {"1-1-a": "ready-for-dev"})
+
+    def bad_dev(spec):
+        # commits work in the worktree, then claims a foreign baseline — the
+        # non-fixable verify retry that routes through _rollback_or_pause
+        cwd = spec.cwd
+        wt = project.rebased(cwd)
+        src = cwd / "src.txt"
+        src.write_text(src.read_text() + "bad attempt\n")
+        git(cwd, "add", "-A")
+        git(cwd, "commit", "-q", "-m", "bad attempt work")
+        sp = wt.implementation_artifacts / "spec-1-1-a.md"
+        write_spec(sp, "in-review", "0" * 40)
+        return SessionResult(
+            status="completed",
+            result_json={
+                "workflow": "auto-dev",
+                "story_key": "1-1-a",
+                "spec_file": str(sp),
+                "escalations": [],
+            },
+        )
+
+    engine, _ = make_engine(
+        project,
+        [
+            bad_dev,
+            wt_dev_effect(project, "1-1-a"),
+            wt_review_effect(project, "1-1-a", clean=True),
+        ],
+        policy=wt_policy(rollback_on_failure=False),
+    )
+    summary = engine.run()
+
+    assert not summary.paused  # the old behavior: paused for manual recovery
+    assert summary.done == 1
+    kinds = journal_kinds(engine)
+    assert "rollback-manual-required" not in kinds
+    assert "rollback-auto" in kinds
+    # the bad attempt's commits were parked on a recovery ref, not lost
+    preserved = [e for e in engine.journal.entries() if e["kind"] == "attempt-commits-preserved"]
+    assert preserved and preserved[0]["ref"].startswith("attempt-preserve/")
+    # only the successful attempt's work merged to the target branch
+    src = (project.project / "src.txt").read_text()
+    assert "change for 1-1-a" in src and "bad attempt" not in src
+    assert worktree_clean(project.project)

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -428,6 +428,55 @@ def test_verify_dev_bundle_absent_dw_ids_passes(project, claim):
     assert task.spec_file == str(sp)
 
 
+def test_verify_dev_bundle_ancestor_baseline_passes(project):
+    """#161: a bundle that adopts a pre-existing story spec (bmad-dev-auto
+    routes a "follow-up review of story X" bundle into that story's done spec)
+    carries the story's original baseline — an *ancestor* of the unit baseline,
+    never equal to it. The bundle gate accepts the ancestor instead of failing
+    the whole attempt after the work is done."""
+    ancestor = verify.rev_parse_head(project.project)
+    (project.project / "story-work.txt").write_text("stories 1.1-1.3\n")
+    git(project.project, "add", "-A")
+    git(project.project, "commit", "-q", "-m", "story work")
+    task = make_bundle_task(project, dw_ids=("DW-1",))  # baseline = new HEAD
+    sp = project.implementation_artifacts / "spec-1-1-a.md"
+    write_spec(sp, "in-review", ancestor)  # adopted spec: the older baseline
+    (project.project / "src.txt").write_text("review fixes\n")
+    rj = {"workflow": "auto-dev", "spec_file": str(sp), "dw_ids": ["DW-1"]}
+    out = verify.verify_dev_bundle(task, project, rj)
+    assert out.ok
+    assert task.spec_file == str(sp)
+
+
+def test_verify_dev_bundle_foreign_baseline_still_fails(project):
+    """The bundle relaxation is ancestor-only: a baseline unknown to (or
+    diverged from) the unit's history still fails the gate."""
+    task = make_bundle_task(project, dw_ids=("DW-1",))
+    sp = project.implementation_artifacts / "spec-dw-test-bundle.md"
+    write_spec(sp, "in-review", "0" * 40)
+    (project.project / "src.txt").write_text("changed\n")
+    rj = {"workflow": "auto-dev", "spec_file": str(sp), "dw_ids": ["DW-1"]}
+    out = verify.verify_dev_bundle(task, project, rj)
+    assert not out.ok and "baseline" in out.reason
+
+
+def test_verify_dev_sprint_ancestor_baseline_still_fails(project):
+    """The ancestor relaxation is bundle-only: a sprint-mode dev spec is
+    authored by this session, so its baseline must match the orchestrator's
+    exactly — an older ancestor means the session planned from a stale tree."""
+    ancestor = verify.rev_parse_head(project.project)
+    (project.project / "story-work.txt").write_text("advance\n")
+    git(project.project, "add", "-A")
+    git(project.project, "commit", "-q", "-m", "advance")
+    write_sprint(project, {"1-1-a": "review"})
+    task = make_task(project)  # baseline = new HEAD
+    sp = spec_path(project, "1-1-a")
+    write_spec(sp, "in-review", ancestor)
+    (project.project / "src.txt").write_text("changed\n")
+    out = verify.verify_dev(task, project, dev_result(sp))
+    assert not out.ok and "baseline" in out.reason
+
+
 def test_verify_dev_bundle_ledger_only_counts_as_real_work(project):
     """Same false-negative as verify_dev (KNOWN-BUG-ledger-only-story-false-no-
     changes.md), on the bundle path: a dw-bundle's entire authorized diff is

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -460,6 +460,26 @@ def test_verify_dev_bundle_foreign_baseline_still_fails(project):
     assert not out.ok and "baseline" in out.reason
 
 
+def test_verify_dev_bundle_ancestor_probe_git_failure_stays_strict(project, monkeypatch):
+    """A git failure inside the ancestor probe (e.g. a timeout, which surfaces
+    as GitError since #156's `_run_git` translation) must read as
+    not-an-ancestor and fail the gate closed — never propagate out of
+    `_verify_shared_gates` and crash the run."""
+    ancestor = verify.rev_parse_head(project.project)
+    (project.project / "story-work.txt").write_text("stories 1.1-1.3\n")
+    git(project.project, "add", "-A")
+    git(project.project, "commit", "-q", "-m", "story work")
+    task = make_bundle_task(project, dw_ids=("DW-1",))
+    sp = project.implementation_artifacts / "spec-1-1-a.md"
+    write_spec(sp, "in-review", ancestor)
+    (project.project / "src.txt").write_text("review fixes\n")
+    rj = {"workflow": "auto-dev", "spec_file": str(sp), "dw_ids": ["DW-1"]}
+    monkeypatch.setattr(verify.subprocess, "run", _timing_out_run)
+    assert verify.is_ancestor(project.project, ancestor, task.baseline_commit) is False
+    out = verify.verify_dev_bundle(task, project, rj)
+    assert not out.ok and "baseline" in out.reason
+
+
 def test_verify_dev_sprint_ancestor_baseline_still_fails(project):
     """The ancestor relaxation is bundle-only: a sprint-mode dev spec is
     authored by this session, so its baseline must match the orchestrator's


### PR DESCRIPTION
Fixes #161 (both bugs).

## What

**1. `verify_dev_bundle` accepts ancestor baselines.** A deferred-work bundle whose intent is "follow-up review of story X" is routed by `bmad-dev-auto` (step-01, `done → step-04`) into that story's existing done spec — whose `baseline_revision` is the story's original dev baseline, necessarily older than the unit worktree cut for the bundle. The exact-match baseline gate therefore failed every such bundle *after* the session had done all its work (~8M tokens in the incident run). The gate now tolerates a claimed baseline that is an **ancestor** of the orchestrator-recorded one, bundle path only:

- ancestor = the session diffed from an earlier commit on the unit's own history — a superset of the unit's changes, sound for a review pass;
- diverged/unknown baselines still fail;
- sprint mode and stories mode keep the exact-match requirement (a spec authored this session must match);
- new `verify.is_ancestor()` reads any git failure as False, so uncertainty keeps the gate strict.

**2. `_rollback_or_pause` auto-recovers mounted unit worktrees.** The mid-drive dev retry (`_dev_phase`) called `_rollback_or_pause` unconditionally — the only recovery path without an isolation guard (the resume, `_defer`, and sweep paths all have one). With `rollback_on_failure = false` this paused the run with in-place manual-recovery instructions: "your commits are intact at the current HEAD … the commits are `<baseline>..HEAD` … `git reset --hard <baseline>`". Under worktree isolation every clause pointed at the wrong tree — the operator's checkout HEAD *is* the baseline (the quoted range is empty) and the commits sit on the unit branch, so step 3 invites a destructive reset of a checkout the attempt never touched. Since a mounted unit worktree is disposable by design (commits are parked on `attempt-preserve/` refs before any reset, per `_preserve_attempt_commits`), the method now auto-recovers it regardless of `rollback_on_failure`, which the policy docs already scope to `isolation="none"` recovery. Detection is by path (`workspace.root != paths.repo_root`), not by policy — a worktree-mode call that reaches the method *outside* a mounted unit still targets the main checkout and still pauses.

**3. Recovery notices name their tree.** The remaining reachable pauses (e.g. preserve-failure while a worktree is mounted) now say "current HEAD of `<root>`" and use `git -C <root> …` commands, so they can't be misread against the wrong checkout.

## Incident evidence

Run `20260716-152154-3aba` (v0.8.1, `isolation="worktree"`): sweep bundle DW-1 completed a follow-up review of three stories, then failed `spec baseline 800adc7deebb does not match orchestrator-recorded baseline 393b55a052dc` — `800adc7` is an ancestor of `393b55a` in that repo, confirmed against the new gate. Full journal excerpts in #161.

## Tests

- `test_verify_dev_bundle_ancestor_baseline_passes` — the incident shape passes
- `test_verify_dev_bundle_foreign_baseline_still_fails` — relaxation is ancestor-only
- `test_verify_dev_sprint_ancestor_baseline_still_fails` — relaxation is bundle-only
- `test_dev_retry_in_worktree_auto_recovers_instead_of_pausing` — e2e: committed bad attempt in a worktree → auto-recover (commits parked on `attempt-preserve/`), retry succeeds, run completes; no `rollback-manual-required`
- `test_manual_recovery_notice_names_committed_work` updated for the `git -C <root>` command form (ordering assertion unchanged)

`uv run pytest -q`: 2270 passed, 8 skipped. `ruff check` + `black --check` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic rollback behavior for failed worktree attempts.
  * Clarified manual recovery instructions, including safer commit preservation and reset steps.
  * Allowed deferred development bundles with valid ancestor baselines to pass verification.
  * Continued rejecting unrelated or invalid baselines and enforcing exact baselines for sprint verification.

* **Tests**
  * Added coverage for worktree rollback isolation and baseline verification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->