### PR TITLE
fix(tui): pending journal jump survives a starved RichLog flush (#178)

### DIFF
--- a/src/bmad_loop/tui/screens/dashboard.py
+++ b/src/bmad_loop/tui/screens/dashboard.py
@@ -378,7 +378,7 @@ class DashboardScreen(Screen[None]):
             self._pin_task = task
         self._tick(force_rescan=False)
 
-    def _scroll_log_to(self, attempts: int = 20) -> None:
+    def _scroll_log_to(self, attempts: int = 20, finalize: bool = False) -> None:
         jump = self._pending_jump
         if jump is None or jump[0] != self._displayed_log_task:
             # jump cancelled or superseded, or the pane re-rendered another
@@ -415,7 +415,22 @@ class DashboardScreen(Screen[None]):
             return
         viewport = max(1, log.scrollable_content_region.height)
         log.scroll_to(y=max(0, target - viewport // 2), animate=False)
-        self._pending_jump = None  # landed: release so later renders don't re-jump
+        if finalize:
+            self._pending_jump = None  # landed: release so later renders don't re-jump
+            return
+        # The open height gate proves the reveal flush *wrote* — not that its
+        # scroll drained: RichLog.on_resize replays the deferred writes, whose
+        # scroll_end goes through call_after_refresh, so a tail-scroll can
+        # still be queued on the log's pump while scroll_to (immediate on a
+        # ScrollView) already landed. Releasing here would let that queued
+        # scroll stomp the jump with nothing left to re-attempt it. Route the
+        # release through the same queue instead: FIFO puts the finalize fire
+        # after any queued stomp, and it re-scrolls to the recomputed target
+        # before letting go. If its guards bail (log reset mid-window), the
+        # jump stays pending for the next ≤1s tick.
+        log.call_after_refresh(
+            lambda: (self._scroll_log_to(finalize=True) if self._pending_jump is jump else None)
+        )
 
     def action_unpin_log(self) -> None:
         if self._resize_mode:  # Escape leaves resize mode before it unpins the log

--- a/src/bmad_loop/tui/screens/dashboard.py
+++ b/src/bmad_loop/tui/screens/dashboard.py
@@ -370,7 +370,7 @@ class DashboardScreen(Screen[None]):
         # retry chain delays the jump instead of losing it.
         self._pending_jump = (task, pos)
         if task == self._displayed_log_task and self._log_index is not None:
-            self._scroll_log_to(self._log_index.line_for_offset(pos))
+            self._scroll_log_to()
             return
         # another session's log (or this one not rendered yet): pin it and
         # finish the jump once a poll has fed and rendered that file
@@ -378,12 +378,17 @@ class DashboardScreen(Screen[None]):
             self._pin_task = task
         self._tick(force_rescan=False)
 
-    def _scroll_log_to(self, line: int | None, attempts: int = 20) -> None:
+    def _scroll_log_to(self, attempts: int = 20) -> None:
         jump = self._pending_jump
         if jump is None or jump[0] != self._displayed_log_task:
             # jump cancelled or superseded, or the pane re-rendered another
             # task's log while a retry was armed — a stale fire must not scroll
             return
+        if self._log_index is None:
+            # not rendered yet (or a log reset mid-chain): the pending jump
+            # survives and the next ≤1s poll tick re-attempts it
+            return
+        line = self._log_index.line_for_offset(jump[1])
         if line is None:
             self._pending_jump = None  # give up for good: a retry would re-notify
             self.notify("log is empty or not loaded yet", severity="warning")
@@ -397,14 +402,14 @@ class DashboardScreen(Screen[None]):
             # so our scroll lands after it instead of being stomped. The chain
             # only covers sub-second snappiness: when it exhausts, the pending
             # jump stays set and the next ≤1s poll tick re-attempts it. Each
-            # fire re-checks the jump identity so a superseded chain dies.
+            # fire re-checks the jump identity so a superseded chain dies, and
+            # recomputes the line from the live index so a same-task repaint
+            # mid-chain (render_base drift) can't scroll to stale coordinates.
             if attempts > 0:
                 self.set_timer(
                     0.05,
                     lambda: (
-                        self._scroll_log_to(line, attempts - 1)
-                        if self._pending_jump is jump
-                        else None
+                        self._scroll_log_to(attempts - 1) if self._pending_jump is jump else None
                     ),
                 )
             return
@@ -859,16 +864,13 @@ class DashboardScreen(Screen[None]):
                 log.write(Text(note, style="yellow"), scroll_end=False)
             if snap.log_lines is not None and snap.log_lines.plain:
                 log.write(snap.log_lines, scroll_end=at_end)
-        if (
-            self._pending_jump is not None
-            and snap.log_task == self._pending_jump[0]
-            and self._log_index is not None
-        ):
+        if self._pending_jump is not None:
             # _scroll_log_to owns clearing the pending jump when the scroll
             # lands (or the log is provably empty) — until then this block
             # re-attempts on every tick, so a flush that outlives the retry
-            # chain delays the jump by ≤1s instead of losing it.
-            self._scroll_log_to(self._log_index.line_for_offset(self._pending_jump[1]))
+            # chain delays the jump by ≤1s instead of losing it. Task-match
+            # and index guards live inside _scroll_log_to.
+            self._scroll_log_to()
 
         attention = self.query_one("#attention", RichLog)
         if snap.attention_reset:

--- a/src/bmad_loop/tui/screens/dashboard.py
+++ b/src/bmad_loop/tui/screens/dashboard.py
@@ -365,18 +365,27 @@ class DashboardScreen(Screen[None]):
         task, pos = str(task), int(pos)
         self.query_one("#tabs", TabbedContent).active = "tab-log"
         self._log_follow_tail = False  # anchor on the jump target, stop chasing the tail
+        # _scroll_log_to owns clearing this once the scroll lands; until then
+        # every poll tick's _apply re-attempts it, so a flush that outlives the
+        # retry chain delays the jump instead of losing it.
+        self._pending_jump = (task, pos)
         if task == self._displayed_log_task and self._log_index is not None:
             self._scroll_log_to(self._log_index.line_for_offset(pos))
             return
         # another session's log (or this one not rendered yet): pin it and
         # finish the jump once a poll has fed and rendered that file
-        self._pending_jump = (task, pos)
         if task != self._displayed_log_task:
             self._pin_task = task
         self._tick(force_rescan=False)
 
-    def _scroll_log_to(self, line: int | None, attempts: int = 60) -> None:
+    def _scroll_log_to(self, line: int | None, attempts: int = 20) -> None:
+        jump = self._pending_jump
+        if jump is None or jump[0] != self._displayed_log_task:
+            # jump cancelled or superseded, or the pane re-rendered another
+            # task's log while a retry was armed — a stale fire must not scroll
+            return
         if line is None:
+            self._pending_jump = None  # give up for good: a retry would re-notify
             self.notify("log is empty or not loaded yet", severity="warning")
             return
         log = self.query_one("#log", RichLog)
@@ -385,19 +394,30 @@ class DashboardScreen(Screen[None]):
             # A previously hidden RichLog defers writes until the tab switch
             # gives it a size, and that flush applies its own scroll_end.
             # Wait for the flush (content taller than the target proves it)
-            # so our scroll lands after it instead of being stomped.
+            # so our scroll lands after it instead of being stomped. The chain
+            # only covers sub-second snappiness: when it exhausts, the pending
+            # jump stays set and the next ≤1s poll tick re-attempts it. Each
+            # fire re-checks the jump identity so a superseded chain dies.
             if attempts > 0:
-                self.set_timer(0.05, lambda: self._scroll_log_to(line, attempts - 1))
+                self.set_timer(
+                    0.05,
+                    lambda: (
+                        self._scroll_log_to(line, attempts - 1)
+                        if self._pending_jump is jump
+                        else None
+                    ),
+                )
             return
         viewport = max(1, log.scrollable_content_region.height)
         log.scroll_to(y=max(0, target - viewport // 2), animate=False)
+        self._pending_jump = None  # landed: release so later renders don't re-jump
 
     def action_unpin_log(self) -> None:
         if self._resize_mode:  # Escape leaves resize mode before it unpins the log
             self._exit_resize_mode()
             return
-        if self._pin_task is None and self._pending_jump is None:
-            return
+        if self._pin_task is None and self._pending_jump is None and self._log_follow_tail:
+            return  # nothing to unpin and already following the tail
         self._pin_task = None
         self._pending_jump = None
         self._log_follow_tail = True
@@ -844,9 +864,11 @@ class DashboardScreen(Screen[None]):
             and snap.log_task == self._pending_jump[0]
             and self._log_index is not None
         ):
-            _, pos = self._pending_jump
-            self._pending_jump = None
-            self._scroll_log_to(self._log_index.line_for_offset(pos))
+            # _scroll_log_to owns clearing the pending jump when the scroll
+            # lands (or the log is provably empty) — until then this block
+            # re-attempts on every tick, so a flush that outlives the retry
+            # chain delays the jump by ≤1s instead of losing it.
+            self._scroll_log_to(self._log_index.line_for_offset(self._pending_jump[1]))
 
         attention = self.query_one("#attention", RichLog)
         if snap.attention_reset:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -580,14 +580,71 @@ async def test_journal_jump_retry_recomputes_line_after_same_task_repaint(projec
         log.virtual_size = Size(80, 500)
         scrolls = []
         log.scroll_to = lambda *a, **kw: scrolls.append((a, kw))
+        finalizes = []
+        log.call_after_refresh = lambda cb, *a, **kw: finalizes.append(cb)
         captured[0]()  # the delayed retry fires
-        del log.scroll_to
         viewport = max(1, log.scrollable_content_region.height)
         expected = max(0, (fresh_line + 1) - viewport // 2)
         stale = max(0, (stale_line + 1) - viewport // 2)
         assert scrolls == [((), {"y": expected, "animate": False})]
         assert expected != stale  # the recompute is what moved the target
+        # the release rides the log's queue (stomp ordering) — still pending here
+        assert screen._pending_jump is not None and len(finalizes) == 1
+        finalizes[0]()  # the queued finalize fire re-scrolls and releases
+        del log.scroll_to, log.call_after_refresh
+        assert scrolls == [((), {"y": expected, "animate": False})] * 2
         assert screen._pending_jump is None  # landed: the jump is released
+
+
+async def test_journal_jump_release_survives_flush_scroll_end_stomp(project):
+    # The reveal flush replays a hidden RichLog's deferred writes: virtual_size
+    # grows synchronously (opening _scroll_log_to's height gate) but the
+    # flushed write's scroll_end is only *queued* via call_after_refresh.
+    # ScrollView.scroll_to applies immediately, so a fire in that window used
+    # to land, release the jump, and then get stomped to the tail by the
+    # queued scroll with nothing left to re-attempt — the win-py3.11 CI
+    # failure. The release now rides the same queue: the finalize fire drains
+    # after the stomp, re-scrolls to the recomputed target, then lets go.
+    # Deterministic: the finalize callback is captured and the stomp is
+    # replayed by hand between the immediate scroll and the finalize.
+    root = project.project
+    run_dir = make_run(root, "20260611-100000-aaaa", alive=True)
+    offsets = write_numbered_log(run_dir, "story-1")
+    journal = Journal(run_dir)
+    journal.set_active_log("story-1")
+    journal.append("session-start", task_id="story-1")
+    app = BmadLoopApp(root)
+    async with app.run_test() as pilot:
+        await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
+        screen = dashboard(app)
+        await until(pilot, lambda: screen.selected_run_id == "20260611-100000-aaaa")
+        await until(
+            pilot,
+            lambda: screen._displayed_log_task == "story-1" and screen._log_index is not None,
+        )
+        log = screen.query_one("#log", RichLog)
+        screen._pending_jump = ("story-1", offsets[100])
+        screen._log_follow_tail = False
+        # the flush just wrote (gate open) but its scroll_end is still queued
+        log.virtual_size = Size(80, 500)
+        scrolls = []
+        log.scroll_to = lambda *a, **kw: scrolls.append((a, kw))
+        finalizes = []
+        log.call_after_refresh = lambda cb, *a, **kw: finalizes.append(cb)
+        screen._scroll_log_to(attempts=0)
+        viewport = max(1, log.scrollable_content_region.height)
+        line = screen._log_index.line_for_offset(offsets[100])
+        expected = max(0, (line + 1) - viewport // 2)
+        assert scrolls == [((), {"y": expected, "animate": False})]  # landed...
+        assert screen._pending_jump is not None  # ...but the jump is not released
+        assert len(finalizes) == 1
+        # the queued flush scroll_end drains first and stomps to the tail
+        log.scroll_y = 400
+        finalizes[0]()  # FIFO on the log's pump: finalize fires after the stomp
+        del log.scroll_to, log.call_after_refresh
+        # the finalize fire re-scrolled to the recomputed target, then let go
+        assert scrolls == [((), {"y": expected, "animate": False})] * 2
+        assert screen._pending_jump is None  # only now is the jump released
 
 
 async def test_journal_enter_without_position_notifies(project):

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -123,9 +123,9 @@ async def until(pilot, condition, timeout: float = 10.0) -> None:
     The dashboard polls on a 1.0s interval and each tick hops through a thread
     worker and a UI callback, so several sequential waits can each need a few
     ticks; the timeout is generous and returns the instant the predicate holds.
-    Genuine stalls (an exclusive poll worker repeatedly superseded under heavy
-    CI IO before it applies a log jump) are handled by @pytest.mark.flaky on the
-    affected smoke tests, which re-rolls the race — see the journal-jump tests."""
+    A pending log jump survives skipped/starved ticks (each tick's _apply
+    re-attempts it until it lands), so waiting on its effect is deterministic —
+    no rerun markers needed on the journal-jump tests."""
     waited = 0.0
     while not condition():
         if waited >= timeout:
@@ -473,7 +473,6 @@ def write_numbered_log(run_dir: Path, task_id: str, count: int = 200) -> list[in
     return offsets
 
 
-@pytest.mark.flaky(reruns=2, reruns_delay=1)
 async def test_journal_enter_jumps_to_log_position(project):
     root = project.project
     run_dir = make_run(root, "20260611-100000-aaaa", alive=True)
@@ -500,6 +499,42 @@ async def test_journal_enter_jumps_to_log_position(project):
         assert "row 100" in log_text(screen)
 
 
+async def test_journal_jump_survives_exhausted_scroll_retry_chain(project):
+    # Regression for #178: the hidden #log pane defers its writes, and on a
+    # starved runner the flush can outlive _scroll_log_to's whole retry chain.
+    # The old code gave up silently and lost the jump forever; now the pending
+    # jump survives exhaustion and the next poll tick re-attempts it. Exhaust
+    # the chain deterministically (attempts=0 against the unflushed pane)
+    # instead of relying on a contended runner to starve it for real.
+    root = project.project
+    run_dir = make_run(root, "20260611-100000-aaaa", alive=True)
+    offsets = write_numbered_log(run_dir, "story-1")
+    journal = Journal(run_dir)
+    journal.set_active_log("story-1")
+    journal.append("session-start", task_id="story-1")
+    app = BmadLoopApp(root)
+    async with app.run_test() as pilot:
+        await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
+        screen = dashboard(app)
+        await until(pilot, lambda: screen.selected_run_id == "20260611-100000-aaaa")
+        # the poll renders the active log while #log is still hidden behind
+        # tab-journal, so its RichLog writes stay deferred (virtual_size 0)
+        await until(
+            pilot,
+            lambda: screen._displayed_log_task == "story-1" and screen._log_index is not None,
+        )
+        screen._pending_jump = ("story-1", offsets[100])
+        screen._log_follow_tail = False
+        screen._scroll_log_to(screen._log_index.line_for_offset(offsets[100]), attempts=0)
+        # chain exhausted against the unflushed pane: the jump must survive
+        assert screen._pending_jump is not None
+        screen.query_one("#tabs", TabbedContent).active = "tab-log"
+        await until(pilot, lambda: screen._pending_jump is None)  # a tick rescued it
+        log = screen.query_one("#log", RichLog)
+        assert 0 < log.scroll_y < log.max_scroll_y
+        assert "row 100" in log_text(screen)
+
+
 async def test_journal_enter_without_position_notifies(project):
     root = project.project
     run_dir = make_run(root, "20260611-100000-aaaa", alive=True)
@@ -517,7 +552,6 @@ async def test_journal_enter_without_position_notifies(project):
         assert screen.query_one("#tabs", TabbedContent).active == "tab-journal"
 
 
-@pytest.mark.flaky(reruns=2, reruns_delay=1)
 async def test_journal_jump_pins_other_sessions_log(project):
     root = project.project
     run_dir = make_run(root, "20260611-100000-aaaa", alive=True)
@@ -546,7 +580,6 @@ async def test_journal_jump_pins_other_sessions_log(project):
         assert "(pinned" not in log_text(screen)
 
 
-@pytest.mark.flaky(reruns=2, reruns_delay=1)
 async def test_journal_jump_near_tail_does_not_chase_growing_log(project):
     # Regression for "pressing enter keeps sending me to the bottom": jumping to
     # an entry near the end lands the view at the tail, and the old code then
@@ -574,12 +607,11 @@ async def test_journal_jump_near_tail_does_not_chase_growing_log(project):
         # scroll end" with scroll_y == max == 0, which would sample anchored=0 before
         # the deferred _scroll_log_to timer runs, then fail when the jump lands late).
         await until(pilot, lambda: log.max_scroll_y > 0 and log.is_vertical_scroll_end)
-        # The flush's own scroll_end can satisfy the wait while one deferred
-        # _scroll_log_to retry is still armed; post-flush that fire clamps to the
-        # tail and ends the chain, but landing after the growth-render below would
-        # re-scroll against the grown content. Drain it before sampling the anchor.
-        await pilot.pause(0.12)
-        assert log.is_vertical_scroll_end  # chain drained at the tail, not mid-log
+        # Wait for the jump to land (landing releases _pending_jump); after that
+        # the jump machinery is inert — armed retries abort on the cleared jump —
+        # so sampling the anchor is race-free even against the growth below.
+        await until(pilot, lambda: screen._pending_jump is None)
+        assert log.is_vertical_scroll_end  # landed at the tail, not mid-log
         anchored, base_max = log.scroll_y, log.max_scroll_y
         # the live session keeps writing; a poll repaints the pane
         with (run_dir / "logs" / "story-1.log").open("ab") as f:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -7,6 +7,7 @@ bindings drive modals into tui.launch calls (monkeypatched — no real tmux)."""
 
 from __future__ import annotations
 
+import dataclasses
 import os
 import tomllib
 from pathlib import Path
@@ -16,7 +17,7 @@ from conftest import install_bmad_config, write_sprint
 from rich.console import Console
 from rich.text import Text
 from textual.events import MouseMove
-from textual.geometry import Offset
+from textual.geometry import Offset, Size
 from textual.selection import Selection
 from textual.widgets import (
     Button,
@@ -525,7 +526,7 @@ async def test_journal_jump_survives_exhausted_scroll_retry_chain(project):
         )
         screen._pending_jump = ("story-1", offsets[100])
         screen._log_follow_tail = False
-        screen._scroll_log_to(screen._log_index.line_for_offset(offsets[100]), attempts=0)
+        screen._scroll_log_to(attempts=0)
         # chain exhausted against the unflushed pane: the jump must survive
         assert screen._pending_jump is not None
         screen.query_one("#tabs", TabbedContent).active = "tab-log"
@@ -533,6 +534,60 @@ async def test_journal_jump_survives_exhausted_scroll_retry_chain(project):
         log = screen.query_one("#log", RichLog)
         assert 0 < log.scroll_y < log.max_scroll_y
         assert "row 100" in log_text(screen)
+
+
+async def test_journal_jump_retry_recomputes_line_after_same_task_repaint(project):
+    # A delayed retry must not reuse the line captured when the chain was
+    # armed: a poll can repaint the same task's log mid-chain (history
+    # eviction advances LogIndex.render_base), shifting the line a byte
+    # offset maps to. The old code scrolled the stale line and cleared
+    # _pending_jump, silencing the fresher chain. Each fire now recomputes
+    # the line from the live index. Fully deterministic: the armed timer
+    # callback is captured and invoked by hand — no reveal, no tick race.
+    root = project.project
+    run_dir = make_run(root, "20260611-100000-aaaa", alive=True)
+    offsets = write_numbered_log(run_dir, "story-1")
+    journal = Journal(run_dir)
+    journal.set_active_log("story-1")
+    journal.append("session-start", task_id="story-1")
+    app = BmadLoopApp(root)
+    async with app.run_test() as pilot:
+        await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
+        screen = dashboard(app)
+        await until(pilot, lambda: screen.selected_run_id == "20260611-100000-aaaa")
+        await until(
+            pilot,
+            lambda: screen._displayed_log_task == "story-1" and screen._log_index is not None,
+        )
+        log = screen.query_one("#log", RichLog)
+        # arm one retry against the unflushed hidden pane, capturing its callback
+        captured = []
+        screen.set_timer = lambda delay, cb: captured.append(cb)
+        screen._pending_jump = ("story-1", offsets[100])
+        screen._log_follow_tail = False
+        screen._scroll_log_to(attempts=1)
+        del screen.set_timer
+        assert len(captured) == 1 and screen._pending_jump is not None
+        stale_line = screen._log_index.line_for_offset(offsets[100])
+        # same-task repaint mid-chain: history eviction shifts render_base,
+        # so the same offset now maps 7 lines earlier
+        screen._log_index = dataclasses.replace(
+            screen._log_index, render_base=screen._log_index.render_base + 7
+        )
+        fresh_line = screen._log_index.line_for_offset(offsets[100])
+        assert fresh_line == stale_line - 7
+        # open the height gate without a real Textual flush, record the scroll
+        log.virtual_size = Size(80, 500)
+        scrolls = []
+        log.scroll_to = lambda *a, **kw: scrolls.append((a, kw))
+        captured[0]()  # the delayed retry fires
+        del log.scroll_to
+        viewport = max(1, log.scrollable_content_region.height)
+        expected = max(0, (fresh_line + 1) - viewport // 2)
+        stale = max(0, (stale_line + 1) - viewport // 2)
+        assert scrolls == [((), {"y": expected, "animate": False})]
+        assert expected != stale  # the recompute is what moved the target
+        assert screen._pending_jump is None  # landed: the jump is released
 
 
 async def test_journal_enter_without_position_notifies(project):


### PR DESCRIPTION
## Problem

`test_journal_enter_jumps_to_log_position` kept flaking on Windows CI (latest: run 29626618672 on PR #160) — all three attempts (initial + 2 rerunfailures reruns) burned the full 10s wait identically. Root cause (#178): a same-task journal jump never set `_pending_jump`, so its only completion was `_scroll_log_to`'s 60×0.05s timer chain. The `#log` RichLog sits hidden in the inactive TabPane with its writes deferred; when the post-tab-switch flush outlived the 3s budget on a starved runner, the chain exhausted and **silently dropped the jump forever**. The deferred (cross-task) path had the same hole after handoff: `_apply` cleared `_pending_jump` before the scroll landed. Five prior patches (budget 1s→3s, rerun markers, PR #108's test-side de-flakes) widened or masked the window without removing it. Not upstream: Textual 8.2.8's changes are unrelated, and Textualize/textual#6311 is a different symptom.

## Fix — single-owner pending jump

- `_pending_jump` is set on **both** jump paths and cleared only by `_scroll_log_to` when the scroll actually lands (or the log is provably empty — cleared before the one-shot notify so per-tick retries can't spam it).
- `_apply` no longer pre-clears; its pending block re-attempts the scroll on every ≤1s poll tick, so a flush that outlives the chain delays the jump instead of losing it.
- The timer chain (now 20×0.05s = 1s) covers sub-second snappiness only. Each fire re-checks the jump **identity** (`is`) and the displayed task, so superseded/cancelled/stale chains abort instead of scrolling a re-rendered pane to an old target — this also closes a latent pane-flip stale-scroll bug.
- `action_unpin_log`: esc after a landed same-task jump now restores tail-follow (previously dead — nothing to unpin, `_log_follow_tail` stuck False).

## Tests

- Removed the three `@pytest.mark.flaky(reruns=2)` markers — with the root cause gone they'd only mask regressions of this fix; updated the stale `until()` docstring.
- Near-tail test: replaced the 0.12s late-fire drain with a deterministic wait for `_pending_jump is None` (with the fix, a starved jump lands *late* instead of vanishing, so the old drain could sample the anchor before a post-growth landing).
- New `test_journal_jump_survives_exhausted_scroll_retry_chain`: exhausts the chain deterministically (`attempts=0` against the unflushed hidden pane), asserts the jump survives, then proves a poll tick rescues it once the tab is revealed — reproduces the CI failure mode without needing a contended runner.

## Verification

- Full suite: 2407 passed, 1 skipped (`-n auto`).
- Determinism soak: 30× `pytest -k journal -p no:rerunfailures` — 30/30 green (note: the plugin name is `rerunfailures`; `-p no:flaky` is a no-op).
- `trunk check` clean.

Fixes #178


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved journal-to-log navigation so “jump” and “scroll to task” behavior reliably lands on the correct entry, even during delayed rendering and re-mapping.
  * Ensured pending navigation requests are retained until the UI confirms the scroll outcome (or determines it’s not possible).
  * Updated unpin behavior to better align with tail-following mode.

* **Tests**
  * Added regression tests covering navigation retry survival across skipped polling, delayed line recomputation, and flush-related scroll interruptions.
  * Reduced timing-dependent assertions to improve stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->