### PR TITLE
fix(hooks): recognize antigravity's registered relay in validate + probe (#159)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,7 +163,10 @@ PATH)`, the TUI notifies `multiplexer backend unavailable — launch/attach disa
   and reported a correctly-installed relay as missing (`FAIL: bmad-loop hooks not registered
 for antigravity`, immediately after a successful `init --cli antigravity`). Both now share
   one `install.relay_registered()` helper that resolves each dialect's container shape, so the
-  two call sites can no longer drift apart.
+  two call sites can no longer drift apart. `init`'s merge dedup keys on the narrow bmad-loop
+  script markers rather than the bare `bmad_loop` substring, so an unrelated hook command whose
+  path merely contains `bmad_loop` can't make init skip a registration that validate would then
+  report missing.
 - **`branch_per=run` + `keep_failed` no longer poisons a multi-story run after the first kept
   failure (#138).** The first story to end deferred under `keep_failed=true` left its worktree
   checked out on the single shared run branch, so every subsequent story's `git worktree add`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,13 @@ PATH)`, the TUI notifies `multiplexer backend unavailable — launch/attach disa
 
 ### Fixed
 
+- **`validate` and `probe-adapter` no longer report antigravity's hooks as unregistered
+  (#159).** The `antigravity-hooks-json` dialect keys `.agents/hooks.json` by hook-group name
+  at the top level, with no `"hooks"` wrapper — but both readers looked up `"hooks"`, got `{}`,
+  and reported a correctly-installed relay as missing (`FAIL: bmad-loop hooks not registered
+for antigravity`, immediately after a successful `init --cli antigravity`). Both now share
+  one `install.relay_registered()` helper that resolves each dialect's container shape, so the
+  two call sites can no longer drift apart.
 - **`branch_per=run` + `keep_failed` no longer poisons a multi-story run after the first kept
   failure (#138).** The first story to end deferred under `keep_failed=true` left its worktree
   checked out on the single shared run branch, so every subsequent story's `git worktree add`

--- a/src/bmad_loop/cli.py
+++ b/src/bmad_loop/cli.py
@@ -242,6 +242,8 @@ def _platform_preflight() -> tuple[list[str], list[str]]:
 
 
 def cmd_validate(args: argparse.Namespace) -> int:
+    from .install import relay_registered
+
     project = _project(args)
     problems: list[str] = []
     notes: list[str] = []
@@ -335,10 +337,9 @@ def cmd_validate(args: argparse.Namespace) -> int:
         hooks_ok = False
         if hook_config.is_file():
             try:
-                hooks = json.loads(hook_config.read_text(encoding="utf-8")).get("hooks", {})
-                hooks_ok = any(
-                    "bmad_loop_hook" in json.dumps(hooks.get(event, []))
-                    for event in profile.hooks.events
+                parsed = json.loads(hook_config.read_text(encoding="utf-8"))
+                hooks_ok = isinstance(parsed, dict) and relay_registered(
+                    parsed, profile.hooks.dialect, profile.hooks.events
                 )
             except json.JSONDecodeError:
                 problems.append(f"{hook_config} is not valid JSON")

--- a/src/bmad_loop/install.py
+++ b/src/bmad_loop/install.py
@@ -32,6 +32,9 @@ HOOK_SCRIPT_REL = ".bmad-loop/bmad_loop_hook.py"
 # relay (bmad_loop_hook.py) and the probe-adapter capture hook
 # (bmad_loop_probe_hook.py) — so merge_hooks stays idempotent for either.
 HOOK_MARKER = "bmad_loop"
+# Narrower than HOOK_MARKER: matches the relay script name specifically, so a
+# project path that merely contains "bmad_loop" can't read as a registration.
+RELAY_MARKER = "bmad_loop_hook"
 # Pre-rename marker: the old relay/probe hooks lived under .automator/ and carried
 # `bmad_auto` in their command. `bmad-loop init` strips them on upgrade so a project
 # renamed from bmad-auto isn't left double-signalling. Underscore form, so it never
@@ -185,6 +188,27 @@ def _hook_entry(dialect: str, command: str) -> dict:
         return handler
     # claude-settings-json and codex-hooks-json share the schema
     return {"hooks": [handler]}
+
+
+def hook_event_container(config: dict, dialect: str) -> dict:
+    """The `native event -> handlers` map inside a parsed hook config.
+
+    Most dialects nest it under "hooks". agy instead keys the file by hook GROUP
+    name at the top level, so our relay lives under ANTIGRAVITY_HOOK_GROUP —
+    reading "hooks" there yields {} and reports a correctly-installed relay as
+    unregistered (issue #159). Every reader must go through this, or it drifts.
+    """
+    if dialect == "antigravity-hooks-json":
+        container = config.get(ANTIGRAVITY_HOOK_GROUP, {})
+    else:
+        container = config.get("hooks", {})
+    return container if isinstance(container, dict) else {}
+
+
+def relay_registered(config: dict, dialect: str, events) -> bool:
+    """True if the bmad-loop relay is registered for any of `events`."""
+    container = hook_event_container(config, dialect)
+    return any(RELAY_MARKER in json.dumps(container.get(event, [])) for event in events)
 
 
 def merge_hooks(config: dict, registrations: dict[str, str], dialect: str) -> tuple[dict, bool]:

--- a/src/bmad_loop/install.py
+++ b/src/bmad_loop/install.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import json
 import shutil
 import subprocess
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from importlib import resources
 from pathlib import Path
 
@@ -28,13 +28,17 @@ from .policy import POLICY_TEMPLATE
 from .process_host import get_process_host
 
 HOOK_SCRIPT_REL = ".bmad-loop/bmad_loop_hook.py"
-# Dedup marker: matches any bmad-loop-managed hook command — both the signal
-# relay (bmad_loop_hook.py) and the probe-adapter capture hook
-# (bmad_loop_probe_hook.py) — so merge_hooks stays idempotent for either.
-HOOK_MARKER = "bmad_loop"
-# Narrower than HOOK_MARKER: matches the relay script name specifically, so a
-# project path that merely contains "bmad_loop" can't read as a registration.
+# Markers for bmad-loop-managed hook commands. RELAY_MARKER is shared by
+# merge_hooks' dedup and validate/probe detection (via relay_registered) so init
+# and the preflight can never disagree about whether the relay is installed. It
+# matches the relay script name specifically: a hook command whose path merely
+# contains "bmad_loop" can't read as a registration — or suppress one.
 RELAY_MARKER = "bmad_loop_hook"
+# The probe-adapter capture hook participates in merge_hooks' dedup only (a
+# probe re-merge must stay idempotent) and never counts as a relay
+# registration. Disjoint from RELAY_MARKER: "bmad_loop_probe_hook" does not
+# contain the substring "bmad_loop_hook".
+PROBE_MARKER = "bmad_loop_probe_hook"
 # Pre-rename marker: the old relay/probe hooks lived under .automator/ and carried
 # `bmad_auto` in their command. `bmad-loop init` strips them on upgrade so a project
 # renamed from bmad-auto isn't left double-signalling. Underscore form, so it never
@@ -205,10 +209,21 @@ def hook_event_container(config: dict, dialect: str) -> dict:
     return container if isinstance(container, dict) else {}
 
 
-def relay_registered(config: dict, dialect: str, events) -> bool:
+def _relay_in_handlers(handlers) -> bool:
+    """True if any handler in a native-event list carries the relay command."""
+    return RELAY_MARKER in json.dumps(handlers)
+
+
+def _managed_hook_in_handlers(handlers) -> bool:
+    """merge_hooks' dedup: a relay OR probe-capture command is already present."""
+    dumped = json.dumps(handlers)
+    return RELAY_MARKER in dumped or PROBE_MARKER in dumped
+
+
+def relay_registered(config: dict, dialect: str, events: Iterable[str]) -> bool:
     """True if the bmad-loop relay is registered for any of `events`."""
     container = hook_event_container(config, dialect)
-    return any(RELAY_MARKER in json.dumps(container.get(event, [])) for event in events)
+    return any(_relay_in_handlers(container.get(event, [])) for event in events)
 
 
 def merge_hooks(config: dict, registrations: dict[str, str], dialect: str) -> tuple[dict, bool]:
@@ -231,14 +246,7 @@ def merge_hooks(config: dict, registrations: dict[str, str], dialect: str) -> tu
                     f"hook event {native_event!r} under {ANTIGRAVITY_HOOK_GROUP!r} "
                     "is not a list; fix the hooks file before re-running init"
                 )
-            already = any(
-                isinstance(cmd := handler.get("command"), str) and HOOK_MARKER in cmd
-                for entry in handlers
-                if isinstance(entry, dict)
-                for handler in (entry, *entry.get("hooks", []))
-                if isinstance(handler, dict)
-            )
-            if not already:
+            if not _managed_hook_in_handlers(handlers):
                 handlers.append(_hook_entry(dialect, command))
                 changed = True
         return config, changed
@@ -248,16 +256,9 @@ def merge_hooks(config: dict, registrations: dict[str, str], dialect: str) -> tu
     for native_event, command in registrations.items():
         matchers = hooks.setdefault(native_event, [])
         # claude/codex/gemini nest handlers under "hooks"; copilot stores the
-        # handler dict directly in the event list — check both shapes so a re-run
-        # stays idempotent for every dialect.
-        already = any(
-            isinstance(cmd := handler.get("command"), str) and HOOK_MARKER in cmd
-            for entry in matchers
-            if isinstance(entry, dict)
-            for handler in (entry, *entry.get("hooks", []))
-            if isinstance(handler, dict)
-        )
-        if not already:
+        # handler dict directly in the event list — the serialized scan covers
+        # both shapes so a re-run stays idempotent for every dialect.
+        if not _managed_hook_in_handlers(matchers):
             matchers.append(_hook_entry(dialect, command))
             changed = True
     return config, changed

--- a/src/bmad_loop/probe.py
+++ b/src/bmad_loop/probe.py
@@ -38,7 +38,7 @@ from pathlib import Path
 from . import sanitize
 from .adapters.multiplexer import MultiplexerError, get_multiplexer
 from .adapters.profile import CLIProfile
-from .install import merge_hooks
+from .install import merge_hooks, relay_registered
 from .process_host import get_process_host
 from .signals import SignalWatcher
 from .tokens import _jsonl_entries, read_usage
@@ -340,12 +340,12 @@ def _hooks_registered(project: Path, profile: CLIProfile) -> bool:
     import json
 
     try:
-        hooks = json.loads(config_path.read_text(encoding="utf-8")).get("hooks", {})
+        config = json.loads(config_path.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError):
         return False
-    return any(
-        "bmad_loop_hook" in json.dumps(hooks.get(event, [])) for event in profile.hooks.events
-    )
+    if not isinstance(config, dict):
+        return False
+    return relay_registered(config, profile.hooks.dialect, profile.hooks.events)
 
 
 # ----------------------------------------------------------------- SCAN mode

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -136,6 +136,48 @@ def test_merge_hooks_antigravity_appends_beside_existing_stop():
     assert len(settings["bmad-loop"]["Stop"]) == 2
 
 
+def test_merge_hooks_unrelated_bmad_loop_path_does_not_suppress_relay():
+    # Dedup keys on the bmad-loop script markers, not the broad "bmad_loop"
+    # substring: an unrelated handler whose command merely mentions a
+    # bmad_loop-containing path must not make init skip the relay — that would
+    # leave `validate` (which detects on the narrow marker) un-passable, the
+    # #159 failure class through the merge/detect seam.
+    profile = get_profile("claude")
+    existing = {
+        "hooks": {
+            "Stop": [
+                {
+                    "hooks": [
+                        {"type": "command", "command": "python /home/me/bmad_loop_fork/notify.py"}
+                    ]
+                }
+            ]
+        }
+    }
+    settings, changed = merge_hooks(existing, _registrations(profile), profile.hooks.dialect)
+    assert changed
+    commands = [
+        handler["command"] for matcher in settings["hooks"]["Stop"] for handler in matcher["hooks"]
+    ]
+    assert "python /home/me/bmad_loop_fork/notify.py" in commands
+    assert any("bmad_loop_hook" in c for c in commands)
+
+
+def test_merge_hooks_antigravity_unrelated_bmad_loop_path_does_not_suppress_relay():
+    # Same guarantee for agy's flat top-level-group shape (the other dedup branch).
+    profile = get_profile("antigravity")
+    existing = {
+        "bmad-loop": {
+            "Stop": [{"type": "command", "command": "python /home/me/bmad_loop_fork/notify.py"}]
+        }
+    }
+    settings, changed = merge_hooks(existing, _registrations(profile), profile.hooks.dialect)
+    assert changed
+    commands = [h["command"] for h in settings["bmad-loop"]["Stop"]]
+    assert "python /home/me/bmad_loop_fork/notify.py" in commands
+    assert any("bmad_loop_hook" in c for c in commands)
+
+
 def test_merge_hooks_antigravity_rejects_malformed_shape():
     # a malformed pre-existing hooks.json yields a clear ProfileError, not an
     # opaque AttributeError during init.
@@ -152,7 +194,7 @@ def test_merge_hooks_antigravity_rejects_malformed_shape():
 
 def test_merge_hooks_antigravity_tolerates_non_string_command():
     # a pre-existing handler whose "command" is a non-string (e.g. None) must not
-    # crash the idempotency dedupe (guarded at both merge walks).
+    # crash the idempotency dedupe.
     profile = get_profile("antigravity")
     existing = {"bmad-loop": {"Stop": [{"type": "command", "command": None}]}}
     settings, changed = merge_hooks(existing, _registrations(profile), profile.hooks.dialect)

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -174,16 +174,22 @@ def test_probe_hook_registers_under_native_events(dialect_cli):
     assert not changed2
 
 
-def test_scan_reports_registered_state(project):
+@pytest.mark.parametrize("cli", ["claude", "antigravity"])
+def test_scan_reports_registered_state(project, cli):
+    """Registration detection must follow each dialect's container shape.
+
+    agy keys .agents/hooks.json by hook-GROUP name with no "hooks" wrapper, so
+    reading "hooks" there reports a correctly-installed relay as unregistered.
+    """
     proj = project.project
-    profile = get_profile("claude")
-    finding = probe.scan(cli="claude", profile=profile, project=proj, hints=probe.Hints())
+    profile = get_profile(cli)
+    finding = probe.scan(cli=cli, profile=profile, project=proj, hints=probe.Hints())
     assert finding.registered is False  # nothing installed in the sandbox
     # now install hooks and re-scan
     from bmad_loop.install import install_into
 
-    install_into(proj, clis=("claude",))
-    finding2 = probe.scan(cli="claude", profile=profile, project=proj, hints=probe.Hints())
+    install_into(proj, clis=(cli,))
+    finding2 = probe.scan(cli=cli, profile=profile, project=proj, hints=probe.Hints())
     assert finding2.registered is True
 
 


### PR DESCRIPTION
## What

`bmad-loop validate` and `probe-adapter` no longer report antigravity's hooks as unregistered when they are, in fact, correctly installed.

## Why

Fixes #159. The `antigravity-hooks-json` dialect keys `.agents/hooks.json` by hook-**group** name at the top level — `install.merge_hooks` writes the relay under the `"bmad-loop"` group, with no `"hooks"` wrapper. Both readers instead looked up `"hooks"`, got `{}`, and reported the relay as missing:

```
FAIL: bmad-loop hooks not registered for antigravity — run bmad-loop init --cli antigravity
```

…immediately after a successful `init --cli antigravity`, leaving users with a preflight they cannot pass.

Reported by @Nips02, who also identified both call sites.

## How

- Added `install.relay_registered()` / `hook_event_container()` — one helper that resolves each dialect's container shape. The two readers had drifted into duplicate copies of the same lookup, so this fixes them at the seam rather than twice; a third reader can't re-introduce the bug.
- `cli.cmd_validate` and `probe._hooks_registered` both go through it.
- `RELAY_MARKER` (`"bmad_loop_hook"`) is deliberately narrower than the existing `HOOK_MARKER` (`"bmad_loop"`), preserving the previous literal so a project path merely containing `bmad_loop` can't read as a registration.

## Testing

`test_scan_reports_registered_state` is parametrized over `claude` + `antigravity`; it **fails on antigravity without this change** (verified by stashing the fix) and passes with it.

Also reproduced #159 end-to-end against a real sandbox — `init --cli antigravity` + `[adapter] name = "antigravity"`, which produces exactly the `hooks.json` in the issue report:

- before: `FAIL: bmad-loop hooks not registered for antigravity`
- after: `ok: bmad-loop hooks registered for antigravity`, and `probe-adapter antigravity` reports `hooks registered: yes`

Full suite green (2328 passed, 1 skipped); `trunk check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed validation and environment scanning that could incorrectly report Antigravity relay hooks as unregistered.
  * Improved relay hook detection to be dialect-aware and consistent, reducing false positives and ensuring idempotent hook merging.
* **Tests**
  * Expanded registration scan tests to cover both Claude and Antigravity configurations.
  * Added regression tests for `merge_hooks` to prevent unrelated command text from skipping required relay hook registration.
* **Documentation**
  * Updated the changelog with the Antigravity relay hook detection fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->