### PR TITLE
fix(verify): git timeouts become GitError; rollback dirty check degrades instead of crashing the run (#156)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,15 @@ PATH)`, the TUI notifies `multiplexer backend unavailable — launch/attach disa
 
 ### Fixed
 
+- **A git call exceeding its timeout no longer crashes the whole run (#156).** Every git
+  subprocess the orchestrator spawns now translates `subprocess.TimeoutExpired` into
+  `GitError`, so the existing degrade guards handle a slow git like any other git failure.
+  The rollback gate specifically (`_rollback_or_pause`'s dirty check — the reported crash
+  path) degrades to assume-dirty: rollback OFF pauses with the manual-recovery notice and
+  the worktree kept; ON / resolved re-drives still auto-recover behind their preserve
+  steps. A `rollback-dirty-check-failed` journal entry records the fault. The bound is now
+  configurable as `limits.git_timeout_s` (default 120).
+
 - **`validate` and `probe-adapter` no longer report antigravity's hooks as unregistered
   (#159).** The `antigravity-hooks-json` dialect keys `.agents/hooks.json` by hook-group name
   at the top level, with no `"hooks"` wrapper — but both readers looked up `"hooks"`, got `{}`,

--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ spec_folder = ""           # required when source = "stories": the epic spec fol
 max_review_cycles = 3
 max_dev_attempts = 2
 session_timeout_min = 90
+git_timeout_s = 120              # bound on any single git subprocess; exceeding it pauses/degrades, never crashes the run
 stop_without_result_nudges = 1   # times to re-prompt a session that stopped with no result.json
 dev_stall_grace_s = 600          # idle grace before a dev session awaiting a background run (e.g. PlayMode) is nudged/stalled
 dev_stall_nudges = 2             # wake-nudges spent on grace expiry before a dev session is called stalled

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -142,7 +142,7 @@ See [README.md](../README.md) for the narrative overview and [setup-guide.md](se
 
 - Single policy file written by `init`, snapshotted at run start (applies to new runs and resumes; editable live from the TUI).
 - Sections: `[gates]`, `[limits]`, `[verify]`, `[notify]`, `[review]`, `[adapter]` (+ per-stage), `[sweep]`, `[scm]` (worktree isolation + merge-back), `[cleanup]` (run-dir retention + disk reclamation), `[plugins]` (trust allowlist + per-plugin `[plugins.<name>]` config — e.g. the opt-in game-engine layer via `[plugins.unity]`, off by default), `[tui]` (`low_frame_rate` for slow/SSH links; persisted dashboard pane sizes).
-- Tunable limits: `max_review_cycles`, `max_dev_attempts`, `max_followup_reviews`, `session_timeout_min`, `stop_without_result_nudges`, `dev_stall_grace_s`, `dev_stall_nudges`, `dev_stall_nudges_cap`, `workflow_stall_nudges_cap`, `max_tokens_per_story`.
+- Tunable limits: `max_review_cycles`, `max_dev_attempts`, `max_followup_reviews`, `session_timeout_min`, `git_timeout_s`, `stop_without_result_nudges`, `dev_stall_grace_s`, `dev_stall_nudges`, `dev_stall_nudges_cap`, `workflow_stall_nudges_cap`, `max_tokens_per_story`.
 
 ### TUI dashboard
 

--- a/src/bmad_loop/data/settings/core.toml
+++ b/src/bmad_loop/data/settings/core.toml
@@ -88,6 +88,12 @@ kind = "int"
 minimum = 1
 default_ref = "LimitsPolicy.session_timeout_min"
 [[section.field]]
+key = "git_timeout_s"
+kind = "int"
+minimum = 1
+default_ref = "LimitsPolicy.git_timeout_s"
+description = "bound on any single git subprocess the orchestrator spawns; exceeding it degrades/pauses (never crashes the run) — raise on a loaded host or a very large worktree"
+[[section.field]]
 key = "stop_without_result_nudges"
 kind = "int"
 minimum = 0

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -169,6 +169,7 @@ class Engine:
         # only mode) → the repo root in place; Phase 3 swaps in per-unit worktrees.
         self.workspace = Workspace.default(paths)
         self.policy = policy
+        verify.configure_git_timeout(policy.limits.git_timeout_s)
         self.adapters = {
             "dev": adapter,
             "review": review_adapter if review_adapter is not None else adapter,
@@ -842,9 +843,25 @@ class Engine:
         # reset; the auto-recover (pause-vs-reset) decision below is unaffected.
         redrive = resolved or task.resolved_redrive
         protected = self._protected_relpaths() if redrive else ()
-        if task.baseline_commit and not verify.attempt_dirty(
-            self.workspace.root, task.baseline_commit, task.baseline_untracked, exclude=protected
-        ):
+        # Un-determinable dirty check (git timeout/failure, #156) ⇒ assume dirty:
+        # never skip recovery on an unproven "clean", never crash the run. The
+        # normal branching below then decides — OFF pauses (worktree kept), ON /
+        # resolved auto-recovers behind its preserve steps, keeping the re-drive
+        # pause-free contract intact.
+        dirty = True
+        if task.baseline_commit:
+            try:
+                dirty = verify.attempt_dirty(
+                    self.workspace.root,
+                    task.baseline_commit,
+                    task.baseline_untracked,
+                    exclude=protected,
+                )
+            except verify.GitError as exc:
+                self.journal.append(
+                    "rollback-dirty-check-failed", story_key=task.story_key, error=str(exc)
+                )
+        if task.baseline_commit and not dirty:
             self.journal.append("rollback-skipped-clean", story_key=task.story_key)
             return
         if resolved or self.policy.scm.rollback_on_failure:

--- a/src/bmad_loop/policy.py
+++ b/src/bmad_loop/policy.py
@@ -69,6 +69,12 @@ class LimitsPolicy:
     # (converge + refile on the first finalized round that still recommends one).
     max_followup_reviews: int = 1
     session_timeout_min: int = 90
+    # hard bound on any single git subprocess the orchestrator spawns (diff,
+    # reset, snapshot, …). The default is a sane normal-case ceiling, but a
+    # loaded host or a very large worktree can legitimately exceed it (#156) —
+    # exceeding it is a handled GitError, never a run crash, and raising the
+    # bound here is the fix when it fires spuriously.
+    git_timeout_s: int = 120
     stop_without_result_nudges: int = 1
     # how long a dev session may sit on a result-less Stop — i.e. it ended its
     # turn awaiting a long-running background process (a Unity PlayMode run, a
@@ -559,6 +565,7 @@ def loads(text: str, plugin_schemas: dict[str, Any] | None = None) -> Policy:
         session_timeout_min=int(
             limits_d.get("session_timeout_min", LimitsPolicy.session_timeout_min)
         ),
+        git_timeout_s=int(limits_d.get("git_timeout_s", LimitsPolicy.git_timeout_s)),
         stop_without_result_nudges=int(
             limits_d.get("stop_without_result_nudges", LimitsPolicy.stop_without_result_nudges)
         ),
@@ -581,6 +588,8 @@ def loads(text: str, plugin_schemas: dict[str, Any] | None = None) -> Policy:
         raise PolicyError(
             f"limits.max_followup_reviews must be >= 0: got {limits.max_followup_reviews}"
         )
+    if limits.git_timeout_s < 1:
+        raise PolicyError(f"limits.git_timeout_s must be >= 1: got {limits.git_timeout_s}")
     if not 0.0 <= limits.cache_read_weight <= 1.0:
         raise PolicyError(
             f"limits.cache_read_weight must be between 0 and 1: got {limits.cache_read_weight}"
@@ -827,6 +836,7 @@ max_review_cycles = 3
 max_dev_attempts = 2
 max_followup_reviews = 1     # additional review rounds granted solely because a finalized (status: done) round still recommended a follow-up; once spent, such a round converges + refiles the recommendation instead of burning another cycle. 0 = never honor a pass's own recommendation
 session_timeout_min = 90
+git_timeout_s = 120          # bound on any single git subprocess; exceeding it pauses/degrades (never crashes the run) — raise on a loaded host or a very large worktree
 stop_without_result_nudges = 1
 dev_stall_grace_s = 600      # grace for a dev session that ended its turn awaiting a background process (e.g. a slow PlayMode/test run) before it is called stalled; each re-invocation resets it. 0 = fail fast on the first result-less Stop
 dev_stall_nudges = 2         # times an idle dev session is nudged awake on grace expiry before it is called stalled (bmad-loop has no background-completion re-invocation); pane output re-arms the grace window and a fresh Stop restores the budget. 0 = stall on grace expiry

--- a/src/bmad_loop/verify.py
+++ b/src/bmad_loop/verify.py
@@ -26,6 +26,19 @@ from .sprintstatus import story_status
 GIT_TIMEOUT_S = 120
 COMMAND_TIMEOUT_S = 30 * 60
 
+# Current bound on a single git subprocess. Module state rather than a per-call
+# parameter so the ~40 git helpers need no threading; the engine overrides it
+# from `limits.git_timeout_s` at startup, everything else keeps the default.
+_git_timeout_s = GIT_TIMEOUT_S
+
+
+def configure_git_timeout(seconds: int) -> None:
+    """Set the per-git-call timeout (`limits.git_timeout_s`). Called once by the
+    engine when it binds its policy; standalone verify users keep GIT_TIMEOUT_S."""
+    global _git_timeout_s
+    _git_timeout_s = seconds
+
+
 # How git's own diff format names the absent side of a creation/deletion. A
 # protocol token git emits verbatim on every platform, Windows included — never
 # opened, never joined onto. Only `patch_new_files` reads it.
@@ -85,13 +98,28 @@ class VerifyOutcome:
         return not self.ok and not self.severity
 
 
+def _run_git(
+    cmd: list[str], repo: Path, *, env: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    """Sole spawn point for git subprocesses. A timeout is raised by
+    `subprocess.run` *before* any return code exists, so left uncaught it would
+    bypass every `except GitError` guard and crash the run (#156); translating
+    it here puts timeouts in the same taxonomy as any other git failure —
+    observation guards degrade, unguarded paths fail typed."""
+    try:
+        return subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=_git_timeout_s,
+            env=env,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise GitError(f"git {cmd[3]} timed out after {_git_timeout_s}s in {repo}") from exc
+
+
 def _git(repo: Path, *args: str) -> tuple[int, str]:
-    proc = subprocess.run(
-        ["git", "-C", str(repo), *args],
-        capture_output=True,
-        text=True,
-        timeout=GIT_TIMEOUT_S,
-    )
+    proc = _run_git(["git", "-C", str(repo), *args], repo)
     return proc.returncode, (proc.stdout + proc.stderr).strip()
 
 
@@ -99,12 +127,7 @@ def _git_raw(repo: Path, *args: str) -> tuple[int, str]:
     """Like `_git` but returns stdout verbatim (no strip, no stderr merge) — for
     NUL-delimited (`-z`) output whose records can begin with a space (porcelain
     status codes like ' M'), which `_git`'s strip() would corrupt."""
-    proc = subprocess.run(
-        ["git", "-C", str(repo), *args],
-        capture_output=True,
-        text=True,
-        timeout=GIT_TIMEOUT_S,
-    )
+    proc = _run_git(["git", "-C", str(repo), *args], repo)
     return proc.returncode, proc.stdout
 
 
@@ -112,13 +135,7 @@ def _git_env(repo: Path, *args: str, env: dict[str, str]) -> tuple[int, str]:
     """Like `_git` but runs with an explicit environment — used to point git at a
     throwaway `GIT_INDEX_FILE` so a snapshot can stage the tree without touching
     the real index."""
-    proc = subprocess.run(
-        ["git", "-C", str(repo), *args],
-        capture_output=True,
-        text=True,
-        timeout=GIT_TIMEOUT_S,
-        env=env,
-    )
+    proc = _run_git(["git", "-C", str(repo), *args], repo, env=env)
     return proc.returncode, (proc.stdout + proc.stderr).strip()
 
 
@@ -848,12 +865,7 @@ def capture_diff(repo: Path, baseline: str, *, max_file_bytes: int | None = None
     size, so a stray build dir or huge log can't balloon the patch. None lifts the
     cap (capture everything regardless of size).
     """
-    proc = subprocess.run(
-        ["git", "-C", str(repo), "diff", baseline, "--"],
-        capture_output=True,
-        text=True,
-        timeout=GIT_TIMEOUT_S,
-    )
+    proc = _run_git(["git", "-C", str(repo), "diff", baseline, "--"], repo)
     if proc.returncode != 0:
         raise GitError(f"git diff {baseline} failed in {repo}: {proc.stderr.strip()}")
     parts = [proc.stdout]
@@ -881,12 +893,7 @@ def capture_diff(repo: Path, baseline: str, *, max_file_bytes: int | None = None
         # it exits 1 precisely because the files differ — expected here. Any other
         # non-zero code is a real failure (bad path, internal error), not "files
         # differ", so don't silently fold it into the patch.
-        u = subprocess.run(
-            ["git", "-C", str(repo), "diff", "--no-index", "--", os.devnull, rel],
-            capture_output=True,
-            text=True,
-            timeout=GIT_TIMEOUT_S,
-        )
+        u = _run_git(["git", "-C", str(repo), "diff", "--no-index", "--", os.devnull, rel], repo)
         if u.returncode not in (0, 1):
             raise GitError(
                 f"git diff --no-index for untracked {rel!r} failed in {repo}: {u.stderr.strip()}"

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2362,6 +2362,82 @@ def test_rollback_or_pause_skips_clean_tree(project):
     assert "rollback-manual-required" not in kinds
 
 
+def test_rollback_gate_git_fault_pauses_instead_of_crashing(project, monkeypatch):
+    """#156: the dirty check timing out (now a GitError) must degrade to
+    assume-dirty, so with rollback OFF the run pauses on the manual-recovery
+    notice with the tree untouched — it must never crash the run."""
+    policy = Policy(
+        gates=GatesPolicy(mode="none"),
+        notify=QUIET,
+        scm=ScmPolicy(rollback_on_failure=False),
+    )
+    engine, _ = make_engine(project, [], policy=policy)
+    repo = project.project
+    task = StoryTask(story_key="1-1-a", epic=1)
+    task.baseline_commit = rev_parse_head(repo)
+    task.baseline_untracked = []
+    head = rev_parse_head(repo)
+
+    def timing_out(*args, **kwargs):
+        raise GitError(f"git diff timed out after 120s in {repo}")
+
+    monkeypatch.setattr(verify, "attempt_dirty", timing_out)
+
+    with pytest.raises(RunPaused):
+        engine._rollback_or_pause(task)
+
+    assert rev_parse_head(repo) == head  # tree untouched
+    kinds = [e["kind"] for e in engine.journal.entries()]
+    assert "rollback-dirty-check-failed" in kinds
+    assert "rollback-skipped-clean" not in kinds
+
+
+def test_rollback_gate_git_fault_still_auto_recovers_when_on(project, monkeypatch):
+    """rollback ON: an un-determinable dirty check still takes the auto-recover
+    branch (preserve + reset) — the degrade must not turn the pause-free path
+    into a pause."""
+    policy = Policy(
+        gates=GatesPolicy(mode="none"),
+        notify=QUIET,
+        scm=ScmPolicy(rollback_on_failure=True),
+    )
+    engine, _ = make_engine(project, [], policy=policy)
+    repo = project.project
+    task = StoryTask(story_key="1-1-a", epic=1)
+    task.baseline_commit = rev_parse_head(repo)
+    task.baseline_untracked = []
+    (repo / "impl.txt").write_text("committed implementation\n")
+    git(repo, "add", "-A")
+    git(repo, "commit", "-q", "-m", "attempt work")
+
+    def timing_out(*args, **kwargs):
+        raise GitError(f"git diff timed out after 120s in {repo}")
+
+    monkeypatch.setattr(verify, "attempt_dirty", timing_out)
+
+    engine._rollback_or_pause(task)  # must not raise
+
+    assert rev_parse_head(repo) == task.baseline_commit  # reset happened
+    kinds = [e["kind"] for e in engine.journal.entries()]
+    assert "rollback-dirty-check-failed" in kinds
+    assert "rollback-auto" in kinds
+
+
+def test_engine_applies_git_timeout_from_policy(project):
+    """Engine construction pushes limits.git_timeout_s into the verify module so
+    every git helper honors the operator's bound."""
+    policy = Policy(
+        gates=GatesPolicy(mode="none"),
+        notify=QUIET,
+        limits=LimitsPolicy(git_timeout_s=7),
+    )
+    try:
+        make_engine(project, [], policy=policy)
+        assert verify._git_timeout_s == 7
+    finally:
+        verify.configure_git_timeout(verify.GIT_TIMEOUT_S)
+
+
 def test_manual_recovery_wording_stopped(project):
     """Only the stopped/abandoned path reaches the manual-recovery notice now (a
     resolved escalation auto-recovers instead). The notice never claims the story

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -265,6 +265,22 @@ def test_zero_budget_rejected(tmp_path):
         policy.load(p)
 
 
+def test_git_timeout_default_parse_and_template():
+    import tomllib
+
+    assert policy.loads("").limits.git_timeout_s == 120
+    assert policy.loads("[limits]\ngit_timeout_s = 600\n").limits.git_timeout_s == 600
+    # the emitted template documents the knob at its dataclass default
+    doc = tomllib.loads(policy.POLICY_TEMPLATE)
+    assert doc["limits"]["git_timeout_s"] == 120
+
+
+@pytest.mark.parametrize("bad", [0, -5])
+def test_git_timeout_must_be_positive(bad):
+    with pytest.raises(policy.PolicyError, match=r"limits\.git_timeout_s"):
+        policy.loads(f"[limits]\ngit_timeout_s = {bad}\n")
+
+
 def test_workflow_stall_nudges_cap_default_parse_and_template():
     import tomllib
 

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -90,6 +90,48 @@ def test_attempt_dirty_excludes_tracked_artifact(project):
     assert verify.attempt_dirty(repo, baseline, [], exclude=(artifact_rel,)) is True
 
 
+def _timing_out_run(cmd, **kwargs):
+    raise subprocess.TimeoutExpired(cmd=cmd, timeout=kwargs.get("timeout", 0))
+
+
+def test_git_timeout_becomes_git_error(project, monkeypatch):
+    """#156: a git call exceeding the timeout must surface as GitError — the type
+    every guard already handles — never as a raw TimeoutExpired, which bypassed
+    them all and crashed the run from the rollback path."""
+    baseline = verify.rev_parse_head(project.project)
+    monkeypatch.setattr(verify.subprocess, "run", _timing_out_run)
+    with pytest.raises(verify.GitError, match=r"git diff timed out after \d+s"):
+        verify.attempt_dirty(project.project, baseline, [])
+
+
+def test_capture_diff_timeout_becomes_git_error(project, monkeypatch):
+    """capture_diff's inline git spawns (verbatim-stdout diff) share the same
+    translation as the `_git` helpers."""
+    baseline = verify.rev_parse_head(project.project)
+    monkeypatch.setattr(verify.subprocess, "run", _timing_out_run)
+    with pytest.raises(verify.GitError, match="timed out"):
+        verify.capture_diff(project.project, baseline)
+
+
+def test_configure_git_timeout_overrides_bound(project, monkeypatch):
+    """The engine-applied `limits.git_timeout_s` value is what reaches
+    subprocess.run; the module default stays GIT_TIMEOUT_S for standalone users."""
+    seen: dict[str, object] = {}
+    real_run = subprocess.run
+
+    def spying_run(cmd, **kwargs):
+        seen["timeout"] = kwargs.get("timeout")
+        return real_run(cmd, **kwargs)
+
+    monkeypatch.setattr(verify.subprocess, "run", spying_run)
+    verify.configure_git_timeout(7)
+    try:
+        verify.rev_parse_head(project.project)
+    finally:
+        verify.configure_git_timeout(verify.GIT_TIMEOUT_S)
+    assert seen["timeout"] == 7
+
+
 @pytest.mark.parametrize(
     "raw,expected",
     [


### PR DESCRIPTION
## Summary

Fixes #156: a single slow git call (`subprocess.TimeoutExpired` on `GIT_TIMEOUT_S` = 120s) crashed the entire run with `crashed: true` — reported from the worst possible place, the failure-*recovery* path (`_rollback_or_pause`'s dirty check), while the story's work sat intact in the worktree.

Root cause: a timeout is raised by `subprocess.run` *before* any return code exists, so it never became a `GitError` and bypassed every `except verify.GitError` guard in the codebase, landing in the top-level `except Exception`.

Note: the issue's proposed fix #1 alone (re-raise as `GitError`) would not have fixed the reported crash — the `attempt_dirty` call site in `_rollback_or_pause` had no guard at all. This PR does both the translation and the gate guard.

## Changes

- **verify**: all five git subprocess spawn sites (`_git`, `_git_raw`, `_git_env`, and `capture_diff`'s two inline runs) now go through one `_run_git` runner that re-raises `TimeoutExpired` as `GitError` — timeouts join the taxonomy every existing degrade guard already handles (`_preserve_attempt_commits`, `_preserve_attempt_worktree`, `_pause_for_manual_recovery`'s advisory probe, sweep's `worktree_clean`, …). Unguarded paths now fail typed instead of raw.
- **engine**: the rollback gate degrades an un-determinable dirty check to **assume dirty** (journaled as `rollback-dirty-check-failed`), then follows the existing branching: rollback OFF (default) pauses on the manual-recovery notice with the tree untouched — the reporter's expected outcome; ON / resolved re-drives still auto-recover behind their preserve steps, keeping the re-drive pause-free contract intact. Covers all three `_rollback_or_pause` call sites (dev-phase retry, resume, defer).
- **policy**: the bound is configurable as `limits.git_timeout_s` (default 120, must be ≥ 1) — 120s is a sane normal-case ceiling, but a loaded host or a very large worktree can legitimately exceed it. Applied by the engine at construction via `verify.configure_git_timeout`; standalone verify users keep the default. Documented in the policy template, README, FEATURES, and the TUI settings schema.

## Testing

- New tests: timeout→`GitError` translation (helper + `capture_diff` paths), configured bound reaches `subprocess.run`, rollback gate pauses (OFF) / auto-recovers (ON) on a dirty-check fault, policy knob default/parse/validation/template.
- Full suite: 2393 passed, 1 skipped. Full `trunk check` clean.
- Live sanity: real git subprocess against a real repo with a sub-second bound → `GitError: git diff timed out after …` (not `TimeoutExpired`).

## Out of scope

- #157 (wedged session, same run) — independent defect; this PR keeps the run alive but doesn't change session teardown.
- #139-class broad hardening (per-site degrade semantics for every unguarded housekeeping git call). After this PR those fail as typed `GitError`s with a clear message; choosing degrade behavior per site is #139's job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Git operations that exceed their time limit no longer crash the entire run.
  - Timed-out operations now follow the standard pause, degrade, or rollback handling.
  - Recovery checks safely assume changes may be present when Git status cannot be determined.

- **New Features**
  - Added configurable Git subprocess timeout via `limits.git_timeout_s`, defaulting to 120 seconds.
  - Invalid timeout values are rejected during policy validation.

- **Documentation**
  - Updated configuration templates and feature documentation with the new timeout setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->