### PR TITLE
fix(adapters,engine): timely + observable session-timeout teardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,27 @@ PATH)`, the TUI notifies `multiplexer backend unavailable — launch/attach disa
   steps. A `rollback-dirty-check-failed` journal entry records the fault. The bound is now
   configurable as `limits.git_timeout_s` (default 120).
 
+- **Session timeouts now fire on time and leave a forensic trail (#157).** A
+  `session_timeout_min` that fired but journaled its session-end 2h19 late — with zero record
+  of _when_ the deadline was declared or why — is now timely and observable on three fronts.
+  (1) `wait_for_completion` gains a **wall-clock co-bound**: a host suspend (macOS sleep)
+  freezes `time.monotonic()`, silently extending the monotonic deadline by the nap's length;
+  the wall clock keeps counting through a suspend, so it may now EXPIRE the deadline — never
+  extend it (a stepped-back wall clock changes nothing, and all sub-waits stay monotonic).
+  (2) The fire moment stamps the result (`timeout_fired_at`, `timeout_expired_clock` —
+  `"wall"` alone is the suspend fingerprint) and appends a `timeout-fired` line to
+  `tasks/<id>/session-lifecycle.jsonl`; each wait tick tops up a throttled
+  `tasks/<id>/heartbeat.json` whose staleness under a still-live session diagnoses a frozen
+  orchestrator (the previously uninstrumented gap). The engine journals **session-end
+  unconditionally** — even a teardown that throws still records the ended session (status
+  `aborted` when the outcome is unknowable), carrying `fired_at`/`teardown_s`/`expired_clock`.
+  (3) Teardown is now a **verified, bounded kill**: `terminate → wait → force_kill` escalation
+  capped by `limits.teardown_grace_s` (default 20; `0` = a single unverified best-effort kill),
+  so a timeout can no longer hang on an unkillable session. Covers the tmux (`generic`) and
+  `opencode-http` adapters alike. A frozen
+  process still cannot run this code while frozen, but recurrence is now diagnosable rather
+  than silent.
+
 - **`validate` and `probe-adapter` no longer report antigravity's hooks as unregistered
   (#159).** The `antigravity-hooks-json` dialect keys `.agents/hooks.json` by hook-group name
   at the top level, with no `"hooks"` wrapper — but both readers looked up `"hooks"`, got `{}`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,9 +180,10 @@ PATH)`, the TUI notifies `multiplexer backend unavailable — launch/attach disa
   orchestrator (the previously uninstrumented gap). The engine journals **session-end
   unconditionally** — even a teardown that throws still records the ended session (status
   `aborted` when the outcome is unknowable), carrying `fired_at`/`teardown_s`/`expired_clock`.
-  (3) Teardown is now a **verified, bounded kill**: `terminate → wait → force_kill` escalation
-  capped by `limits.teardown_grace_s` (default 20; `0` = a single unverified best-effort kill),
-  so a timeout can no longer hang on an unkillable session. Covers the tmux (`generic`) and
+  (3) Teardown is now a **verified kill escalation**: `terminate → wait → force_kill`, where
+  `limits.teardown_grace_s` bounds the liveness-wait before escalating (default 20; `0` = a
+  single unverified best-effort kill) and every escalation step carries its own bound, so a
+  timeout can no longer hang on an unkillable session. Covers the tmux (`generic`) and
   `opencode-http` adapters alike. A frozen
   process still cannot run this code while frozen, but recurrence is now diagnosable rather
   than silent.

--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ max_review_cycles = 3
 max_dev_attempts = 2
 session_timeout_min = 90
 git_timeout_s = 120              # bound on any single git subprocess; exceeding it pauses/degrades, never crashes the run
+teardown_grace_s = 20            # verified session teardown: poll a killed session up to this long, then force-kill its pane pids and re-kill; 0 = one best-effort kill
 stop_without_result_nudges = 1   # times to re-prompt a session that stopped with no result.json
 dev_stall_grace_s = 600          # idle grace before a dev session awaiting a background run (e.g. PlayMode) is nudged/stalled
 dev_stall_nudges = 2             # wake-nudges spent on grace expiry before a dev session is called stalled
@@ -486,7 +487,9 @@ For `per_worktree`, set `editor_mode = "per_worktree"` with `[scm] isolation = "
 
 ## Run state
 
-Everything about a run lives in `.bmad-loop/runs/<run-id>/` (gitignored): `state.json` (resumable engine state), `journal.jsonl` (every decision), `events/` (hook signals), `tasks/<id>/` (per-session prompt + result + escalations), `logs/` (raw pane output, debugging only), `deferred/` (stashed specs from deferred stories), `resolve/<story>/` (escalation `context.json` + the resolve agent's `resolution.json`), `ATTENTION` (human-readable alerts).
+Everything about a run lives in `.bmad-loop/runs/<run-id>/` (gitignored): `state.json` (resumable engine state), `journal.jsonl` (every decision), `events/` (hook signals), `tasks/<id>/` (per-session prompt + result + escalations, plus diagnostic breadcrumbs — `session-lifecycle.jsonl` records when a timeout fired, `heartbeat.json` is the wait loop's proof-of-life, `resultless-stops.jsonl` records give-up Stops), `logs/` (raw pane output, debugging only), `deferred/` (stashed specs from deferred stories), `resolve/<story>/` (escalation `context.json` + the resolve agent's `resolution.json`), `ATTENTION` (human-readable alerts).
+
+`journal.jsonl` records a `session-end` for every session unconditionally — even a teardown that throws still lands one (status `aborted` when the outcome is unknowable). A timed-out session's `session-end` carries `fired_at` (wall time the deadline was declared elapsed), `teardown_s` (wall seconds from that fire to this `session-end` — the teardown gap that ran 2h19 in the #157 incident), and `expired_clock` (`monotonic` / `wall` / `both`); `wall` alone fingerprints a host suspend (e.g. macOS sleep) that froze the monotonic clock the deadline was computed from.
 
 Token usage is read from each CLI's local session transcript (selected by the profile's `usage_parser`) and aggregated per story (`bmad-loop status`); the hookless `opencode` profile is the exception — its adapter pulls token usage from the OpenCode server over HTTP just before teardown (server state is sqlite; there is no local transcript).
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -91,7 +91,8 @@ See [README.md](../README.md) for the narrative overview and [setup-guide.md](se
 ### Resumability & state
 
 - Every run is a resumable on-disk state machine: `bmad-loop resume <run-id>` continues from a gate, escalation, or interruption.
-- All run state in `.bmad-loop/runs/<run-id>/` (gitignored): `state.json`, `journal.jsonl` (every decision), `events/` (hook signals), `tasks/<id>/`, `logs/`, `deferred/`, `resolve/`, `ATTENTION`.
+- All run state in `.bmad-loop/runs/<run-id>/` (gitignored): `state.json`, `journal.jsonl` (every decision), `events/` (hook signals), `tasks/<id>/` (per-session prompt + `result.json` + diagnostic breadcrumbs — `session-lifecycle.jsonl` records timeout-fire, `heartbeat.json` is the wait loop's proof-of-life, `resultless-stops.jsonl` records give-up Stops), `logs/`, `deferred/`, `resolve/`, `ATTENTION`.
+- `journal.jsonl` records `session-end` for every session unconditionally — even a teardown that throws still lands one (status `aborted` when the outcome is unknowable). A timed-out session's entry carries `fired_at` (wall time the deadline was declared), `teardown_s` (wall seconds from that fire to this entry — the teardown gap), and `expired_clock` (`monotonic` / `wall` / `both` — `wall` alone fingerprints a host suspend that froze the monotonic clock).
 
 ### Hook-based transport (no pane-scraping)
 
@@ -142,7 +143,7 @@ See [README.md](../README.md) for the narrative overview and [setup-guide.md](se
 
 - Single policy file written by `init`, snapshotted at run start (applies to new runs and resumes; editable live from the TUI).
 - Sections: `[gates]`, `[limits]`, `[verify]`, `[notify]`, `[review]`, `[adapter]` (+ per-stage), `[sweep]`, `[scm]` (worktree isolation + merge-back), `[cleanup]` (run-dir retention + disk reclamation), `[plugins]` (trust allowlist + per-plugin `[plugins.<name>]` config — e.g. the opt-in game-engine layer via `[plugins.unity]`, off by default), `[tui]` (`low_frame_rate` for slow/SSH links; persisted dashboard pane sizes).
-- Tunable limits: `max_review_cycles`, `max_dev_attempts`, `max_followup_reviews`, `session_timeout_min`, `git_timeout_s`, `stop_without_result_nudges`, `dev_stall_grace_s`, `dev_stall_nudges`, `dev_stall_nudges_cap`, `workflow_stall_nudges_cap`, `max_tokens_per_story`.
+- Tunable limits: `max_review_cycles`, `max_dev_attempts`, `max_followup_reviews`, `session_timeout_min`, `git_timeout_s`, `teardown_grace_s`, `stop_without_result_nudges`, `dev_stall_grace_s`, `dev_stall_nudges`, `dev_stall_nudges_cap`, `workflow_stall_nudges_cap`, `max_tokens_per_story`.
 
 ### TUI dashboard
 

--- a/docs/tui-guide.md
+++ b/docs/tui-guide.md
@@ -194,10 +194,11 @@ One row per story (or sweep bundle/triage task) in the selected run:
   unknowable, even after a teardown that threw); a timed-out one carries
   `fired_at`, `teardown_s`, and `expired_clock` (`monotonic` / `wall` / `both` —
   `wall` alone fingerprints a host suspend that froze the monotonic clock). The
-  matching `tasks/<id>/` dir holds the forensic breadcrumbs the engine wrote
-  while the session ran: `session-lifecycle.jsonl` (the timeout-fire line),
-  `heartbeat.json` (the wait loop's proof-of-life — stale under a live session
-  means the orchestrator itself was frozen), and `resultless-stops.jsonl`.
+  matching `tasks/<id>/` dir holds the forensic breadcrumbs the adapter wrote
+  while the session ran: `session-lifecycle.jsonl` (timeout-fire and
+  kill-escalation lines), `heartbeat.json` (the wait loop's proof-of-life —
+  stale under a live session means the orchestrator itself was frozen), and
+  `resultless-stops.jsonl`.
 - **Log** — the active agent session's pane output (`logs/<task-id>.log`),
   ANSI colors preserved, starting with a dim `— <task-id>.log —` header. The
   active task is the last `session-start` without a matching `session-end`

--- a/docs/tui-guide.md
+++ b/docs/tui-guide.md
@@ -189,7 +189,15 @@ One row per story (or sweep bundle/triage task) in the selected run:
 
 - **Journal** — every engine decision, live-tailed from `journal.jsonl`. Line
   format: `HH:MM:SS  <kind>  field=value …` (long values truncated with `…`).
-  Kinds are color-coded — see the reference below.
+  Kinds are color-coded — see the reference below. Every session lands a
+  `session-end` unconditionally (status `aborted` when the outcome is
+  unknowable, even after a teardown that threw); a timed-out one carries
+  `fired_at`, `teardown_s`, and `expired_clock` (`monotonic` / `wall` / `both` —
+  `wall` alone fingerprints a host suspend that froze the monotonic clock). The
+  matching `tasks/<id>/` dir holds the forensic breadcrumbs the engine wrote
+  while the session ran: `session-lifecycle.jsonl` (the timeout-fire line),
+  `heartbeat.json` (the wait loop's proof-of-life — stale under a live session
+  means the orchestrator itself was frozen), and `resultless-stops.jsonl`.
 - **Log** — the active agent session's pane output (`logs/<task-id>.log`),
   ANSI colors preserved, starting with a dim `— <task-id>.log —` header. The
   active task is the last `session-start` without a matching `session-end`

--- a/src/bmad_loop/adapters/base.py
+++ b/src/bmad_loop/adapters/base.py
@@ -57,6 +57,12 @@ class SessionResult:
     result_json: dict[str, Any] | None = None
     session_id: str | None = None
     transcript_path: str | None = None
+    # wall time.time() when wait_for_completion declared the deadline elapsed;
+    # None unless this session's timeout actually fired (#157).
+    timeout_fired_at: float | None = None
+    # which clock(s) had expired at fire time: "monotonic" | "wall" | "both".
+    # "wall" alone is the suspend signature — a frozen monotonic clock.
+    timeout_expired_clock: str | None = None
 
 
 class CodingCLIAdapter(ABC):

--- a/src/bmad_loop/adapters/generic.py
+++ b/src/bmad_loop/adapters/generic.py
@@ -28,6 +28,7 @@ from ..bmadconfig import ProjectPaths
 from ..journal import LOGS_DIR
 from ..model import TokenUsage
 from ..policy import Policy
+from ..process_host import get_process_host
 from ..signals import SignalWatcher
 from ..tokens import read_usage as tally_usage
 from .base import CodingCLIAdapter, SessionHandle, SessionResult, SessionSpec
@@ -39,6 +40,7 @@ PANE_COLUMNS = 220
 PANE_LINES = 50
 RESULT_GRACE_S = 15.0
 RESULT_POLL_S = 0.5
+KILL_POLL_S = 0.5
 # min spacing between heartbeat.json overwrites in wait_for_completion; the
 # heartbeat's staleness is what makes a frozen orchestrator (#157) diagnosable.
 HEARTBEAT_INTERVAL_S = 30.0
@@ -510,7 +512,40 @@ class GenericAdapter(_ResultFileMixin, CodingCLIAdapter):
         self.mux.send_text(handle.native_id, text)
 
     def kill(self, handle: SessionHandle) -> None:
+        # First strike stays the plain best-effort window kill; everything below
+        # verifies it landed. teardown_grace_s = 0 restores this line alone.
         self.mux.kill_window(handle.native_id)
+        grace = float(self.policy.limits.teardown_grace_s)
+        if grace <= 0:
+            return
+        deadline = time.monotonic() + grace
+        while True:
+            try:
+                if not self._window_alive(handle):
+                    return  # normal case: dead on the first probe
+            except MultiplexerError:
+                pass  # transport hiccup — liveness unknown this tick, keep polling
+            if time.monotonic() >= deadline:
+                break
+            time.sleep(KILL_POLL_S)
+        # The window outlived the grace: the kill was ignored (a wedged CLI, a
+        # shell that trapped the hangup). Harvest the pane pids NOW, while the
+        # window is provably still alive, so a reused pid can never be signalled.
+        # [] = capability not offered / unknown — degrade to the re-kill alone.
+        pids = self.mux.window_pane_pids(handle.native_id)
+        self._note_lifecycle(handle.task_id, "kill-escalated", pids=pids)
+        host = get_process_host()
+        for pid in pids:
+            try:
+                host.force_kill(pid)
+            except Exception:  # noqa: BLE001  # nosec B110 - already-gone races are fine
+                pass
+        self.mux.kill_window(handle.native_id)
+        try:
+            alive: bool | None = self._window_alive(handle)
+        except MultiplexerError:
+            alive = None  # unknown is not dead — record it honestly
+        self._note_lifecycle(handle.task_id, "kill-outcome", alive=alive, escalated=True)
 
     def read_usage(self, result: SessionResult) -> TokenUsage | None:
         if not result.transcript_path:

--- a/src/bmad_loop/adapters/generic.py
+++ b/src/bmad_loop/adapters/generic.py
@@ -39,6 +39,9 @@ PANE_COLUMNS = 220
 PANE_LINES = 50
 RESULT_GRACE_S = 15.0
 RESULT_POLL_S = 0.5
+# min spacing between heartbeat.json overwrites in wait_for_completion; the
+# heartbeat's staleness is what makes a frozen orchestrator (#157) diagnosable.
+HEARTBEAT_INTERVAL_S = 30.0
 EVENT_KINDS = {"SessionStart", "Stop", "SessionEnd"}
 NUDGE_TEXT = (
     "You are running in bmad-loop automation mode. Finish the workflow now: "
@@ -102,22 +105,51 @@ class _ResultFileMixin:
     def _result_path(self, task_id: str) -> Path:
         return self.tasks_dir / task_id / "result.json"
 
+    def _append_diag_jsonl(self, task_id: str, filename: str, payload: dict) -> None:
+        """Append ``payload`` as one JSON line to ``tasks/<task_id>/<filename>``.
+        Pure observability, best-effort: an unwritable run dir must never break
+        the completion loop."""
+        try:
+            path = self.tasks_dir / task_id / filename
+            path.parent.mkdir(parents=True, exist_ok=True)
+            line = json.dumps(payload, ensure_ascii=False)
+            with path.open("a", encoding="utf-8") as fh:
+                fh.write(line + "\n")
+        except OSError:
+            pass
+
     def _note_resultless_stop(self, task_id: str, verdict: str, detail: str = "") -> None:
         """Append a diagnostic breadcrumb when a Stop's artifact read-back gives
         up empty: one JSON line ({ts, verdict, detail}) in
-        ``tasks/<task_id>/resultless-stops.jsonl``. Pure observability — the
-        #149 nudge livelock was undiagnosable because nothing recorded *why*
-        each Stop read as result-less. Best-effort: an unwritable run dir must
-        never break the completion loop."""
+        ``tasks/<task_id>/resultless-stops.jsonl`` — the #149 nudge livelock
+        was undiagnosable because nothing recorded *why* each Stop read as
+        result-less."""
+        self._append_diag_jsonl(
+            task_id,
+            "resultless-stops.jsonl",
+            {"ts": time.time_ns(), "verdict": verdict, "detail": detail},
+        )
+
+    def _note_lifecycle(self, task_id: str, event: str, **fields) -> None:
+        """Append a session-lifecycle breadcrumb ({ts, event, ...}) to
+        ``tasks/<task_id>/session-lifecycle.jsonl`` — issue #157's timeout fired
+        with zero record of *when* the adapter declared it or which clock had
+        elapsed, so a 2h19 journaling gap was unattributable."""
+        self._append_diag_jsonl(
+            task_id,
+            "session-lifecycle.jsonl",
+            {"ts": time.time_ns(), "event": event, **fields},
+        )
+
+    def _write_heartbeat(self, task_id: str, payload: dict) -> None:
+        """Best-effort overwrite of ``tasks/<task_id>/heartbeat.json``: the wait
+        loop's proof-of-life. A heartbeat much staler than HEARTBEAT_INTERVAL_S
+        under a still-running session means the orchestrator itself was frozen
+        (host starvation, macOS sleep — #157), not the CLI."""
         try:
-            path = self.tasks_dir / task_id / "resultless-stops.jsonl"
-            path.parent.mkdir(parents=True, exist_ok=True)
-            line = json.dumps(
-                {"ts": time.time_ns(), "verdict": verdict, "detail": detail},
-                ensure_ascii=False,
+            (self.tasks_dir / task_id / "heartbeat.json").write_text(
+                json.dumps(payload, ensure_ascii=False), encoding="utf-8"
             )
-            with path.open("a", encoding="utf-8") as fh:
-                fh.write(line + "\n")
         except OSError:
             pass
 
@@ -259,6 +291,12 @@ class GenericAdapter(_ResultFileMixin, CodingCLIAdapter):
 
     def wait_for_completion(self, handle: SessionHandle, spec: SessionSpec) -> SessionResult:
         deadline = time.monotonic() + spec.timeout_s
+        # Wall-clock co-bound (#157): a host suspend freezes time.monotonic(),
+        # silently extending the monotonic deadline by the nap's length. The
+        # wall clock keeps counting through a suspend, so it may EXPIRE the
+        # deadline — never extend it; all sub-waits below stay monotonic (a
+        # wall clock stepped backward must not stretch the session).
+        wall_deadline = time.time() + spec.timeout_s
         session_id: str | None = None
         transcript_path: str | None = None
         nudges_left = self._stop_nudges
@@ -289,14 +327,47 @@ class GenericAdapter(_ResultFileMixin, CodingCLIAdapter):
         # of death; spec.timeout_s already bounds a persistent failure to a
         # timeout.
         probe_failures = 0
+        # monotonic ts of the last heartbeat.json overwrite; None = not yet
+        # written, so the first tick always stamps one.
+        last_heartbeat: float | None = None
 
         while True:
             remaining = deadline - time.monotonic()
-            if remaining <= 0:
+            wall_expired = time.time() >= wall_deadline
+            if remaining <= 0 or wall_expired:
+                if remaining <= 0 and wall_expired:
+                    expired = "both"
+                elif remaining <= 0:
+                    expired = "monotonic"
+                else:
+                    # wall-only expiry with monotonic time to spare: the
+                    # monotonic clock stood still — the suspend signature.
+                    expired = "wall"
+                self._note_lifecycle(
+                    handle.task_id,
+                    "timeout-fired",
+                    expired_clock=expired,
+                    timeout_s=spec.timeout_s,
+                    mono_remaining_s=round(remaining, 3),
+                )
                 return SessionResult(
                     status="timeout",
                     session_id=session_id,
                     transcript_path=transcript_path,
+                    timeout_fired_at=time.time(),
+                    timeout_expired_clock=expired,
+                )
+            now = time.monotonic()
+            if last_heartbeat is None or now - last_heartbeat >= HEARTBEAT_INTERVAL_S:
+                last_heartbeat = now
+                self._write_heartbeat(
+                    handle.task_id,
+                    {
+                        "ts": time.time(),
+                        "remaining_s": round(remaining, 3),
+                        "stall_armed": stall_deadline is not None,
+                        "stall_nudges_sent": stall_nudges_sent,
+                    },
                 )
             event = self.watcher.wait_for(
                 handle.task_id,
@@ -688,6 +759,11 @@ class _DevSynthesisMixin(_ResultFileMixin):
             result_json=rj,
             session_id=result.session_id,
             transcript_path=result.transcript_path,
+            # a rescued timeout upgrades the outcome, not the timing evidence:
+            # the deadline did fire on this session, and that record must
+            # survive the rescue (#157).
+            timeout_fired_at=result.timeout_fired_at,
+            timeout_expired_clock=result.timeout_expired_clock,
         )
 
 

--- a/src/bmad_loop/adapters/multiplexer.py
+++ b/src/bmad_loop/adapters/multiplexer.py
@@ -254,6 +254,14 @@ class TerminalMultiplexer(ABC):
         stays behind the seam."""
         return None
 
+    def window_pane_pids(self, target: str) -> list[int]:
+        """Best-effort OS pids of ``target``'s pane root processes, for the kill
+        escalation. Not abstract: backends that can't (or don't) report pids
+        inherit this default. ``[]`` means unknown or capability not offered —
+        callers must degrade (skip the pid-level escalation) and never read
+        ``[]`` as "no processes". Must not raise."""
+        return []
+
 
 # (name, matches(platform) -> bool, factory() -> TerminalMultiplexer)
 _BACKENDS: list[tuple[str, Callable[[str], bool], Callable[[], TerminalMultiplexer]]] = []

--- a/src/bmad_loop/adapters/opencode_http.py
+++ b/src/bmad_loop/adapters/opencode_http.py
@@ -94,7 +94,13 @@ from ..model import TokenUsage
 from ..policy import Policy
 from ..process_host import get_process_host
 from .base import CodingCLIAdapter, SessionHandle, SessionResult, SessionSpec
-from .generic import NUDGE_TEXT, STALL_NUDGE_TEXT, _DevSynthesisMixin, _ResultFileMixin
+from .generic import (
+    HEARTBEAT_INTERVAL_S,
+    NUDGE_TEXT,
+    STALL_NUDGE_TEXT,
+    _DevSynthesisMixin,
+    _ResultFileMixin,
+)
 from .profile import CLIProfile
 
 # Spawn/readiness defaults; per-instance attributes so tests shrink them.
@@ -527,6 +533,12 @@ class OpencodeHttpAdapter(_ResultFileMixin, CodingCLIAdapter):
         if sess is None:
             raise OpencodeServerError(f"no live opencode server for task {handle.task_id!r}")
         deadline = time.monotonic() + spec.timeout_s
+        # Wall-clock co-bound (#157): a host suspend freezes time.monotonic(),
+        # silently extending the monotonic deadline by the nap's length. The
+        # wall clock keeps counting through a suspend, so it may EXPIRE the
+        # deadline — never extend it; all sub-waits below stay monotonic (a
+        # wall clock stepped backward must not stretch the session).
+        wall_deadline = time.time() + spec.timeout_s
         session_id = sess.session_id
         nudges_left = self._stop_nudges
         # Mirrors generic.wait_for_completion: stall-grace window armed by a
@@ -539,14 +551,49 @@ class OpencodeHttpAdapter(_ResultFileMixin, CodingCLIAdapter):
         # Loop-owned silence clock: updated on every dequeue, so a dead reader
         # thread degrades to the poll fallback instead of disabling it.
         last_seen = time.monotonic()
+        # monotonic ts of the last heartbeat.json overwrite; None = not yet
+        # written, so the first tick always stamps one.
+        last_heartbeat: float | None = None
 
         while True:
             remaining = deadline - time.monotonic()
-            if remaining <= 0:
+            wall_expired = time.time() >= wall_deadline
+            if remaining <= 0 or wall_expired:
+                if remaining <= 0 and wall_expired:
+                    expired = "both"
+                elif remaining <= 0:
+                    expired = "monotonic"
+                else:
+                    # wall-only expiry with monotonic time to spare: the
+                    # monotonic clock stood still — the suspend signature.
+                    expired = "wall"
+                self._note_lifecycle(
+                    handle.task_id,
+                    "timeout-fired",
+                    expired_clock=expired,
+                    timeout_s=spec.timeout_s,
+                    mono_remaining_s=round(remaining, 3),
+                )
                 self._abort(sess)
                 transcript = self._capture_usage(handle, sess)
                 return SessionResult(
-                    status="timeout", session_id=session_id, transcript_path=transcript
+                    status="timeout",
+                    session_id=session_id,
+                    transcript_path=transcript,
+                    timeout_fired_at=time.time(),
+                    timeout_expired_clock=expired,
+                )
+            now = time.monotonic()
+            if last_heartbeat is None or now - last_heartbeat >= HEARTBEAT_INTERVAL_S:
+                last_heartbeat = now
+                self._write_heartbeat(
+                    handle.task_id,
+                    {
+                        "ts": time.time(),
+                        "remaining_s": round(remaining, 3),
+                        "stall_armed": stall_deadline is not None,
+                        "stall_nudges_sent": stall_nudges_sent,
+                    },
                 )
             try:
                 event: str | None = sess.events.get(timeout=min(remaining, self.poll_tick_s))

--- a/src/bmad_loop/adapters/tmux_base.py
+++ b/src/bmad_loop/adapters/tmux_base.py
@@ -317,6 +317,19 @@ class BaseTmuxBackend(TerminalMultiplexer):
         except (subprocess.SubprocessError, OSError):
             pass
 
+    def window_pane_pids(self, target: str) -> list[int]:
+        # Capability method (see the seam default): a transport failure, a dead
+        # window, or unparsable output all degrade to the documented "unknown"
+        # sentinel [] — this feeds the kill escalation, which must never be the
+        # thing that raises.
+        try:
+            probe = self._run(["list-panes", "-t", target, "-F", "#{pane_pid}"], check=False)
+            if probe.returncode != 0:
+                return []
+            return [int(line) for line in probe.stdout.split()]
+        except (subprocess.SubprocessError, OSError, ValueError):
+            return []
+
     def list_windows(self, session: str, fields: list[str]) -> list[tuple[str, ...]]:
         fmt = "\t".join(f"#{{{field}}}" for field in fields)
         try:

--- a/src/bmad_loop/data/settings/core.toml
+++ b/src/bmad_loop/data/settings/core.toml
@@ -94,6 +94,12 @@ minimum = 1
 default_ref = "LimitsPolicy.git_timeout_s"
 description = "bound on any single git subprocess the orchestrator spawns; exceeding it degrades/pauses (never crashes the run) — raise on a loaded host or a very large worktree"
 [[section.field]]
+key = "teardown_grace_s"
+kind = "int"
+minimum = 0
+default_ref = "LimitsPolicy.teardown_grace_s"
+description = "verified session teardown: poll the killed window up to this long, then force-kill its pane pids and re-kill the window · 0 = single unverified best-effort kill"
+[[section.field]]
 key = "stop_without_result_nudges"
 kind = "int"
 minimum = 0

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import contextlib
 import functools
+import os
 import shutil
 import signal
 import sys
@@ -2270,6 +2271,26 @@ class Engine:
             "expired_clock": result.timeout_expired_clock,
         }
 
+    @staticmethod
+    def _session_timeout_s(default_s: float) -> float:
+        """Per-session wall-clock budget in seconds. Normally
+        ``limits.session_timeout_min * 60``; ``BMAD_LOOP_SESSION_TIMEOUT_S``
+        overrides it (test / override hook, à la ``BMAD_LOOP_PROCESS_HOST``).
+        The policy floor is 1 minute — too coarse to exercise the #157
+        timeout-teardown path in a deterministic sub-minute E2E, and a real
+        binary run can't be monkeypatched. A non-positive or unparseable
+        override is ignored, so a fat-fingered value can never silently shorten
+        a real run's budget."""
+        raw = os.environ.get("BMAD_LOOP_SESSION_TIMEOUT_S")
+        if raw is not None:
+            try:
+                override = float(raw)
+            except ValueError:
+                override = 0.0
+            if override > 0:
+                return override
+        return default_s
+
     def _run_session(
         self,
         task: StoryTask,
@@ -2347,7 +2368,7 @@ class Engine:
             cwd=self.workspace.root,
             env=env,
             model=cfg.model,
-            timeout_s=self.policy.limits.session_timeout_min * 60,
+            timeout_s=self._session_timeout_s(self.policy.limits.session_timeout_min * 60),
             stall_nudges_cap=(
                 self.policy.limits.workflow_stall_nudges_cap
                 if label is not None

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -13,6 +13,7 @@ import functools
 import shutil
 import signal
 import sys
+import time
 import traceback
 from dataclasses import dataclass
 from pathlib import Path
@@ -2256,6 +2257,19 @@ class Engine:
 
     # ------------------------------------------------------------- helpers
 
+    @staticmethod
+    def _session_end_extras(result: SessionResult) -> dict:
+        """Timeout forensics for the session-end entry (#157). ``teardown_s``
+        is the timeout-fire → journal gap — the window the incident showed
+        could silently stretch for hours."""
+        if result.timeout_fired_at is None:
+            return {}
+        return {
+            "fired_at": result.timeout_fired_at,
+            "teardown_s": max(0.0, round(time.time() - result.timeout_fired_at, 3)),
+            "expired_clock": result.timeout_expired_clock,
+        }
+
     def _run_session(
         self,
         task: StoryTask,
@@ -2342,49 +2356,84 @@ class Engine:
         )
         self.journal.set_active_log(task_id)
         self.journal.append("session-start", task_id=task_id, role=role, prompt=prompt)
-        result = adapter.run(spec)
-        # A post-kill rescue (#61) is otherwise indistinguishable from a normal
-        # completion in the journal; leave a breadcrumb for forensics.
-        if result.result_json is not None and result.result_json.get("post_kill_reconciled"):
-            self.journal.append("session-rescued-post-kill", task_id=task_id, role=role)
-        # Only dev/review sessions are resumable — `_resumable_session` matches
-        # exactly those task ids under DEV_RUNNING/REVIEW_RUNNING. For everything
-        # else (triage/sweep, labeled plugin-workflow sessions) the payload is
-        # never consumed on resume, so persisting it is pure state.json bloat.
-        # For resumable sessions, store a defensive copy: `result.result_json`
-        # is mutated in place downstream (`_reconcile_generic_terminal_status`),
-        # and the durable record must stay a stable snapshot of what the adapter
-        # returned rather than aliasing a later, half-mutated dict. Shallow is
-        # enough — reconcile only touches top-level keys.
-        resumable = label is None and role in ("dev", "review")
-        task.record_session(
-            SessionRecord(
-                task_id=task_id,
-                role=role,
-                status=result.status,
-                session_id=result.session_id,
-                transcript_path=result.transcript_path,
-                result_json=(
-                    dict(result.result_json)
-                    if resumable and result.result_json is not None
-                    else None
-                ),
+        # Every session-start must be paired with a session-end, whatever path
+        # leaves this method: on an abort (RunStopped / KeyboardInterrupt / a
+        # transport error out of adapter.run) the top-level handlers record
+        # run-stop/run-crash but know nothing of the open session, and the
+        # journal would show it running forever (#157).
+        result: SessionResult | None = None
+        ended = False
+        try:
+            result = adapter.run(spec)
+            # A post-kill rescue (#61) is otherwise indistinguishable from a normal
+            # completion in the journal; leave a breadcrumb for forensics.
+            if result.result_json is not None and result.result_json.get("post_kill_reconciled"):
+                self.journal.append("session-rescued-post-kill", task_id=task_id, role=role)
+            # Only dev/review sessions are resumable — `_resumable_session` matches
+            # exactly those task ids under DEV_RUNNING/REVIEW_RUNNING. For everything
+            # else (triage/sweep, labeled plugin-workflow sessions) the payload is
+            # never consumed on resume, so persisting it is pure state.json bloat.
+            # For resumable sessions, store a defensive copy: `result.result_json`
+            # is mutated in place downstream (`_reconcile_generic_terminal_status`),
+            # and the durable record must stay a stable snapshot of what the adapter
+            # returned rather than aliasing a later, half-mutated dict. Shallow is
+            # enough — reconcile only touches top-level keys.
+            resumable = label is None and role in ("dev", "review")
+            task.record_session(
+                SessionRecord(
+                    task_id=task_id,
+                    role=role,
+                    status=result.status,
+                    session_id=result.session_id,
+                    transcript_path=result.transcript_path,
+                    result_json=(
+                        dict(result.result_json)
+                        if resumable and result.result_json is not None
+                        else None
+                    ),
+                )
             )
-        )
-        # Make the completed session durable before the usage read, post-session
-        # hooks, and follow-up verification. If the host kills the process in
-        # that window, the resume path can see the session instead of a stale
-        # dev-running task with no evidence; usage stays best-effort metadata,
-        # not a durability gate.
-        self._save()
-        usage = adapter.read_usage(result)
-        task.attach_session_usage(task_id, usage)
-        self.journal.append(
-            "session-end",
-            task_id=task_id,
-            status=result.status,
-            tokens=usage.total if usage else None,
-        )
+            # Make the completed session durable before the usage read, post-session
+            # hooks, and follow-up verification. If the host kills the process in
+            # that window, the resume path can see the session instead of a stale
+            # dev-running task with no evidence; usage stays best-effort metadata,
+            # not a durability gate.
+            self._save()
+            usage = adapter.read_usage(result)
+            task.attach_session_usage(task_id, usage)
+            self.journal.append(
+                "session-end",
+                task_id=task_id,
+                status=result.status,
+                tokens=usage.total if usage else None,
+                **self._session_end_extras(result),
+            )
+            ended = True
+        finally:
+            if not ended:
+                # Best-effort: a journal IO error here must never mask the
+                # exception that is unwinding this frame.
+                try:
+                    if result is not None:
+                        # A post-run step raised (e.g. read_usage): the session
+                        # itself finished — journal its real status, sans usage.
+                        self.journal.append(
+                            "session-end",
+                            task_id=task_id,
+                            status=result.status,
+                            tokens=None,
+                            **self._session_end_extras(result),
+                        )
+                    else:
+                        exc = sys.exc_info()[1]
+                        self.journal.append(
+                            "session-end",
+                            task_id=task_id,
+                            status="aborted",
+                            error=type(exc).__name__ if exc is not None else None,
+                        )
+                except Exception:  # noqa: BLE001  # nosec B110
+                    pass
         self._save()
         self._emit(
             "post_session",

--- a/src/bmad_loop/policy.py
+++ b/src/bmad_loop/policy.py
@@ -75,6 +75,12 @@ class LimitsPolicy:
     # exceeding it is a handled GitError, never a run crash, and raising the
     # bound here is the fix when it fires spuriously.
     git_timeout_s: int = 120
+    # bounded grace for verified session teardown (#157): after the first
+    # best-effort window kill the adapter polls liveness up to this many
+    # seconds; a window that survives it gets its pane pids force-killed and
+    # the window killed again. 0 = the old single unverified best-effort kill
+    # (the rollback lever if escalation ever misfires).
+    teardown_grace_s: int = 20
     stop_without_result_nudges: int = 1
     # how long a dev session may sit on a result-less Stop — i.e. it ended its
     # turn awaiting a long-running background process (a Unity PlayMode run, a
@@ -566,6 +572,7 @@ def loads(text: str, plugin_schemas: dict[str, Any] | None = None) -> Policy:
             limits_d.get("session_timeout_min", LimitsPolicy.session_timeout_min)
         ),
         git_timeout_s=int(limits_d.get("git_timeout_s", LimitsPolicy.git_timeout_s)),
+        teardown_grace_s=int(limits_d.get("teardown_grace_s", LimitsPolicy.teardown_grace_s)),
         stop_without_result_nudges=int(
             limits_d.get("stop_without_result_nudges", LimitsPolicy.stop_without_result_nudges)
         ),
@@ -590,6 +597,8 @@ def loads(text: str, plugin_schemas: dict[str, Any] | None = None) -> Policy:
         )
     if limits.git_timeout_s < 1:
         raise PolicyError(f"limits.git_timeout_s must be >= 1: got {limits.git_timeout_s}")
+    if limits.teardown_grace_s < 0:
+        raise PolicyError(f"limits.teardown_grace_s must be >= 0: got {limits.teardown_grace_s}")
     if not 0.0 <= limits.cache_read_weight <= 1.0:
         raise PolicyError(
             f"limits.cache_read_weight must be between 0 and 1: got {limits.cache_read_weight}"
@@ -837,6 +846,7 @@ max_dev_attempts = 2
 max_followup_reviews = 1     # additional review rounds granted solely because a finalized (status: done) round still recommended a follow-up; once spent, such a round converges + refiles the recommendation instead of burning another cycle. 0 = never honor a pass's own recommendation
 session_timeout_min = 90
 git_timeout_s = 120          # bound on any single git subprocess; exceeding it pauses/degrades (never crashes the run) — raise on a loaded host or a very large worktree
+teardown_grace_s = 20        # verified teardown: poll a killed session window up to this long, then force-kill its pane pids and re-kill (#157). 0 = single unverified best-effort kill
 stop_without_result_nudges = 1
 dev_stall_grace_s = 600      # grace for a dev session that ended its turn awaiting a background process (e.g. a slow PlayMode/test run) before it is called stalled; each re-invocation resets it. 0 = fail fast on the first result-less Stop
 dev_stall_nudges = 2         # times an idle dev session is nudged awake on grace expiry before it is called stalled (bmad-loop has no background-completion re-invocation); pane output re-arms the grace window and a fresh Stop restores the budget. 0 = stall on grace expiry

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -4,6 +4,7 @@ import os
 import re
 import signal
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -160,6 +161,82 @@ def test_run_session_persists_session_when_usage_read_raises(project):
     assert saved_task.sessions[0].session_id == "sess-1"
     assert saved_task.sessions[0].transcript_path == "events.jsonl"
     assert saved_task.sessions[0].usage is None
+    # the session still ends in the journal, with its real status — only the
+    # usage total is lost with the failed read
+    ends = [e for e in engine.journal.entries() if e["kind"] == "session-end"]
+    assert len(ends) == 1
+    assert ends[0]["status"] == "completed"
+    assert ends[0]["tokens"] is None
+
+
+def test_run_session_journals_exactly_one_session_end(project):
+    """The finally-fallback must not double-journal a session that already
+    ended on the happy path."""
+    write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(project, [SessionResult(status="completed")])
+    task = StoryTask(story_key="1-1-a", epic=1)
+    engine.state.tasks[task.story_key] = task
+    engine._save()
+
+    engine._run_session(task, role="dev", prompt="/bmad-dev-auto 1-1-a", seq=1)
+
+    ends = [e for e in engine.journal.entries() if e["kind"] == "session-end"]
+    assert len(ends) == 1
+    assert ends[0]["status"] == "completed"
+    assert "fired_at" not in ends[0]  # no timeout → no forensics fields
+
+
+def test_adapter_crash_journals_aborted_session_end(project, monkeypatch):
+    """adapter.run raising must not leave the session open forever in the
+    journal: run-crash records the run, the aborted session-end the session."""
+    monkeypatch.setattr("bmad_loop.engine.kill_session", lambda rid: None)
+
+    def explode(_spec):
+        raise RuntimeError("transport died")
+
+    write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(project, [explode])
+
+    summary = engine.run()
+
+    assert summary.crashed
+    entries = engine.journal.entries()
+    crashes = [e for e in entries if e["kind"] == "run-crash"]
+    assert crashes and crashes[0]["error"] == "RuntimeError"
+    ends = [e for e in entries if e["kind"] == "session-end"]
+    assert len(ends) == 1
+    assert "1-1-a" in ends[0]["task_id"]
+    assert ends[0]["status"] == "aborted"
+    assert ends[0]["error"] == "RuntimeError"
+
+
+def test_timeout_session_end_carries_fire_forensics(project):
+    """A timed-out session's end entry records when the timeout fired, the
+    fire→journal teardown gap, and which clock had expired."""
+    write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
+    fired = time.time() - 5.0
+    engine, _ = make_engine(
+        project,
+        [
+            SessionResult(
+                status="timeout",
+                timeout_fired_at=fired,
+                timeout_expired_clock="monotonic",
+            )
+        ],
+    )
+    task = StoryTask(story_key="1-1-a", epic=1)
+    engine.state.tasks[task.story_key] = task
+    engine._save()
+
+    engine._run_session(task, role="dev", prompt="/bmad-dev-auto 1-1-a", seq=1)
+
+    ends = [e for e in engine.journal.entries() if e["kind"] == "session-end"]
+    assert len(ends) == 1
+    assert ends[0]["status"] == "timeout"
+    assert ends[0]["fired_at"] == fired
+    assert ends[0]["teardown_s"] >= 0
+    assert ends[0]["expired_clock"] == "monotonic"
 
 
 def test_keyboard_interrupt_records_stopped_run(project, monkeypatch):
@@ -181,8 +258,15 @@ def test_keyboard_interrupt_records_stopped_run(project, monkeypatch):
     assert not summary.crashed
     assert not saved.crashed
     assert killed == ["test-run"]
-    stops = [e for e in engine.journal.entries() if e["kind"] == "run-stop"]
-    assert stops and stops[0]["reason"] == "KeyboardInterrupt"
+    entries = engine.journal.entries()
+    stops = [i for i, e in enumerate(entries) if e["kind"] == "run-stop"]
+    assert stops and entries[stops[0]]["reason"] == "KeyboardInterrupt"
+    # the interrupted session is closed out in the journal before the stop
+    ends = [i for i, e in enumerate(entries) if e["kind"] == "session-end"]
+    assert len(ends) == 1
+    assert entries[ends[0]]["status"] == "aborted"
+    assert entries[ends[0]]["error"] == "KeyboardInterrupt"
+    assert ends[0] < stops[0]
 
 
 def test_nested_engine_reraises_keyboard_interrupt(project, monkeypatch):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -239,6 +239,43 @@ def test_timeout_session_end_carries_fire_forensics(project):
     assert ends[0]["expired_clock"] == "monotonic"
 
 
+def test_session_timeout_s_env_override(monkeypatch):
+    """BMAD_LOOP_SESSION_TIMEOUT_S overrides limits.session_timeout_min*60 — the
+    deterministic-E2E seam for the #157 timeout path, whose 1-minute policy floor
+    is too coarse to exercise in a fast real-binary run. Only a positive, parseable
+    value wins; anything else falls back so a fat-fingered env can never silently
+    shorten a real run's budget."""
+    monkeypatch.delenv("BMAD_LOOP_SESSION_TIMEOUT_S", raising=False)
+    assert Engine._session_timeout_s(5400.0) == 5400.0  # unset -> policy default
+    monkeypatch.setenv("BMAD_LOOP_SESSION_TIMEOUT_S", "2.5")
+    assert Engine._session_timeout_s(5400.0) == 2.5  # positive -> override wins
+    for bad in ("0", "-1", "nonsense", ""):
+        monkeypatch.setenv("BMAD_LOOP_SESSION_TIMEOUT_S", bad)
+        assert Engine._session_timeout_s(5400.0) == 5400.0  # ignored -> fall back
+
+
+def test_session_timeout_env_override_flows_into_spec(project, monkeypatch):
+    """The override reaches the SessionSpec the adapter actually receives, not
+    just the helper — so a sub-minute E2E can drive the real timeout path."""
+    monkeypatch.setenv("BMAD_LOOP_SESSION_TIMEOUT_S", "3")
+    write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
+    engine, adapter = make_engine(
+        project,
+        [
+            SessionResult(
+                status="timeout", timeout_fired_at=time.time(), timeout_expired_clock="both"
+            )
+        ],
+    )
+    task = StoryTask(story_key="1-1-a", epic=1)
+    engine.state.tasks[task.story_key] = task
+    engine._save()
+
+    engine._run_session(task, role="dev", prompt="/bmad-dev-auto 1-1-a", seq=1)
+
+    assert adapter.sessions[0].timeout_s == 3.0  # not the 90-min policy default
+
+
 def test_keyboard_interrupt_records_stopped_run(project, monkeypatch):
     """A raw KeyboardInterrupt (Windows console-ctrl bypassing the signal
     handler) records a controlled stop, not a crash."""

--- a/tests/test_generic_tmux.py
+++ b/tests/test_generic_tmux.py
@@ -51,7 +51,7 @@ sleep 60  # stay alive like an idle interactive session
 
 
 def make_adapter(
-    tmp_path, profile_name="claude", binary=None, extra_args=None, **policy_kw
+    tmp_path, profile_name="claude", binary=None, extra_args=None, mux=None, **policy_kw
 ) -> GenericTmuxAdapter:
     # session_name derives from run_dir.name, and the live tests all share one
     # tmux server — a fixed "run" name races one test's kill-session teardown
@@ -66,6 +66,7 @@ def make_adapter(
         profile=profile,
         binary=binary,
         extra_args=extra_args,
+        mux=mux,
     )
 
 
@@ -167,6 +168,111 @@ def test_await_result_grace_expires_fast(tmp_path):
     start = time.monotonic()
     assert adapter._await_result("t1", grace_s=0.2) is None
     assert time.monotonic() - start < 5
+
+
+# ------------------------------------------- verified kill escalation (#157)
+#
+# GenericAdapter.kill was a single best-effort kill_window with no verification
+# the window died. These pin the new bounded escalation: verify within
+# teardown_grace_s, then force-kill the pane pids and re-kill — degrading
+# cleanly for a backend that doesn't offer window_pane_pids (herdr returns the
+# seam default []).
+
+
+class _TeardownMux:
+    """Only the ops kill() drives — kill_window, list_window_ids (liveness),
+    window_pane_pids — with scriptable survival: the window stays alive until
+    ``survives_kills`` kill_window calls have landed."""
+
+    def __init__(self, survives_kills=0, pids=()):
+        self.survives_kills = survives_kills
+        self.pids = list(pids)
+        self.kill_windows = 0
+        self.liveness_probes = 0
+        self.pane_pid_reads = 0
+
+    def kill_window(self, target):
+        self.kill_windows += 1
+
+    def list_window_ids(self, session):
+        self.liveness_probes += 1
+        return ["@w1"] if self.kill_windows <= self.survives_kills else []
+
+    def window_pane_pids(self, target):
+        self.pane_pid_reads += 1
+        return list(self.pids)
+
+
+class _RecordingHost:
+    def __init__(self):
+        self.force_killed: list[int] = []
+
+    def force_kill(self, pid):
+        self.force_killed.append(pid)
+
+
+def _kill_handle() -> SessionHandle:
+    return SessionHandle(task_id="3-1-dev-1", native_id="@w1")
+
+
+def _lifecycle_lines(adapter, task_id="3-1-dev-1"):
+    path = adapter.tasks_dir / task_id / "session-lifecycle.jsonl"
+    if not path.is_file():
+        return []
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+def test_kill_returns_on_first_dead_probe_without_escalating(tmp_path, monkeypatch):
+    monkeypatch.setattr(generic, "KILL_POLL_S", 0)
+    mux = _TeardownMux(survives_kills=0)
+    adapter = make_adapter(tmp_path, mux=mux, teardown_grace_s=0.05)
+    adapter.kill(_kill_handle())
+    assert mux.kill_windows == 1
+    assert mux.liveness_probes == 1
+    assert mux.pane_pid_reads == 0
+    assert _lifecycle_lines(adapter) == []  # the normal path leaves no breadcrumbs
+
+
+def test_kill_escalates_to_pane_pid_force_kill(tmp_path, monkeypatch):
+    monkeypatch.setattr(generic, "KILL_POLL_S", 0)
+    host = _RecordingHost()
+    monkeypatch.setattr(generic, "get_process_host", lambda: host)
+    mux = _TeardownMux(survives_kills=99, pids=[4242])
+    adapter = make_adapter(tmp_path, mux=mux, teardown_grace_s=0.05)
+    adapter.kill(_kill_handle())
+    assert host.force_killed == [4242]
+    assert mux.kill_windows == 2  # first strike + post-escalation re-kill
+    events = _lifecycle_lines(adapter)
+    assert [e["event"] for e in events] == ["kill-escalated", "kill-outcome"]
+    assert events[0]["pids"] == [4242]
+    assert events[1]["alive"] is True  # honest outcome: the window survived even the escalation
+    assert events[1]["escalated"] is True
+
+
+def test_kill_degrades_when_backend_offers_no_pids(tmp_path, monkeypatch):
+    """A herdr-shaped backend inherits the seam default [] — the escalation
+    degrades to the re-kill + breadcrumb, force-killing nothing."""
+    monkeypatch.setattr(generic, "KILL_POLL_S", 0)
+    host = _RecordingHost()
+    monkeypatch.setattr(generic, "get_process_host", lambda: host)
+    mux = _TeardownMux(survives_kills=99, pids=())
+    adapter = make_adapter(tmp_path, mux=mux, teardown_grace_s=0.05)
+    adapter.kill(_kill_handle())
+    assert host.force_killed == []
+    assert mux.kill_windows == 2
+    events = _lifecycle_lines(adapter)
+    assert [e["event"] for e in events] == ["kill-escalated", "kill-outcome"]
+    assert events[0]["pids"] == []
+
+
+def test_kill_grace_zero_is_the_legacy_single_strike(tmp_path):
+    mux = _TeardownMux(survives_kills=99, pids=[4242])
+    adapter = make_adapter(tmp_path, mux=mux, teardown_grace_s=0)
+    adapter.kill(_kill_handle())
+    assert mux.kill_windows == 1
+    assert mux.liveness_probes == 0
+    assert mux.pane_pid_reads == 0
+    assert _lifecycle_lines(adapter) == []
 
 
 # ----------------------------------------------- GenericDevAdapter (B1/B7)

--- a/tests/test_generic_tmux.py
+++ b/tests/test_generic_tmux.py
@@ -803,6 +803,7 @@ def test_dev_grace_result_does_not_complete_while_window_alive(tmp_path, monkeyp
 
     class _Clock:  # scoped shim so we don't mutate the real time module
         monotonic = staticmethod(lambda: clock["t"])
+        time = staticmethod(lambda: 0.0)  # frozen wall clock: the co-bound never fires
         sleep = staticmethod(lambda *_: None)
         time_ns = staticmethod(lambda: 0)
 
@@ -859,6 +860,7 @@ def test_dev_stalls_when_grace_elapses_without_reinvocation(tmp_path, monkeypatc
 
     class _Clock:  # scoped shim so we don't mutate the real time module
         monotonic = staticmethod(lambda: clock["t"])
+        time = staticmethod(lambda: 0.0)  # frozen wall clock: the co-bound never fires
         sleep = staticmethod(lambda *_: None)
         time_ns = staticmethod(lambda: 0)
 
@@ -900,6 +902,7 @@ def test_dev_grace_expiry_rechecks_liveness_and_honors_just_dead_window(tmp_path
 
     class _Clock:  # scoped shim so we don't mutate the real time module
         monotonic = staticmethod(lambda: clock["t"])
+        time = staticmethod(lambda: 0.0)  # frozen wall clock: the co-bound never fires
         sleep = staticmethod(lambda *_: None)
         time_ns = staticmethod(lambda: 0)
 
@@ -948,6 +951,7 @@ def test_dev_grace_expiry_stall_recheck_transport_error_still_stalls(tmp_path, m
 
     class _Clock:  # scoped shim so we don't mutate the real time module
         monotonic = staticmethod(lambda: clock["t"])
+        time = staticmethod(lambda: 0.0)  # frozen wall clock: the co-bound never fires
         sleep = staticmethod(lambda *_: None)
         time_ns = staticmethod(lambda: 0)
 
@@ -988,6 +992,7 @@ def test_dev_log_activity_keeps_grace_window_alive(tmp_path, monkeypatch):
 
     class _Clock:
         monotonic = staticmethod(lambda: clock["t"])
+        time = staticmethod(lambda: 0.0)  # frozen wall clock: the co-bound never fires
         sleep = staticmethod(lambda *_: None)
         time_ns = staticmethod(lambda: 0)
 
@@ -1031,6 +1036,7 @@ def test_dev_grace_expiry_nudges_awake_before_stalling(tmp_path, monkeypatch):
 
     class _Clock:
         monotonic = staticmethod(lambda: clock["t"])
+        time = staticmethod(lambda: 0.0)  # frozen wall clock: the co-bound never fires
         sleep = staticmethod(lambda *_: None)
         time_ns = staticmethod(lambda: 0)
 
@@ -1066,6 +1072,7 @@ def test_dev_stall_nudge_wakes_session_that_then_completes(tmp_path, monkeypatch
 
     class _Clock:
         monotonic = staticmethod(lambda: clock["t"])
+        time = staticmethod(lambda: 0.0)  # frozen wall clock: the co-bound never fires
         sleep = staticmethod(lambda *_: None)
         time_ns = staticmethod(lambda: 0)
 
@@ -1121,6 +1128,7 @@ def _stall_loop_adapter(tmp_path, monkeypatch):
 
     class _Clock:
         monotonic = staticmethod(lambda: clock["t"])
+        time = staticmethod(lambda: 0.0)  # frozen wall clock: the co-bound never fires
         sleep = staticmethod(lambda *_: None)
         time_ns = staticmethod(lambda: 0)
 
@@ -1201,6 +1209,161 @@ def test_capped_session_still_completes_when_marker_lands_late(tmp_path, monkeyp
     assert sent == [generic.STALL_NUDGE_TEXT]  # the cap was already exhausted
 
 
+# ---------------------- timeout instrumentation + wall-clock co-bound (#157)
+#
+# The #157 timeout fired with zero record of when the adapter declared it, and
+# a host suspend (macOS sleep) freezing time.monotonic() could silently extend
+# the deadline by the nap's length. The fire moment now stamps the result and
+# a session-lifecycle.jsonl line, a wall-clock co-bound fires through a frozen
+# monotonic clock (but may never EXTEND the deadline), and each tick tops up a
+# throttled heartbeat.json whose staleness diagnoses a frozen orchestrator.
+
+
+def _lifecycle_lines(adapter, task_id="3-1-dev-1"):
+    path = adapter.tasks_dir / task_id / "session-lifecycle.jsonl"
+    if not path.is_file():
+        return []
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+def _timeout_clock_adapter(tmp_path, monkeypatch):
+    """Adapter + independently steerable monotonic/wall clocks for driving the
+    timeout-fire path. The window stays alive and no hook event ever arrives,
+    so only a clock crossing its deadline can end the wait."""
+    monkeypatch.setattr(generic, "RESULT_GRACE_S", 0.0)
+    monkeypatch.setattr(generic, "RESULT_POLL_S", 0.0)
+    adapter, _ = make_dev_adapter(tmp_path)
+    adapter._window_alive = lambda handle: True
+
+    clock = {"mono": 1000.0, "wall": 5000.0}
+
+    class _Clock:
+        monotonic = staticmethod(lambda: clock["mono"])
+        time = staticmethod(lambda: clock["wall"])
+        sleep = staticmethod(lambda *_: None)
+        time_ns = staticmethod(lambda: 0)
+
+    monkeypatch.setattr(generic, "time", _Clock)
+    return adapter, clock
+
+
+def _short_spec(tmp_path, timeout_s=30.0) -> SessionSpec:
+    return SessionSpec(
+        task_id="3-1-dev-1",
+        role="dev",
+        prompt="/bmad-dev-auto 3-1",
+        cwd=tmp_path,
+        env={"BMAD_LOOP_STORY_KEY": "3-1"},
+        timeout_s=timeout_s,
+    )
+
+
+def test_timeout_monotonic_expiry_is_instrumented(tmp_path, monkeypatch):
+    """A plain monotonic expiry records WHEN and BY WHICH CLOCK the deadline
+    was declared elapsed: fields on the result plus exactly one timeout-fired
+    line in session-lifecycle.jsonl."""
+    adapter, clock = _timeout_clock_adapter(tmp_path, monkeypatch)
+
+    def advance(call_n):
+        clock["mono"] += 11.0  # wall frozen: only the monotonic clock expires
+
+    adapter.watcher = _ScriptedWatcher([], on_call=advance)
+    result = adapter.wait_for_completion(_dev_handle(), _short_spec(tmp_path))
+    assert result.status == "timeout"
+    assert result.timeout_expired_clock == "monotonic"
+    assert result.timeout_fired_at == 5000.0  # the fake wall clock at fire time
+    fired = [ln for ln in _lifecycle_lines(adapter) if ln["event"] == "timeout-fired"]
+    assert len(fired) == 1
+    assert fired[0]["expired_clock"] == "monotonic"
+    assert fired[0]["timeout_s"] == 30.0
+    assert fired[0]["mono_remaining_s"] <= 0
+
+
+def test_timeout_fires_on_wall_clock_when_monotonic_frozen(tmp_path, monkeypatch):
+    """The #157 suspend signature: time.monotonic() stands still through a host
+    suspend, so the monotonic deadline alone would stretch the session by the
+    nap's length. The wall-clock co-bound fires anyway, and the wall-only
+    expiry (monotonic time still to spare) is stamped as the evidence."""
+    adapter, clock = _timeout_clock_adapter(tmp_path, monkeypatch)
+
+    def advance(call_n):
+        clock["wall"] += 11.0  # suspended host: wall counts on, monotonic frozen
+
+    adapter.watcher = _ScriptedWatcher([], on_call=advance)
+    result = adapter.wait_for_completion(_dev_handle(), _short_spec(tmp_path))
+    assert result.status == "timeout"
+    assert result.timeout_expired_clock == "wall"
+    (fired,) = [ln for ln in _lifecycle_lines(adapter) if ln["event"] == "timeout-fired"]
+    assert fired["expired_clock"] == "wall"
+    assert fired["mono_remaining_s"] == 30.0  # the frozen clock never advanced
+
+
+def test_timeout_wall_clock_step_back_cannot_extend_deadline(tmp_path, monkeypatch):
+    """The co-bound may only EXPIRE the deadline, never stretch it: a wall
+    clock stepped backward (an NTP correction) leaves the monotonic expiry on
+    its original schedule."""
+    adapter, clock = _timeout_clock_adapter(tmp_path, monkeypatch)
+
+    def advance(call_n):
+        clock["mono"] += 11.0
+        clock["wall"] -= 3600.0  # NTP step-back: must change nothing
+
+    adapter.watcher = _ScriptedWatcher([], on_call=advance)
+    result = adapter.wait_for_completion(_dev_handle(), _short_spec(tmp_path))
+    assert result.status == "timeout"
+    assert result.timeout_expired_clock == "monotonic"
+    assert adapter.watcher.calls == 3  # same tick count as an untouched wall clock
+
+
+def test_heartbeat_written_and_throttled(tmp_path, monkeypatch):
+    """Each tick tops up tasks/<id>/heartbeat.json with the loop's view of the
+    session — but at most once per HEARTBEAT_INTERVAL_S: two ticks inside one
+    interval produce one write."""
+    adapter, clock = _timeout_clock_adapter(tmp_path, monkeypatch)
+    (adapter.tasks_dir / "3-1-dev-1").mkdir()  # start_session creates it in production
+
+    writes: list[dict] = []
+    real_write = adapter._write_heartbeat
+
+    def spy(task_id, payload):
+        writes.append(payload)
+        real_write(task_id, payload)
+
+    adapter._write_heartbeat = spy
+
+    def advance(call_n):
+        if call_n == 1:
+            clock["mono"] += 1.0  # next tick lands inside the same interval
+        elif call_n == 2:
+            clock["mono"] += generic.HEARTBEAT_INTERVAL_S + 10.0  # crosses it
+        else:
+            clock["mono"] += 1000.0  # past spec.timeout_s: end the loop
+
+    adapter.watcher = _ScriptedWatcher([], on_call=advance)
+    result = adapter.wait_for_completion(_dev_handle(), _short_spec(tmp_path, timeout_s=100.0))
+    assert result.status == "timeout"
+    assert writes[0] == {
+        "ts": 5000.0,
+        "remaining_s": 100.0,
+        "stall_armed": False,
+        "stall_nudges_sent": 0,
+    }
+    assert [w["remaining_s"] for w in writes] == [100.0, 59.0]  # tick 2 was throttled
+    hb = json.loads((adapter.tasks_dir / "3-1-dev-1" / "heartbeat.json").read_text())
+    assert hb == writes[-1]  # the on-disk file is the last overwrite
+
+
+def test_lifecycle_and_heartbeat_write_failure_is_swallowed(tmp_path):
+    """Like the resultless-stop breadcrumb: pure observability, so an
+    unwritable tasks dir must never break the completion loop."""
+    adapter, _ = make_dev_adapter(tmp_path)
+    blocker = tmp_path / "blocker"
+    blocker.write_text("a file where the tasks dir should be")
+    adapter.tasks_dir = blocker / "tasks"  # any write under it raises OSError
+    adapter._note_lifecycle("3-1-dev-1", "timeout-fired", expired_clock="wall")  # must not raise
+    adapter._write_heartbeat("3-1-dev-1", {"ts": 0.0})  # must not raise
+
+
 # ----------------------------------------------- post-kill reconcile (#61)
 #
 # A session that finished its work but lost its final Stop ends "stalled"
@@ -1218,8 +1381,8 @@ _DONE_SPEC = (
 )
 
 
-def _unvouched(status="stalled") -> SessionResult:
-    return SessionResult(status=status, session_id="sess", transcript_path="/t.jsonl")
+def _unvouched(status="stalled", **extra) -> SessionResult:
+    return SessionResult(status=status, session_id="sess", transcript_path="/t.jsonl", **extra)
 
 
 def test_post_kill_reconcile_rescues_consistent_done_artifact(tmp_path):
@@ -1238,13 +1401,17 @@ def test_post_kill_reconcile_rescues_consistent_done_artifact(tmp_path):
 def test_post_kill_reconcile_rescues_timeout(tmp_path):
     """Total hook loss (misconfigured hooks, events-dir write failure) never arms
     the stall grace — the session exits `timeout` with no artifact check at all.
-    The same post-kill rescue must cover it."""
+    The same post-kill rescue must cover it — upgrading the outcome, not the
+    timing evidence: the fired-deadline stamps survive the rescue (#157)."""
     adapter, impl = make_dev_adapter(tmp_path)
     adapter._window_alive = lambda handle: False
     (impl / "spec-3-1-foo.md").write_text(_DONE_SPEC)
-    result = adapter._post_kill_reconcile(_dev_handle(), _dev_spec(tmp_path), _unvouched("timeout"))
+    original = _unvouched("timeout", timeout_fired_at=1234.5, timeout_expired_clock="wall")
+    result = adapter._post_kill_reconcile(_dev_handle(), _dev_spec(tmp_path), original)
     assert result.status == "completed"
     assert result.result_json["post_kill_reconciled"] is True
+    assert result.timeout_fired_at == 1234.5
+    assert result.timeout_expired_clock == "wall"
 
 
 def test_post_kill_reconcile_leaves_other_statuses_alone(tmp_path):
@@ -1546,6 +1713,7 @@ def test_wait_for_completion_persistent_probe_failure_times_out_not_crashes(tmp_
 
     class _Clock:
         monotonic = staticmethod(lambda: clock["t"])
+        time = staticmethod(lambda: 0.0)  # frozen wall clock: the co-bound never fires
         sleep = staticmethod(lambda *_: None)
         time_ns = staticmethod(lambda: 0)
 

--- a/tests/test_generic_tmux.py
+++ b/tests/test_generic_tmux.py
@@ -1325,13 +1325,6 @@ def test_capped_session_still_completes_when_marker_lands_late(tmp_path, monkeyp
 # throttled heartbeat.json whose staleness diagnoses a frozen orchestrator.
 
 
-def _lifecycle_lines(adapter, task_id="3-1-dev-1"):
-    path = adapter.tasks_dir / task_id / "session-lifecycle.jsonl"
-    if not path.is_file():
-        return []
-    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
-
-
 def _timeout_clock_adapter(tmp_path, monkeypatch):
     """Adapter + independently steerable monotonic/wall clocks for driving the
     timeout-fire path. The window stays alive and no hook event ever arrives,

--- a/tests/test_multiplexer.py
+++ b/tests/test_multiplexer.py
@@ -245,6 +245,7 @@ def test_seam_methods_never_leak_raw_subprocess_error(boom_run, tmp_path):
     assert mux.unset_window_option("@1", "opt") is None
     assert mux.detach_client() is None
     assert mux.pipe_pane("@1", tmp_path / "log") is None
+    assert mux.window_pane_pids("@1") == []
 
     # Already-correct swallowers stay swallowing (lock-in).
     assert mux.kill_session("s") is None
@@ -271,6 +272,47 @@ def test_seam_honesty_holds_for_psmux_style_run_override(monkeypatch):
         mux.window_alive("s", "@1")
     # sentinel methods still degrade rather than leak the raw timeout
     assert mux.list_windows("s", ["window_id"]) == []
+
+
+# ------------------------------------- window_pane_pids capability (#157)
+#
+# Like version(), window_pane_pids is a NON-abstract capability method: an
+# out-of-tree backend implementing only the abstract set (herdr) keeps working
+# with zero edits and inherits the "capability not offered" sentinel [].
+
+
+def test_window_pane_pids_default_is_capability_not_offered():
+    # StubMux implements only the abstract contract — it instantiates without
+    # window_pane_pids and inherits the degrade sentinel from the seam base.
+    assert StubMux().window_pane_pids("@1") == []
+
+
+def test_tmux_window_pane_pids_parses_pane_pid_lines(monkeypatch):
+    mux = TmuxMultiplexer()
+    seen: dict = {}
+
+    def fake_run(argv, **kwargs):
+        seen["argv"] = list(argv)
+        return subprocess.CompletedProcess(argv, 0, stdout="1234\n5678\n", stderr="")
+
+    monkeypatch.setattr(tmux_base.subprocess, "run", fake_run)
+    assert mux.window_pane_pids("@7") == [1234, 5678]
+    assert seen["argv"] == ["tmux", "list-panes", "-t", "@7", "-F", "#{pane_pid}"]
+
+
+@pytest.mark.parametrize(
+    "outcome",
+    [
+        lambda argv: (_ for _ in ()).throw(subprocess.TimeoutExpired(argv, 30)),
+        lambda argv: subprocess.CompletedProcess(argv, 1, stdout="", stderr="no window"),
+        lambda argv: subprocess.CompletedProcess(argv, 0, stdout="not-a-pid\n", stderr=""),
+    ],
+    ids=["timeout", "dead-window", "garbage-output"],
+)
+def test_tmux_window_pane_pids_degrades_to_empty(monkeypatch, outcome):
+    mux = TmuxMultiplexer()
+    monkeypatch.setattr(tmux_base.subprocess, "run", lambda argv, **k: outcome(argv))
+    assert mux.window_pane_pids("@7") == []
 
 
 # ---------------------------------------------- _run seam: encoding + env (#40)

--- a/tests/test_opencode_http.py
+++ b/tests/test_opencode_http.py
@@ -11,6 +11,7 @@ Everything binds 127.0.0.1; no real opencode binary or network access anywhere.
 from __future__ import annotations
 
 import json
+import queue
 import sys
 import time
 from pathlib import Path
@@ -18,7 +19,7 @@ from pathlib import Path
 import pytest
 from conftest import write_script_launcher
 
-from bmad_loop.adapters import generic
+from bmad_loop.adapters import generic, opencode_http
 from bmad_loop.adapters.base import SessionHandle, SessionSpec
 from bmad_loop.adapters.generic import NUDGE_TEXT, STALL_NUDGE_TEXT
 from bmad_loop.adapters.opencode_http import (
@@ -28,6 +29,7 @@ from bmad_loop.adapters.opencode_http import (
     _free_port,
     _now_ms,
     _parse_sse_lines,
+    _ServerSession,
     _sum_usage,
 )
 from bmad_loop.adapters.profile import get_profile
@@ -604,6 +606,142 @@ def test_e2e_timeout_aborts(tmp_path, fake_opencode):
     aborts = read_jsonl(rec / "aborts.jsonl")
     assert aborts and "/abort" in aborts[0]["path"]
     assert_server_gone(rec)
+
+
+# ---------------- timeout instrumentation + wall-clock co-bound (#157)
+#
+# Mirrors the generic-adapter coverage on the HTTP transport: the fire moment
+# stamps the result and one timeout-fired line in session-lifecycle.jsonl, and
+# a wall-clock co-bound fires through a frozen time.monotonic() (the macOS-sleep
+# signature) but may never EXTEND the deadline. There is no watcher here — a
+# tick is one sess.events.get(), so a fake queue advances the steerable clock
+# each tick, exactly as _ScriptedWatcher.on_call does for the generic adapter.
+
+
+def _install_clock(monkeypatch, mono=1000.0, wall=5000.0):
+    clock = {"mono": mono, "wall": wall}
+
+    class _Clock:
+        monotonic = staticmethod(lambda: clock["mono"])
+        time = staticmethod(lambda: clock["wall"])
+        sleep = staticmethod(lambda *_: None)
+        time_ns = staticmethod(lambda: 0)
+
+    monkeypatch.setattr(opencode_http, "time", _Clock)
+    return clock
+
+
+def _timeout_driven_session(adapter, advance, task_id="t-1"):
+    """Register a live session whose event queue never yields a frame but runs
+    ``advance`` each tick, so only a clock crossing its deadline can end the
+    wait. client=None makes _abort/_capture_usage no-ops."""
+
+    class _AliveProc:
+        def poll(self):
+            return None
+
+    class _TickingQueue:
+        def get(self, timeout=None):
+            advance()
+            raise queue.Empty
+
+        def empty(self):
+            return True
+
+    sess = _ServerSession(process=_AliveProc(), port=0, base_url="", password="", log_fh=None)
+    sess.session_id = "ses_1"
+    sess.client = None
+    sess.events = _TickingQueue()
+    adapter._sessions[task_id] = sess
+    # There is no real server behind the fake process, so the atexit sweep must
+    # not try to signal its (absent) pid or close its (None) log handle.
+    adapter._teardown = lambda _sess: None
+    return sess
+
+
+def _lifecycle_lines(adapter, task_id="t-1"):
+    path = adapter.tasks_dir / task_id / "session-lifecycle.jsonl"
+    if not path.is_file():
+        return []
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line]
+
+
+def _timeout_spec(tmp_path, timeout_s=30.0) -> SessionSpec:
+    return SessionSpec(task_id="t-1", role="dev", prompt="p", cwd=tmp_path, timeout_s=timeout_s)
+
+
+def test_timeout_monotonic_expiry_is_instrumented(tmp_path, monkeypatch):
+    """A plain monotonic expiry records WHEN and BY WHICH CLOCK the deadline was
+    declared elapsed — result stamps, one timeout-fired lifecycle line, and a
+    heartbeat.json topped up while the loop still ran."""
+    adapter = make_adapter(tmp_path)
+    clock = _install_clock(monkeypatch)
+    (adapter.tasks_dir / "t-1").mkdir(parents=True)  # start_session makes it in production
+
+    def advance():
+        clock["mono"] += 11.0  # wall frozen: only the monotonic clock expires
+
+    _timeout_driven_session(adapter, advance)
+    result = adapter.wait_for_completion(
+        SessionHandle(task_id="t-1", native_id="ses_1"), _timeout_spec(tmp_path)
+    )
+
+    assert result.status == "timeout"
+    assert result.timeout_expired_clock == "monotonic"
+    assert result.timeout_fired_at == 5000.0  # the fake wall clock at fire time
+    (fired,) = [ln for ln in _lifecycle_lines(adapter) if ln["event"] == "timeout-fired"]
+    assert fired["expired_clock"] == "monotonic"
+    assert fired["timeout_s"] == 30.0
+    assert fired["mono_remaining_s"] <= 0
+    hb = json.loads((adapter.tasks_dir / "t-1" / "heartbeat.json").read_text(encoding="utf-8"))
+    assert hb["remaining_s"] == 30.0 and hb["stall_armed"] is False
+
+
+def test_timeout_fires_on_wall_clock_when_monotonic_frozen(tmp_path, monkeypatch):
+    """The #157 suspend signature on the HTTP transport: time.monotonic() stands
+    still through a host suspend, so the monotonic deadline alone would stretch
+    the session by the nap's length. The wall-clock co-bound fires anyway, and
+    the wall-only expiry (monotonic time still to spare) is stamped as the
+    evidence."""
+    adapter = make_adapter(tmp_path)
+    clock = _install_clock(monkeypatch)
+
+    def advance():
+        clock["wall"] += 11.0  # suspended host: wall counts on, monotonic frozen
+
+    _timeout_driven_session(adapter, advance)
+    result = adapter.wait_for_completion(
+        SessionHandle(task_id="t-1", native_id="ses_1"), _timeout_spec(tmp_path)
+    )
+
+    assert result.status == "timeout"
+    assert result.timeout_expired_clock == "wall"
+    (fired,) = [ln for ln in _lifecycle_lines(adapter) if ln["event"] == "timeout-fired"]
+    assert fired["expired_clock"] == "wall"
+    assert fired["mono_remaining_s"] == 30.0  # the frozen clock never advanced
+
+
+def test_timeout_wall_clock_step_back_cannot_extend_deadline(tmp_path, monkeypatch):
+    """The co-bound may only EXPIRE the deadline, never stretch it: a wall clock
+    stepped backward (an NTP correction) leaves the monotonic expiry on its
+    original schedule."""
+    adapter = make_adapter(tmp_path)
+    clock = _install_clock(monkeypatch)
+    ticks = {"n": 0}
+
+    def advance():
+        ticks["n"] += 1
+        clock["mono"] += 11.0
+        clock["wall"] -= 3600.0  # NTP step-back: must change nothing
+
+    _timeout_driven_session(adapter, advance)
+    result = adapter.wait_for_completion(
+        SessionHandle(task_id="t-1", native_id="ses_1"), _timeout_spec(tmp_path)
+    )
+
+    assert result.status == "timeout"
+    assert result.timeout_expired_clock == "monotonic"
+    assert ticks["n"] == 3  # same tick count as an untouched wall clock
 
 
 def test_e2e_server_death_with_artifact_completes(tmp_path, fake_opencode):

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -281,6 +281,23 @@ def test_git_timeout_must_be_positive(bad):
         policy.loads(f"[limits]\ngit_timeout_s = {bad}\n")
 
 
+def test_teardown_grace_default_parse_and_template():
+    import tomllib
+
+    assert policy.loads("").limits.teardown_grace_s == 20
+    assert policy.loads("[limits]\nteardown_grace_s = 45\n").limits.teardown_grace_s == 45
+    # 0 is legal: the rollback lever back to the single unverified best-effort kill
+    assert policy.loads("[limits]\nteardown_grace_s = 0\n").limits.teardown_grace_s == 0
+    # the emitted template documents the knob at its dataclass default
+    doc = tomllib.loads(policy.POLICY_TEMPLATE)
+    assert doc["limits"]["teardown_grace_s"] == policy.LimitsPolicy.teardown_grace_s
+
+
+def test_teardown_grace_must_be_nonnegative():
+    with pytest.raises(policy.PolicyError, match=r"limits\.teardown_grace_s"):
+        policy.loads("[limits]\nteardown_grace_s = -1\n")
+
+
 def test_workflow_stall_nudges_cap_default_parse_and_template():
     import tomllib
 

--- a/tests/test_stories_e2e.py
+++ b/tests/test_stories_e2e.py
@@ -32,10 +32,12 @@ the end-to-end CLI stack.
 
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -180,6 +182,21 @@ events = {{ SessionStart = "SessionStart", Stop = "Stop" }}
 SPEC_FOLDER = "_bmad-output/epic-1"
 CLI = [sys.executable, "-m", "bmad_loop.cli"]
 
+# A fake CLI that writes SessionStart and then sleeps forever — it NEVER fires a
+# Stop hook, so the dev session can only end via the orchestrator's own timeout
+# fire + bounded teardown (#157). Because the session never ends a turn, the
+# result-less-Stop stall machinery never engages either, exactly the wedged-in-a-
+# tool-call shape the issue reported.
+TIMEOUT_FAKE_CLI = r"""#!/usr/bin/env bash
+set -e
+rd="$BMAD_LOOP_RUN_DIR"; tid="$BMAD_LOOP_TASK_ID"
+ts=$(date +%s%N)
+mkdir -p "$rd/events"
+printf '{"ts": %s, "event": "SessionStart", "task_id": "%s", "session_id": "fake-1"}' \
+    "$ts" "$tid" > "$rd/events/$ts-$tid-SessionStart.json"
+sleep 100000
+"""
+
 
 def _git(root: Path, *args: str) -> None:
     subprocess.run(["git", "-C", str(root), *args], check=True, capture_output=True, text=True)
@@ -242,12 +259,16 @@ def _scaffold(root: Path, entries: list[dict]) -> None:
     _git(root, "commit", "-q", "-m", "sandbox")
 
 
-def _scaffold_sprint(root: Path, story_key: str) -> None:
+def _scaffold_sprint(
+    root: Path, story_key: str, fake_cli: str = FAKE_CLI, extra_policy: str = ""
+) -> None:
     """A committed, clean SPRINT-mode sandbox carrying the SAME new folder+id-
     capable bmad-dev-auto skill stub as `_scaffold` (with the folder+id dispatch
     probe content) — the regression point: installing that skill must not disturb
     the default sprint path. sprint-status.yaml holds one ready-for-dev story; the
-    policy has NO [stories] section, so the run is plain sprint mode."""
+    policy has NO [stories] section, so the run is plain sprint mode. ``fake_cli``
+    swaps the CLI script (e.g. a never-Stop timeout fake); ``extra_policy`` appends
+    to policy.toml (e.g. a [limits] block)."""
     root.mkdir(parents=True, exist_ok=True)
     (root / "src.txt").write_text("original\n", encoding="utf-8")
     (root / ".gitignore").write_text(".bmad-loop/runs/\n", encoding="utf-8")
@@ -281,7 +302,7 @@ def _scaffold_sprint(root: Path, story_key: str) -> None:
 
     fake = root / ".bmad-loop" / "fake-cli.sh"
     fake.parent.mkdir(parents=True, exist_ok=True)
-    fake.write_text(FAKE_CLI, encoding="utf-8")
+    fake.write_text(fake_cli, encoding="utf-8")
     os.chmod(fake, 0o755)
     profiles = root / ".bmad-loop" / "profiles"
     profiles.mkdir(parents=True)
@@ -291,7 +312,7 @@ def _scaffold_sprint(root: Path, story_key: str) -> None:
     (root / ".bmad-loop" / "policy.toml").write_text(
         '[adapter]\nname = "fakestories"\n\n'
         "[review]\nenabled = false\n\n"
-        '[gates]\nmode = "none"\n',
+        '[gates]\nmode = "none"\n' + extra_policy,
         encoding="utf-8",
     )
 
@@ -538,6 +559,67 @@ def test_e2e_sprint_intent_gap_patch_restore(tmp_path):
     run_dir = root / ".bmad-loop" / "runs" / run_id
     prompts = [p.read_text(encoding="utf-8") for p in (run_dir / "tasks").glob("*/prompt.txt")]
     assert any(str(spec) in p for p in prompts)
+
+
+def _tmux_has_session(name: str) -> bool:
+    return subprocess.run(["tmux", "has-session", "-t", name], capture_output=True).returncode == 0
+
+
+def test_e2e_session_timeout_teardown(tmp_path, monkeypatch):
+    """#157 end to end through the real binary + real tmux: a dev session wedged
+    forever (SessionStart, then sleep — never a Stop) is bounded only by the
+    session timeout, and the fix makes that firing timely and observable. The
+    1-minute policy floor is too coarse for a fast test, so the engine's
+    BMAD_LOOP_SESSION_TIMEOUT_S seam drives a 3-second budget."""
+    root = tmp_path / "sbx"
+    story = "1-1-timeout"
+    _scaffold_sprint(
+        root,
+        story,
+        fake_cli=TIMEOUT_FAKE_CLI,
+        extra_policy="\n[limits]\nmax_dev_attempts = 1\nteardown_grace_s = 5\n",
+    )
+    # inherited by the `bmad-loop run` subprocess (_run passes no env=)
+    monkeypatch.setenv("BMAD_LOOP_SESSION_TIMEOUT_S", "3")
+
+    proc = _run(root, "run", timeout=90)
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+
+    run_id = _run_id(root)
+    run_dir = root / ".bmad-loop" / "runs" / run_id
+
+    # (1) session-end status=timeout, journaled promptly, with the fire forensics
+    journal = [
+        json.loads(ln)
+        for ln in (run_dir / "journal.jsonl").read_text(encoding="utf-8").splitlines()
+        if ln.strip()
+    ]
+    ends = [j for j in journal if j["kind"] == "session-end" and j.get("status") == "timeout"]
+    assert ends, f"no session-end status=timeout: {[j['kind'] for j in journal]}"
+    end = ends[0]
+    assert end.get("fired_at"), end
+    assert end["teardown_s"] < 15.0, f"teardown gap not small (kill hung?): {end['teardown_s']}"
+    assert end.get("expired_clock") in ("monotonic", "wall", "both"), end
+    task_id = end["task_id"]
+
+    # (2) the fire moment left a timeout-fired breadcrumb, distinct from teardown
+    tdir = run_dir / "tasks" / task_id
+    life = [
+        json.loads(ln)
+        for ln in (tdir / "session-lifecycle.jsonl").read_text(encoding="utf-8").splitlines()
+        if ln.strip()
+    ]
+    assert any(ln.get("event") == "timeout-fired" for ln in life), life
+
+    # (3) the wait loop's proof-of-life exists and is recent (not the frozen gap)
+    hb = json.loads((tdir / "heartbeat.json").read_text(encoding="utf-8"))
+    assert time.time() - hb["ts"] < 120, hb
+
+    # (4) teardown actually reaped the session — no orphan tmux session/process
+    assert not _tmux_has_session(f"bmad-loop-{run_id}")
+    if shutil.which("pgrep"):
+        pg = subprocess.run(["pgrep", "-af", "fake-cli.sh"], capture_output=True, text=True)
+        assert not [ln for ln in pg.stdout.splitlines() if str(root) in ln], pg.stdout
 
 
 def test_e2e_sweep_intent_gap_patch_restore(tmp_path):

--- a/tests/test_stories_e2e.py
+++ b/tests/test_stories_e2e.py
@@ -194,7 +194,13 @@ ts=$(date +%s%N)
 mkdir -p "$rd/events"
 printf '{"ts": %s, "event": "SessionStart", "task_id": "%s", "session_id": "fake-1"}' \
     "$ts" "$tid" > "$rd/events/$ts-$tid-SessionStart.json"
-sleep 100000
+# Background + wait keeps the same process group as a foreground sleep, but
+# records the child's pid so the test can prove teardown reaped descendants,
+# not just this shell (whose cmdline is all the pgrep check can see).
+sleep 100000 &
+child=$!
+printf '%s\n' "$child" > "$rd/tasks/$tid/fake-child.pid"
+wait "$child"
 """
 
 
@@ -620,6 +626,22 @@ def test_e2e_session_timeout_teardown(tmp_path, monkeypatch):
     if shutil.which("pgrep"):
         pg = subprocess.run(["pgrep", "-af", "fake-cli.sh"], capture_output=True, text=True)
         assert not [ln for ln in pg.stdout.splitlines() if str(root) in ln], pg.stdout
+    # The pgrep filter can only see the shell's cmdline; probe the recorded sleep
+    # descendant directly — the escalation force-kills pane-root pids, so a
+    # regression there would leak exactly this child while pgrep stays clean.
+    # Poll briefly: a just-killed child can linger as a zombie (kill 0 succeeds)
+    # until init reaps it after the shell died.
+    pid_file = tdir / "fake-child.pid"
+    assert pid_file.is_file(), "fake CLI never recorded its sleep child"
+    fake_pid = int(pid_file.read_text(encoding="utf-8"))
+    deadline = time.monotonic() + 10
+    while True:
+        try:
+            os.kill(fake_pid, 0)
+        except ProcessLookupError:
+            break  # dead and reaped — teardown covered the descendant
+        assert time.monotonic() < deadline, f"sleep child {fake_pid} survived teardown"
+        time.sleep(0.1)
 
 
 def test_e2e_sweep_intent_gap_patch_restore(tmp_path):

--- a/tests/test_tui_data.py
+++ b/tests/test_tui_data.py
@@ -753,6 +753,10 @@ def test_active_task_id_from_journal(tmp_path):
 
 
 def test_active_task_id_clears_on_aborted_session_end(tmp_path):
+    # No logs/ here on purpose: this pins the journal-scan contract (an explicit
+    # aborted end clears the active id). With logs present the newest-log
+    # fallback would still tail the ended session — deliberate, so the operator
+    # keeps the aborted log on screen; covered by the fallback test below.
     entries = [
         {"kind": "session-start", "task_id": "t1"},
         {"kind": "session-end", "task_id": "t1", "status": "aborted", "error": "RuntimeError"},

--- a/tests/test_tui_data.py
+++ b/tests/test_tui_data.py
@@ -752,6 +752,14 @@ def test_active_task_id_from_journal(tmp_path):
     assert data.active_task_id(tmp_path, entries) is None  # no logs fallback either
 
 
+def test_active_task_id_clears_on_aborted_session_end(tmp_path):
+    entries = [
+        {"kind": "session-start", "task_id": "t1"},
+        {"kind": "session-end", "task_id": "t1", "status": "aborted", "error": "RuntimeError"},
+    ]
+    assert data.active_task_id(tmp_path, entries) is None
+
+
 def test_active_task_id_falls_back_to_newest_log(tmp_path):
     logs = tmp_path / "logs"
     logs.mkdir()


### PR DESCRIPTION
## Problem (#157)

A run's `session_timeout_min` fired, but the engine journaled the `session-end`
**2h19 late** — with zero record of *when* the adapter declared the deadline
elapsed, which clock had expired, or what happened in the gap. The likely
trigger was a frozen orchestrator process (host resource starvation — same run
as #156's git-subprocess timeouts — and/or a macOS sleep freezing the
`time.monotonic()` clock the deadline was computed from). The incident was
undiagnosable because nothing on the timeout/teardown path was instrumented.

## Fix — three mechanisms

**1. Wall-clock co-bound (fires on time).** `wait_for_completion` now derives a
wall-clock deadline alongside the monotonic one. A host suspend freezes
`time.monotonic()`, silently extending the monotonic deadline by the nap's
length; the wall clock keeps counting through a suspend, so it may now **EXPIRE**
the deadline — never **extend** it (all sub-waits stay monotonic, and a
stepped-back wall clock changes nothing). Landed for the tmux (`generic`)
adapter and mirrored here into `opencode-http`.

**2. Fire-time breadcrumb + heartbeat + unconditional session-end (observable).**
The fire moment stamps the result (`timeout_fired_at`, `timeout_expired_clock` —
`"wall"` alone is the suspend fingerprint) and appends a `timeout-fired` line to
`tasks/<id>/session-lifecycle.jsonl`; each wait tick tops up a throttled
`tasks/<id>/heartbeat.json` whose staleness under a still-live session diagnoses
a frozen orchestrator (the previously uninstrumented gap). The engine journals
`session-end` **unconditionally** — even a teardown that throws still records the
ended session (status `aborted` when unknowable), carrying
`fired_at`/`teardown_s`/`expired_clock`. `teardown_s` is exactly the fire→journal
gap that ran 2h19 in the incident.

**3. Verified, bounded kill (can't hang).** Teardown is a
`terminate → wait → force_kill` escalation capped by `limits.teardown_grace_s`
(default 20; `0` = a single unverified best-effort kill), so a timeout can no
longer hang on an unkillable session.

## Honest scope

A frozen process cannot run any of this code *while* frozen — that is not
fixable in-process. What changes: recurrence is now **diagnosable** rather than
silent (`expired_clock="wall"` fingerprints a suspend; a stale `heartbeat.json`
under a live session pins a frozen orchestrator), and the wall-clock co-bound
removes the post-wake deadline extension.

## Verification

- Full suite: **2365 passed, 1 skipped** (opencode-live binary-absent skip).
- Full `trunk check`: **no issues**.
- **Committed real-tmux E2E** (`test_e2e_session_timeout_teardown`): a fake
  `claude` that starts and sleeps without ever firing Stop times out at a 3s
  budget; the journal records `session-end status=timeout` with `fired_at` and a
  sub-second `teardown_s`, `tasks/<id>/session-lifecycle.jsonl` carries
  `timeout-fired`, `heartbeat.json` is recent, and neither the run's tmux session
  nor the fake process survives. Runs in ~3s via a new
  `BMAD_LOOP_SESSION_TIMEOUT_S` engine seam (the `session_timeout_min` policy
  floor is 1 minute — too coarse for a fast real-binary test).

## Commits

- `c1a75c7` adapter fire-time instrumentation + wall-clock co-bound (generic)
- `4c7a8c3` unconditional session-end + fire/teardown forensics (engine)
- `04b905c` verified kill with bounded SIGKILL escalation behind `teardown_grace_s`
- `0666622` mirror the wall-clock co-bound into `opencode-http` + docs
- `93c2bb4` `BMAD_LOOP_SESSION_TIMEOUT_S` seam + committed sub-minute timeout E2E

Fixes #157

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session timeouts stay accurate across host sleep/suspend and clock shifts, with wall-clock vs monotonic expiry recorded for forensics.
  * `session-end` journaling is now consistently written, including `aborted` outcomes when teardown/result status can’t be determined.
  * Heartbeats and lifecycle diagnostics are now throttled and more resilient, improving stall/timeout visibility.

* **New Features**
  * Added configurable `teardown_grace_s` to bound verified teardown and escalate to force-kill when needed.

* **Documentation**
  * Updated README and TUI/journal docs with the new timeout/teardown fields and journal semantics.

* **Tests**
  * Expanded coverage for timeout forensics, teardown escalation behavior, and heartbeat timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
