### PR TITLE
feat(adapters): core opencode-http adapter over HTTP/SSE (Phase 3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ tui = ["textual>=8.0,<9", "tomlkit>=0.13", "pyte>=0.8.2"]
 # macOS opt-in for psutil (identity/force-kill niceties); win32 gets it as a core
 # dep above, Linux stays dep-free. `pip install bmad-loop[non-linux]` on macOS.
 non-linux = ["psutil>=7.2.2"]
+# HTTP client for the opencode-http adapter (drives `opencode serve` over
+# HTTP/SSE). `pip install 'bmad-loop[opencode]'`.
+opencode = ["httpx>=0.28"]
 
 [dependency-groups]
 # dev gets tui via `uv sync --all-extras` (groups can't self-reference an extra).
@@ -35,6 +38,8 @@ dev = [
   "pytest-asyncio>=1.0",
   "pytest-rerunfailures>=16.0",
   "pytest-xdist>=3.6",
+  # the opencode-http adapter tests exercise the real httpx client
+  "httpx>=0.28",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/src/bmad_loop/adapters/opencode_http.py
+++ b/src/bmad_loop/adapters/opencode_http.py
@@ -1,42 +1,786 @@
-"""opencode driver stub — proves the adapter seam for a non-tmux transport.
+"""OpenCode driver: sessions over the local HTTP server, no tmux, no hooks.
 
-opencode is architecturally client/server: its TUI is just a client of a local
-HTTP server (`opencode serve`), which exposes an OpenAPI 3.1 API —
-POST /session, POST /session/:id/prompt_async, POST /session/:id/command,
-POST /session/:id/abort — plus SSE event streams at GET /event. An adapter can
-therefore drive sessions entirely over HTTP (injection="http",
-observation="sse") with no tmux and no hook scripts, while a human can still
-attach the TUI to watch the same session.
+OpenCode (opencode.ai) is client/server: its TUI is just a client of a local
+HTTP server (``opencode serve``) exposing an OpenAPI 3.1 API. This adapter
+drives sessions entirely over that API (``injection="http"``,
+``observation="sse"``) — every load-bearing endpoint, event name and body
+schema is pinned against the real 1.18.2 binary in
+``docs/notes/opencode-api-pins.md`` (read that first; it wins over memory).
 
-Implementation notes for whoever picks this up:
-- start_session: POST /session, then POST /session/:id/command to run the
-  skill (opencode commands/skills live in .opencode/commands|skills/), or
-  prompt_async with the same "/skill args" text.
-- wait_for_completion: subscribe to GET /event SSE; `session.idle` is the
-  turn-complete signal (no Stop-hook needed). The result.json contract is
-  unchanged — the skill still writes it; read it on idle.
-- state: session/message/part JSON under ~/.local/share/opencode/storage/;
-  token usage is in the message JSON.
-- env: pass BMAD_LOOP_* via the server process or per-session env support.
+Transport shape (the settled design drivers):
+
+- **One ``opencode serve`` per session.** The API has no per-session env, and
+  the ``BMAD_LOOP_*`` contract must reach tool subprocesses via the server
+  process env — so each session gets its own server spawned with
+  ``cwd=spec.cwd`` and the session env. Ports are OS-assigned free ports,
+  re-picked on a bind race.
+- **Config injected via ``OPENCODE_CONFIG_CONTENT``** (outranks the project's
+  ``opencode.json``; pins §9): a blanket permission allow (the bypass-flags
+  analogue), the pins §10 hermetic-skills recipe (project ``.claude/skills``
+  only — without it every session sees the operator's personal skills), and
+  the policy model when set. A per-session ``OPENCODE_SERVER_PASSWORD`` makes
+  the health poll self-discriminating against a foreign server on a reused
+  port and keeps other local processes from driving an allow-all server.
+- **SSE ``session.idle`` ≙ the Stop hook**, filtered to this session's id —
+  child/subagent sessions share the stream and emit their own idles. SSE is
+  lossy upstream, so a silent or reconnecting stream degrades to an HTTP poll
+  (``GET /session/status`` + message-level proof-of-work): an idle event alone
+  is NOT proof a turn ran (abort emits one on an idle session; pins §3/§8),
+  so the fallback demands an assistant message completed *after* the last
+  prompt this adapter sent. OpenCode timestamps are epoch **milliseconds**.
+- **Server death ≙ window death** (``crashed``, landed artifact honored);
+  stall verdicts under a live server pin ``accept_result=False`` — the
+  #48/#53 artifact-distrust invariant, unchanged.
+- **Usage is read over HTTP before teardown** (server state is sqlite, not a
+  readable file tree): assistant-message token sums, stashed by session id,
+  raw messages dumped to ``tasks/<task_id>/messages.json`` as the transcript.
+  Child-session (subagent) tokens are not counted — the API scopes messages
+  per session.
+- ``opencode serve`` survives parent death (pins §11), so teardown is
+  authoritative: kill in ``run()``'s finally plus an atexit sweep. On Windows
+  the binary is an npm ``.cmd`` shim, so the kill goes straight to the
+  process-tree force-kill while the wrapper is still alive to enumerate.
 """
 
 from __future__ import annotations
 
+import atexit
+import json
+import os
+import queue
+import secrets
+import shutil
+import socket
+import subprocess
+import sys
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from ..journal import LOGS_DIR
+from ..model import TokenUsage
+from ..policy import Policy
+from ..process_host import get_process_host
 from .base import CodingCLIAdapter, SessionHandle, SessionResult, SessionSpec
+from .generic import NUDGE_TEXT, STALL_NUDGE_TEXT, _ResultFileMixin
+from .profile import CLIProfile
+
+# Spawn/readiness defaults; per-instance attributes so tests shrink them.
+HEALTH_TIMEOUT_S = 30.0
+HEALTH_POLL_S = 0.25
+SSE_READ_TIMEOUT_S = 30.0  # server heartbeats ~10s; 3 misses = stream is gone
+SILENCE_THRESHOLD_S = 30.0
+RECONNECT_SLEEP_S = 1.0
+KILL_WAIT_S = 5.0
+SPAWN_ATTEMPTS = 3
+POLL_TICK_S = 5.0  # max event-queue wait per loop tick (generic's cadence)
+
+# Fixed basic-auth username in OPENCODE_SERVER_PASSWORD mode (pins §2).
+AUTH_USER = "opencode"
 
 
-class OpencodeHttpAdapter(CodingCLIAdapter):
-    name = "opencode-http"
+class OpencodeServerError(Exception):
+    """An ``opencode serve`` instance could not be spawned, readied or driven."""
+
+
+def _require_httpx():
+    """Import httpx lazily — it ships as the ``opencode`` extra, so the
+    dep-free core never pays for it (the ``_psutil()`` pattern)."""
+    try:
+        import httpx  # noqa: PLC0415  (intentional lazy import — optional extra)
+    except ImportError as exc:
+        raise OpencodeServerError(
+            "the opencode-http adapter needs httpx; "
+            "install it with `pip install 'bmad-loop[opencode]'`"
+        ) from exc
+    return httpx
+
+
+def _now_ms() -> int:
+    """Wall clock in epoch milliseconds — OpenCode's ``time.*`` unit (pins §4).
+    Comparisons against ``SessionHandle.launched_ns`` must divide by 1e6 first;
+    a raw ns-vs-ms comparison is always False and silently disables the poll
+    fallback."""
+    return time.time_ns() // 1_000_000
+
+
+def _free_port() -> int:
+    """An OS-assigned free localhost port. Racy by nature (the bind is
+    released before ``opencode serve`` re-binds); the spawn loop retries with a
+    fresh port when the server dies during the health poll."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _parse_sse_lines(lines) -> Any:
+    """Minimal SSE frame parser: accumulate ``data:`` lines until a blank line,
+    then yield the JSON-decoded payload. Tolerates comments, unknown fields and
+    undecodable payloads (skipped) — the stream is advisory, never trusted."""
+    data: list[str] = []
+    for line in lines:
+        if line == "":
+            if data:
+                try:
+                    yield json.loads("\n".join(data))
+                except (json.JSONDecodeError, ValueError):
+                    pass
+                data = []
+            continue
+        if line.startswith("data:"):
+            data.append(line[5:].lstrip())
+
+
+@dataclass
+class _ServerSession:
+    """Everything the adapter tracks for one live ``opencode serve``."""
+
+    process: subprocess.Popen
+    port: int
+    base_url: str
+    password: str
+    log_fh: Any
+    client: Any = None  # control httpx.Client — main thread only
+    session_id: str = ""
+    events: queue.Queue = field(default_factory=queue.Queue)
+    sse_thread: threading.Thread | None = None
+    sse_stop: threading.Event = field(default_factory=threading.Event)
+    sse_connected: threading.Event = field(default_factory=threading.Event)
+    # Bumped by the SSE reader on any non-heartbeat frame (any session — the
+    # parent is silent while a child session streams, exactly like subagent
+    # output in a tmux pane). The wait loop snapshots it to re-arm the
+    # dev-stall grace window, mirroring generic._log_activity_key.
+    activity: int = 0
+    # Monotonic timestamp of the last SSE frame of any kind (heartbeats
+    # included) — a healthy-but-quiet stream keeps this fresh, so the wait
+    # loop only falls back to HTTP polling when BOTH its own dequeue clock and
+    # this are stale (a dead reader thread leaves it stale, preserving the
+    # degraded path).
+    last_frame_monotonic: float = 0.0
+    # Monotonic completion floor in epoch ms: the poll fallback only
+    # synthesizes an idle for an assistant message completed strictly after
+    # this. Starts at prompt-send, advances on every prompt this adapter sends
+    # and on every completion it consumes — otherwise one stale completed
+    # message re-synthesizes idle on every probe (each fake "Stop" refills the
+    # stall budget) and the session livelocks or burns its nudges.
+    floor_ms: int = 0
+
+
+class OpencodeHttpAdapter(_ResultFileMixin, CodingCLIAdapter):
     injection = "http"
     observation = "sse"
-    state = "local-json-tree"
+    state = "remote"
 
-    def __init__(self, base_url: str = "http://127.0.0.1:4096"):
-        self.base_url = base_url
-        raise NotImplementedError("opencode-http adapter is a design stub — see module docstring")
+    def __init__(
+        self,
+        run_dir: Path,
+        policy: Policy,
+        profile: CLIProfile,
+        binary: str | None = None,
+        extra_args: tuple[str, ...] | None = None,
+        usage_grace_s: float | None = None,
+        stop_without_result_nudges: int | None = None,
+    ):
+        self._httpx = _require_httpx()
+        self.run_dir = run_dir
+        self.policy = policy
+        self.profile = profile
+        self.name = profile.name
+        self.binary = binary or profile.binary
+        # None = no extra serve args; unlike the tmux adapters there are no
+        # bypass flags to default to (permissions ride OPENCODE_CONFIG_CONTENT).
+        self.extra_args = extra_args
+        self._usage_grace_s = usage_grace_s if usage_grace_s is not None else profile.usage_grace_s
+        self._stop_nudges = (
+            stop_without_result_nudges
+            if stop_without_result_nudges is not None
+            else (
+                profile.stop_without_result_nudges
+                if profile.stop_without_result_nudges is not None
+                else policy.limits.stop_without_result_nudges
+            )
+        )
+        # Same base semantics as GenericAdapter: fail fast on a result-less
+        # Stop. The Phase 4 dev subclass raises these via _configure_dev_knobs.
+        self._stall_grace_s = 0.0
+        self._stall_nudges = 0
+        # Timing knobs — instance attributes so tests shrink them per-adapter.
+        self.health_timeout_s = HEALTH_TIMEOUT_S
+        self.health_poll_s = HEALTH_POLL_S
+        self.sse_read_timeout_s = SSE_READ_TIMEOUT_S
+        self.silence_threshold_s = SILENCE_THRESHOLD_S
+        self.reconnect_sleep_s = RECONNECT_SLEEP_S
+        self.kill_wait_s = KILL_WAIT_S
+        self.poll_tick_s = POLL_TICK_S
+        self.result_grace_s: float | None = None  # None = the mixin default
+        self.tasks_dir = run_dir / "tasks"
+        self.logs_dir = run_dir / LOGS_DIR
+        self.tasks_dir.mkdir(parents=True, exist_ok=True)
+        self.logs_dir.mkdir(parents=True, exist_ok=True)
+        self._sessions: dict[str, _ServerSession] = {}
+        self._usage: dict[str, TokenUsage] = {}
+        # opencode serve survives parent death (pins §11): sweep whatever is
+        # still registered when the interpreter exits cooperatively. A hard
+        # SIGKILL of the engine still leaks — documented residual risk.
+        atexit.register(self._atexit_sweep)
+
+    # ------------------------------------------------------------- spawning
+
+    def _serve_argv(self, resolved_binary: str, port: int) -> list[str]:
+        """argv for one server. A seam: tests monkeypatch it to launch the
+        FakeOpencode sidecar wrapper-free."""
+        extra = self.extra_args or ()
+        return [
+            resolved_binary,
+            "serve",
+            "--port",
+            str(port),
+            "--hostname",
+            "127.0.0.1",
+            "--print-logs",
+            *extra,
+        ]
+
+    def _config_content(self, spec: SessionSpec) -> str:
+        """The OPENCODE_CONFIG_CONTENT JSON for this session (pins §9/§10):
+        blanket permission allow (the bypass-flags analogue), the hermetic
+        skills path (project skills only, paired with
+        OPENCODE_DISABLE_EXTERNAL_SKILLS=1 in the env), and the model when the
+        policy sets one (config-file model is the "provider/model" string
+        form)."""
+        config: dict[str, Any] = {
+            "permission": "allow",
+            "skills": {"paths": [str(Path(spec.cwd) / self.profile.skill_tree)]},
+        }
+        if spec.model:
+            config["model"] = spec.model
+        return json.dumps(config)
+
+    def _session_env(self, spec: SessionSpec, password: str) -> dict[str, str]:
+        return {
+            **os.environ,
+            **self.profile.env,
+            **spec.env,
+            "OPENCODE_DISABLE_EXTERNAL_SKILLS": "1",
+            "OPENCODE_SERVER_PASSWORD": password,
+            "OPENCODE_CONFIG_CONTENT": self._config_content(spec),
+        }
+
+    def _make_client(self, sess: _ServerSession):
+        return self._httpx.Client(
+            base_url=sess.base_url,
+            auth=(AUTH_USER, sess.password),
+            timeout=self._httpx.Timeout(10.0, connect=5.0),
+        )
+
+    def _spawn_server(self, spec: SessionSpec) -> _ServerSession:
+        """Spawn `opencode serve` and wait for readiness, retrying with a fresh
+        port when the process dies during the health poll (the free-port bind
+        is released before the server re-binds, so a collision is possible)."""
+        resolved = shutil.which(self.binary)
+        if resolved is None:
+            # shutil.which honors PATHEXT — on Windows the npm install is an
+            # `opencode.cmd` shim that a bare-name Popen (which appends only
+            # .exe) would never find.
+            raise OpencodeServerError(
+                f"opencode binary {self.binary!r} not found on PATH; " f"see `bmad-loop validate`"
+            )
+        password = secrets.token_urlsafe(16)
+        env = self._session_env(spec, password)
+        log_path = self.logs_dir / f"{spec.task_id}.log"
+        log_fh = log_path.open("ab")  # append: retries share one log
+        last_error = "server did not become healthy"
+        try:
+            for _ in range(SPAWN_ATTEMPTS):
+                port = _free_port()
+                process = subprocess.Popen(  # noqa: S603 - argv built from profile
+                    self._serve_argv(resolved, port),
+                    cwd=str(spec.cwd),
+                    env=env,
+                    stdout=log_fh,
+                    stderr=subprocess.STDOUT,
+                    stdin=subprocess.DEVNULL,
+                )
+                sess = _ServerSession(
+                    process=process,
+                    port=port,
+                    base_url=f"http://127.0.0.1:{port}",
+                    password=password,
+                    log_fh=log_fh,
+                )
+                if self._await_healthy(sess):
+                    sess.client = self._make_client(sess)
+                    return sess
+                # Died or never readied: reap and try a fresh port. A live-but-
+                # unhealthy server is killed too — never leak what we spawned.
+                if process.poll() is None:
+                    last_error = "server did not become healthy in time"
+                    self._kill_process(sess)
+                else:
+                    last_error = f"server exited rc={process.returncode} during startup"
+        except BaseException:
+            log_fh.close()
+            raise
+        log_fh.close()
+        raise OpencodeServerError(
+            f"could not start `{self.binary} serve` after {SPAWN_ATTEMPTS} attempts "
+            f"({last_error}); log: {log_path}"
+        )
+
+    def _await_healthy(self, sess: _ServerSession) -> bool:
+        """Poll /global/health (authenticated) until it answers healthy. The
+        process liveness is re-checked after *every* probe: a foreign server
+        answering 200 on a stolen port must not mask our own corpse, and the
+        auth + shape check means a foreign 200 without our password never
+        reads as ready."""
+        deadline = time.monotonic() + self.health_timeout_s
+        with self._make_client(sess) as client:
+            while time.monotonic() < deadline:
+                healthy = False
+                try:
+                    resp = client.get("/global/health")
+                    healthy = resp.status_code == 200 and resp.json().get("healthy") is True
+                except Exception:  # noqa: BLE001 - not up yet (conn refused, junk)
+                    healthy = False
+                if sess.process.poll() is not None:
+                    return False
+                if healthy:
+                    return True
+                time.sleep(self.health_poll_s)
+        return False
+
+    # -------------------------------------------------------------- adapter
 
     def start_session(self, spec: SessionSpec) -> SessionHandle:
-        raise NotImplementedError
+        task_dir = self.tasks_dir / spec.task_id
+        task_dir.mkdir(parents=True, exist_ok=True)
+        (task_dir / "prompt.txt").write_text(spec.prompt + "\n", encoding="utf-8")
+        # A re-armed/resumed run reuses task_ids; drop any prior cycle's result
+        # so a session that writes nothing can't be read as a stale completion.
+        (task_dir / "result.json").unlink(missing_ok=True)
+
+        launched_ns = time.time_ns()
+        sess = self._spawn_server(spec)
+        # Registered before the API handshake so the atexit sweep (and kill())
+        # covers a crash mid-setup; run()'s finally-kill only exists once
+        # start_session has returned a handle.
+        self._sessions[spec.task_id] = sess
+        try:
+            resp = sess.client.post("/session", json={"title": spec.task_id})
+            if resp.status_code != 200:
+                raise OpencodeServerError(
+                    f"POST /session failed: {resp.status_code} {resp.text[:200]}"
+                )
+            sess.session_id = resp.json()["id"]
+
+            self._start_sse_reader(sess)
+            # Wait for the stream to actually attach before prompting: a fast
+            # turn can emit session.idle before the subscription exists, and a
+            # lost idle degrades every completion to the (slow) poll fallback.
+            if not sess.sse_connected.wait(timeout=self.health_timeout_s):
+                raise OpencodeServerError("event stream did not connect")
+
+            self._prompt(sess, self.profile.render_prompt(spec.prompt))
+        except Exception:
+            self._sessions.pop(spec.task_id, None)
+            self._teardown(sess)
+            raise
+        return SessionHandle(
+            task_id=spec.task_id, native_id=sess.session_id, launched_ns=launched_ns
+        )
+
+    def _prompt(self, sess: _ServerSession, text: str) -> None:
+        """prompt_async — the injection primitive for both the initial prompt
+        and the nudges. Advances the completion floor: anything completed
+        before this send is a previous turn's evidence."""
+        sess.floor_ms = max(sess.floor_ms, _now_ms())
+        resp = sess.client.post(
+            f"/session/{sess.session_id}/prompt_async",
+            json={"parts": [{"type": "text", "text": text}]},
+        )
+        if resp.status_code != 204:
+            raise OpencodeServerError(f"prompt_async failed: {resp.status_code} {resp.text[:200]}")
+
+    def send_text(self, handle: SessionHandle, text: str) -> None:
+        """Nudge the running session. Best-effort: a server that died between
+        the liveness probe and the nudge is caught as `crashed` on the next
+        tick, not by blowing up the completion loop."""
+        sess = self._sessions.get(handle.task_id)
+        if sess is None:
+            return
+        try:
+            self._prompt(sess, text)
+        except Exception:  # noqa: BLE001  # nosec B110 - next tick's poll() settles liveness
+            pass
+
+    def _start_sse_reader(self, sess: _ServerSession) -> None:
+        thread = threading.Thread(
+            target=self._sse_loop,
+            args=(sess,),
+            name=f"opencode-sse-{sess.port}",
+            daemon=True,
+        )
+        sess.sse_thread = thread
+        thread.start()
+
+    def _sse_loop(self, sess: _ServerSession) -> None:
+        """SSE reader: owns its own client (created and closed here — kill()
+        never touches it; killing the server is what unblocks the read, with
+        the read timeout as backstop). Filters idle/error to this session's id
+        (child sessions share the stream), counts every other non-heartbeat
+        frame as activity, and turns any disconnect into a single `gap`
+        sentinel so the wait loop probes over HTTP for what the stream may
+        have dropped."""
+        httpx = self._httpx
+        while not sess.sse_stop.is_set():
+            try:
+                with httpx.Client(
+                    base_url=sess.base_url,
+                    auth=(AUTH_USER, sess.password),
+                    timeout=httpx.Timeout(5.0, read=self.sse_read_timeout_s),
+                ) as client:
+                    with client.stream("GET", "/event") as resp:
+                        if resp.status_code != 200:
+                            raise OpencodeServerError(f"/event -> {resp.status_code}")
+                        # The server registers the subscriber once the response
+                        # starts; events published after this are delivered.
+                        sess.sse_connected.set()
+                        for event in _parse_sse_lines(resp.iter_lines()):
+                            if sess.sse_stop.is_set():
+                                return
+                            self._dispatch_sse(sess, event)
+            except Exception:  # noqa: BLE001  # nosec B110 - reader must never die silently
+                pass
+            if sess.sse_stop.is_set():
+                return
+            sess.events.put("gap")
+            sess.sse_stop.wait(self.reconnect_sleep_s)
+
+    def _dispatch_sse(self, sess: _ServerSession, event: Any) -> None:
+        if not isinstance(event, dict):
+            return
+        sess.last_frame_monotonic = time.monotonic()
+        etype = event.get("type")
+        if etype in ("server.heartbeat", "server.connected"):
+            return
+        # Any substantive frame — including child-session traffic — proves the
+        # session tree is working (the parent is silent while a subagent
+        # streams, exactly like subagent output in a tmux pane log).
+        sess.activity += 1
+        props = event.get("properties") or {}
+        if props.get("sessionID") != sess.session_id:
+            return
+        if etype == "session.idle":
+            sess.events.put("idle")
+        elif etype == "session.error":
+            sess.events.put("error")
+
+    # ------------------------------------------------------ completion loop
+
+    def _result_json(self, handle: SessionHandle, spec: SessionSpec, *, wait: bool) -> dict | None:
+        if not wait:
+            return self._read_result(handle.task_id)
+        # Pass the grace explicitly: the mixin's grace_s default is bound at
+        # def time, so an instance override is the only reachable knob.
+        if self.result_grace_s is not None:
+            return self._await_result(handle.task_id, grace_s=self.result_grace_s)
+        return self._await_result(handle.task_id)
 
     def wait_for_completion(self, handle: SessionHandle, spec: SessionSpec) -> SessionResult:
-        raise NotImplementedError
+        sess = self._sessions.get(handle.task_id)
+        if sess is None:
+            raise OpencodeServerError(f"no live opencode server for task {handle.task_id!r}")
+        deadline = time.monotonic() + spec.timeout_s
+        session_id = sess.session_id
+        nudges_left = self._stop_nudges
+        # Mirrors generic.wait_for_completion: stall-grace window armed by a
+        # result-less Stop (idle), re-armed by activity, spent via wake-nudges
+        # bounded by the monotonic spec.stall_nudges_cap (#149).
+        stall_deadline: float | None = None
+        last_activity: int | None = None
+        stall_nudges_left = self._stall_nudges
+        stall_nudges_sent = 0
+        # Loop-owned silence clock: updated on every dequeue, so a dead reader
+        # thread degrades to the poll fallback instead of disabling it.
+        last_seen = time.monotonic()
+
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                self._abort(sess)
+                transcript = self._capture_usage(handle, sess)
+                return SessionResult(
+                    status="timeout", session_id=session_id, transcript_path=transcript
+                )
+            try:
+                event: str | None = sess.events.get(timeout=min(remaining, self.poll_tick_s))
+            except queue.Empty:
+                event = None
+            if event is not None:
+                last_seen = time.monotonic()
+
+            if event == "error":
+                # session.error may precede a retry, not a turn-end (status
+                # "retry" exists); only a settled not-busy session reads as a
+                # result-less Stop — an errored turn may never get
+                # time.completed, so waiting on proof-of-work alone would burn
+                # the whole timeout. A dead server takes the crash path.
+                if sess.process.poll() is not None:
+                    transcript = self._capture_usage(handle, sess)
+                    return self._final(handle, spec, "crashed", session_id, transcript)
+                if self._status_running(sess):
+                    continue
+                event = "idle"
+
+            if event in (None, "gap"):
+                if sess.process.poll() is not None:
+                    # Server death ≙ window death: the crash path vouches for a
+                    # landed artifact (accept_result=True), same as generic.
+                    transcript = self._capture_usage(handle, sess)
+                    return self._final(handle, spec, "crashed", session_id, transcript)
+                silent = (
+                    time.monotonic() - max(last_seen, sess.last_frame_monotonic)
+                    > self.silence_threshold_s
+                )
+                if (event == "gap" or silent) and self._probe_completion(sess):
+                    event = "idle"  # fall through to the Stop path below
+                    last_seen = time.monotonic()
+                else:
+                    if stall_deadline is not None:
+                        # Re-arm on activity (any SSE traffic since arming) —
+                        # a session streaming subagent work is working, not
+                        # stalled; only genuine silence trips the stall below.
+                        key = sess.activity
+                        if last_activity is None or key != last_activity:
+                            last_activity = key
+                            stall_deadline = time.monotonic() + self._stall_grace_s
+                            continue
+                        if time.monotonic() >= stall_deadline:
+                            if stall_nudges_left > 0 and (
+                                spec.stall_nudges_cap is None
+                                or stall_nudges_sent < spec.stall_nudges_cap
+                            ):
+                                if self._status_running(sess):
+                                    # Mid-turn (a busy child/parent the SSE
+                                    # missed): re-arm rather than injecting a
+                                    # prompt into a working session.
+                                    stall_deadline = time.monotonic() + self._stall_grace_s
+                                    continue
+                                stall_nudges_left -= 1
+                                stall_nudges_sent += 1
+                                self.send_text(handle, STALL_NUDGE_TEXT)
+                                stall_deadline = time.monotonic() + self._stall_grace_s
+                                last_activity = sess.activity
+                                continue
+                            # Re-probe liveness before finalizing: a hard death
+                            # in the gap since the top-of-tick check flows
+                            # through the crash path (artifact honored) instead
+                            # of a stall that discards a just-flushed result.
+                            if sess.process.poll() is not None:
+                                transcript = self._capture_usage(handle, sess)
+                                return self._final(handle, spec, "crashed", session_id, transcript)
+                            transcript = self._capture_usage(handle, sess)
+                            return self._final(
+                                handle,
+                                spec,
+                                "stalled",
+                                session_id,
+                                transcript,
+                                accept_result=False,
+                            )
+                    continue
+
+            if event == "idle":
+                result_json = self._result_json(handle, spec, wait=True)
+                if result_json is not None:
+                    transcript = self._capture_usage(handle, sess)
+                    return SessionResult(
+                        status="completed",
+                        result_json=result_json,
+                        session_id=session_id,
+                        transcript_path=transcript,
+                    )
+                if nudges_left > 0:
+                    nudges_left -= 1
+                    self.send_text(handle, NUDGE_TEXT)
+                    continue
+                if self._stall_grace_s <= 0:
+                    transcript = self._capture_usage(handle, sess)
+                    return self._final(handle, spec, "stalled", session_id, transcript)
+                # A result-less Stop, but the session may have ended its turn
+                # awaiting a background process: open/re-arm the idle-grace
+                # window; a fresh Stop lands here again and resets it.
+                stall_deadline = time.monotonic() + self._stall_grace_s
+                last_activity = sess.activity
+                # a real turn-end proves the session responsive: restore the
+                # wake-nudge budget (the monotonic cap still bounds the total).
+                stall_nudges_left = self._stall_nudges
+                continue
+
+    def _status_running(self, sess: _ServerSession) -> bool:
+        """Whether /session/status reports this session busy or retrying.
+        Idle sessions are ABSENT from the map (pins §6) — absence means not
+        running. Unreachable server reads as not-running; the process poll
+        settles real death."""
+        try:
+            resp = sess.client.get("/session/status")
+            if resp.status_code != 200:
+                return False
+            status = resp.json().get(sess.session_id) or {}
+            return status.get("type") in ("busy", "retry")
+        except Exception:  # noqa: BLE001 - probe is advisory
+            return False
+
+    def _probe_completion(self, sess: _ServerSession) -> bool:
+        """HTTP fallback for a lossy stream (pins §6): the turn is finished
+        only when the session is not busy/retrying AND an assistant message
+        completed strictly after the completion floor exists — an idle status
+        alone is not proof a turn ran (pins §3/§8). Consuming the evidence
+        advances the floor so one completion can never be consumed twice."""
+        if self._status_running(sess):
+            return False
+        try:
+            resp = sess.client.get(f"/session/{sess.session_id}/message")
+            if resp.status_code != 200:
+                return False
+            completed = 0
+            for msg in resp.json():
+                info = msg.get("info") or {}
+                if info.get("role") != "assistant":
+                    continue
+                done_ms = (info.get("time") or {}).get("completed") or 0
+                completed = max(completed, int(done_ms))
+        except Exception:  # noqa: BLE001 - probe is advisory
+            return False
+        if completed > sess.floor_ms:
+            sess.floor_ms = completed
+            return True
+        return False
+
+    def _abort(self, sess: _ServerSession) -> None:
+        if sess.client is None or not sess.session_id or sess.process.poll() is not None:
+            return
+        try:
+            sess.client.post(f"/session/{sess.session_id}/abort")
+        except Exception:  # noqa: BLE001  # nosec B110 - abort is best-effort
+            pass
+
+    # ----------------------------------------------------------------- usage
+
+    def _capture_usage(self, handle: SessionHandle, sess: _ServerSession) -> str | None:
+        """Read usage over HTTP before teardown (state is server-side sqlite):
+        dump the raw messages as the transcript and stash the token sum by
+        session id for read_usage(). Best-effort in full — the crashed path
+        runs this against a dead server and the verdict must not change."""
+        if sess.client is None or not sess.session_id:
+            return None
+        try:
+            resp = sess.client.get(f"/session/{sess.session_id}/message")
+            if resp.status_code != 200:
+                return None
+            messages = resp.json()
+            path = self.tasks_dir / handle.task_id / "messages.json"
+            path.write_text(json.dumps(messages, ensure_ascii=False, indent=2), encoding="utf-8")
+            self._usage[sess.session_id] = _sum_usage(messages)
+            return str(path)
+        except Exception:  # noqa: BLE001 - usage is metadata, never a gate
+            return None
+
+    def read_usage(self, result: SessionResult) -> TokenUsage | None:
+        if not result.session_id:
+            return None
+        return self._usage.get(result.session_id)
+
+    # -------------------------------------------------------------- teardown
+
+    def kill(self, handle: SessionHandle) -> None:
+        sess = self._sessions.pop(handle.task_id, None)
+        if sess is None:
+            return
+        self._abort(sess)
+        self._teardown(sess)
+
+    def _teardown(self, sess: _ServerSession) -> None:
+        sess.sse_stop.set()
+        self._kill_process(sess)
+        if sess.sse_thread is not None:
+            # Bounded: killing the server closed the stream socket, which
+            # unblocks the reader; the join is a courtesy, never a gate.
+            sess.sse_thread.join(timeout=2.0)
+        if sess.client is not None:
+            try:
+                sess.client.close()
+            except Exception:  # noqa: BLE001  # nosec B110 - closing is best-effort
+                pass
+        try:
+            sess.log_fh.close()
+        except OSError:
+            pass
+
+    def _kill_process(self, sess: _ServerSession) -> None:
+        process = sess.process
+        if process.poll() is not None:
+            return
+        host = get_process_host()
+        # The live Popen handle pins the pid (win32 handle / unreaped POSIX
+        # child), so signalling it cannot hit a reused pid — the identity
+        # confirmation force_kill's contract asks for.
+        if sys.platform == "win32":
+            # Both the npm install and the test launcher are `.cmd` wrappers:
+            # Popen.pid is cmd.exe. Go straight to the tree force-kill while
+            # the tree is still intact — a polite taskkill can reap cmd.exe
+            # alone (orphaning the server with the port bound), and once the
+            # wrapper is gone `/T` can never enumerate the child again.
+            try:
+                host.force_kill(process.pid)
+            except Exception:  # noqa: BLE001  # nosec B110 - already-gone races are fine
+                pass
+        else:
+            try:
+                host.terminate(process.pid)  # SIGTERM exits opencode cleanly (pins §11)
+            except OSError:
+                pass
+        try:
+            process.wait(timeout=self.kill_wait_s)
+        except subprocess.TimeoutExpired:
+            try:
+                host.force_kill(process.pid)
+            except Exception:  # noqa: BLE001  # nosec B110 - already-gone races are fine
+                pass
+            try:
+                process.wait(timeout=self.kill_wait_s)
+            except subprocess.TimeoutExpired:
+                pass
+
+    def _atexit_sweep(self) -> None:
+        for task_id in list(self._sessions):
+            sess = self._sessions.pop(task_id, None)
+            if sess is not None:
+                self._teardown(sess)
+
+
+def _sum_usage(messages: Any) -> TokenUsage:
+    """Sum assistant-message token counts (pins §7). Reasoning tokens are
+    billed as output; OpenCode's cache read/write map onto the claude-style
+    cache_read/cache_creation fields. Child-session (subagent) tokens are not
+    visible here — the messages endpoint is scoped per session."""
+    usage = TokenUsage()
+    if not isinstance(messages, list):
+        return usage
+    for msg in messages:
+        info = (msg or {}).get("info") or {}
+        if info.get("role") != "assistant":
+            continue
+        tokens = info.get("tokens") or {}
+        cache = tokens.get("cache") or {}
+        usage.add(
+            TokenUsage(
+                input_tokens=int(tokens.get("input") or 0),
+                output_tokens=int(tokens.get("output") or 0) + int(tokens.get("reasoning") or 0),
+                cache_read_tokens=int(cache.get("read") or 0),
+                cache_creation_tokens=int(cache.get("write") or 0),
+            )
+        )
+    return usage

--- a/src/bmad_loop/adapters/opencode_http.py
+++ b/src/bmad_loop/adapters/opencode_http.py
@@ -394,14 +394,18 @@ class OpencodeHttpAdapter(_ResultFileMixin, CodingCLIAdapter):
     def _prompt(self, sess: _ServerSession, text: str) -> None:
         """prompt_async — the injection primitive for both the initial prompt
         and the nudges. Advances the completion floor: anything completed
-        before this send is a previous turn's evidence."""
-        sess.floor_ms = max(sess.floor_ms, _now_ms())
+        before this send is a previous turn's evidence. The floor moves only
+        once the server ACCEPTS the prompt (204) — a rejected/failed send
+        starts no new turn, and consuming the floor for it would discard
+        still-valid completion evidence of the previous turn."""
+        sent_ms = _now_ms()  # sampled before the POST: it precedes the new turn
         resp = sess.client.post(
             f"/session/{sess.session_id}/prompt_async",
             json={"parts": [{"type": "text", "text": text}]},
         )
         if resp.status_code != 204:
             raise OpencodeServerError(f"prompt_async failed: {resp.status_code} {resp.text[:200]}")
+        sess.floor_ms = max(sess.floor_ms, sent_ms)
 
     def send_text(self, handle: SessionHandle, text: str) -> None:
         """Nudge the running session. Best-effort: a server that died between
@@ -523,14 +527,17 @@ class OpencodeHttpAdapter(_ResultFileMixin, CodingCLIAdapter):
 
             if event == "error":
                 # session.error may precede a retry, not a turn-end (status
-                # "retry" exists); only a settled not-busy session reads as a
+                # "retry" exists); only a PROVABLY settled session reads as a
                 # result-less Stop — an errored turn may never get
                 # time.completed, so waiting on proof-of-work alone would burn
-                # the whole timeout. A dead server takes the crash path.
+                # the whole timeout. A dead server takes the crash path; an
+                # unknowable status (probe failure) keeps waiting rather than
+                # mis-nudging a session that may still be retrying — timeout_s
+                # bounds a persistently unreadable one.
                 if sess.process.poll() is not None:
                     transcript = self._capture_usage(handle, sess)
                     return self._final(handle, spec, "crashed", session_id, transcript)
-                if self._status_running(sess):
+                if self._session_status(sess) is not False:
                     continue
                 event = "idle"
 
@@ -562,10 +569,14 @@ class OpencodeHttpAdapter(_ResultFileMixin, CodingCLIAdapter):
                                 spec.stall_nudges_cap is None
                                 or stall_nudges_sent < spec.stall_nudges_cap
                             ):
-                                if self._status_running(sess):
-                                    # Mid-turn (a busy child/parent the SSE
-                                    # missed): re-arm rather than injecting a
-                                    # prompt into a working session.
+                                if self._session_status(sess):
+                                    # Provably mid-turn (a busy child/parent the
+                                    # SSE missed): re-arm rather than injecting a
+                                    # prompt into a working session. Unknown
+                                    # (None) proceeds to the nudge — a transport
+                                    # too broken to answer the probe would fail
+                                    # the nudge too, and burning the bounded
+                                    # budget converges to an honest stall.
                                     stall_deadline = time.monotonic() + self._stall_grace_s
                                     continue
                                 stall_nudges_left -= 1
@@ -619,27 +630,29 @@ class OpencodeHttpAdapter(_ResultFileMixin, CodingCLIAdapter):
                 stall_nudges_left = self._stall_nudges
                 continue
 
-    def _status_running(self, sess: _ServerSession) -> bool:
-        """Whether /session/status reports this session busy or retrying.
-        Idle sessions are ABSENT from the map (pins §6) — absence means not
-        running. Unreachable server reads as not-running; the process poll
-        settles real death."""
+    def _session_status(self, sess: _ServerSession) -> bool | None:
+        """Tri-state /session/status probe: True = busy/retrying, False =
+        provably settled (absent from the map — pins §6 — or explicit idle),
+        None = unknowable (unreachable server, non-200). Unknown is not
+        settled: callers must not treat a failed probe as proof a turn ended
+        (the liveness-parity doctrine); the process poll settles real death."""
         try:
             resp = sess.client.get("/session/status")
             if resp.status_code != 200:
-                return False
+                return None
             status = resp.json().get(sess.session_id) or {}
             return status.get("type") in ("busy", "retry")
         except Exception:  # noqa: BLE001 - probe is advisory
-            return False
+            return None
 
     def _probe_completion(self, sess: _ServerSession) -> bool:
         """HTTP fallback for a lossy stream (pins §6): the turn is finished
-        only when the session is not busy/retrying AND an assistant message
-        completed strictly after the completion floor exists — an idle status
-        alone is not proof a turn ran (pins §3/§8). Consuming the evidence
-        advances the floor so one completion can never be consumed twice."""
-        if self._status_running(sess):
+        only when the session is PROVABLY settled (an unknowable status is not
+        settled) AND an assistant message completed strictly after the
+        completion floor exists — an idle status alone is not proof a turn ran
+        (pins §3/§8). Consuming the evidence advances the floor so one
+        completion can never be consumed twice."""
+        if self._session_status(sess) is not False:
             return False
         try:
             resp = sess.client.get(f"/session/{sess.session_id}/message")

--- a/src/bmad_loop/cli.py
+++ b/src/bmad_loop/cli.py
@@ -259,6 +259,10 @@ def cmd_validate(args: argparse.Namespace) -> int:
 
     profiles = []
     pol = None
+    # Hookless profile names the policy assigns to the synthesizing dev/review
+    # roles — unrunnable until the opencode-http plan's Phase 4 lands, so
+    # validate must FAIL them exactly like `_make_adapters` would at run start.
+    synth_hookless: set[str] = set()
     try:
         pol = policy_mod.load(_policy_path(project))
         role_names = {role: pol.adapter.resolved(role).name for role in ROLES}
@@ -267,11 +271,19 @@ def cmd_validate(args: argparse.Namespace) -> int:
             f"adapter dev={role_names['dev']}, review={role_names['review']}, "
             f"triage={role_names['triage']}"
         )
+        by_raw_name = {}
         for name in dict.fromkeys(role_names.values()):
             try:
-                profiles.append(get_profile(name, project))
+                profile = get_profile(name, project)
+                profiles.append(profile)
+                by_raw_name[name] = profile
             except ProfileError as e:
                 problems.append(str(e))
+        if pol.dev.skill == "bmad-dev-auto":  # mirrors _make_adapters' synthesizes
+            for role in ("dev", "review"):
+                profile = by_raw_name.get(role_names[role])
+                if profile is not None and profile.hookless:
+                    synth_hookless.add(profile.name)
     except policy_mod.PolicyError as e:
         problems.append(str(e))
 
@@ -316,6 +328,12 @@ def cmd_validate(args: argparse.Namespace) -> int:
             notes.append(
                 f"{profile.name}: hookless (HTTP/SSE transport) — no hook registration needed"
             )
+            if profile.name in synth_hookless:
+                problems.append(
+                    f"{profile.name}: cannot drive the dev/review roles yet — dev/review "
+                    f"synthesis lands in Phase 4 of the opencode-http plan; assign it to "
+                    f"triage only (e.g. [adapter.triage])"
+                )
             # The HTTP adapter needs httpx, which ships as an optional extra —
             # surface a missing install here instead of at run start.
             if importlib.util.find_spec("httpx") is not None:

--- a/src/bmad_loop/cli.py
+++ b/src/bmad_loop/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import json
 import os
 import shutil
@@ -126,26 +127,44 @@ def _make_adapters(project: Path, run_dir: Path, policy) -> dict[str, CodingCLIA
                 profile = get_profile(cfg.name, project)
             except ProfileError as e:
                 raise SystemExit(f"error: {e}") from e
-            # TODO(opencode-http Phase 3): dispatch hookless profiles to the HTTP
-            # adapter instead of erroring — the tmux adapters below cannot drive them.
             if profile.hookless:
-                raise SystemExit(
-                    f"error: profile '{profile.name}' needs the HTTP adapter (not yet wired)"
+                # Hookless profiles (opencode-http) are driven over HTTP/SSE —
+                # the tmux adapters below cannot host them.
+                if synthesizes:
+                    # TODO(opencode-http Phase 4): OpencodeDevAdapter composes
+                    # _DevSynthesisMixin over the HTTP adapter for dev/review.
+                    raise SystemExit(
+                        f"error: profile '{profile.name}' cannot drive dev/review yet — "
+                        f"dev/review synthesis lands in Phase 4 of the opencode-http plan"
+                    )
+                from .adapters.opencode_http import OpencodeHttpAdapter, OpencodeServerError
+
+                try:
+                    by_cfg[key] = OpencodeHttpAdapter(
+                        run_dir=run_dir,
+                        policy=policy,
+                        profile=profile,
+                        extra_args=cfg.extra_args,
+                        usage_grace_s=cfg.usage_grace_s,
+                        stop_without_result_nudges=cfg.stop_without_result_nudges,
+                    )
+                except OpencodeServerError as e:
+                    raise SystemExit(f"error: {e}") from e
+            else:
+                common = dict(
+                    run_dir=run_dir,
+                    policy=policy,
+                    profile=profile,
+                    extra_args=cfg.extra_args,
+                    usage_grace_s=cfg.usage_grace_s,
+                    stop_without_result_nudges=cfg.stop_without_result_nudges,
+                    mux=mux,
                 )
-            common = dict(
-                run_dir=run_dir,
-                policy=policy,
-                profile=profile,
-                extra_args=cfg.extra_args,
-                usage_grace_s=cfg.usage_grace_s,
-                stop_without_result_nudges=cfg.stop_without_result_nudges,
-                mux=mux,
-            )
-            by_cfg[key] = (
-                GenericDevAdapter(**common, paths=paths)
-                if synthesizes
-                else GenericAdapter(**common)
-            )
+                by_cfg[key] = (
+                    GenericDevAdapter(**common, paths=paths)
+                    if synthesizes
+                    else GenericAdapter(**common)
+                )
         adapters[role] = by_cfg[key]
     return adapters
 
@@ -297,6 +316,15 @@ def cmd_validate(args: argparse.Namespace) -> int:
             notes.append(
                 f"{profile.name}: hookless (HTTP/SSE transport) — no hook registration needed"
             )
+            # The HTTP adapter needs httpx, which ships as an optional extra —
+            # surface a missing install here instead of at run start.
+            if importlib.util.find_spec("httpx") is not None:
+                notes.append(f"httpx available for {profile.name}")
+            else:
+                problems.append(
+                    f"{profile.name}: httpx not installed — "
+                    f"run `pip install 'bmad-loop[opencode]'`"
+                )
             continue
         hook_config = project / profile.hooks.config_path
         hooks_ok = False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1819,12 +1819,13 @@ def _validate_output(capsys):
 
 
 def test_validate_hookless_profile_notes_no_hook_registration(project, capsys):
-    """A hookless profile (opencode-http, via its `opencode` alias) validates with
-    an informational note instead of the 'hooks not registered' FAIL — there is no
-    hook config to check. Exit code is not asserted: other gates (binary on PATH,
-    upstream skills) legitimately vary by machine."""
+    """A hookless profile (opencode-http, via its `opencode` alias) on a role it
+    can drive (triage) validates with an informational note instead of the
+    'hooks not registered' FAIL — there is no hook config to check. Exit code is
+    not asserted: other gates (binary on PATH, upstream skills) legitimately
+    vary by machine."""
     install_bmad_config(project)
-    _write_policy(project.project, '[adapter]\nname = "opencode"\n')
+    _write_policy(project.project, '[adapter.triage]\nname = "opencode"\n')
     args = argparse.Namespace(project=str(project.project), spec=None)
 
     cli.cmd_validate(args)
@@ -1833,6 +1834,22 @@ def test_validate_hookless_profile_notes_no_hook_registration(project, capsys):
     assert "hooks not registered for opencode-http" not in text
     # httpx ships in the dev group, so the extra-dependency gate passes here
     assert "httpx available for opencode-http" in text
+    # triage-only is runnable today: no Phase 4 guard problem
+    assert "phase 4" not in text
+
+
+def test_validate_hookless_dev_review_fails_until_phase4(project, capsys):
+    """A policy that assigns a hookless profile to the synthesizing dev/review
+    roles is unrunnable until Phase 4 — validate must FAIL it the way
+    `_make_adapters` would at run start, not approve a doomed config."""
+    install_bmad_config(project)
+    _write_policy(project.project, '[adapter]\nname = "opencode"\n')
+    args = argparse.Namespace(project=str(project.project), spec=None)
+
+    assert cli.cmd_validate(args) == 1
+    text = _validate_output(capsys)
+    assert "cannot drive the dev/review roles yet" in text
+    assert "phase 4" in text
 
 
 def test_validate_hookless_profile_flags_missing_httpx(project, capsys, monkeypatch):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -628,15 +628,36 @@ def test_make_adapters_review_synthesizes_from_spec(project):
     assert not isinstance(adapters["triage"], GenericDevAdapter)
 
 
-def test_make_adapters_hookless_profile_not_yet_wired(project):
-    """Temporary Phase 1 guard (opencode-http plan): selecting a hookless profile
-    is a clean error until the HTTP adapter lands (Phase 3) — the tmux-transport
-    adapters cannot drive a profile that registers no hooks."""
+def test_make_adapters_hookless_synthesizing_roles_guarded(project):
+    """Temporary Phase 3 guard (opencode-http plan): dev/review are synthesizing
+    bmad-dev-auto roles, and the OpencodeDevAdapter that hosts the synthesis
+    mixin over HTTP lands in Phase 4 — until then selecting a hookless profile
+    for those roles is a clean error, not a silent misdrive."""
     install_bmad_config(project)
     _write_policy(project.project, '[adapter]\nname = "opencode"\n')
     pol = policy_mod.load(project.project / ".bmad-loop" / "policy.toml")
-    with pytest.raises(SystemExit, match="needs the HTTP adapter"):
+    with pytest.raises(SystemExit, match="dev/review synthesis lands in Phase 4"):
         cli._make_adapters(project.project, project.project / ".bmad-loop" / "runs" / "r", pol)
+
+
+def test_make_adapters_hookless_triage_dispatches_http_adapter(project):
+    """A hookless profile on a non-synthesizing role (triage) dispatches to the
+    HTTP adapter — resolved via the `opencode` alias — while dev/review keep the
+    shared spec-synthesizing tmux adapter. The HTTP adapter exposes `profile`
+    (worktree provisioning keys off it) and never constructs a multiplexer."""
+    from bmad_loop.adapters.generic import GenericDevAdapter
+    from bmad_loop.adapters.opencode_http import OpencodeHttpAdapter
+
+    install_bmad_config(project)
+    _write_policy(project.project, '[adapter.triage]\nname = "opencode"\n')
+    pol = policy_mod.load(project.project / ".bmad-loop" / "policy.toml")
+    adapters = cli._make_adapters(
+        project.project, project.project / ".bmad-loop" / "runs" / "r", pol
+    )
+    assert isinstance(adapters["triage"], OpencodeHttpAdapter)
+    assert adapters["triage"].profile.name == "opencode-http"
+    assert isinstance(adapters["dev"], GenericDevAdapter)
+    assert adapters["dev"] is adapters["review"]  # (cfg, synthesizes) sharing intact
 
 
 class _StubEngine:
@@ -1810,6 +1831,31 @@ def test_validate_hookless_profile_notes_no_hook_registration(project, capsys):
     text = _validate_output(capsys)
     assert "opencode-http: hookless (http/sse transport)" in text
     assert "hooks not registered for opencode-http" not in text
+    # httpx ships in the dev group, so the extra-dependency gate passes here
+    assert "httpx available for opencode-http" in text
+
+
+def test_validate_hookless_profile_flags_missing_httpx(project, capsys, monkeypatch):
+    """A hookless profile whose httpx extra is not installed FAILs validate with
+    the actionable install hint — at validate time, not deep in a run start."""
+    import importlib.util
+
+    real_find_spec = importlib.util.find_spec
+
+    def fake_find_spec(name, *args, **kwargs):
+        if name == "httpx":
+            return None
+        return real_find_spec(name, *args, **kwargs)
+
+    install_bmad_config(project)
+    _write_policy(project.project, '[adapter]\nname = "opencode"\n')
+    monkeypatch.setattr(cli.importlib.util, "find_spec", fake_find_spec)
+    args = argparse.Namespace(project=str(project.project), spec=None)
+
+    cli.cmd_validate(args)
+    text = _validate_output(capsys)
+    assert "httpx not installed" in text
+    assert "bmad-loop[opencode]" in text
 
 
 def test_validate_stories_mode_skips_sprint_gate(project, capsys):

--- a/tests/test_opencode_http.py
+++ b/tests/test_opencode_http.py
@@ -1,0 +1,653 @@
+"""OpencodeHttpAdapter: unit tests + fake-binary E2E against a FakeOpencode.
+
+The E2E cases spawn the adapter's real code path end to end: a fake `opencode`
+binary (a stdlib-only HTTP server implementing the pinned 1.18.2 surface —
+docs/notes/opencode-api-pins.md) is launched by the adapter itself via the
+conftest ``write_script_launcher`` shim, scripted per scenario through env vars
+riding ``spec.env`` (the same channel the engine's BMAD_LOOP_* contract uses).
+Everything binds 127.0.0.1; no real opencode binary or network access anywhere.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+
+import pytest
+from conftest import write_script_launcher
+
+from bmad_loop.adapters.base import SessionHandle, SessionSpec
+from bmad_loop.adapters.generic import NUDGE_TEXT, STALL_NUDGE_TEXT
+from bmad_loop.adapters.opencode_http import (
+    OpencodeHttpAdapter,
+    OpencodeServerError,
+    _free_port,
+    _now_ms,
+    _parse_sse_lines,
+    _sum_usage,
+)
+from bmad_loop.adapters.profile import get_profile
+from bmad_loop.model import TokenUsage
+from bmad_loop.policy import LimitsPolicy, Policy
+from bmad_loop.process_host import get_process_host
+
+# A pinned example timestamp from the pins file (§4): OpenCode `time.*` values
+# are epoch MILLISECONDS. The proof-of-work floor must live in the same unit —
+# a ns-vs-ms comparison is always False and silently disables the poll
+# fallback, so these tests anchor the unit explicitly.
+PINNED_EPOCH_MS = 1_784_218_739_410
+
+# ---------------------------------------------------------------- FakeOpencode
+#
+# Scenario contract (FAKE_OPENCODE_SCENARIO):
+#   completed          prompt -> write result.json -> SSE session.idle
+#   nudge-then-complete first prompt idles result-less; the second (the nudge)
+#                      writes the result and idles
+#   stall              every prompt idles result-less, forever
+#   busy-forever       the turn never finishes and never idles
+#   die-after-result   prompt -> write result.json -> the server process exits
+#   die-no-result      prompt -> the server process exits
+#   sse-black-hole     the SSE stream closes right after connecting (every
+#                      reconnect); the turn completes result+messages only —
+#                      completion is reachable only via the HTTP poll fallback
+# FAKE_OPENCODE_START_FAILURES=N makes the first N spawns exit(1) pre-bind.
+#
+# Recordings under FAKE_OPENCODE_DIR: sessions.jsonl (incl. the Authorization
+# header), prompts.jsonl, aborts.jsonl, pid (the server's own pid).
+
+FAKE_OPENCODE = r"""
+import json, os, sys, threading, time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+SCENARIO = os.environ.get("FAKE_OPENCODE_SCENARIO", "completed")
+REC_DIR = os.environ["FAKE_OPENCODE_DIR"]
+RESULT_PATH = os.environ.get("FAKE_OPENCODE_RESULT_PATH", "")
+START_FAILURES = int(os.environ.get("FAKE_OPENCODE_START_FAILURES", "0"))
+
+argv = sys.argv[1:]
+assert argv and argv[0] == "serve", argv
+PORT = int(argv[argv.index("--port") + 1])
+HOST = argv[argv.index("--hostname") + 1]
+
+if START_FAILURES:
+    counter = os.path.join(REC_DIR, "start-count")
+    n = 0
+    if os.path.exists(counter):
+        with open(counter, encoding="utf-8") as fh:
+            n = int(fh.read().strip() or 0)
+    with open(counter, "w", encoding="utf-8") as fh:
+        fh.write(str(n + 1))
+    if n < START_FAILURES:
+        sys.exit(1)
+
+SESSION_ID = "ses_fake0000000000000000000001"
+LOCK = threading.Lock()
+STATE = {"busy": False, "completed_ms": 0, "prompts": 0}
+EVENTS = []
+
+
+def now_ms():
+    return int(time.time() * 1000)
+
+
+def record(name, obj):
+    with LOCK:
+        with open(os.path.join(REC_DIR, name), "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(obj) + "\n")
+
+
+def push(evt):
+    with LOCK:
+        EVENTS.append(evt)
+
+
+def pop_events():
+    with LOCK:
+        out, EVENTS[:] = EVENTS[:], []
+    return out
+
+
+def idle_event():
+    return {"type": "session.idle", "properties": {"sessionID": SESSION_ID}}
+
+
+def write_result():
+    if RESULT_PATH:
+        with open(RESULT_PATH, "w", encoding="utf-8") as fh:
+            json.dump({"ok": True, "workflow": "fake-triage"}, fh)
+
+
+def finish_turn():
+    with LOCK:
+        STATE["completed_ms"] = now_ms()
+        STATE["busy"] = False
+
+
+def run_turn():
+    with LOCK:
+        STATE["busy"] = True
+        n = STATE["prompts"]
+    # let the 204 flush before any scripted death tears the connection down
+    time.sleep(0.15)
+    if SCENARIO == "completed":
+        write_result(); finish_turn(); push(idle_event())
+    elif SCENARIO == "nudge-then-complete":
+        if n >= 2:
+            write_result()
+        finish_turn(); push(idle_event())
+    elif SCENARIO == "stall":
+        finish_turn(); push(idle_event())
+    elif SCENARIO == "busy-forever":
+        pass  # stays busy: no finish, no idle
+    elif SCENARIO == "die-after-result":
+        write_result(); os._exit(0)
+    elif SCENARIO == "die-no-result":
+        os._exit(0)
+    elif SCENARIO == "sse-black-hole":
+        write_result(); finish_turn()  # completion visible over HTTP only
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *a):
+        pass
+
+    def _json(self, code, obj):
+        body = json.dumps(obj).encode("utf-8")
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        if self.path == "/global/health":
+            self._json(200, {"healthy": True, "version": "1.18.2"})
+        elif self.path == "/session/status":
+            with LOCK:
+                busy = STATE["busy"]
+            self._json(200, {SESSION_ID: {"type": "busy"}} if busy else {})
+        elif self.path.startswith("/session/") and self.path.endswith("/message"):
+            with LOCK:
+                done = STATE["completed_ms"]
+            msgs = []
+            if done:
+                msgs = [{
+                    "info": {
+                        "id": "msg_fake1", "role": "assistant",
+                        "time": {"created": done - 10, "completed": done},
+                        "tokens": {"input": 100, "output": 50, "reasoning": 5,
+                                   "cache": {"read": 7, "write": 3}},
+                        "cost": 0.01,
+                    },
+                    "parts": [],
+                }]
+            self._json(200, msgs)
+        elif self.path == "/event":
+            self._sse()
+        else:
+            self._json(404, {"name": "NotFoundError"})
+
+    def _sse(self):
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.end_headers()
+
+        def emit(evt):
+            self.wfile.write(b"data: " + json.dumps(evt).encode("utf-8") + b"\n\n")
+            self.wfile.flush()
+
+        try:
+            emit({"type": "server.connected", "properties": {}})
+            if SCENARIO == "sse-black-hole":
+                return  # close the stream: events are never deliverable
+            last_beat = time.time()
+            while True:
+                for evt in pop_events():
+                    emit(evt)
+                if time.time() - last_beat > 0.2:
+                    emit({"type": "server.heartbeat", "properties": {}})
+                    last_beat = time.time()
+                time.sleep(0.02)
+        except OSError:
+            return  # client went away
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length") or 0)
+        body = json.loads(self.rfile.read(length) or b"{}")
+        if self.path == "/session":
+            record("sessions.jsonl",
+                   {"body": body, "auth": self.headers.get("Authorization", "")})
+            self._json(200, {"id": SESSION_ID, "title": body.get("title", ""),
+                             "cost": 0,
+                             "tokens": {"input": 0, "output": 0, "reasoning": 0,
+                                        "cache": {"read": 0, "write": 0}},
+                             "time": {"created": now_ms(), "updated": now_ms()}})
+        elif self.path.endswith("/prompt_async"):
+            record("prompts.jsonl", body)
+            with LOCK:
+                STATE["prompts"] += 1
+            threading.Thread(target=run_turn, daemon=True).start()
+            self.send_response(204)
+            self.end_headers()
+        elif self.path.endswith("/abort"):
+            record("aborts.jsonl", {"path": self.path})
+            self._json(200, True)
+        else:
+            self._json(404, {"name": "NotFoundError"})
+
+
+if sys.platform == "win32":
+    # SO_REUSEADDR on Windows allows binding a port already in LISTEN — under
+    # xdist two fakes could silently share one port. Bind exclusively instead.
+    ThreadingHTTPServer.allow_reuse_address = False
+ThreadingHTTPServer.daemon_threads = True
+ThreadingHTTPServer.block_on_close = False
+
+server = ThreadingHTTPServer((HOST, PORT), Handler)
+with open(os.path.join(REC_DIR, "pid"), "w", encoding="utf-8") as fh:
+    fh.write(str(os.getpid()))
+server.serve_forever(poll_interval=0.05)
+"""
+
+
+# -------------------------------------------------------------------- helpers
+
+
+def _policy(**limits) -> Policy:
+    return Policy(limits=LimitsPolicy(**limits) if limits else LimitsPolicy())
+
+
+def make_adapter(tmp_path: Path, binary: str = "opencode", **kwargs) -> OpencodeHttpAdapter:
+    adapter = OpencodeHttpAdapter(
+        run_dir=tmp_path / "run",
+        policy=kwargs.pop("policy", _policy()),
+        profile=get_profile("opencode"),
+        binary=binary,
+        **kwargs,
+    )
+    # Shrink every cadence for tests; the defaults are minutes of wall clock.
+    adapter.health_timeout_s = 10.0
+    adapter.health_poll_s = 0.05
+    adapter.reconnect_sleep_s = 0.05
+    adapter.silence_threshold_s = 2.0
+    adapter.poll_tick_s = 0.05
+    adapter.result_grace_s = 0.5
+    return adapter
+
+
+@pytest.fixture
+def fake_opencode(tmp_path):
+    """The fake `opencode` launcher plus its recording dir."""
+    rec = tmp_path / "recordings"
+    rec.mkdir()
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    launcher = write_script_launcher(bin_dir, "opencode", FAKE_OPENCODE)
+    return launcher, rec
+
+
+def make_spec(
+    tmp_path: Path,
+    rec: Path,
+    scenario: str,
+    task_id: str = "t-1",
+    timeout_s: float = 30.0,
+    stall_nudges_cap: int | None = 6,
+    extra_env: dict | None = None,
+) -> SessionSpec:
+    env = {
+        "FAKE_OPENCODE_SCENARIO": scenario,
+        "FAKE_OPENCODE_DIR": str(rec),
+        "FAKE_OPENCODE_RESULT_PATH": str(tmp_path / "run" / "tasks" / task_id / "result.json"),
+        **(extra_env or {}),
+    }
+    return SessionSpec(
+        task_id=task_id,
+        role="triage",
+        prompt="/bmad-loop-sweep run it",
+        cwd=tmp_path,
+        env=env,
+        timeout_s=timeout_s,
+        stall_nudges_cap=stall_nudges_cap,
+    )
+
+
+def read_jsonl(path: Path) -> list[dict]:
+    if not path.is_file():
+        return []
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line]
+
+
+def assert_server_gone(rec: Path) -> None:
+    """The fake's recorded pid must be dead once the adapter is done with it —
+    `opencode serve` survives parent death, so a leak here is a real leak."""
+    pid_file = rec / "pid"
+    if not pid_file.is_file():
+        return  # never got far enough to serve
+    pid = int(pid_file.read_text(encoding="utf-8"))
+    host = get_process_host()
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        if not host.is_alive(pid):
+            return
+        time.sleep(0.05)
+    raise AssertionError(f"fake opencode server (pid {pid}) is still alive")
+
+
+def prompt_texts(rec: Path) -> list[str]:
+    return [p["parts"][0]["text"] for p in read_jsonl(rec / "prompts.jsonl")]
+
+
+# ------------------------------------------------------------------ unit tests
+
+
+def test_free_port_is_bindable():
+    import socket
+
+    port = _free_port()
+    assert 0 < port < 65536
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", port))  # still free (racy by design, but just picked)
+
+
+def test_ms_floor_unit_matches_opencode_timestamps():
+    """OpenCode timestamps are epoch ms (pins §4). The completion floor derives
+    from time_ns // 1e6 and MUST be comparable to them: same unit, same epoch."""
+    floor = time.time_ns() // 1_000_000
+    assert abs(floor - _now_ms()) < 5_000
+    # comparable to the pins' pinned example (a real 1.18.2 response value):
+    # the floor is later than that 2026 timestamp but within the same magnitude.
+    assert PINNED_EPOCH_MS < floor < PINNED_EPOCH_MS * 10
+
+
+def test_config_content_shapes(tmp_path):
+    adapter = make_adapter(tmp_path)
+    spec = SessionSpec(task_id="t", role="triage", prompt="p", cwd=tmp_path)
+    config = json.loads(adapter._config_content(spec))
+    assert config["permission"] == "allow"
+    # pins §10 hermetic recipe: the project skill tree, absolute
+    assert config["skills"]["paths"] == [str(tmp_path / ".claude" / "skills")]
+    assert "model" not in config
+
+    spec_model = SessionSpec(
+        task_id="t", role="triage", prompt="p", cwd=tmp_path, model="anthropic/claude-x"
+    )
+    config = json.loads(adapter._config_content(spec_model))
+    assert config["model"] == "anthropic/claude-x"
+
+
+def test_session_env_carries_contract(tmp_path):
+    adapter = make_adapter(tmp_path)
+    spec = SessionSpec(
+        task_id="t", role="triage", prompt="p", cwd=tmp_path, env={"BMAD_LOOP_TASK_ID": "t"}
+    )
+    env = adapter._session_env(spec, "sekrit")
+    assert env["BMAD_LOOP_TASK_ID"] == "t"
+    assert env["OPENCODE_SERVER_PASSWORD"] == "sekrit"
+    assert env["OPENCODE_DISABLE_EXTERNAL_SKILLS"] == "1"
+    json.loads(env["OPENCODE_CONFIG_CONTENT"])  # valid JSON
+
+
+def test_sse_parser_accumulates_and_tolerates_junk():
+    lines = [
+        "data: " + json.dumps({"type": "server.connected", "properties": {}}),
+        "",
+        ": a comment",
+        "id: 42",
+        "data: not json",
+        "",
+        "data: " + json.dumps({"type": "session.idle", "properties": {"sessionID": "ses_1"}}),
+        "",
+    ]
+    events = list(_parse_sse_lines(lines))
+    assert [e["type"] for e in events] == ["server.connected", "session.idle"]
+
+
+def test_sse_dispatch_filters_child_sessions(tmp_path):
+    """A child/subagent session's idle must not read as the parent's turn-end,
+    but its frames DO count as activity (the parent is silent while a child
+    streams — the tmux pane-log analogue)."""
+    from bmad_loop.adapters.opencode_http import _ServerSession
+
+    adapter = make_adapter(tmp_path)
+    sess = _ServerSession(process=None, port=0, base_url="", password="", log_fh=None)
+    sess.session_id = "ses_parent"
+    adapter._dispatch_sse(sess, {"type": "server.heartbeat", "properties": {}})
+    assert sess.activity == 0 and sess.events.empty()
+    adapter._dispatch_sse(sess, {"type": "session.idle", "properties": {"sessionID": "ses_child"}})
+    assert sess.activity == 1 and sess.events.empty()
+    adapter._dispatch_sse(
+        sess, {"type": "message.part.updated", "properties": {"sessionID": "ses_child"}}
+    )
+    assert sess.activity == 2 and sess.events.empty()
+    adapter._dispatch_sse(sess, {"type": "session.idle", "properties": {"sessionID": "ses_parent"}})
+    assert sess.events.get_nowait() == "idle"
+    adapter._dispatch_sse(
+        sess, {"type": "session.error", "properties": {"sessionID": "ses_parent"}}
+    )
+    assert sess.events.get_nowait() == "error"
+
+
+def test_sum_usage_maps_opencode_tokens():
+    messages = [
+        {"info": {"role": "user", "tokens": {"input": 999}}},  # not assistant: ignored
+        {
+            "info": {
+                "role": "assistant",
+                "tokens": {
+                    "input": 100,
+                    "output": 50,
+                    "reasoning": 5,
+                    "cache": {"read": 7, "write": 3},
+                },
+            }
+        },
+        {
+            "info": {
+                "role": "assistant",
+                "tokens": {
+                    "input": 10,
+                    "output": 20,
+                    "reasoning": 0,
+                    "cache": {"read": 1, "write": 2},
+                },
+            }
+        },
+        {"info": {"role": "assistant"}},  # tokenless (e.g. aborted): ignored
+    ]
+    usage = _sum_usage(messages)
+    assert usage == TokenUsage(
+        input_tokens=110, output_tokens=75, cache_read_tokens=8, cache_creation_tokens=5
+    )
+    assert _sum_usage("garbage") == TokenUsage()
+
+
+def test_missing_httpx_names_the_extra(tmp_path, monkeypatch):
+    monkeypatch.setitem(sys.modules, "httpx", None)
+    with pytest.raises(OpencodeServerError, match=r"bmad-loop\[opencode\]"):
+        make_adapter(tmp_path)
+
+
+def test_missing_binary_is_a_clean_error(tmp_path):
+    adapter = make_adapter(tmp_path, binary="definitely-not-a-real-binary-xyz")
+    spec = SessionSpec(task_id="t", role="triage", prompt="p", cwd=tmp_path)
+    with pytest.raises(OpencodeServerError, match="not found on PATH"):
+        adapter.start_session(spec)
+
+
+def test_kill_unknown_handle_is_a_noop(tmp_path):
+    adapter = make_adapter(tmp_path)
+    adapter.kill(SessionHandle(task_id="never-started", native_id="ses_x"))
+
+
+def test_read_usage_returns_stash_by_session_id(tmp_path):
+    from bmad_loop.adapters.base import SessionResult
+
+    adapter = make_adapter(tmp_path)
+    adapter._usage["ses_1"] = TokenUsage(input_tokens=1)
+    assert adapter.read_usage(SessionResult(status="completed", session_id="ses_1")).total == 1
+    assert adapter.read_usage(SessionResult(status="completed", session_id="ses_2")) is None
+    assert adapter.read_usage(SessionResult(status="completed")) is None
+
+
+# ------------------------------------------------------------------- E2E tests
+
+
+def test_e2e_completed(tmp_path, fake_opencode):
+    launcher, rec = fake_opencode
+    adapter = make_adapter(tmp_path, binary=str(launcher))
+    spec = make_spec(tmp_path, rec, "completed")
+
+    result = adapter.run(spec)
+
+    assert result.status == "completed"
+    assert result.result_json == {"ok": True, "workflow": "fake-triage"}
+    assert result.session_id and result.session_id.startswith("ses_")
+    # transcript = the raw messages dump; usage stashed for read_usage
+    assert result.transcript_path and Path(result.transcript_path).is_file()
+    usage = adapter.read_usage(result)
+    assert usage == TokenUsage(
+        input_tokens=100, output_tokens=55, cache_read_tokens=7, cache_creation_tokens=3
+    )
+    # the prompt went through the profile's template
+    assert prompt_texts(rec) == ["Use the bmad-loop-sweep skill now: run it"]
+    # authenticated transport end to end
+    sessions = read_jsonl(rec / "sessions.jsonl")
+    assert sessions and sessions[0]["auth"].startswith("Basic ")
+    # teardown: registry empty, server dead, log tee landed
+    assert adapter._sessions == {}
+    assert_server_gone(rec)
+    assert (tmp_path / "run" / "logs" / "t-1.log").exists()
+
+
+def test_e2e_result_less_stop_nudges_then_completes(tmp_path, fake_opencode):
+    launcher, rec = fake_opencode
+    adapter = make_adapter(tmp_path, binary=str(launcher))
+    spec = make_spec(tmp_path, rec, "nudge-then-complete")
+
+    result = adapter.run(spec)
+
+    assert result.status == "completed"
+    texts = prompt_texts(rec)
+    assert len(texts) == 2
+    assert texts[1] == NUDGE_TEXT  # the wake-up carried the result-contract nudge
+    assert_server_gone(rec)
+
+
+def test_e2e_stall_after_nudge_budget(tmp_path, fake_opencode):
+    launcher, rec = fake_opencode
+    adapter = make_adapter(tmp_path, binary=str(launcher))
+    spec = make_spec(tmp_path, rec, "stall")
+
+    result = adapter.run(spec)
+
+    # default budget: 1 stop-nudge; the second result-less idle is a stall
+    assert result.status == "stalled"
+    assert result.result_json is None
+    assert len(prompt_texts(rec)) == 2
+    breadcrumbs = read_jsonl(tmp_path / "run" / "tasks" / "t-1" / "resultless-stops.jsonl")
+    assert breadcrumbs and all(b["verdict"] == "no-result-json" for b in breadcrumbs)
+    assert_server_gone(rec)
+
+
+def test_e2e_monotonic_stall_cap(tmp_path, fake_opencode):
+    """#149 on the HTTP transport: every result-less idle refills the per-silence
+    wake budget, so only the monotonic spec.stall_nudges_cap bounds a session
+    that keeps ending its turn without a result."""
+    launcher, rec = fake_opencode
+    adapter = make_adapter(tmp_path, binary=str(launcher), stop_without_result_nudges=0)
+    adapter._stall_grace_s = 0.3
+    adapter._stall_nudges = 99  # per-silence budget effectively unbounded
+    spec = make_spec(tmp_path, rec, "stall", stall_nudges_cap=2, timeout_s=60.0)
+
+    result = adapter.run(spec)
+
+    assert result.status == "stalled"
+    assert result.result_json is None
+    texts = prompt_texts(rec)
+    # initial prompt + exactly cap stall-nudges, then the stall verdict
+    assert len(texts) == 3
+    assert texts[1] == STALL_NUDGE_TEXT and texts[2] == STALL_NUDGE_TEXT
+    assert_server_gone(rec)
+
+
+def test_e2e_timeout_aborts(tmp_path, fake_opencode):
+    launcher, rec = fake_opencode
+    adapter = make_adapter(tmp_path, binary=str(launcher))
+    spec = make_spec(tmp_path, rec, "busy-forever", timeout_s=1.5)
+
+    result = adapter.run(spec)
+
+    assert result.status == "timeout"
+    assert result.result_json is None
+    aborts = read_jsonl(rec / "aborts.jsonl")
+    assert aborts and "/abort" in aborts[0]["path"]
+    assert_server_gone(rec)
+
+
+def test_e2e_server_death_with_artifact_completes(tmp_path, fake_opencode):
+    """Server death ≙ window death: the crash path vouches for a landed
+    result.json (accept_result=True), so finished-then-died reads completed."""
+    launcher, rec = fake_opencode
+    adapter = make_adapter(tmp_path, binary=str(launcher))
+    spec = make_spec(tmp_path, rec, "die-after-result")
+
+    result = adapter.run(spec)
+
+    assert result.status == "completed"
+    assert result.result_json == {"ok": True, "workflow": "fake-triage"}
+    assert_server_gone(rec)
+
+
+def test_e2e_server_death_without_artifact_crashes(tmp_path, fake_opencode):
+    launcher, rec = fake_opencode
+    adapter = make_adapter(tmp_path, binary=str(launcher))
+    spec = make_spec(tmp_path, rec, "die-no-result")
+
+    result = adapter.run(spec)
+
+    assert result.status == "crashed"
+    assert result.result_json is None
+    assert_server_gone(rec)
+
+
+def test_e2e_sse_loss_degrades_to_poll_fallback(tmp_path, fake_opencode):
+    """The stream closes after every connect, so session.idle is never
+    deliverable; completion must arrive via GET /session/status + the
+    message-level proof-of-work — in epoch-ms units (the regression test for
+    the ns-vs-ms floor bug, which silently disables this whole path)."""
+    launcher, rec = fake_opencode
+    adapter = make_adapter(tmp_path, binary=str(launcher))
+    spec = make_spec(tmp_path, rec, "sse-black-hole")
+
+    result = adapter.run(spec)
+
+    assert result.status == "completed"
+    assert result.result_json == {"ok": True, "workflow": "fake-triage"}
+    assert_server_gone(rec)
+
+
+def test_e2e_spawn_retry_survives_one_early_death(tmp_path, fake_opencode):
+    launcher, rec = fake_opencode
+    adapter = make_adapter(tmp_path, binary=str(launcher))
+    spec = make_spec(tmp_path, rec, "completed", extra_env={"FAKE_OPENCODE_START_FAILURES": "1"})
+
+    result = adapter.run(spec)
+
+    assert result.status == "completed"
+    assert int((rec / "start-count").read_text(encoding="utf-8")) == 2
+    assert_server_gone(rec)
+
+
+def test_e2e_spawn_gives_up_after_attempts(tmp_path, fake_opencode):
+    launcher, rec = fake_opencode
+    adapter = make_adapter(tmp_path, binary=str(launcher))
+    spec = make_spec(tmp_path, rec, "completed", extra_env={"FAKE_OPENCODE_START_FAILURES": "99"})
+
+    with pytest.raises(OpencodeServerError, match="after 3 attempts"):
+        adapter.run(spec)
+    assert adapter._sessions == {}
+    # every attempt appended to one log for the task
+    assert (tmp_path / "run" / "logs" / "t-1.log").exists()

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,19 @@ revision = 3
 requires-python = ">=3.11"
 
 [[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+]
+
+[[package]]
 name = "bmad-loop"
 version = "0.8.1"
 source = { editable = "." }
@@ -15,6 +28,9 @@ dependencies = [
 non-linux = [
     { name = "psutil" },
 ]
+opencode = [
+    { name = "httpx" },
+]
 tui = [
     { name = "pyte" },
     { name = "textual" },
@@ -23,6 +39,7 @@ tui = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "httpx" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-rerunfailures" },
@@ -32,6 +49,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "httpx", marker = "extra == 'opencode'", specifier = ">=0.28" },
     { name = "psutil", marker = "sys_platform == 'win32'", specifier = ">=7.2.2" },
     { name = "psutil", marker = "extra == 'non-linux'", specifier = ">=7.2.2" },
     { name = "pyte", marker = "extra == 'tui'", specifier = ">=0.8.2" },
@@ -39,15 +57,25 @@ requires-dist = [
     { name = "textual", marker = "extra == 'tui'", specifier = ">=8.0,<9" },
     { name = "tomlkit", marker = "extra == 'tui'", specifier = ">=0.13" },
 ]
-provides-extras = ["tui", "non-linux"]
+provides-extras = ["tui", "non-linux", "opencode"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "httpx", specifier = ">=0.28" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=1.0" },
     { name = "pytest-rerunfailures", specifier = ">=16.0" },
     { name = "pytest-xdist", specifier = ">=3.6" },
     { name = "ruff", specifier = ">=0.4" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.6.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
 ]
 
 [[package]]
@@ -66,6 +94,52 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Phase 3 of the opencode-http plan (follows #163 hookless profiles and #164 dev-synthesis mixins): rewrite `src/bmad_loop/adapters/opencode_http.py` from a NotImplementedError design stub into the real adapter for classic result.json-writing sessions (triage/sweep roles). Dev/review synthesis stays cleanly guarded until Phase 4's `OpencodeDevAdapter`.

Every endpoint path, event name, body schema and quirk is implemented against `docs/notes/opencode-api-pins.md` (pinned vs the real OpenCode 1.18.2 binary).

## Adapter design

- **One `opencode serve` per session** (the API has no per-session env; `BMAD_LOOP_*` must reach tool subprocesses via the server process env), spawned on an OS-assigned free port with retry on the bind race, `cwd=spec.cwd`, stdout/stderr teed to `run_dir/logs/<task_id>.log`.
- **Config via `OPENCODE_CONFIG_CONTENT`** (outranks project `opencode.json`, pins §9): blanket `permission: allow` (the bypass-flags analogue), the pins §10 **hermetic skills recipe** (`OPENCODE_DISABLE_EXTERNAL_SKILLS=1` + `skills.paths`) so sessions never see the operator's personal `~/.claude/skills`, and the policy model when set.
- **Per-session `OPENCODE_SERVER_PASSWORD`** with Basic auth on every request, including the readiness poll — a foreign server on a stolen port can never read as ready, and no other local process can drive an allow-all server.
- **Completion**: SSE `session.idle` ≙ the Stop hook (session-id filtered — child/subagent sessions share the stream and their idles must not read as the parent's turn-end). SSE is lossy upstream, so a gap/silent stream degrades to `GET /session/status` + message-level proof-of-work — in **epoch-ms** units behind a forward-advancing completion floor, so abort-emitted idles (pins §3/§8) and stale completed messages can never re-vouch a turn.
- **Verdict semantics mirror the generic tmux loop exactly**: server death ≙ window death (crash path honors a landed artifact), stalls under a live server pin `accept_result=False` (#48/#53), stall nudges honor the monotonic `spec.stall_nudges_cap` (#149) with `resultless-stops.jsonl` breadcrumbs — so Phase 4 gets the machinery by subclassing with zero loop edits.
- **Usage over HTTP before teardown** (server state is sqlite): raw messages dumped to `tasks/<task_id>/messages.json` as the transcript, assistant token sums stashed for `read_usage()`.
- **Teardown**: abort → SSE stop → platform-branched kill — straight to the process-**tree** force-kill on Windows (the npm shim is a `.cmd` wrapper; a polite kill reaps cmd.exe and orphans the server with the port bound) and SIGTERM-then-escalate on POSIX (pins §11: SIGTERM exits cleanly) — plus an atexit sweep, since `opencode serve` survives parent death.

## Wiring

- `_make_adapters`: hookless profiles dispatch to `OpencodeHttpAdapter` for non-synthesizing roles; synthesizing roles (dev/review under bmad-dev-auto) keep a SystemExit guard naming Phase 4.
- `cmd_validate`: hookless profiles get an `importlib.util.find_spec("httpx")` gate with the `pip install 'bmad-loop[opencode]'` hint.
- `pyproject.toml`: new `opencode` extra (`httpx>=0.28`, current is 0.28.1) + httpx in the dev group; `uv.lock` regenerated.

## Tests

`tests/test_opencode_http.py`: a stdlib-only **FakeOpencode** sidecar served as the fake `opencode` binary (conftest `write_script_launcher`), scenario-scripted through `spec.env` — the same channel the engine's env contract rides. E2E: completed / result-less-Stop→nudge→completed / stalled+breadcrumbs / monotonic stall cap / timeout→abort / server-death with+without artifact / **SSE-loss→poll-fallback** (the regression test for the ms-floor unit) / spawn retry + give-up. Every E2E asserts the server process is actually dead afterwards. Units: config content, SSE parse + child-session filtering, usage mapping, ms-unit anchor against the pins' example value, missing-httpx/binary errors, kill idempotence. All sockets 127.0.0.1; Windows-CI-safe (exclusive port bind, daemon threads, `os._exit` death scenarios).

`tests/test_cli.py`: Phase 1 guard test replaced by dispatch tests (triage→HTTP adapter via the `opencode` alias, dev/review sharing intact, Phase 4 guard) + validate httpx present/missing.

## Verification

- Full suite: **2307 passed, 1 skipped** (`pytest -n auto`); new E2E file stable across repeated runs, no leaked fake servers.
- black clean, full `trunk check` clean, `uv sync --locked --all-extras` green.

Phase 4 (`OpencodeDevAdapter` dev/review synthesis) and Phase 5 (operator surfaces, docs, live smoke + CHANGELOG) follow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for running OpenCode sessions via an HTTP/SSE adapter.
  * Introduced an `opencode` optional install extra and enabled real HTTP client usage for adapter tests.
  * Hookless profiles can use the HTTP adapter for the supported triage flow.

* **Validation**
  * Improved `validate` behavior with role-specific checks for hookless OpenCode profiles.
  * Added actionable messaging to install the missing optional HTTP dependency when needed.

* **Tests**
  * Added extensive unit + end-to-end coverage for completion, stalling, timeouts, crashes, SSE loss fallback, authentication, retries, and teardown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->