### PR TITLE
fix: keep committed work across a dev retry; accept the baseline it advances past (#172)

### DIFF
--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -2503,13 +2503,24 @@ class Engine:
         assigned, so a failure partway through can't advance one and not the
         other. Best-effort: on a git failure the old baseline stands — the
         resumed session's verify_dev may then flag a baseline mismatch, which is
-        no worse than today's unconditional rollback."""
+        no worse than today's unconditional rollback.
+
+        Latches ``baseline_advanced`` on success: the kept attempt already
+        stamped the spec's ``baseline_revision`` with the PRE-advance sha and
+        nothing re-stamps it (deliberately — that sha is the diff base the whole
+        story's review must span, so narrowing it to the advanced one would hide
+        the kept attempt's own work from the review). Only the flag tells verify's
+        baseline gate that the resulting spec/orchestrator split is one the
+        orchestrator caused, so it can accept an ancestor there and nowhere
+        else. Set last, and only if both git reads landed: an un-advanced
+        baseline must not claim to have been advanced."""
         try:
             repo = self.workspace.root
             head = verify.rev_parse_head(repo)
             untracked = sorted(verify.untracked_files(repo))
             task.baseline_commit = head
             task.baseline_untracked = untracked
+            task.baseline_advanced = True
         except Exception:  # noqa: BLE001  # nosec B110 - best-effort git read, must not fail retry
             pass
 

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -1510,6 +1510,7 @@ class Engine:
             # session's own tree.
             task.baseline_untracked = sorted(verify.untracked_files(self.workspace.root))
         feedback: Path | None = None
+        resume_note: str = ""
         while True:
             if resume_result is None:
                 # a resumed result replays the attempt it was recorded under, so
@@ -1538,7 +1539,7 @@ class Engine:
                 result = self._run_session(
                     task,
                     role="dev",
-                    prompt=self._dev_prompt(task, feedback),
+                    prompt=self._dev_prompt(task, feedback, resume_note=resume_note),
                     seq=task.attempt,
                 )
             advance(task, Phase.DEV_VERIFY)
@@ -1595,10 +1596,38 @@ class Engine:
                     return False
                 return True
             if decision.action == Action.RETRY:
+                resume_note = ""
                 if outcome is not None and outcome.fixable:
                     # work exists and the failure is concrete: keep the tree,
                     # hand the failing output to a repair session
                     feedback = self._write_feedback(task, decision.reason)
+                elif outcome is None and (commits := self._committed_attempt_work(task)):
+                    # the session never reached a terminal result (timeout/stalled/
+                    # crashed), so verify never ran — but it already landed real
+                    # commits above baseline. Rolling those back on a same-story
+                    # retry is pure waste: the next attempt would silently redo
+                    # work that already exists, burning the retry budget on
+                    # re-deriving it instead of finishing it (the failure mode
+                    # that orphaned story 17-3's first attempt on 2026-07-09).
+                    # Keep the tree and tell the resumed session what is already
+                    # there instead of discarding it.
+                    feedback = self._write_resume_feedback(task, result.status, commits)
+                    resume_note = (
+                        f"The previous session did not reach a terminal result "
+                        f"({result.status}), most likely because it ran out of "
+                        "time — not because its work was wrong. It already "
+                        "committed real progress; do not discard it or restart "
+                        "from scratch. Inspect the current git state, verify it "
+                        "against the story's acceptance criteria, and continue "
+                        "or finish the remaining work."
+                    )
+                    # the kept commits are now authorized input for the resumed
+                    # session, not failed-attempt debris — advance the baseline
+                    # past them (mirrors runs.rearm_escalation's re-drive baseline
+                    # advance) so verify_dev compares the next session's report
+                    # against where the tree actually is, not the pre-attempt
+                    # baseline it has already moved past.
+                    self._advance_baseline_to_head(task)
                 else:
                     feedback = None
                     self._rollback_or_pause(task)
@@ -2378,10 +2407,12 @@ class Engine:
         )
         return result
 
-    def _dev_prompt(self, task: StoryTask, feedback: Path | None) -> str:
-        return self._generic_dev_prompt(task, feedback)
+    def _dev_prompt(self, task: StoryTask, feedback: Path | None, *, resume_note: str = "") -> str:
+        return self._generic_dev_prompt(task, feedback, resume_note=resume_note)
 
-    def _generic_dev_prompt(self, task: StoryTask, feedback: Path | None) -> str:
+    def _generic_dev_prompt(
+        self, task: StoryTask, feedback: Path | None, *, resume_note: str = ""
+    ) -> str:
         """Invocation for the generic `bmad-dev-auto` dev skill, which has no
         `--feedback` flag: feedback is inlined as freeform intent pointing at the
         existing spec. On a repair re-invocation the spec is first re-opened
@@ -2393,7 +2424,13 @@ class Engine:
         the re-arm set — and it exits before step-01's version-control sanity
         check, which would otherwise HALT `blocked` on the very diff
         `_restore_patch` just laid onto the tree. A bare story key takes the
-        freeform/epic path instead, where that dirty-tree check runs first."""
+        freeform/epic path instead, where that dirty-tree check runs first.
+
+        ``resume_note`` overrides the default "failed verification, repair it"
+        framing — used when the previous session didn't fail so much as run out
+        of time after already committing real progress (see the RETRY branch in
+        ``_dev_phase``); telling that resumed session its predecessor's work
+        "failed" would mislead it into redoing good work from scratch."""
         if feedback is None:
             if task.restore_patch and task.spec_file:
                 return (
@@ -2405,12 +2442,14 @@ class Engine:
             return f"/bmad-dev-auto {task.story_key}"
         self._reset_spec_for_repair(task)
         spec_ref = task.spec_file or task.story_key
+        note = resume_note or (
+            "The previous session's work failed deterministic verification; "
+            "repair the working tree so verification passes without changing "
+            "the spec's frozen intent contract."
+        )
         return (
             f"/bmad-dev-auto Resume the autonomous dev session on the in-progress "
-            f"spec at `{spec_ref}`. The previous session's work failed deterministic "
-            f"verification; repair the working tree so verification passes without "
-            f"changing the spec's frozen intent contract. Verification evidence is "
-            f"in `{feedback}`."
+            f"spec at `{spec_ref}`. {note} Evidence is in `{feedback}`."
         )
 
     def _reset_spec_for_repair(self, task: StoryTask) -> None:
@@ -2439,6 +2478,62 @@ class Engine:
             "Repair the working tree so verification passes, without violating\n"
             "the spec's frozen intent.\n\n"
             f"```\n{reason}\n```\n",
+            encoding="utf-8",
+        )
+        return path
+
+    def _committed_attempt_work(self, task: StoryTask) -> list[str]:
+        """Commit shas this attempt already landed on top of ``task.baseline_commit``,
+        newest-reachability order per ``verify.commits_above``; ``[]`` if none, or
+        no baseline was ever recorded (nothing to compare against). Distinguishes a
+        non-completed session (timeout/stalled/crashed) that made durable progress
+        from one that made none — see the RETRY branch in ``_dev_phase``."""
+        if not task.baseline_commit:
+            return []
+        return verify.commits_above(self.workspace.root, task.baseline_commit)
+
+    def _advance_baseline_to_head(self, task: StoryTask) -> None:
+        """Advance ``task.baseline_commit``/``baseline_untracked`` to the
+        project's current HEAD. Mirrors ``runs.rearm_escalation``'s re-drive
+        baseline advance for the same reason: a kept (non-rolled-back) attempt's
+        commits are authorized input for the resumed session, not failed-attempt
+        debris, so later comparisons (verify_dev's proof-of-work check, a later
+        retry's own rollback) must anchor on them rather than the stale
+        pre-attempt baseline. The two locals are read before either task field is
+        assigned, so a failure partway through can't advance one and not the
+        other. Best-effort: on a git failure the old baseline stands — the
+        resumed session's verify_dev may then flag a baseline mismatch, which is
+        no worse than today's unconditional rollback."""
+        try:
+            repo = self.workspace.root
+            head = verify.rev_parse_head(repo)
+            untracked = sorted(verify.untracked_files(repo))
+            task.baseline_commit = head
+            task.baseline_untracked = untracked
+        except Exception:  # noqa: BLE001  # nosec B110 - best-effort git read, must not fail retry
+            pass
+
+    def _write_resume_feedback(self, task: StoryTask, status: str, commits: list[str]) -> Path:
+        """Persist a note for a resumed session after a dev session that ended
+        without a terminal result (``status``) but had already committed real
+        progress. Deliberately distinct from ``_write_feedback``: this is not a
+        verification failure (verify never ran — the session never completed), so
+        framing it as one would mislead the resumed session into distrusting or
+        redoing otherwise-good work."""
+        path = self.run_dir / "feedback" / f"{task.story_key}-{len(task.sessions)}.md"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        shas = "\n".join(f"- {c}" for c in commits)
+        path.write_text(
+            f"# Resume after {status}: {task.story_key}\n\n"
+            f"The previous session did not reach a terminal result ({status}), "
+            "most likely because it ran out of time — not because its work was "
+            "wrong. It already committed real progress on top of baseline "
+            f"`{task.baseline_commit}`:\n\n"
+            f"{shas}\n\n"
+            "Do not restart from scratch or assume this work is broken. Inspect "
+            "the current git log/diff, verify it against the story's acceptance "
+            "criteria, and continue or finish the remaining work — only redo "
+            "what is actually missing or wrong.\n",
             encoding="utf-8",
         )
         return path

--- a/src/bmad_loop/model.py
+++ b/src/bmad_loop/model.py
@@ -151,6 +151,15 @@ class StoryTask:
     # user already had on disk are never deleted. None = pre-upgrade run (no
     # snapshot); rollback then removes no untracked files at all.
     baseline_untracked: list[str] | None = None
+    # set by engine._advance_baseline_to_head: the orchestrator moved
+    # `baseline_commit` forward onto a kept attempt's commits AFTER the session
+    # that stamped the spec's own `baseline_revision` had already exited. The two
+    # then legitimately differ, so verify's baseline gate accepts a claimed
+    # baseline that is an ANCESTOR of the recorded one while this is set (a
+    # diverged baseline still fails). Never set on the ordinary path, where the
+    # session that stamps the spec and the orchestrator share one baseline and
+    # exact match still holds. Survives the round-trip.
+    baseline_advanced: bool = False
     spec_file: str | None = None
     commit_sha: str | None = None
     defer_reason: str | None = None
@@ -243,6 +252,7 @@ class StoryTask:
             "followup_review_recommended": self.followup_review_recommended,
             "baseline_commit": self.baseline_commit,
             "baseline_untracked": self.baseline_untracked,
+            "baseline_advanced": self.baseline_advanced,
             "spec_file": self._serialized_spec_file(),
             "commit_sha": self.commit_sha,
             "defer_reason": self.defer_reason,
@@ -290,6 +300,7 @@ class StoryTask:
                 if d.get("baseline_untracked") is not None
                 else None
             ),
+            baseline_advanced=bool(d.get("baseline_advanced", False)),
             spec_file=d.get("spec_file"),
             commit_sha=d.get("commit_sha"),
             defer_reason=d.get("defer_reason"),

--- a/src/bmad_loop/runs.py
+++ b/src/bmad_loop/runs.py
@@ -723,6 +723,12 @@ def rearm_escalation(
     task.review_cycle = 0
     task.followup_reviews_spent = 0  # human-resolved re-drive gets a fresh damping budget
     task.defer_reason = None
+    # Both re-drive routes re-establish an exact spec/orchestrator baseline match
+    # — ready-for-dev re-runs step-03, which stamps the advanced sha itself, and
+    # the patch-restore route re-stamps it below — so a latch left by a kept
+    # attempt of the PREVIOUS, escalated cycle must not survive into this one and
+    # keep the ancestor relaxation armed for work it never covered.
+    task.baseline_advanced = False
     task.rearmed = True  # resume-time recovery notice describes a clean rebuild,
     # not a failed attempt (engine._finish_inflight clears it once the rebuild runs)
     # Always (re)assign the latch: a None restore_patch clears a stale one left by

--- a/src/bmad_loop/stories_engine.py
+++ b/src/bmad_loop/stories_engine.py
@@ -337,10 +337,12 @@ class StoriesEngine(Engine):
             env["BMAD_LOOP_PLAN_HALT"] = "1"
         return env
 
-    def _dev_prompt(self, task: StoryTask, feedback: Path | None) -> str:
-        return self._stories_dev_prompt(task, feedback)
+    def _dev_prompt(self, task: StoryTask, feedback: Path | None, *, resume_note: str = "") -> str:
+        return self._stories_dev_prompt(task, feedback, resume_note=resume_note)
 
-    def _stories_dev_prompt(self, task: StoryTask, feedback: Path | None) -> str:
+    def _stories_dev_prompt(
+        self, task: StoryTask, feedback: Path | None, *, resume_note: str = ""
+    ) -> str:
         """Folder+id dispatch for a fresh (or resumed-to-implement) story; the
         repair leg falls back to the inherited explicit-spec-file resume.
 
@@ -351,7 +353,12 @@ class StoriesEngine(Engine):
 
         The folder is always project-relative (kills the absolute-path concern;
         the contract allows an absolute one but we never emit it). ``invoke_dev_with``
-        is appended verbatim — the single planner→dev channel, never interpreted."""
+        is appended verbatim — the single planner→dev channel, never interpreted.
+
+        ``resume_note`` overrides the repair framing for the same reason the base
+        ``Engine._generic_dev_prompt`` takes it: a timed-out attempt that already
+        committed real progress did not fail verification, and telling the resumed
+        session it did would have it redo good work."""
         if feedback is not None:
             # Deterministic-verify repair: re-open the id-keyed story spec and
             # resume on it in place. Identical to the base generic repair leg (an
@@ -359,12 +366,14 @@ class StoriesEngine(Engine):
             # is just a normal spec file.
             self._reset_spec_for_repair(task)
             spec_ref = task.spec_file or task.story_key
+            note = resume_note or (
+                "The previous session's work failed deterministic verification; "
+                "repair the working tree so verification passes without changing "
+                "the spec's frozen intent contract."
+            )
             return (
                 f"/bmad-dev-auto Resume the autonomous dev session on the in-progress "
-                f"spec at `{spec_ref}`. The previous session's work failed deterministic "
-                f"verification; repair the working tree so verification passes without "
-                f"changing the spec's frozen intent contract. Verification evidence is "
-                f"in `{feedback}`."
+                f"spec at `{spec_ref}`. {note} Evidence is in `{feedback}`."
             )
         entry = self._entry_for(task)
         prompt = f"/bmad-dev-auto Spec folder: {self._spec_folder_rel}. Story id: {task.story_key}."

--- a/src/bmad_loop/sweep.py
+++ b/src/bmad_loop/sweep.py
@@ -1125,10 +1125,12 @@ class SweepEngine(Engine):
 
     # ------------------------------------------------------ override seams
 
-    def _dev_prompt(self, task: StoryTask, feedback: Path | None) -> str:
-        return self._generic_bundle_prompt(task, feedback)
+    def _dev_prompt(self, task: StoryTask, feedback: Path | None, *, resume_note: str = "") -> str:
+        return self._generic_bundle_prompt(task, feedback, resume_note=resume_note)
 
-    def _generic_bundle_prompt(self, task: StoryTask, feedback: Path | None) -> str:
+    def _generic_bundle_prompt(
+        self, task: StoryTask, feedback: Path | None, *, resume_note: str = ""
+    ) -> str:
         """Bundle invocation for the generic bmad-dev-auto dev skill: the self-contained
         intent.md (intent + verbatim ledger entries) is handed over as freeform
         intent. The orchestrator owns the deferred-work ledger — the skill is told
@@ -1140,7 +1142,11 @@ class SweepEngine(Engine):
         `in-review` status the re-arm set — before step-01's version-control
         sanity check, which would otherwise HALT `blocked` on the diff
         `_restore_patch` just laid onto the tree. The freeform intent.md pointer
-        takes the path where that dirty-tree check runs first."""
+        takes the path where that dirty-tree check runs first.
+
+        ``resume_note`` overrides the default "failed verification, repair it"
+        framing — see ``Engine._generic_dev_prompt`` for why (a timed-out attempt
+        that already committed real progress isn't a verification failure)."""
         bundle_ref = task.bundle_file or task.story_key
         if feedback is None:
             if task.restore_patch and task.spec_file:
@@ -1160,13 +1166,15 @@ class SweepEngine(Engine):
             )
         self._reset_spec_for_repair(task)
         spec_ref = task.spec_file or bundle_ref
+        note = resume_note or (
+            "The previous session's work failed deterministic verification; "
+            "repair the working tree so verification passes without changing "
+            "the frozen intent contract or editing the deferred-work ledger."
+        )
         return (
             f"/bmad-dev-auto Resume the autonomous dev session on the in-progress "
-            f"spec at `{spec_ref}` for the deferred-work bundle `{bundle_ref}`. The "
-            f"previous session's work failed deterministic verification; repair the "
-            f"working tree so verification passes without changing the frozen intent "
-            f"contract or editing the deferred-work ledger. Verification evidence is "
-            f"in `{feedback}`."
+            f"spec at `{spec_ref}` for the deferred-work bundle `{bundle_ref}`. "
+            f"{note} Evidence is in `{feedback}`."
         )
 
     def _post_dev_state_sync(self, task: StoryTask, result_json: dict | None) -> None:

--- a/src/bmad_loop/verify.py
+++ b/src/bmad_loop/verify.py
@@ -149,6 +149,15 @@ def same_commit(a: str, b: str) -> bool:
     return a.startswith(b) or b.startswith(a)
 
 
+def is_ancestor(repo: Path, ancestor: str, descendant: str) -> bool:
+    """True if ``ancestor`` is reachable from ``descendant`` — i.e. the two sit on
+    one history and ``ancestor`` is the older end. Any git failure (unknown sha,
+    no repo, timeout) reads as False, so uncertainty keeps a caller's gate strict
+    rather than waving work through on a bad rev."""
+    rc, _ = _git(repo, "merge-base", "--is-ancestor", ancestor, descendant)
+    return rc == 0
+
+
 def has_changes_since(
     repo: Path,
     baseline: str,
@@ -1175,7 +1184,21 @@ def _verify_shared_gates(
     # same idiom as `devcontract.synthesize_result`.
     claimed_baseline = str(fm.get("baseline_commit", fm.get("baseline_revision", ""))).strip()
     if task.baseline_commit and claimed_baseline not in ("", "NO_VCS"):
-        if not same_commit(claimed_baseline, task.baseline_commit):
+        # Exact match is the rule: the session that stamps the spec and the
+        # orchestrator normally share one baseline, and a spec claiming a
+        # different one means the session worked against a tree the orchestrator
+        # never authorized. The single exception is when the orchestrator ITSELF
+        # moved the baseline forward after that stamp (`baseline_advanced`, set
+        # by engine._advance_baseline_to_head when a kept attempt's commits are
+        # adopted): the spec then legitimately holds the older, pre-advance sha —
+        # deliberately so, since it is the diff base the whole story's review
+        # must span. Accept it only when it is an ANCESTOR of the recorded
+        # baseline, which proves the two sit on one history and the session
+        # merely started earlier; a diverged sha still fails.
+        matched = same_commit(claimed_baseline, task.baseline_commit)
+        if not matched and task.baseline_advanced:
+            matched = is_ancestor(paths.project, claimed_baseline, task.baseline_commit)
+        if not matched:
             return VerifyOutcome.retry(
                 f"spec baseline {claimed_baseline[:12]} does not match "
                 f"orchestrator-recorded baseline {task.baseline_commit[:12]}"

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -3440,6 +3440,72 @@ def test_dev_stall_retries_then_succeeds(project):
     assert engine.state.tasks["1-1-a"].attempt == 2
 
 
+def test_dev_timeout_with_committed_work_keeps_tree_and_resumes(project):
+    """The 2026-07-09 story-17-3 incident: a dev session committed real, working
+    code and then hit the wall-clock timeout 9 minutes later while still
+    mid-turn. The old unconditional rollback-on-retry discarded that commit, so
+    the retry had to re-derive the same implementation from scratch (burning
+    ~3x the tokens) before ALSO timing out. A retry after a non-completed
+    session must keep the tree when the attempt already landed commits, and
+    tell the resumed session to build on them instead of silently redoing the
+    work."""
+    write_sprint(project, {"1-1-a": "ready-for-dev"})
+    repo = project.project
+
+    def timeout_after_committing(spec):
+        (repo / "impl.txt").write_text("committed implementation\n")
+        git(repo, "add", "-A")
+        git(repo, "commit", "-q", "-m", "attempt work")
+        return SessionResult(status="timeout")
+
+    engine, adapter = make_engine(
+        project,
+        [
+            timeout_after_committing,
+            dev_effect(project, "1-1-a"),
+            review_effect(project, "1-1-a", clean=True),
+        ],
+    )
+    summary = engine.run()
+
+    assert summary.done == 1
+    assert engine.state.tasks["1-1-a"].attempt == 2
+    assert not any(e["kind"] == "rollback-auto" for e in engine.journal.entries())
+    assert (repo / "impl.txt").read_text() == "committed implementation\n"  # never rolled back
+
+    resumed_prompt = adapter.sessions[1].prompt
+    assert resumed_prompt.startswith("/bmad-dev-auto Resume the autonomous")
+    assert "did not reach a terminal result" in resumed_prompt
+    assert "failed deterministic verification" not in resumed_prompt
+
+
+def test_dev_timeout_without_committed_work_still_rolls_back(project):
+    """A timeout that produced no durable progress (no commits above baseline)
+    must keep the old behavior: roll back to baseline rather than resuming a
+    tree with nothing but stray uncommitted noise in it."""
+    write_sprint(project, {"1-1-a": "ready-for-dev"})
+    repo = project.project
+
+    def timeout_with_dirty_no_commit(spec):
+        (repo / "src.txt").write_text("uncommitted, never landed\n")
+        return SessionResult(status="timeout")
+
+    engine, adapter = make_engine(
+        project,
+        [
+            timeout_with_dirty_no_commit,
+            dev_effect(project, "1-1-a"),
+            review_effect(project, "1-1-a", clean=True),
+        ],
+    )
+    summary = engine.run()
+
+    assert summary.done == 1
+    assert any(e["kind"] == "rollback-auto" for e in engine.journal.entries())
+    resumed_prompt = adapter.sessions[1].prompt
+    assert resumed_prompt == "/bmad-dev-auto 1-1-a"  # plain restart, no resume framing
+
+
 def test_dev_exhausted_defers_and_run_continues(project):
     write_sprint(project, {"1-1-a": "ready-for-dev", "1-2-b": "ready-for-dev"})
     engine, adapter = make_engine(

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -3479,6 +3479,29 @@ def test_dev_timeout_with_committed_work_keeps_tree_and_resumes(project):
     assert "failed deterministic verification" not in resumed_prompt
 
 
+def test_advance_baseline_latches_only_when_the_advance_landed(monkeypatch, project):
+    """The latch is what tells verify's gate an ancestor is legitimate here, so it
+    must never outrun the advance itself: a git failure leaves the OLD baseline
+    standing, and claiming it was advanced would wave a genuinely foreign spec
+    baseline through."""
+    engine, _ = make_engine(project, [])
+    task = StoryTask(story_key="1-1-a", epic=1)
+    task.baseline_commit = "abc123"
+
+    def boom(repo):
+        raise verify.GitError("simulated failure")
+
+    monkeypatch.setattr(verify, "untracked_files", boom)
+    engine._advance_baseline_to_head(task)
+    assert task.baseline_commit == "abc123"
+    assert task.baseline_advanced is False
+
+    monkeypatch.undo()
+    engine._advance_baseline_to_head(task)
+    assert task.baseline_commit == verify.rev_parse_head(project.project)
+    assert task.baseline_advanced is True
+
+
 def test_dev_timeout_without_committed_work_still_rolls_back(project):
     """A timeout that produced no durable progress (no commits above baseline)
     must keep the old behavior: roll back to baseline rather than resuming a
@@ -3504,6 +3527,65 @@ def test_dev_timeout_without_committed_work_still_rolls_back(project):
     assert any(e["kind"] == "rollback-auto" for e in engine.journal.entries())
     resumed_prompt = adapter.sessions[1].prompt
     assert resumed_prompt == "/bmad-dev-auto 1-1-a"  # plain restart, no resume framing
+
+
+def test_dev_timeout_resume_keeping_the_attempts_own_spec_baseline_completes(project):
+    """md2pdf-auto run 20260716-153340-9183: dev-1 stamped the spec, committed
+    eight commits and timed out; the retry adopted them (baseline advanced), dev-2
+    finished the story — and the baseline gate then failed the whole thing on
+    `spec baseline 68eda05 does not match orchestrator-recorded baseline 1ead148`,
+    after ~83M tokens. A resumed session does NOT re-run step-03: it keeps the
+    attempt's spec (that is the point of the resume note), so its
+    `baseline_revision` stays at the pre-advance sha and exact match cannot hold.
+
+    The sibling keep-tree test passes only because `dev_effect` re-stamps the spec
+    with the current HEAD on every session — a fixture artifact no resumed
+    production session reproduces, the same masking that hid issue #89."""
+    write_sprint(project, {"1-1-a": "ready-for-dev"})
+    repo = project.project
+    sp = spec_path(project, "1-1-a")
+    original_baseline = verify.rev_parse_head(repo)
+
+    def timeout_after_stamping_and_committing(spec):
+        write_spec(sp, "ready-for-dev", original_baseline)  # step-03's stamp
+        (repo / "impl.txt").write_text("committed implementation\n")
+        git(repo, "add", "-A")
+        git(repo, "commit", "-q", "-m", "attempt work")
+        return SessionResult(status="timeout")
+
+    def resume_finishing_without_restamping(spec):
+        (repo / "impl.txt").write_text("committed implementation\nfinished\n")
+        write_spec(sp, "done", _spec_baseline(sp))  # keeps dev-1's baseline
+        return SessionResult(
+            status="completed",
+            result_json={
+                "workflow": "auto-dev",
+                "story_key": "1-1-a",
+                "spec_file": str(sp),
+                "tasks_total": 3,
+                "tasks_done": 3,
+                "verification": [],
+                "escalations": [],
+                "followup_review_recommended": False,
+            },
+        )
+
+    engine, _ = make_engine(
+        project,
+        [
+            timeout_after_stamping_and_committing,
+            resume_finishing_without_restamping,
+            review_effect(project, "1-1-a", clean=True),
+        ],
+    )
+    summary = engine.run()
+
+    assert summary.done == 1
+    task = engine.state.tasks["1-1-a"]
+    assert task.phase is not Phase.ESCALATED
+    assert task.baseline_advanced  # the orchestrator moved it, so the gate relaxed
+    assert _spec_baseline(sp) == original_baseline  # and nothing re-stamped the spec
+    assert (repo / "impl.txt").read_text().endswith("finished\n")
 
 
 def test_dev_exhausted_defers_and_run_continues(project):

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -259,6 +259,22 @@ def test_rearm_advances_baseline_to_resolved_head(project):
     assert "leftover.txt" in task.baseline_untracked
 
 
+def test_rearm_clears_the_baseline_advanced_latch(project):
+    """A kept attempt of the escalated cycle may have latched `baseline_advanced`
+    (engine._advance_baseline_to_head). Both re-drive routes re-establish an exact
+    spec/orchestrator match — ready-for-dev re-runs step-03, patch-restore
+    re-stamps — so the latch must not survive and leave verify's ancestor
+    relaxation armed for a cycle whose spec no longer needs it."""
+    root = project.project
+    run_dir, state, task = _escalated_run(root)
+    task.baseline_advanced = True
+    save_state(run_dir, state)
+
+    runs.rearm_escalation(run_dir)
+
+    assert load_state(run_dir).tasks["6-4-cli-list-command"].baseline_advanced is False
+
+
 def test_rearm_baseline_all_or_nothing_on_partial_git_failure(monkeypatch, project):
     """rev_parse_head succeeding but untracked_files failing must not advance
     baseline_commit while leaving baseline_untracked stale: both locals are

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1556,6 +1556,75 @@ def test_verify_dev_baseline_gate_reads_the_skills_baseline_revision_key(project
     assert verify.verify_dev(task, project, dev_result(sp)).ok
 
 
+def _advanced_baseline_incident(project, task, sp):
+    """The shape `_advance_baseline_to_head` leaves behind: a timed-out attempt
+    stamped the spec with the pre-attempt baseline and committed real work, after
+    which the orchestrator adopted those commits as the new baseline. Returns the
+    original (pre-advance) sha the spec still claims."""
+    original = task.baseline_commit
+    write_spec(sp, "in-review", original)
+    (project.project / "src.txt").write_text("work the timed-out attempt committed\n")
+    git(project.project, "add", "-A")
+    git(project.project, "commit", "-q", "-m", "kept attempt work")
+    task.baseline_commit = verify.rev_parse_head(project.project)
+    task.baseline_advanced = True
+    (project.project / "more.txt").write_text("work the resumed session added\n")
+    return original
+
+
+def test_verify_dev_advanced_baseline_accepts_the_ancestor_it_left_in_the_spec(project):
+    """The orchestrator adopts a timed-out attempt's commits as the new baseline
+    but never re-stamps the spec, so the spec keeps the older sha ON PURPOSE (it
+    is the diff base the whole story's review must span). Exact match then fails a
+    story the resumed session actually finished — the drift that discarded ~27M
+    tokens of completed work on md2pdf-auto run 20260716-153340-9183."""
+    write_sprint(project, {"1-1-a": "review"})
+    task = make_task(project)
+    sp = spec_path(project, "1-1-a")
+
+    original = _advanced_baseline_incident(project, task, sp)
+    assert original != task.baseline_commit
+    assert verify.is_ancestor(project.project, original, task.baseline_commit)
+    assert verify.verify_dev(task, project, dev_result(sp)).ok
+
+
+def test_verify_dev_advanced_baseline_still_rejects_a_diverged_baseline(project):
+    """The relaxation is ancestor-only: a spec claiming a sha that is not on the
+    recorded baseline's history means the session worked against a tree the
+    orchestrator never authorized, advance latch or not."""
+    write_sprint(project, {"1-1-a": "review"})
+    task = make_task(project)
+    sp = spec_path(project, "1-1-a")
+
+    _advanced_baseline_incident(project, task, sp)
+    write_spec(sp, "in-review", "0" * 40)  # foreign sha, not an ancestor
+    out = verify.verify_dev(task, project, dev_result(sp))
+    assert not out.ok and "does not match" in out.reason
+
+
+def test_verify_dev_ancestor_baseline_without_the_advance_latch_still_fails(project):
+    """Exact match stays the rule everywhere the orchestrator did NOT move the
+    baseline itself. Without the latch an ancestor is just a spec claiming a
+    baseline nobody authorized, and PR #162's bundle-mode relaxation must stay the
+    only other way past this gate."""
+    write_sprint(project, {"1-1-a": "review"})
+    task = make_task(project)
+    sp = spec_path(project, "1-1-a")
+
+    _advanced_baseline_incident(project, task, sp)
+    task.baseline_advanced = False
+    out = verify.verify_dev(task, project, dev_result(sp))
+    assert not out.ok and "does not match" in out.reason
+
+
+def test_is_ancestor_reads_an_unknown_rev_as_false(project):
+    """Uncertainty keeps the gate strict: a git failure must never read as "yes,
+    that baseline is fine"."""
+    head = verify.rev_parse_head(project.project)
+    assert verify.is_ancestor(project.project, head, head) is True
+    assert verify.is_ancestor(project.project, "0" * 40, head) is False
+
+
 def test_verify_dev_exclude_relpaths_normalizes_dotdot_segments(project):
     """A spec_path with a lexical '..' hop (as an un-normalized session-reported
     spec_file could produce) must resolve to the same exclude entry as the plain


### PR DESCRIPTION
## What

A same-story dev retry after a non-completed session (timeout/stalled/crashed) now keeps
commits the attempt already landed, and the baseline gate accepts the spec baseline that
keeping them leaves behind.

## Why

Fixes #172.

A timed-out session's commits were rolled back and re-derived from scratch by the retry
(~3x tokens, usually into a second timeout). Keeping them requires advancing
`baseline_commit` past them — which splits it from the spec's `baseline_revision`, stamped
by the timed-out attempt and deliberately not re-stamped (it is the diff base the story's
whole review must span). The exact-match gate then failed the *finished* story on that
split alone: 83.6M tokens, re-escalated instead of committed (evidence in #172).

## How

- Keep the tree when `commits_above(baseline)` is non-empty; feedback + prompt tell the
  resumed session its predecessor ran out of time, not that its work was wrong.
- `_advance_baseline_to_head` adopts those commits and latches `baseline_advanced`.
- The gate accepts an **ancestor** baseline only while that latch is set; diverged shas
  still fail, and every other path keeps exact match. `rearm_escalation` clears it.

Note: `verify.is_ancestor()` overlaps #162 — happy to rebase onto whichever lands first.

## Testing

`uv run pytest -q`: 2330 passed, 4 failed (`test_module_skills_sync`, pre-existing on main
in this checkout), 6 skipped. black/ruff clean on changed files. Each new gate test was
re-run with the relaxation disabled to confirm it fails without the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved development retries after interrupted sessions.
  - Preserves committed work when a session ends after making progress, avoiding unnecessary rollback or duplicated work.
  - Automatically rolls back attempts that produced no durable progress.
  - Resumed sessions now receive clearer instructions to continue existing work.
  - Improved validation for previously recorded progress while preventing invalid or unrelated baselines.
  - Reset escalation state correctly when a task is reactivated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->