### PR TITLE
feat(adapters): opencode dev/review synthesis parity (Phase 4)

### DIFF
--- a/src/bmad_loop/adapters/opencode_http.py
+++ b/src/bmad_loop/adapters/opencode_http.py
@@ -59,12 +59,13 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from ..bmadconfig import ProjectPaths
 from ..journal import LOGS_DIR
 from ..model import TokenUsage
 from ..policy import Policy
 from ..process_host import get_process_host
 from .base import CodingCLIAdapter, SessionHandle, SessionResult, SessionSpec
-from .generic import NUDGE_TEXT, STALL_NUDGE_TEXT, _ResultFileMixin
+from .generic import NUDGE_TEXT, STALL_NUDGE_TEXT, _DevSynthesisMixin, _ResultFileMixin
 from .profile import CLIProfile
 
 # Spawn/readiness defaults; per-instance attributes so tests shrink them.
@@ -772,6 +773,40 @@ class OpencodeHttpAdapter(_ResultFileMixin, CodingCLIAdapter):
             sess = self._sessions.pop(task_id, None)
             if sess is not None:
                 self._teardown(sess)
+
+
+class OpencodeDevAdapter(_DevSynthesisMixin, OpencodeHttpAdapter):
+    """Dev/review adapter for the generic ``bmad-dev-auto`` skill over HTTP.
+
+    That skill writes NO ``result.json`` — its outcome lives in the terminal
+    spec it leaves on disk, which :class:`_DevSynthesisMixin` locates and
+    synthesizes into the legacy result dict via :mod:`devcontract` (the same
+    machinery as GenericDevAdapter, mixin-shared rather than duplicated).
+    Selected by ``policy.dev.skill == "bmad-dev-auto"`` (see
+    ``cli._make_adapters``).
+    """
+
+    def __init__(self, *args, paths: ProjectPaths, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.paths = paths
+        self._configure_dev_knobs()
+        # task_id -> server process, kept past kill(): kill() pops the
+        # _ServerSession registry, but _post_kill_reconcile still needs to
+        # settle liveness after the teardown.
+        self._server_procs: dict[str, subprocess.Popen] = {}
+
+    def start_session(self, spec: SessionSpec) -> SessionHandle:
+        handle = super().start_session(spec)
+        self._server_procs[spec.task_id] = self._sessions[spec.task_id].process
+        return handle
+
+    def _probe_alive(self, handle: SessionHandle) -> bool | None:
+        proc = self._server_procs.get(handle.task_id)
+        if proc is None:
+            return False  # never spawned: nothing we own is alive
+        # Never None: the live Popen handle pins the pid, so poll() is always
+        # answerable — unlike a tmux transport there is no probe that can hang.
+        return proc.poll() is None
 
 
 def _sum_usage(messages: Any) -> TokenUsage:

--- a/src/bmad_loop/cli.py
+++ b/src/bmad_loop/cli.py
@@ -130,23 +130,25 @@ def _make_adapters(project: Path, run_dir: Path, policy) -> dict[str, CodingCLIA
             if profile.hookless:
                 # Hookless profiles (opencode-http) are driven over HTTP/SSE —
                 # the tmux adapters below cannot host them.
-                if synthesizes:
-                    # TODO(opencode-http Phase 4): OpencodeDevAdapter composes
-                    # _DevSynthesisMixin over the HTTP adapter for dev/review.
-                    raise SystemExit(
-                        f"error: profile '{profile.name}' cannot drive dev/review yet — "
-                        f"dev/review synthesis lands in Phase 4 of the opencode-http plan"
-                    )
-                from .adapters.opencode_http import OpencodeHttpAdapter, OpencodeServerError
+                from .adapters.opencode_http import (
+                    OpencodeDevAdapter,
+                    OpencodeHttpAdapter,
+                    OpencodeServerError,
+                )
 
+                common = dict(
+                    run_dir=run_dir,
+                    policy=policy,
+                    profile=profile,
+                    extra_args=cfg.extra_args,
+                    usage_grace_s=cfg.usage_grace_s,
+                    stop_without_result_nudges=cfg.stop_without_result_nudges,
+                )
                 try:
-                    by_cfg[key] = OpencodeHttpAdapter(
-                        run_dir=run_dir,
-                        policy=policy,
-                        profile=profile,
-                        extra_args=cfg.extra_args,
-                        usage_grace_s=cfg.usage_grace_s,
-                        stop_without_result_nudges=cfg.stop_without_result_nudges,
+                    by_cfg[key] = (
+                        OpencodeDevAdapter(**common, paths=paths)
+                        if synthesizes
+                        else OpencodeHttpAdapter(**common)
                     )
                 except OpencodeServerError as e:
                     raise SystemExit(f"error: {e}") from e
@@ -259,10 +261,6 @@ def cmd_validate(args: argparse.Namespace) -> int:
 
     profiles = []
     pol = None
-    # Hookless profile names the policy assigns to the synthesizing dev/review
-    # roles — unrunnable until the opencode-http plan's Phase 4 lands, so
-    # validate must FAIL them exactly like `_make_adapters` would at run start.
-    synth_hookless: set[str] = set()
     try:
         pol = policy_mod.load(_policy_path(project))
         role_names = {role: pol.adapter.resolved(role).name for role in ROLES}
@@ -271,19 +269,11 @@ def cmd_validate(args: argparse.Namespace) -> int:
             f"adapter dev={role_names['dev']}, review={role_names['review']}, "
             f"triage={role_names['triage']}"
         )
-        by_raw_name = {}
         for name in dict.fromkeys(role_names.values()):
             try:
-                profile = get_profile(name, project)
-                profiles.append(profile)
-                by_raw_name[name] = profile
+                profiles.append(get_profile(name, project))
             except ProfileError as e:
                 problems.append(str(e))
-        if pol.dev.skill == "bmad-dev-auto":  # mirrors _make_adapters' synthesizes
-            for role in ("dev", "review"):
-                profile = by_raw_name.get(role_names[role])
-                if profile is not None and profile.hookless:
-                    synth_hookless.add(profile.name)
     except policy_mod.PolicyError as e:
         problems.append(str(e))
 
@@ -328,12 +318,6 @@ def cmd_validate(args: argparse.Namespace) -> int:
             notes.append(
                 f"{profile.name}: hookless (HTTP/SSE transport) — no hook registration needed"
             )
-            if profile.name in synth_hookless:
-                problems.append(
-                    f"{profile.name}: cannot drive the dev/review roles yet — dev/review "
-                    f"synthesis lands in Phase 4 of the opencode-http plan; assign it to "
-                    f"triage only (e.g. [adapter.triage])"
-                )
             # The HTTP adapter needs httpx, which ships as an optional extra —
             # surface a missing install here instead of at run start.
             if importlib.util.find_spec("httpx") is not None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -628,16 +628,25 @@ def test_make_adapters_review_synthesizes_from_spec(project):
     assert not isinstance(adapters["triage"], GenericDevAdapter)
 
 
-def test_make_adapters_hookless_synthesizing_roles_guarded(project):
-    """Temporary Phase 3 guard (opencode-http plan): dev/review are synthesizing
-    bmad-dev-auto roles, and the OpencodeDevAdapter that hosts the synthesis
-    mixin over HTTP lands in Phase 4 — until then selecting a hookless profile
-    for those roles is a clean error, not a silent misdrive."""
+def test_make_adapters_hookless_synthesizing_roles_get_dev_adapter(project):
+    """Hookless dev/review (bmad-dev-auto roles) dispatch to OpencodeDevAdapter —
+    the _DevSynthesisMixin composed over the HTTP transport — sharing one
+    instance via the (cfg, synthesizes) key, while triage on the same config
+    gets a separate plain OpencodeHttpAdapter (it reads a real result.json)."""
+    from bmad_loop.adapters.opencode_http import OpencodeDevAdapter, OpencodeHttpAdapter
+
     install_bmad_config(project)
     _write_policy(project.project, '[adapter]\nname = "opencode"\n')
     pol = policy_mod.load(project.project / ".bmad-loop" / "policy.toml")
-    with pytest.raises(SystemExit, match="dev/review synthesis lands in Phase 4"):
-        cli._make_adapters(project.project, project.project / ".bmad-loop" / "runs" / "r", pol)
+    adapters = cli._make_adapters(
+        project.project, project.project / ".bmad-loop" / "runs" / "r", pol
+    )
+    assert isinstance(adapters["dev"], OpencodeDevAdapter)
+    assert adapters["dev"] is adapters["review"]  # (cfg, synthesizes) sharing intact
+    assert adapters["dev"].paths.project == project.project
+    assert isinstance(adapters["triage"], OpencodeHttpAdapter)
+    assert not isinstance(adapters["triage"], OpencodeDevAdapter)
+    assert adapters["triage"] is not adapters["dev"]
 
 
 def test_make_adapters_hookless_triage_dispatches_http_adapter(project):
@@ -1838,18 +1847,20 @@ def test_validate_hookless_profile_notes_no_hook_registration(project, capsys):
     assert "phase 4" not in text
 
 
-def test_validate_hookless_dev_review_fails_until_phase4(project, capsys):
-    """A policy that assigns a hookless profile to the synthesizing dev/review
-    roles is unrunnable until Phase 4 — validate must FAIL it the way
-    `_make_adapters` would at run start, not approve a doomed config."""
+def test_validate_hookless_dev_review_is_runnable(project, capsys):
+    """A hookless profile on the synthesizing dev/review roles is runnable
+    since Phase 4 (OpencodeDevAdapter) — validate must not raise the retired
+    'cannot drive dev/review' problem. Exit code is not asserted: other gates
+    (binary on PATH, upstream skills) legitimately vary by machine."""
     install_bmad_config(project)
     _write_policy(project.project, '[adapter]\nname = "opencode"\n')
     args = argparse.Namespace(project=str(project.project), spec=None)
 
-    assert cli.cmd_validate(args) == 1
+    cli.cmd_validate(args)
     text = _validate_output(capsys)
-    assert "cannot drive the dev/review roles yet" in text
-    assert "phase 4" in text
+    assert "opencode-http: hookless (http/sse transport)" in text
+    assert "cannot drive the dev/review roles" not in text
+    assert "phase 4" not in text
 
 
 def test_validate_hookless_profile_flags_missing_httpx(project, capsys, monkeypatch):

--- a/tests/test_opencode_http.py
+++ b/tests/test_opencode_http.py
@@ -18,9 +18,11 @@ from pathlib import Path
 import pytest
 from conftest import write_script_launcher
 
+from bmad_loop.adapters import generic
 from bmad_loop.adapters.base import SessionHandle, SessionSpec
 from bmad_loop.adapters.generic import NUDGE_TEXT, STALL_NUDGE_TEXT
 from bmad_loop.adapters.opencode_http import (
+    OpencodeDevAdapter,
     OpencodeHttpAdapter,
     OpencodeServerError,
     _free_port,
@@ -29,6 +31,7 @@ from bmad_loop.adapters.opencode_http import (
     _sum_usage,
 )
 from bmad_loop.adapters.profile import get_profile
+from bmad_loop.bmadconfig import ProjectPaths
 from bmad_loop.model import TokenUsage
 from bmad_loop.policy import LimitsPolicy, Policy
 from bmad_loop.process_host import get_process_host
@@ -53,6 +56,9 @@ PINNED_EPOCH_MS = 1_784_218_739_410
 #                      reconnect); the turn completes result+messages only —
 #                      completion is reachable only via the HTTP poll fallback
 # FAKE_OPENCODE_START_FAILURES=N makes the first N spawns exit(1) pre-bind.
+# FAKE_OPENCODE_SPEC_PATH/_SPEC_TEXT: a bmad-dev-auto-style terminal spec the
+# turn writes wherever a scenario writes its result (and at the start of
+# busy-forever, for the post-kill rescue). Unset = no-op, like RESULT_PATH.
 #
 # Recordings under FAKE_OPENCODE_DIR: sessions.jsonl (incl. the Authorization
 # header), prompts.jsonl, aborts.jsonl, pid (the server's own pid).
@@ -64,6 +70,8 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 SCENARIO = os.environ.get("FAKE_OPENCODE_SCENARIO", "completed")
 REC_DIR = os.environ["FAKE_OPENCODE_DIR"]
 RESULT_PATH = os.environ.get("FAKE_OPENCODE_RESULT_PATH", "")
+SPEC_PATH = os.environ.get("FAKE_OPENCODE_SPEC_PATH", "")
+SPEC_TEXT = os.environ.get("FAKE_OPENCODE_SPEC_TEXT", "")
 START_FAILURES = int(os.environ.get("FAKE_OPENCODE_START_FAILURES", "0"))
 
 argv = sys.argv[1:]
@@ -119,6 +127,13 @@ def write_result():
             json.dump({"ok": True, "workflow": "fake-triage"}, fh)
 
 
+def write_spec():
+    if SPEC_PATH:
+        os.makedirs(os.path.dirname(SPEC_PATH), exist_ok=True)
+        with open(SPEC_PATH, "w", encoding="utf-8") as fh:
+            fh.write(SPEC_TEXT)
+
+
 def finish_turn():
     with LOCK:
         STATE["completed_ms"] = now_ms()
@@ -132,7 +147,7 @@ def run_turn():
     # let the 204 flush before any scripted death tears the connection down
     time.sleep(0.15)
     if SCENARIO == "completed":
-        write_result(); finish_turn(); push(idle_event())
+        write_result(); write_spec(); finish_turn(); push(idle_event())
     elif SCENARIO == "nudge-then-complete":
         if n >= 2:
             write_result()
@@ -140,7 +155,7 @@ def run_turn():
     elif SCENARIO == "stall":
         finish_turn(); push(idle_event())
     elif SCENARIO == "busy-forever":
-        pass  # stays busy: no finish, no idle
+        write_spec()  # visible only post-kill: the turn never ends or idles
     elif SCENARIO == "die-after-result":
         write_result(); os._exit(0)
     elif SCENARIO == "die-no-result":
@@ -259,6 +274,17 @@ def _policy(**limits) -> Policy:
     return Policy(limits=LimitsPolicy(**limits) if limits else LimitsPolicy())
 
 
+def _shrink_timing(adapter: OpencodeHttpAdapter) -> OpencodeHttpAdapter:
+    """Shrink every cadence for tests; the defaults are minutes of wall clock."""
+    adapter.health_timeout_s = 10.0
+    adapter.health_poll_s = 0.05
+    adapter.reconnect_sleep_s = 0.05
+    adapter.silence_threshold_s = 2.0
+    adapter.poll_tick_s = 0.05
+    adapter.result_grace_s = 0.5
+    return adapter
+
+
 def make_adapter(tmp_path: Path, binary: str = "opencode", **kwargs) -> OpencodeHttpAdapter:
     adapter = OpencodeHttpAdapter(
         run_dir=tmp_path / "run",
@@ -267,14 +293,7 @@ def make_adapter(tmp_path: Path, binary: str = "opencode", **kwargs) -> Opencode
         binary=binary,
         **kwargs,
     )
-    # Shrink every cadence for tests; the defaults are minutes of wall clock.
-    adapter.health_timeout_s = 10.0
-    adapter.health_poll_s = 0.05
-    adapter.reconnect_sleep_s = 0.05
-    adapter.silence_threshold_s = 2.0
-    adapter.poll_tick_s = 0.05
-    adapter.result_grace_s = 0.5
-    return adapter
+    return _shrink_timing(adapter)
 
 
 @pytest.fixture
@@ -651,3 +670,193 @@ def test_e2e_spawn_gives_up_after_attempts(tmp_path, fake_opencode):
     assert adapter._sessions == {}
     # every attempt appended to one log for the task
     assert (tmp_path / "run" / "logs" / "t-1.log").exists()
+
+
+# --------------------------------------------- OpencodeDevAdapter (Phase 4)
+#
+# Dev/review sessions run the generic bmad-dev-auto skill, which writes NO
+# result.json: the outcome lives in the terminal spec it leaves on disk,
+# synthesized via devcontract by _DevSynthesisMixin — the same machinery
+# GenericDevAdapter uses, composed over the HTTP transport.
+
+_DONE_SPEC = (
+    "---\nstatus: done\nbaseline_revision: abc123\n---\n\n"
+    "## Auto Run Result\n\nStatus: done\nImplemented.\n"
+)
+
+
+def make_dev_adapter(
+    tmp_path: Path, binary: str = "opencode", **kwargs
+) -> tuple[OpencodeDevAdapter, Path]:
+    impl = tmp_path / "impl"
+    impl.mkdir(exist_ok=True)
+    # project root == tmp_path so rebased(spec.cwd=tmp_path) is a no-op: these
+    # sessions run in place, where cwd == the project root.
+    paths = ProjectPaths(
+        project=tmp_path,
+        implementation_artifacts=impl,
+        planning_artifacts=tmp_path / "plan",
+    )
+    adapter = OpencodeDevAdapter(
+        run_dir=tmp_path / "run",
+        policy=kwargs.pop("policy", _policy()),
+        profile=get_profile("opencode"),
+        binary=binary,
+        paths=paths,
+        **kwargs,
+    )
+    return _shrink_timing(adapter), impl
+
+
+def make_dev_spec(
+    tmp_path: Path,
+    rec: Path,
+    scenario: str,
+    spec_path: Path,
+    spec_text: str = _DONE_SPEC,
+    story_key: str = "3-1",
+    task_id: str = "3-1-dev-1",
+    timeout_s: float = 30.0,
+    extra_env: dict | None = None,
+) -> SessionSpec:
+    env = {
+        "FAKE_OPENCODE_SCENARIO": scenario,
+        "FAKE_OPENCODE_DIR": str(rec),
+        # Deliberately NO FAKE_OPENCODE_RESULT_PATH: the dev skill writes no
+        # result.json, and the dev adapter must never lean on one.
+        "FAKE_OPENCODE_SPEC_PATH": str(spec_path),
+        "FAKE_OPENCODE_SPEC_TEXT": spec_text,
+        "BMAD_LOOP_STORY_KEY": story_key,
+        **(extra_env or {}),
+    }
+    return SessionSpec(
+        task_id=task_id,
+        role="dev",
+        prompt=f"/bmad-dev-auto {story_key}",
+        cwd=tmp_path,
+        env=env,
+        timeout_s=timeout_s,
+        stall_nudges_cap=6,
+    )
+
+
+def test_dev_knobs_configured(tmp_path):
+    """_configure_dev_knobs over the HTTP knob names: no result-contract stop
+    nudges (the skill writes no result.json), stall grace + wake budget from
+    policy — same contract as GenericDevAdapter."""
+    adapter, _ = make_dev_adapter(
+        tmp_path, policy=_policy(dev_stall_grace_s=123, dev_stall_nudges=4)
+    )
+    assert adapter._stop_nudges == 0
+    assert adapter._stall_grace_s == 123.0
+    assert adapter._stall_nudges == 4
+
+
+def test_dev_probe_alive_never_none(tmp_path):
+    """The post-kill liveness seam: poll() on the retained Popen handle is
+    always answerable (True/False), never the tri-state unknown a tmux probe
+    can hit — and a task with no retained process owns nothing alive."""
+
+    class _Proc:
+        def __init__(self, rc):
+            self._rc = rc
+
+        def poll(self):
+            return self._rc
+
+    adapter, _ = make_dev_adapter(tmp_path)
+    handle = SessionHandle(task_id="t", native_id="ses_x")
+    assert adapter._probe_alive(handle) is False  # never spawned
+    adapter._server_procs["t"] = _Proc(None)
+    assert adapter._probe_alive(handle) is True  # kill silently failed: keep verdict
+    adapter._server_procs["t"] = _Proc(0)
+    assert adapter._probe_alive(handle) is False
+
+
+def test_dev_result_json_ignores_result_file(tmp_path):
+    """MRO pin: _DevSynthesisMixin's spec synthesis shadows the core adapter's
+    result.json read-back — a stray result.json with no spec on disk is not a
+    dev result."""
+    adapter, _ = make_dev_adapter(tmp_path)
+    task_dir = adapter.tasks_dir / "3-1-dev-1"
+    task_dir.mkdir(parents=True)
+    (task_dir / "result.json").write_text('{"ok": true}', encoding="utf-8")
+    spec = SessionSpec(
+        task_id="3-1-dev-1",
+        role="dev",
+        prompt="/bmad-dev-auto 3-1",
+        cwd=tmp_path,
+        env={"BMAD_LOOP_STORY_KEY": "3-1"},
+    )
+    handle = SessionHandle(task_id="3-1-dev-1", native_id="ses_x")
+    assert adapter._result_json(handle, spec, wait=False) is None
+
+
+def test_e2e_dev_synthesizes_terminal_spec(tmp_path, fake_opencode):
+    launcher, rec = fake_opencode
+    adapter, impl = make_dev_adapter(tmp_path, binary=str(launcher))
+    spec = make_dev_spec(tmp_path, rec, "completed", impl / "spec-3-1-foo.md")
+
+    result = adapter.run(spec)
+
+    assert result.status == "completed"
+    rj = result.result_json
+    assert rj["workflow"] == "auto-dev"
+    assert rj["status"] == "done"
+    assert rj["baseline_commit"] == "abc123"  # mapped from baseline_revision
+    assert rj["story_key"] == "3-1"
+    assert rj["escalations"] == []
+    assert "post_kill_reconciled" not in rj  # vouched by the idle, not rescued
+    # transport parity with the classic path: usage, template, teardown
+    assert adapter.read_usage(result) == TokenUsage(
+        input_tokens=100, output_tokens=55, cache_read_tokens=7, cache_creation_tokens=3
+    )
+    assert prompt_texts(rec) == ["Use the bmad-dev-auto skill now: 3-1"]
+    assert adapter._sessions == {}
+    assert_server_gone(rec)
+
+
+def test_e2e_dev_stories_mode_resolves_by_id(tmp_path, fake_opencode, monkeypatch):
+    """Folder+id dispatch (BMAD_LOOP_SPEC_FOLDER): the story spec is resolved
+    at its deterministic id-keyed path — never via the mtime scan."""
+    launcher, rec = fake_opencode
+    adapter, impl = make_dev_adapter(tmp_path, binary=str(launcher))
+
+    def boom(*a, **k):
+        raise AssertionError("stories mode must not call the mtime scan")
+
+    monkeypatch.setattr(generic.devcontract, "find_result_artifact", boom)
+    spec = make_dev_spec(
+        tmp_path,
+        rec,
+        "completed",
+        tmp_path / "epic" / "stories" / "1-foo.md",
+        story_key="1",
+        task_id="1-dev-1",
+        extra_env={"BMAD_LOOP_SPEC_FOLDER": "epic"},
+    )
+
+    result = adapter.run(spec)
+
+    assert result.status == "completed"
+    assert result.result_json["status"] == "done"
+    assert result.result_json["story_key"] == "1"
+    assert_server_gone(rec)
+
+
+def test_e2e_dev_post_kill_rescue(tmp_path, fake_opencode):
+    """#61 over HTTP: the turn wrote its terminal spec but its idle was never
+    seen (the fake stays busy forever), so the loop times out — a verdict
+    reached under a live server, where the artifact is advisory (#48/#53).
+    run()'s kill settles the liveness question; _post_kill_reconcile re-probes
+    the now-dead server process and rescues the self-consistent done spec."""
+    launcher, rec = fake_opencode
+    adapter, impl = make_dev_adapter(tmp_path, binary=str(launcher))
+    spec = make_dev_spec(tmp_path, rec, "busy-forever", impl / "spec-3-1-foo.md", timeout_s=1.5)
+
+    result = adapter.run(spec)
+
+    assert result.status == "completed"
+    assert result.result_json["status"] == "done"
+    assert result.result_json["post_kill_reconciled"] is True
+    assert_server_gone(rec)


### PR DESCRIPTION
Phase 4 of the opencode-http adapter plan (#163 → #164 → #165 → this): hookless dev/review roles now run the real bmad-dev-auto loop over HTTP/SSE.

## What

- **`OpencodeDevAdapter(_DevSynthesisMixin, OpencodeHttpAdapter)`** — the Phase 2 synthesis mixin composed over the Phase 3 transport, `paths=` kwarg + `_configure_dev_knobs()`, mirroring `GenericDevAdapter`. Terminal-spec synthesis, stories mode, DW bundles, plan-halt, and the #61 post-kill rescue all arrive via the mixin unchanged (no fork of the synthesis logic; `devcontract.py` and `generic.py` untouched).
- **`_probe_alive`** (the one seam the host must implement) = `poll()` on a per-task `Popen` stash populated in `start_session` and kept past `kill()` — the kill pops the `_ServerSession` registry before `_post_kill_reconcile` runs, and the retained handle answers liveness truthfully: never `None` (no probe that can hang), `True` when a force-kill-surviving process means the live-server invariant still applies.
- **MRO note:** the mixin's `_result_json` (spec synthesis) deliberately shadows the core adapter's result.json read-back — the dev skill writes no result.json, and a unit test pins that.
- **`_make_adapters`**: synthesizing hookless roles construct `OpencodeDevAdapter` (shared per `(cfg, synthesizes)` key); the temporary Phase 3 `SystemExit` guard is deleted, and `cmd_validate`'s mirroring FAIL (added in #165's review round to match the guard) is removed with it.

## Tests

FakeOpencode gains a spec-write mechanic (`FAKE_OPENCODE_SPEC_PATH`/`_SPEC_TEXT`, no-op when unset — existing scenarios byte-compatible). New coverage:

- E2E terminal-spec synthesis: scripted turn writes a `status: done` + `## Auto Run Result` spec → synthesized dict matches devcontract (`auto-dev`, `baseline_commit`, `story_key`), usage captured, template-rendered prompt, clean teardown, and **no** `FAKE_OPENCODE_RESULT_PATH` set — proving dev never leans on result.json.
- E2E stories mode: `BMAD_LOOP_SPEC_FOLDER` id-keyed resolve with the mtime scan monkeypatched to raise.
- E2E post-kill rescue: spec written, idle never delivered (fake stays busy) → `timeout` under a live server → run()'s kill settles liveness → rescued `completed` with `post_kill_reconciled: true`.
- Units: dev knobs from policy, never-`None` probe tri-state, result.json-shadowing MRO pin.
- `test_cli.py`: guard tests flipped to their post-Phase-4 counterparts (dispatch + validate-passes).

All tests bind 127.0.0.1 and reuse the Phase 3 Windows-safe harness mechanics. CHANGELOG deferred to Phase 5 by plan design.

## Verification

- Full suite: **2314 passed, 1 skipped**
- `trunk fmt` (black) + full `trunk check` (no filter): clean