### PR TITLE
Copy bmad-review into isolated worktrees for merged-reviewer installs

### DIFF
--- a/src/bmad_loop/install.py
+++ b/src/bmad_loop/install.py
@@ -83,7 +83,13 @@ DEV_BASE_SKILLS = {
     "bmad-review-verification-gap": (),
 }
 # Every non-bundled skill that might need copying into an isolated worktree.
-BASE_SKILLS = dict(DEV_BASE_SKILLS)
+# bmad-review is the merged lens-based reviewer (BMAD-METHOD core-streamline):
+# on new bmm installs the three hunter IDs above are thin forwarders to it, so a
+# worktree must carry the real skill for those forwards to resolve. It is NOT in
+# DEV_BASE_SKILLS (preflight) so pre-merge bmm installs — which have the three
+# real hunters and no bmad-review — keep validating; provision_worktree skips
+# skills the main repo lacks, so copy-if-present is safe in both directions.
+BASE_SKILLS = {**DEV_BASE_SKILLS, "bmad-review": ()}
 
 # Stories mode (folder+id dispatch, BMAD-METHOD #2549) needs a *newer* bmad-dev-auto
 # than sprint mode: one whose step-01 routes a spec-folder + story-id invocation.


### PR DESCRIPTION
## What

Adds `bmad-review` to `BASE_SKILLS` in `install.py` so worktree provisioning copies it when present. One line plus an explanatory comment.

## Why

BMAD-METHOD's core-streamline branch (bmad-code-org/BMAD-METHOD#2603) merges the three hunter skills — `bmad-review-adversarial-general`, `bmad-review-edge-case-hunter`, `bmad-review-verification-gap` — into the lens-based `bmad-review` skill, leaving thin forwarder shims at the old IDs for compatibility.

Loop copies skills by ID into isolated worktrees. On a post-merge install, the three IDs resolve to forwarders; copying them without their target leaves review broken inside the worktree — the shim says "load bmad-review" and it isn't there.

## Compatibility

Safe in both directions:

- **Pre-merge installs** (three real hunters, no bmad-review): `provision_worktree` copies-if-present and skips absent skills; `bmad-review` is deliberately **not** added to `DEV_BASE_SKILLS`, so preflight keeps validating against the three real hunters.
- **Post-merge installs**: worktrees now carry the merged skill, so the forwarders resolve.

Should land before or with the core-streamline release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Isolated worktree setup now includes the `bmad-review` skill alongside existing development skills.
  * Missing `bmad-review` files are copied automatically during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
