### PR TITLE
fix(engine): strip the stale Auto Run Result before every review launch (#160)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -236,6 +236,14 @@ for antigravity`, immediately after a successful `init --cli antigravity`). Both
   `isolation = "none"` (the default) works; `isolation = "worktree"` hangs on every run, since
   each worktree is a fresh untrusted path — now called out in the profile and setup guide, and
   tracked in #169. Replaces the profile's previous "verify during probe" placeholder.
+- **Follow-up review sessions are no longer killed on their first Stop by the dev pass's stale
+  `## Auto Run Result` (#160).** The review leg re-invokes bmad-dev-auto on the finalized (`done`)
+  spec whose dev pass left that terminal marker; the review's own entry write lifted it past the
+  adapter's launch-mtime floor, so the first result-less Stop read the stale marker as this
+  session's result and ended the review mid-flight (the #109 stall grace never armed). The engine
+  now strips the marker before every review launch — the frontmatter `done` stays, so step-01
+  still routes to a review pass. The review-budget exhaustion defer reason now reports the last
+  pass's actual status instead of always claiming a lingering follow-up recommendation.
 - **`branch_per=run` + `keep_failed` no longer poisons a multi-story run after the first kept
   failure (#138).** The first story to end deferred under `keep_failed=true` left its worktree
   checked out on the single shared run branch, so every subsequent story's `git worktree add`

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -1688,6 +1688,11 @@ class Engine:
         # (status: done) while still recommending an independent follow-up — the
         # only state the budget-exhaustion rescue below is allowed to commit.
         refileable_followup = False
+        # The last *completed* pass's parsed frontmatter status, so the exhaustion
+        # defer reason can name what actually happened instead of the fixed
+        # follow-up wording (issue #160). None until a pass reaches the parse below
+        # (a crash/stall that DEFERs never gets there).
+        last_status: str | None = None
         # A resumed result must enter the loop even when the crash landed in the
         # post-session window of the *final* allowed cycle (review_cycle already
         # == max_review_cycles): its recorded pass was already counted, and the
@@ -1710,6 +1715,13 @@ class Engine:
                 result = resume_result
                 resume_result = None
             else:
+                # Strip the prior pass's stale `## Auto Run Result` before launch:
+                # the review re-invokes bmad-dev-auto on the done spec, and the
+                # session's own entry write would otherwise lift that leftover
+                # marker past the adapter's launch-mtime floor and end the review
+                # on its first result-less Stop (issue #160). Non-replay branch
+                # only — the replay path above launches no session.
+                self._reset_spec_for_review(task)
                 result = self._run_session(
                     task,
                     role="review",
@@ -1756,6 +1768,7 @@ class Engine:
             # convergence/damping gate below sees the finalized state.
             self._reconcile_generic_terminal_status(task, rj)
             status = str(rj.get("status", "")).strip()
+            last_status = status  # remember the last completed pass for the defer reason
             followup = bool(rj.get("followup_review_recommended", False))
             task.followup_review_recommended = followup  # latest pass wins
             refileable_followup = status == "done" and followup
@@ -1851,9 +1864,26 @@ class Engine:
                 self._record_review_budget_followup(task)
                 self._commit(task)
                 return
-            self._defer(
-                task, "review did not converge within budget (still recommending a follow-up pass)"
-            )
+            # Name the last completed pass's real outcome (issue #160): the fixed
+            # follow-up wording is only correct when a finalized pass actually left
+            # a refileable recommendation. "did not converge" stays in every variant
+            # (callers grep it).
+            if refileable_followup:
+                detail = "still recommending a follow-up pass"
+            elif last_status == "done":
+                detail = "last review pass finalized but its verification failed"
+            elif last_status is not None:
+                # A pass completed but its status is non-terminal — or "" when the
+                # observe-degrade paths left `rj` with no status (spec read fault,
+                # out-of-tree spec, or a result.json with no spec_file so the
+                # reconcile bailed). Render "" honestly rather than mislabeling it as
+                # "no pass ran" (which is what `last_status is None` below means).
+                detail = (
+                    f"last review pass ended at non-terminal status {(last_status or 'unknown')!r}"
+                )
+            else:
+                detail = "no review pass completed"
+            self._defer(task, f"review did not converge within budget ({detail})")
             return
 
         self._commit(task)
@@ -2527,6 +2557,29 @@ class Engine:
         spec_path = Path(task.spec_file)
         devcontract.reset_spec_status(spec_path, "in-progress")
         devcontract.strip_auto_run_result(spec_path)
+
+    def _reset_spec_for_review(self, task: StoryTask) -> None:
+        """Strip the prior pass's stale `## Auto Run Result` before a review launch.
+
+        A follow-up review session re-invokes bmad-dev-auto on the FINALIZED spec,
+        which still carries the dev pass's terminal `## Auto Run Result` section.
+        The review's own step-04 entry write (it stamps the transient `in-review`
+        status) bumps the spec's mtime past `find_result_artifact`'s launch floor,
+        so the review's first result-less Stop reads that stale marker as this
+        session's terminal result and kills the session mid-flight — the #109 stall
+        grace can never arm on the review leg (issue #160). Cycle 2+ carries the
+        PREVIOUS review pass's own marker, so this runs before every review launch,
+        never on the crash-resume replay branch (no session launches there). Unlike
+        `_reset_spec_for_repair` the frontmatter is left untouched: `status: done` is
+        what routes the re-invocation's step-01 to a fresh step-04 review pass.
+
+        No-op when the dev skill is not the generic one or no spec is recorded yet.
+        Repair-write doctrine (see `devcontract.strip_auto_run_result`): a present-
+        but-unreadable spec raises rather than silently proceeding stale — skipping
+        the strip recreates the exact bug state, so it must surface."""
+        if not self._generic_dev() or not task.spec_file:
+            return
+        devcontract.strip_auto_run_result(Path(task.spec_file))
 
     def _write_feedback(self, task: StoryTask, reason: str) -> Path:
         """Persist a verification failure where the next session can read it —

--- a/tests/test_devcontract.py
+++ b/tests/test_devcontract.py
@@ -616,6 +616,18 @@ def test_strip_auto_run_result_noop_when_spec_absent(tmp_path):
     assert devcontract.strip_auto_run_result(sp) is False
 
 
+def test_strip_auto_run_result_raises_on_undecodable_spec(tmp_path):
+    """Repair-write doctrine: a present-but-unreadable spec must RAISE, never
+    no-op. Only an absent file is guarded; a spec that cannot be decoded is left
+    to raise so the stale terminal section can't silently survive the re-open —
+    the #160 review-launch strip site depends on that surfacing (silently skipping
+    the strip recreates the exact bug it fixes)."""
+    sp = tmp_path / "spec.md"
+    sp.write_bytes(b"---\nstatus: done\n---\n\n\xff\xfe## Auto Run Result\n\nStatus: done\n")
+    with pytest.raises(UnicodeDecodeError):
+        devcontract.strip_auto_run_result(sp)
+
+
 def test_strip_auto_run_result_ignores_heading_quoted_in_code_fence(tmp_path):
     """A spec whose frozen intent quotes the heading inside a fenced example must
     not lose that content — stripping is destructive, so fenced pseudo-headings

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -18,6 +18,7 @@ from conftest import (
     generic_dev_effect,
     git,
     review_effect,
+    set_sprint,
     spec_path,
     write_spec,
     write_sprint,
@@ -2073,6 +2074,78 @@ def test_review_loop_converges_within_budget(project):
     assert "review-followup-damped" not in kinds
 
 
+def test_review_strips_stale_auto_run_result_before_each_launch(project):
+    """The review leg strips the prior pass's `## Auto Run Result` before every
+    launch (issue #160). The dev pass leaves a real terminal marker on the done
+    spec; left in place, the review's own entry write lifts it past the adapter's
+    launch-mtime floor and the first result-less Stop reads it as this session's
+    result — killing the review mid-flight. Each review effect asserts the on-disk
+    spec carries no marker at ENTRY; both passes finalize with their own marker, so
+    the cycle-2 entry assertion proves the strip runs per launch (not just once)
+    while the final pass's marker legitimately survives on the committed spec (no
+    later launch strips it)."""
+    from bmad_loop import devcontract
+
+    write_sprint(project, {"1-1-a": "ready-for-dev"})
+
+    def review_cycle1(spec):
+        sp = spec_path(project, "1-1-a")
+        # the dev pass's marker must be gone by the time this session runs
+        assert not devcontract.parse_auto_run_result(sp.read_text()).present
+        baseline = _spec_baseline(sp)
+        # finalize like review_effect, but leave our OWN terminal marker behind so
+        # cycle 2 can prove it too is stripped before the next launch
+        write_spec(sp, "done", baseline, prose_status="done")
+        set_sprint(project, "1-1-a", "done")
+        return SessionResult(
+            status="completed",
+            result_json={
+                "workflow": "auto-dev",
+                "story_key": "1-1-a",
+                "spec_file": str(sp),
+                "baseline_commit": baseline,
+                "status": "done",
+                "followup_review_recommended": True,  # non-clean -> a cycle 2 runs
+                "escalations": [],
+            },
+        )
+
+    def review_cycle2(spec):
+        sp = spec_path(project, "1-1-a")
+        # cycle 1's own marker must be stripped too — proves per-launch stripping
+        assert not devcontract.parse_auto_run_result(sp.read_text()).present
+        baseline = _spec_baseline(sp)
+        # this converging pass finalizes with its OWN marker, exactly as a real
+        # bmad-dev-auto finalize does — nothing strips it after the last launch
+        write_spec(sp, "done", baseline, prose_status="done")
+        set_sprint(project, "1-1-a", "done")
+        return SessionResult(
+            status="completed",
+            result_json={
+                "workflow": "auto-dev",
+                "story_key": "1-1-a",
+                "spec_file": str(sp),
+                "baseline_commit": baseline,
+                "status": "done",
+                "followup_review_recommended": False,  # converges
+                "escalations": [],
+            },
+        )
+
+    engine, _ = make_engine(
+        project,
+        [dev_effect(project, "1-1-a", prose_status="done"), review_cycle1, review_cycle2],
+    )
+    summary = engine.run()
+
+    assert summary.done == 1
+    task = engine.state.tasks["1-1-a"]
+    assert task.review_cycle == 2
+    # the FINAL pass's own marker legitimately survives — nothing launches after it,
+    # so no strip runs; the strip is a before-launch guard, not a scrub-on-commit
+    assert devcontract.parse_auto_run_result(spec_path(project, "1-1-a").read_text()).present
+
+
 def test_budget_exhausted_finalized_work_commits(project):
     """A finalized story (status: done, sprint done, verify green) whose review
     pass keeps recommending an independent follow-up is COMMITTED when the review
@@ -2142,6 +2215,149 @@ def test_budget_exhausted_unfinalized_defers(project):
     assert not spec_path(project, "1-1-a").exists()
     stashed = engine.run_dir / "deferred" / "1-1-a" / "spec-1-1-a.md"
     assert stashed.is_file() and "status: 'in-progress'" in stashed.read_text()
+
+
+def test_budget_exhausted_defer_reason_names_last_status(project):
+    """The exhaustion defer reason reflects the last completed pass's real status
+    (issue #160). Every review pass leaves the spec non-terminal (in-progress), so
+    it never finalizes: the reason must name that status, not the fixed
+    'still recommending a follow-up pass' text (which is only true of a finalized
+    pass that keeps recommending one)."""
+    write_sprint(project, {"1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(
+        project,
+        [dev_effect(project, "1-1-a")]
+        + [
+            review_effect(project, "1-1-a", clean=False, patched=1, finalized=False)
+            for _ in range(3)
+        ],
+    )
+    summary = engine.run()
+
+    assert summary.deferred == 1
+    task = engine.state.tasks["1-1-a"]
+    assert "did not converge" in task.defer_reason
+    assert "in-progress" in task.defer_reason
+    assert "recommending a follow-up" not in task.defer_reason
+
+
+def test_budget_exhausted_refileable_followup_keeps_followup_wording(project):
+    """Exhaustion with a refileable follow-up whose rescue verify FAILS still uses
+    the 'still recommending a follow-up pass' wording (issue #160). Every pass
+    finalizes done + recommends a follow-up (refileable_followup), but the last
+    pass's tree breaks the verify gate, so the exhaustion rescue's _verify_review
+    fails and the commit-instead-of-rollback is skipped → defer. Because the last
+    completed pass really did leave a lingering recommendation, the reason keeps the
+    follow-up wording (the in-loop verify never runs for a followup-recommending
+    pass, so the broken gate only surfaces in the rescue)."""
+    marker = project.project / "review-budget.marker"
+    write_sprint(project, {"1-1-a": "ready-for-dev"})
+
+    def dev_with_marker(spec):
+        marker.write_text("ok\n")
+        return dev_effect(project, "1-1-a")(spec)
+
+    def breaking_final_review(spec):
+        marker.unlink()  # the last pass's tree no longer passes the verify gate
+        return review_effect(project, "1-1-a", clean=False, patched=1)(spec)
+
+    engine, _ = make_engine(
+        project,
+        [
+            dev_with_marker,
+            review_effect(project, "1-1-a", clean=False, patched=1),
+            review_effect(project, "1-1-a", clean=False, patched=1),
+            breaking_final_review,
+        ],
+        policy=Policy(
+            gates=GatesPolicy(mode="none"),
+            notify=QUIET,
+            scm=ScmPolicy(rollback_on_failure=True),
+            limits=LimitsPolicy(max_followup_reviews=99),
+            verify=VerifyPolicy(commands=(_file_exists_cmd(marker),)),
+        ),
+    )
+    summary = engine.run()
+
+    assert summary.deferred == 1
+    task = engine.state.tasks["1-1-a"]
+    assert "did not converge" in task.defer_reason
+    assert "still recommending a follow-up pass" in task.defer_reason
+
+
+def test_budget_exhausted_finalized_but_verify_failed_wording(project):
+    """Exhaustion where the last pass finalized (status: done, no follow-up) but its
+    verify gate fails names the finalized-but-verification-failed mode (issue #160).
+    The single review pass converges (done, no follow-up), so the in-loop verify
+    runs and fails; with max_review_cycles == 1 there is no cycle left to run a fix
+    session, so the loop exits and the exhaustion reason reflects last_status 'done'
+    with no follow-up claim (refileable_followup is False here)."""
+    marker = project.project / "review-verify.marker"
+    write_sprint(project, {"1-1-a": "ready-for-dev"})
+
+    def dev_with_marker(spec):
+        marker.write_text("ok\n")
+        return dev_effect(project, "1-1-a")(spec)
+
+    def converged_but_broken_review(spec):
+        marker.unlink()  # converges done, but the tree fails the verify gate
+        return review_effect(project, "1-1-a", clean=True)(spec)
+
+    engine, _ = make_engine(
+        project,
+        [dev_with_marker, converged_but_broken_review],
+        policy=Policy(
+            gates=GatesPolicy(mode="none"),
+            notify=QUIET,
+            scm=ScmPolicy(rollback_on_failure=True),
+            limits=LimitsPolicy(max_review_cycles=1),
+            verify=VerifyPolicy(commands=(_file_exists_cmd(marker),)),
+        ),
+    )
+    summary = engine.run()
+
+    assert summary.deferred == 1
+    task = engine.state.tasks["1-1-a"]
+    assert "did not converge" in task.defer_reason
+    assert "finalized but its verification failed" in task.defer_reason
+    assert "recommending a follow-up" not in task.defer_reason
+
+
+def test_budget_exhausted_unreconciled_status_reads_as_unknown(project):
+    """A completed pass whose status could not be resolved defers as 'unknown', not
+    'no review pass completed' (issue #160). When a review result.json carries no
+    `spec_file`, `_reconcile_generic_terminal_status` bails and leaves `rj` with no
+    `status`, so `last_status` parses as "" — an empty-but-not-None value that means
+    'a pass ran, its status was unreadable'. The defer reason must render that
+    honestly (`''` != None), distinguishing it from the no-pass-ran case."""
+    write_sprint(project, {"1-1-a": "ready-for-dev"})
+
+    def statusless_review(spec):
+        sp = spec_path(project, "1-1-a")
+        # deliberately NO "status" and NO "spec_file": the reconcile returns early,
+        # so `rj` never gains a status and the loop parses "" (a completed pass with
+        # an unreadable/unreconciled status), not None (no pass ran)
+        return SessionResult(
+            status="completed",
+            result_json={
+                "workflow": "auto-dev",
+                "story_key": "1-1-a",
+                "baseline_commit": _spec_baseline(sp),
+                "escalations": [],
+            },
+        )
+
+    engine, _ = make_engine(
+        project,
+        [dev_effect(project, "1-1-a"), statusless_review, statusless_review, statusless_review],
+    )
+    summary = engine.run()
+
+    assert summary.deferred == 1
+    task = engine.state.tasks["1-1-a"]
+    assert "did not converge" in task.defer_reason
+    assert "'unknown'" in task.defer_reason
+    assert "no review pass completed" not in task.defer_reason
 
 
 def test_budget_exhausted_failed_review_sessions_defer_not_commit(project):


### PR DESCRIPTION
Closes #160.

## Root cause (confirmed on main @ 39e9cbc)

A follow-up review session re-invokes `bmad-dev-auto` on the finalized spec, which still carries the dev pass's terminal `## Auto Run Result` section. The adapter's launch-mtime floor (`find_result_artifact since_ns`) cannot help: the review's own step-04 entry write (transient `in-review`) bumps the spec's mtime past the floor, so the review's very first result-less Stop synthesizes a result from the **stale** marker and ends the session mid-flight — `dev_stall_grace_s`/`dev_stall_nudges` (#109) can never arm on the review leg.

Worse than reported: after the kill, `_reconcile_generic_terminal_status` on the review leg can advance `in-review` → `done` off the stale prose — in non-isolated runs a review that never actually ran could falsely converge and commit. (Worktree isolation likely masked this into the loop-and-defer the issue documents.)

The review leg was the **only** launch path leaving a stale marker in place — repair (`_reset_spec_for_repair`), resolve re-arm (`runs.py`), and the TUI reset all already strip.

## Fix (issue's suggested fix 2, orchestrator-side)

- New `Engine._reset_spec_for_review`: strips the prior pass's `## Auto Run Result` before **every** review-session launch (cycle 2+ carries the previous review pass's own marker). Frontmatter untouched — `status: done` is what routes the re-invocation's step-01 to a step-04 review pass. Never on the crash-resume replay branch (no session launches there). Repair-write doctrine: a present-but-unreadable spec raises. With the strip, review-leg prose can only ever be current-pass, closing the false-convergence hazard without touching the reconcile.
- Secondary (also from #160): the review-budget exhaustion defer reason now names the last pass's real outcome instead of always claiming "still recommending a follow-up pass" — 4 variants (refileable follow-up / finalized-but-verify-failed / non-terminal status named / no pass completed), "did not converge" retained in every one. A completed pass whose status could not be reconciled ("" vs None) renders as `'unknown'`, never as "no review pass completed".

Considered and rejected: the issue's fix 1 (scope the marker via a content floor) — it needs a launch-time snapshot threaded through the adapter seam for every transport and becomes dead weight once no launch path leaves a stale marker behind.

## Tests

- `test_review_strips_stale_auto_run_result_before_each_launch` — per-launch stripping asserted on-disk at session entry (dev marker gone at cycle 1; cycle 1's own marker gone at cycle 2); the final pass's own marker legitimately survives on the committed spec.
- `test_budget_exhausted_defer_reason_names_last_status`, `..._refileable_followup_keeps_followup_wording`, `..._finalized_but_verify_failed_wording`, `..._unreconciled_status_reads_as_unknown` — one per defer-wording branch.
- `test_strip_auto_run_result_raises_on_undecodable_spec` — characterizes the repair-write raise doctrine the strip site depends on.

## Verification

- Full suite: 2412 passed, 1 skipped.
- `trunk check` (full, no filter): no issues.
- Adversarial review (3 parallel layers: general, edge-case, verification-gap) ran pre-commit; both surviving findings patched (the ""-vs-None defer wording and a vacuous test assertion).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Follow-up review sessions no longer stop prematurely because of stale completion markers.
  * Review sessions now begin at the correct stage while preserving final completion status.
  * Defer reasons now accurately describe the last review pass, including verification failures, follow-up recommendations, and unknown statuses.
  * Invalid review specifications are surfaced instead of being silently processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->