### PR TITLE
fix(worktree): degrade post-merge teardown failures instead of crashing the run (#139)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,15 @@ PATH)`, the TUI notifies `multiplexer backend unavailable — launch/attach disa
 
 ### Fixed
 
+- **A failed worktree teardown no longer crashes the run after the merge landed (#139).** When a
+  process the just-ended session left running (e.g. pytest recreating `.pytest_cache`) makes
+  `git worktree remove` fail with ENOTEMPTY, git still drops its admin entry, so the `force=True`
+  retry failed with "is not a working tree" and that second `GitError` crashed the run. The
+  teardown tail of `close_unit_workspace` now degrades every `GitError` (worktree remove and branch
+  delete alike) to an `rmtree` + `worktree prune` fallback and a journaled
+  `worktree-teardown-degraded` event — teardown is post-merge housekeeping and never raises.
+  `discard_worktree` gains the same fallback so a stuck dir can't block the resume re-mount.
+
 - **A git call exceeding its timeout no longer crashes the whole run (#156).** Every git
   subprocess the orchestrator spawns now translates `subprocess.TimeoutExpired` into
   `GitError`, so the existing degrade guards handle a slow git like any other git failure.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,10 +174,13 @@ PATH)`, the TUI notifies `multiplexer backend unavailable — launch/attach disa
   process the just-ended session left running (e.g. pytest recreating `.pytest_cache`) makes
   `git worktree remove` fail with ENOTEMPTY, git still drops its admin entry, so the `force=True`
   retry failed with "is not a working tree" and that second `GitError` crashed the run. The
-  teardown tail of `close_unit_workspace` now degrades every `GitError` (worktree remove and branch
-  delete alike) to an `rmtree` + `worktree prune` fallback and a journaled
-  `worktree-teardown-degraded` event — teardown is post-merge housekeeping and never raises.
-  `discard_worktree` gains the same fallback so a stuck dir can't block the resume re-mount.
+  teardown tail of `close_unit_workspace` never raises now: a failed worktree removal falls back to
+  `rmtree` + `worktree prune` (the rmtree confined to the run's own worktrees dir — the path can
+  arrive from persisted state), a failed branch delete is reported and swallowed, and both journal a
+  `worktree-teardown-degraded` event — teardown is post-merge housekeeping. A failed forensic diff
+  capture instead preserves the worktree + branch (they hold the only copy of a dropped unit's
+  changes). `discard_worktree` gains the same removal fallback so a stuck dir can't block the
+  resume re-mount.
 
 - **A git call exceeding its timeout no longer crashes the whole run (#156).** Every git
   subprocess the orchestrator spawns now translates `subprocess.TimeoutExpired` into

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -690,7 +690,7 @@ class Engine:
             if task.phase == Phase.DONE and task.worktree_path:
                 wt = Path(task.worktree_path)
                 if wt.is_dir():
-                    discard_worktree(repo, task.worktree_path, task.branch)
+                    discard_worktree(repo, task.worktree_path, task.branch, run_dir=self.run_dir)
             elif task.terminal and task.worktree_path and Path(task.worktree_path).is_dir():
                 # kept on purpose (keep_failed): leave it, but surface where.
                 self.journal.append(
@@ -1247,7 +1247,9 @@ class Engine:
                 )
                 if isolated:
                     # drop the half-built worktree; _run_story mounts a fresh one
-                    discard_worktree(self.paths.repo_root, task.worktree_path, task.branch)
+                    discard_worktree(
+                        self.paths.repo_root, task.worktree_path, task.branch, run_dir=self.run_dir
+                    )
                     task.worktree_path = ""
                     task.branch = ""
                 elif task.baseline_commit:

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -566,6 +566,9 @@ class Engine:
                 delete_branch=scm.delete_branch,
                 detach_kept=scm.branch_per == "run",
                 diff_max_file_bytes=self._failed_diff_max_bytes(),
+                on_teardown_degraded=lambda msg: self.journal.append(
+                    "worktree-teardown-degraded", story_key=task.story_key, error=msg
+                ),
             )
             self.journal.append(
                 "unit-closed",
@@ -635,6 +638,9 @@ class Engine:
             run_dir=self.run_dir,
             unit_key=task.story_key,
             delete_branch=scm.delete_branch,
+            on_teardown_degraded=lambda msg: self.journal.append(
+                "worktree-teardown-degraded", story_key=task.story_key, error=msg
+            ),
         )
 
     def _keep_branch_and_escalate(self, task: StoryTask, unit: UnitWorkspace, reason: str) -> None:

--- a/src/bmad_loop/sweep.py
+++ b/src/bmad_loop/sweep.py
@@ -642,7 +642,9 @@ class SweepEngine(Engine):
             return True
         if isolated:
             # drop the half-built worktree; _run_story mounts a fresh one
-            discard_worktree(self.paths.repo_root, task.worktree_path, task.branch)
+            discard_worktree(
+                self.paths.repo_root, task.worktree_path, task.branch, run_dir=self.run_dir
+            )
             task.worktree_path = ""
             task.branch = ""
         elif task.baseline_commit:

--- a/src/bmad_loop/verify.py
+++ b/src/bmad_loop/verify.py
@@ -691,10 +691,13 @@ def worktree_prune(repo: Path) -> None:
     but since #156 `_git` can *raise* GitError on a timeout, which would bypass
     this never-raise contract (and the teardown degrade paths that lean on it —
     close_unit_workspace / discard_worktree call prune from inside their own
-    GitError guards). Swallow it here so the contract holds at its source."""
+    GitError guards). `subprocess.run` can also raise OSError outright (a spawn
+    failure — EMFILE, ENOMEM — happens before any return code exists), which the
+    #156 translation doesn't cover. Swallow both here so the contract holds at
+    its source."""
     try:
         _git(repo, "worktree", "prune")
-    except GitError:
+    except (GitError, OSError):
         pass
 
 

--- a/src/bmad_loop/verify.py
+++ b/src/bmad_loop/verify.py
@@ -687,8 +687,15 @@ def worktree_remove(repo: Path, path: Path, force: bool = False) -> None:
 
 def worktree_prune(repo: Path) -> None:
     """Drop administrative entries for worktrees whose directories are gone.
-    Best-effort housekeeping — never raises."""
-    _git(repo, "worktree", "prune")
+    Best-effort housekeeping — never raises. The return code is already ignored,
+    but since #156 `_git` can *raise* GitError on a timeout, which would bypass
+    this never-raise contract (and the teardown degrade paths that lean on it —
+    close_unit_workspace / discard_worktree call prune from inside their own
+    GitError guards). Swallow it here so the contract holds at its source."""
+    try:
+        _git(repo, "worktree", "prune")
+    except GitError:
+        pass
 
 
 def worktree_list(repo: Path) -> list[Path]:

--- a/src/bmad_loop/workspace.py
+++ b/src/bmad_loop/workspace.py
@@ -16,6 +16,8 @@ lives in the main repo and is passed separately — it never moves.
 
 from __future__ import annotations
 
+import shutil
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -121,6 +123,7 @@ def close_unit_workspace(
     delete_branch: bool = True,
     detach_kept: bool = False,
     diff_max_file_bytes: int | None = None,
+    on_teardown_degraded: Callable[[str], None] | None = None,
 ) -> Path | None:
     """Tear down (or preserve) a unit's worktree.
 
@@ -130,6 +133,15 @@ def close_unit_workspace(
     happens. On success (or failure without keep_failed) the worktree is removed
     and, if delete_branch, the branch deleted. Returns the patch path it wrote,
     or None.
+
+    Invariant: the teardown tail is post-merge/post-capture housekeeping — the
+    unit's content is already safe (merged on success, patch-captured on failure)
+    before it runs, so no git teardown failure escapes it. Every `GitError` from
+    the worktree removal or branch deletion degrades to a call of
+    on_teardown_degraded (given the failure message) instead of crashing the run;
+    a clean or force-retried removal is silent (see the teardown tail below). The
+    callback itself is the caller's (the engine's `journal.append`, whose OSError
+    is engine-wide journal semantics, deliberately unguarded here).
 
     detach_kept (branch_per=run only): when keep_failed preserves the worktree,
     detach its HEAD so the shared run branch it holds is freed for the next unit
@@ -173,13 +185,47 @@ def close_unit_workspace(
     # tree is clean, but force is harmless and tolerant of stray artifacts.
     try:
         verify.worktree_remove(unit.repo_root, unit.path, force=not success)
-    except verify.GitError:
-        verify.worktree_remove(unit.repo_root, unit.path, force=True)
-    if delete_branch and verify.branch_exists(unit.repo_root, unit.branch):
-        # the unit's content is already on the target branch (success) or saved
-        # to a patch (failure), so a force delete loses nothing — and squash
-        # merges leave the branch looking "unmerged" to `git branch -d`.
-        verify.delete_branch(unit.repo_root, unit.branch, force=True)
+    except verify.GitError as first_err:
+        try:
+            # Ordinary dirty-tree case: the plain remove refused stray untracked
+            # artifacts, which --force clears. Not a degradation — stay silent.
+            verify.worktree_remove(unit.repo_root, unit.path, force=True)
+        except verify.GitError as retry_err:
+            # gh-139 fingerprint the retry CAN'T fix: a process the just-ended
+            # session left running (e.g. pytest recreating `.pytest_cache`) makes
+            # the plain remove fail with ENOTEMPTY (first_err), and by then git has
+            # already deleted its admin entry `.git/worktrees/<id>` — so the --force
+            # retry fails with "is not a working tree" (retry_err). Force can't
+            # restore a dropped admin entry, so fall back to git's own reclaim path
+            # (plain rmtree + prune) and degrade to a warning: the content already
+            # landed, so this is housekeeping, not a run failure. Both git errors
+            # go into the message — each half of the fingerprint is diagnostic.
+            shutil.rmtree(unit.path, ignore_errors=True)
+            verify.worktree_prune(unit.repo_root)
+            msg = (
+                f"worktree remove failed for {unit.path} ({first_err}); "
+                f"force retry failed ({retry_err}); fell back to rmtree+prune"
+            )
+            if unit.path.exists():
+                # rmtree lost the race too (the writer recreated files under it):
+                # the dir survives under the gitignored run dir and is reclaimed
+                # later by trim_run_dir / clean — note it, don't block on it.
+                msg += f" (dir still present: {unit.path})"
+            if on_teardown_degraded is not None:
+                on_teardown_degraded(msg)
+    try:
+        if delete_branch and verify.branch_exists(unit.repo_root, unit.branch):
+            # the unit's content is already on the target branch (success) or saved
+            # to a patch (failure), so a force delete loses nothing — and squash
+            # merges leave the branch looking "unmerged" to `git branch -d`.
+            # prune above frees a branch whose worktree dir was rmtree'd, so this
+            # still runs after a degraded removal.
+            verify.delete_branch(unit.repo_root, unit.branch, force=True)
+    except verify.GitError as e:
+        # second crash door in this teardown tail: branch deletion is likewise
+        # post-merge housekeeping, so degrade it rather than raise past here.
+        if on_teardown_degraded is not None:
+            on_teardown_degraded(f"branch delete failed for {unit.branch}: {e}")
     return patch
 
 
@@ -192,7 +238,14 @@ def discard_worktree(repo_root: Path, worktree_path: str, branch: str) -> None:
             if wt.exists():
                 verify.worktree_remove(repo_root, wt, force=True)
         except verify.GitError:
-            pass
+            # same gh-139 hazard as close_unit_workspace: a stray process (or a
+            # dropped admin entry) can keep `git worktree remove` from clearing
+            # the dir. A leftover dir breaks the resume re-mount at this same path
+            # (`git worktree add` refuses a non-empty target), so drop to rmtree.
+            shutil.rmtree(wt, ignore_errors=True)
+        # prune git's admin entry regardless (harmless when nothing is stale) so a
+        # half-removed worktree can't block that re-mount.
+        verify.worktree_prune(repo_root)
     if branch:
         try:
             if verify.branch_exists(repo_root, branch):

--- a/src/bmad_loop/workspace.py
+++ b/src/bmad_loop/workspace.py
@@ -39,6 +39,27 @@ def unit_worktrees_dir(run_dir: Path) -> Path:
     return run_dir / WORKTREE_DIRNAME
 
 
+def _rmtree_confined(wt: Path, run_dir: Path) -> bool:
+    """rmtree `wt` only when it resolves to a strict descendant of this run's
+    worktrees dir; returns whether deletion was attempted. The teardown fallbacks
+    reach for rmtree with paths that can arrive from persisted task state
+    (`task.worktree_path` via discard_worktree and `_reopen_unit`), and rmtree —
+    unlike `git worktree remove` — performs no validation of its own, so a
+    corrupt or hand-edited state entry must not be able to point it at the repo
+    root or anywhere else outside the run's scaffolding (same doctrine as
+    runs.reconcile_orphan_worktrees / resolve_run_dir)."""
+    try:
+        root = unit_worktrees_dir(run_dir).resolve()
+        target = wt.resolve()
+        target.relative_to(root)
+    except (ValueError, OSError):
+        return False
+    if target == root:
+        return False
+    shutil.rmtree(target, ignore_errors=True)
+    return True
+
+
 @dataclass(frozen=True)
 class Workspace:
     root: Path  # where sessions run (cwd) and git operates
@@ -139,7 +160,10 @@ def close_unit_workspace(
     before it runs, so no git teardown failure escapes it. Every `GitError` from
     the worktree removal or branch deletion degrades to a call of
     on_teardown_degraded (given the failure message) instead of crashing the run;
-    a clean or force-retried removal is silent (see the teardown tail below). The
+    a clean or force-retried removal is silent (see the teardown tail below). A
+    failed diff *capture* breaks the tail's premise instead — the worktree would
+    then hold the only copy of the unit's changes — so it is reported the same
+    way but preserves the worktree + branch rather than tearing them down. The
     callback itself is the caller's (the engine's `journal.append`, whose OSError
     is engine-wide journal semantics, deliberately unguarded here).
 
@@ -153,19 +177,29 @@ def close_unit_workspace(
     """
     patch: Path | None = None
     if not success:
+        capture_err: verify.GitError | None = None
         try:
             diff = (
                 verify.capture_diff(unit.path, unit.baseline, max_file_bytes=diff_max_file_bytes)
                 if unit.baseline
                 else ""
             )
-        except verify.GitError:
+        except verify.GitError as e:
+            capture_err = e
             diff = ""
         if diff:
             patch = run_dir / "failed" / safe_segment(unit_key) / "changes.patch"
             patch.parent.mkdir(parents=True, exist_ok=True)
             patch.write_text(diff, encoding="utf-8")
-        if keep_failed:
+        if capture_err is not None and on_teardown_degraded is not None:
+            # the forensic patch is the only copy of a dropped unit's changes; a
+            # failed capture means the teardown below would destroy them, so the
+            # unit is preserved as if keep_failed (the `or` on the branch below).
+            on_teardown_degraded(
+                f"diff capture failed for {unit.path}: {capture_err}; "
+                "worktree and branch preserved (uncaptured changes)"
+            )
+        if keep_failed or capture_err is not None:
             if detach_kept:
                 # branch_per=run shares one branch across the run; a kept worktree
                 # left checked out on it blocks every later unit's `git worktree
@@ -200,13 +234,18 @@ def close_unit_workspace(
             # (plain rmtree + prune) and degrade to a warning: the content already
             # landed, so this is housekeeping, not a run failure. Both git errors
             # go into the message — each half of the fingerprint is diagnostic.
-            shutil.rmtree(unit.path, ignore_errors=True)
+            # The rmtree is confined to the run's worktrees dir: on resume the
+            # path comes from persisted state (_reopen_unit), which git validates
+            # but rmtree would not.
+            removed = _rmtree_confined(unit.path, run_dir)
             verify.worktree_prune(unit.repo_root)
             msg = (
                 f"worktree remove failed for {unit.path} ({first_err}); "
                 f"force retry failed ({retry_err}); fell back to rmtree+prune"
             )
-            if unit.path.exists():
+            if not removed:
+                msg += f" (rmtree refused: {unit.path} resolves outside this run's worktrees dir)"
+            elif unit.path.exists():
                 # rmtree lost the race too (the writer recreated files under it):
                 # the dir survives under the gitignored run dir and is reclaimed
                 # later by trim_run_dir / clean — note it, don't block on it.
@@ -229,9 +268,11 @@ def close_unit_workspace(
     return patch
 
 
-def discard_worktree(repo_root: Path, worktree_path: str, branch: str) -> None:
+def discard_worktree(repo_root: Path, worktree_path: str, branch: str, *, run_dir: Path) -> None:
     """Best-effort force teardown of a worktree + branch by path/name, for
-    resume-restart of a crashed/interrupted unit. Tolerant of partial state."""
+    resume-restart of a crashed/interrupted unit. Tolerant of partial state.
+    `worktree_path` arrives from persisted task state, so the rmtree fallback is
+    confined to `run_dir`'s worktrees dir (see _rmtree_confined)."""
     if worktree_path:
         wt = Path(worktree_path)
         try:
@@ -242,7 +283,7 @@ def discard_worktree(repo_root: Path, worktree_path: str, branch: str) -> None:
             # dropped admin entry) can keep `git worktree remove` from clearing
             # the dir. A leftover dir breaks the resume re-mount at this same path
             # (`git worktree add` refuses a non-empty target), so drop to rmtree.
-            shutil.rmtree(wt, ignore_errors=True)
+            _rmtree_confined(wt, run_dir)
         # prune git's admin entry regardless (harmless when nothing is stale) so a
         # half-removed worktree can't block that re-mount.
         verify.worktree_prune(repo_root)

--- a/tests/test_engine_worktree.py
+++ b/tests/test_engine_worktree.py
@@ -1050,14 +1050,18 @@ def test_close_dirty_tree_force_retry_is_not_degraded(project):
     assert reports == []  # NOT a degradation
 
 
-def test_close_deferred_without_keep_degrades(project):
+def test_close_deferred_without_keep_degrades(project, monkeypatch):
     """The DEFERRED, no-keep teardown (success=False) runs the same fallback chain:
     the patch is already captured, so a dropped admin entry degrades to a report
-    while the worktree is reclaimed via rmtree+prune — the run continues."""
+    while the worktree is reclaimed via rmtree+prune — the run continues. (In the
+    real gh-139 sequence capture runs before the remove drops the admin entry;
+    dropping it up front here would break capture too and flip the close into the
+    capture-failure preserve path, so pin capture to its real-life outcome.)"""
     from bmad_loop.workspace import close_unit_workspace
 
     unit, run_dir = _open_unit(project)
     _drop_admin_entry(project)
+    monkeypatch.setattr(verify, "capture_diff", lambda *a, **k: "")
 
     reports: list[str] = []
     close_unit_workspace(
@@ -1071,6 +1075,67 @@ def test_close_deferred_without_keep_degrades(project):
     assert not unit.path.exists()
     assert not branch_exists(project.project, unit.branch)
     assert len(reports) == 1 and "is not a working tree" in reports[0]
+
+
+def test_close_capture_failure_preserves_worktree_and_branch(project, monkeypatch):
+    """The teardown tail's premise is that a dropped unit's changes are already
+    patch-captured — a failed capture (e.g. a #156 git timeout) breaks it, and
+    tearing down anyway would destroy the only copy of the unit's work. The
+    close must instead preserve the worktree + branch (as if keep_failed) and
+    report the degradation."""
+    from bmad_loop.workspace import close_unit_workspace
+
+    unit, run_dir = _open_unit(project)
+
+    def boom(*a, **k):
+        raise verify.GitError("git diff timed out")
+
+    monkeypatch.setattr(verify, "capture_diff", boom)
+
+    reports: list[str] = []
+    patch = close_unit_workspace(
+        unit,
+        success=False,
+        keep_failed=False,
+        run_dir=run_dir,
+        unit_key="1-1-a",
+        on_teardown_degraded=reports.append,
+    )
+
+    assert patch is None
+    assert unit.path.exists()  # preserved: the worktree holds the only copy
+    assert branch_exists(project.project, unit.branch)
+    assert len(reports) == 1 and "diff capture failed" in reports[0]
+
+
+def test_close_capture_failure_frees_shared_branch(project, monkeypatch):
+    """branch_per=run: a worktree preserved by a failed capture holds the shared
+    run branch, which would collide with every later unit's mount (gh-138). The
+    detach_kept handling must apply to this preserve path exactly as it does to
+    keep_failed: HEAD detaches, so the branch is mountable elsewhere."""
+    from bmad_loop.workspace import close_unit_workspace
+
+    unit, run_dir = _open_unit(project, branch_per="run")
+
+    def boom(*a, **k):
+        raise verify.GitError("git diff timed out")
+
+    monkeypatch.setattr(verify, "capture_diff", boom)
+
+    close_unit_workspace(
+        unit,
+        success=False,
+        keep_failed=False,
+        run_dir=run_dir,
+        unit_key="1-1-a",
+        detach_kept=True,
+        on_teardown_degraded=lambda _msg: None,
+    )
+
+    assert unit.path.exists()  # preserved for recovery
+    # the shared branch is free again: a sibling worktree can mount it
+    sibling = run_dir / "worktrees" / "1-1-b"
+    verify.worktree_add(project.project, sibling, unit.branch, create=False)
 
 
 def test_close_notes_leftover_path_when_rmtree_loses_race(project, monkeypatch):
@@ -1134,13 +1199,65 @@ def test_discard_worktree_falls_back_to_rmtree_and_prunes(project):
     same path is free to re-mount on resume, without raising."""
     from bmad_loop.workspace import discard_worktree
 
-    unit, _ = _open_unit(project)
+    unit, run_dir = _open_unit(project)
     _drop_admin_entry(project)
 
-    discard_worktree(project.project, str(unit.path), unit.branch)  # no raise
+    discard_worktree(project.project, str(unit.path), unit.branch, run_dir=run_dir)  # no raise
 
     assert not unit.path.exists()  # rmtree reclaimed the stuck dir
     assert not branch_exists(project.project, unit.branch)  # pruned → deletable
+
+
+def test_discard_refuses_rmtree_outside_run_worktrees_dir(project, tmp_path):
+    """`task.worktree_path` arrives from persisted state (state.json), which can
+    be corrupt or hand-edited. git itself refuses to remove a dir that is not a
+    worktree — but that very refusal used to hand the path to the rmtree
+    fallback, which validates nothing. The fallback must decline any path that
+    does not resolve under this run's worktrees dir."""
+    from bmad_loop.workspace import discard_worktree
+
+    victim = tmp_path / "not-a-worktree"
+    victim.mkdir()
+    (victim / "precious.txt").write_text("do not delete\n")
+    run_dir = project.project / ".bmad-loop" / "runs" / "test-run"
+
+    discard_worktree(project.project, str(victim), "", run_dir=run_dir)  # no raise
+
+    assert (victim / "precious.txt").exists()  # confinement guard refused the rmtree
+
+
+def test_close_refuses_rmtree_outside_run_worktrees_dir(project, tmp_path):
+    """close_unit_workspace's rmtree fallback can receive a persisted path too
+    (_reopen_unit rebuilds the UnitWorkspace from task.worktree_path on resume).
+    A path outside the run's worktrees dir is never rmtree'd, and the degraded
+    report says the fallback was refused."""
+    from bmad_loop.workspace import UnitWorkspace, Workspace, close_unit_workspace
+
+    victim = tmp_path / "elsewhere"
+    victim.mkdir()
+    (victim / "precious.txt").write_text("do not delete\n")
+    run_dir = project.project / ".bmad-loop" / "runs" / "test-run"
+    unit = UnitWorkspace(
+        workspace=Workspace(root=victim, paths=project.rebased(victim)),
+        repo_root=project.project,
+        branch="bmad-loop/test-run/1-1-a",
+        path=victim,
+        baseline="",
+    )
+
+    reports: list[str] = []
+    close_unit_workspace(
+        unit,
+        success=True,
+        keep_failed=False,
+        run_dir=run_dir,
+        unit_key="1-1-a",
+        delete_branch=False,
+        on_teardown_degraded=reports.append,
+    )
+
+    assert (victim / "precious.txt").exists()  # confinement guard refused the rmtree
+    assert len(reports) == 1 and "rmtree refused" in reports[0]
 
 
 def test_engine_run_completes_when_worktree_remove_always_fails(project, monkeypatch):

--- a/tests/test_engine_worktree.py
+++ b/tests/test_engine_worktree.py
@@ -8,6 +8,8 @@ adapter (no tmux, no LLM).
 
 from __future__ import annotations
 
+import shutil
+
 from conftest import (
     _OK,
     _exists_run,
@@ -20,6 +22,7 @@ from conftest import (
     write_sprint,
 )
 
+from bmad_loop import verify
 from bmad_loop.adapters.base import SessionResult
 from bmad_loop.adapters.mock import MockAdapter
 from bmad_loop.engine import Engine
@@ -160,6 +163,8 @@ def test_worktree_happy_path_merges_to_target(project):
     assert worktree_clean(project.project)
     kinds = journal_kinds(engine)
     assert "worktree-opened" in kinds and "unit-merged" in kinds
+    # a clean teardown degrades nothing (gh-139): no warning event is emitted
+    assert "worktree-teardown-degraded" not in kinds
 
 
 def test_worktree_run_dir_is_outside_worktree(project):
@@ -943,6 +948,302 @@ def test_spec_file_serialized_relative_to_worktree():
     task.worktree_path = ""
     task.spec_file = "/repo/_out/spec.md"
     assert task.to_dict()["spec_file"] == "/repo/_out/spec.md"
+
+
+# ---------------------------------------------- gh-139 resilient teardown
+
+
+def _open_unit(project, key="1-1-a", branch_per="story"):
+    """Mount a real unit worktree (commits the sprint board first, like every
+    direct-open test) and return (unit, run_dir)."""
+    from bmad_loop.workspace import open_unit_workspace
+
+    commit_sprint(project, {key: "ready-for-dev"})
+    run_dir = project.project / ".bmad-loop" / "runs" / "test-run"
+    unit = open_unit_workspace(
+        project.project, project, "test-run", key, "main", branch_per, run_dir
+    )
+    return unit, run_dir
+
+
+def _drop_admin_entry(project):
+    """Delete git's worktree admin dir under the main repo, reproducing the
+    gh-139 post-ENOTEMPTY state where both `git worktree remove` calls fail with
+    'is not a working tree'. Exactly one linked worktree is open at call time."""
+    admin = list((project.project / ".git" / "worktrees").iterdir())
+    assert len(admin) == 1
+    shutil.rmtree(admin[0])
+
+
+def test_close_after_admin_entry_dropped_degrades_not_crashes(project):
+    """gh-139 fingerprint: a process the just-ended session left running keeps
+    `git worktree remove` from clearing the tree (ENOTEMPTY), and by then git has
+    already dropped its admin entry — so the force=True retry fails with 'is not a
+    working tree' and the second GitError used to crash the whole run after the
+    merge already landed. Teardown now degrades: rmtree+prune reclaim the dir, the
+    branch is still deleted, and the failure is reported, not raised."""
+    from bmad_loop.workspace import close_unit_workspace
+
+    unit, run_dir = _open_unit(project)
+    _drop_admin_entry(project)
+
+    reports: list[str] = []
+    close_unit_workspace(
+        unit,
+        success=True,
+        keep_failed=False,
+        run_dir=run_dir,
+        unit_key="1-1-a",
+        on_teardown_degraded=reports.append,
+    )
+
+    assert not unit.path.exists()  # rmtree reclaimed the stuck dir
+    assert not branch_exists(project.project, unit.branch)  # prune freed it → deleted
+    assert len(reports) == 1 and "is not a working tree" in reports[0]
+
+
+def test_close_degrades_when_branch_delete_fails(project, monkeypatch):
+    """The branch-delete tail is the second crash door: a `delete_branch` GitError
+    is degraded to a report, not raised, so a merged unit's run still completes."""
+    from bmad_loop.workspace import close_unit_workspace
+
+    unit, run_dir = _open_unit(project)
+
+    def boom(*a, **k):
+        raise verify.GitError("branch is checked out elsewhere")
+
+    monkeypatch.setattr(verify, "delete_branch", boom)
+
+    reports: list[str] = []
+    close_unit_workspace(
+        unit,
+        success=True,
+        keep_failed=False,
+        run_dir=run_dir,
+        unit_key="1-1-a",
+        on_teardown_degraded=reports.append,
+    )
+    assert not unit.path.exists()  # the worktree itself removed cleanly
+    assert len(reports) == 1 and "branch delete failed" in reports[0]
+
+
+def test_close_dirty_tree_force_retry_is_not_degraded(project):
+    """A stray untracked file makes the plain `git worktree remove` refuse; the
+    force=True retry clears it. That is the ordinary dirty-tree case, not a
+    degradation — no report is emitted and behavior matches today."""
+    from bmad_loop.workspace import close_unit_workspace
+
+    unit, run_dir = _open_unit(project)
+    (unit.path / "stray.txt").write_text("dirty\n")  # untracked → plain remove refuses
+
+    reports: list[str] = []
+    close_unit_workspace(
+        unit,
+        success=True,
+        keep_failed=False,
+        run_dir=run_dir,
+        unit_key="1-1-a",
+        on_teardown_degraded=reports.append,
+    )
+    assert not unit.path.exists()  # force retry handled the dirty tree
+    assert not branch_exists(project.project, unit.branch)
+    assert reports == []  # NOT a degradation
+
+
+def test_close_deferred_without_keep_degrades(project):
+    """The DEFERRED, no-keep teardown (success=False) runs the same fallback chain:
+    the patch is already captured, so a dropped admin entry degrades to a report
+    while the worktree is reclaimed via rmtree+prune — the run continues."""
+    from bmad_loop.workspace import close_unit_workspace
+
+    unit, run_dir = _open_unit(project)
+    _drop_admin_entry(project)
+
+    reports: list[str] = []
+    close_unit_workspace(
+        unit,
+        success=False,
+        keep_failed=False,
+        run_dir=run_dir,
+        unit_key="1-1-a",
+        on_teardown_degraded=reports.append,
+    )
+    assert not unit.path.exists()
+    assert not branch_exists(project.project, unit.branch)
+    assert len(reports) == 1 and "is not a working tree" in reports[0]
+
+
+def test_close_notes_leftover_path_when_rmtree_loses_race(project, monkeypatch):
+    """If the writing process recreates files faster than rmtree(ignore_errors)
+    can clear them, the dir survives the fallback. The degraded report then names
+    the leftover path — the dir lives under the gitignored run dir and is reclaimed
+    later by trim_run_dir / clean, so the run still continues."""
+    from bmad_loop import workspace
+    from bmad_loop.workspace import close_unit_workspace
+
+    unit, run_dir = _open_unit(project)
+    _drop_admin_entry(project)  # force both worktree_remove calls to fail
+    # rmtree loses the race: the dir survives the fallback (deterministic no-op)
+    monkeypatch.setattr(workspace.shutil, "rmtree", lambda *a, **k: None)
+
+    reports: list[str] = []
+    close_unit_workspace(
+        unit,
+        success=True,
+        keep_failed=False,
+        run_dir=run_dir,
+        unit_key="1-1-a",
+        on_teardown_degraded=reports.append,
+    )
+    assert unit.path.exists()  # the no-op rmtree left it in place
+    assert len(reports) == 1
+    assert str(unit.path) in reports[0] and "still present" in reports[0]
+
+
+def test_close_double_degradation_reports_both(project, monkeypatch):
+    """Both teardown doors can fail in one close: a dropped admin entry degrades
+    the worktree removal AND a raising delete_branch degrades the branch deletion.
+    Both are reported, in order (worktree first, branch second), no raise."""
+    from bmad_loop.workspace import close_unit_workspace
+
+    unit, run_dir = _open_unit(project)
+    _drop_admin_entry(project)
+
+    def boom(*a, **k):
+        raise verify.GitError("branch is checked out elsewhere")
+
+    monkeypatch.setattr(verify, "delete_branch", boom)
+
+    reports: list[str] = []
+    close_unit_workspace(
+        unit,
+        success=True,
+        keep_failed=False,
+        run_dir=run_dir,
+        unit_key="1-1-a",
+        on_teardown_degraded=reports.append,
+    )
+    assert len(reports) == 2
+    assert "fell back to rmtree+prune" in reports[0]  # worktree-remove degradation first
+    assert "branch delete failed" in reports[1]  # branch-delete degradation second
+
+
+def test_discard_worktree_falls_back_to_rmtree_and_prunes(project):
+    """Resume-restart discard: if `git worktree remove` can't clear a stale unit
+    worktree (gh-139-style dropped admin entry), fall back to rmtree + prune so the
+    same path is free to re-mount on resume, without raising."""
+    from bmad_loop.workspace import discard_worktree
+
+    unit, _ = _open_unit(project)
+    _drop_admin_entry(project)
+
+    discard_worktree(project.project, str(unit.path), unit.branch)  # no raise
+
+    assert not unit.path.exists()  # rmtree reclaimed the stuck dir
+    assert not branch_exists(project.project, unit.branch)  # pruned → deletable
+
+
+def test_engine_run_completes_when_worktree_remove_always_fails(project, monkeypatch):
+    """gh-139 end-to-end: with `git worktree remove` failing on every call, a
+    worktree-isolation run still merges the unit to the target and reaches
+    run-complete — teardown degrades to a journaled warning instead of crashing
+    the run after the work already landed."""
+    commit_sprint(project, {"1-1-a": "ready-for-dev"})
+    head_before = rev_parse_head(project.project)
+
+    def always_fail(*a, **k):
+        raise verify.GitError("worktree remove boom")
+
+    monkeypatch.setattr(verify, "worktree_remove", always_fail)
+
+    engine, _ = make_engine(
+        project,
+        [wt_dev_effect(project, "1-1-a"), wt_review_effect(project, "1-1-a", clean=True)],
+    )
+    summary = engine.run()
+
+    assert summary.done == 1 and not summary.paused and not summary.crashed
+    # the merge still landed on the target branch (main, checked out in the repo)
+    assert rev_parse_head(project.project) != head_before
+    assert "change for 1-1-a" in (project.project / "src.txt").read_text()
+    # admin entry is INTACT here (only the remove call fails), so prune's
+    # branch-freeing is load-bearing: after rmtree+prune the branch is deletable
+    assert not branch_exists(project.project, "bmad-loop/test-run/1-1-a")
+    kinds = journal_kinds(engine)
+    assert "unit-merged" in kinds and "run-complete" in kinds
+    assert "worktree-teardown-degraded" in kinds
+
+
+def test_engine_deferred_teardown_degrades_are_journaled(project, monkeypatch):
+    """The DEFERRED (no-keep) close site must wire on_teardown_degraded too: with
+    `git worktree remove` always failing, the deferral still finishes and its
+    teardown degradation is journaled — so dropping the kwarg from the deferral
+    call site would be caught here (only the success path is asserted E2E above)."""
+
+    commit_sprint(project, {"1-1-a": "ready-for-dev"})
+
+    def always_fail(*a, **k):
+        raise verify.GitError("worktree remove boom")
+
+    monkeypatch.setattr(verify, "worktree_remove", always_fail)
+
+    engine, _ = make_engine(
+        project,
+        _defer_script(project, "1-1-a"),
+        policy=wt_policy(keep_failed=False, limits=_NO_DAMP),
+    )
+    summary = engine.run()
+
+    assert summary.deferred == 1 and not summary.paused
+    assert "worktree-teardown-degraded" in journal_kinds(engine)
+
+
+def test_resume_remount_survives_discard_remove_failure(project, monkeypatch):
+    """The discard fallback's prune is load-bearing: if `git worktree remove` can't
+    clear a stale unit worktree on resume-restart (admin entry INTACT — the dir is
+    stuck, not the entry), rmtree drops the dir but only the prune clears git's
+    admin entry so `git worktree add` can re-mount at the same path. Without the
+    prune the re-mount would collide and the unit would defer instead of finishing."""
+    from bmad_loop.workspace import open_unit_workspace
+
+    commit_sprint(project, {"1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(project, [wt_dev_effect(project, "1-1-a")])
+    unit = open_unit_workspace(
+        project.project, project, "test-run", "1-1-a", "main", "story", engine.run_dir
+    )
+    task = StoryTask("1-1-a", 1)
+    engine.state.tasks["1-1-a"] = task
+    task.phase = Phase.DEV_RUNNING
+    task.worktree_path = str(unit.path)
+    task.branch = unit.branch
+    task.baseline_commit = unit.baseline
+    engine._save()
+
+    # `git worktree remove` always fails, admin entry left intact → only
+    # worktree_prune can free the path for the resume re-mount
+    def always_fail(*a, **k):
+        raise verify.GitError("worktree remove boom")
+
+    monkeypatch.setattr(verify, "worktree_remove", always_fail)
+
+    state = load_state(engine.run_dir)
+    state.clear_pause()
+    adapter = MockAdapter(
+        [wt_dev_effect(project, "1-1-a"), wt_review_effect(project, "1-1-a", clean=True)]
+    )
+    resumed = Engine(
+        paths=project,
+        policy=wt_policy(),
+        adapter=adapter,
+        run_dir=engine.run_dir,
+        journal=engine.journal,
+        state=state,
+    )
+    summary = resumed.run()
+
+    assert summary.done == 1  # re-mounted at the same path and finished
+    assert "change for 1-1-a" in (project.project / "src.txt").read_text()
+    assert "worktree-open-failed" not in journal_kinds(resumed)
 
 
 def test_spec_file_serialized_with_posix_separators():

--- a/tests/test_verify_worktree.py
+++ b/tests/test_verify_worktree.py
@@ -95,6 +95,19 @@ def test_worktree_prune_swallows_git_error(project, monkeypatch):
     verify.worktree_prune(project.project)  # returns without raising
 
 
+def test_worktree_prune_swallows_os_error(project, monkeypatch):
+    """`subprocess.run` can raise OSError outright (a spawn failure — EMFILE,
+    ENOMEM — happens before any return code exists), which #156's timeout
+    translation doesn't cover. prune's never-raise contract must hold for it
+    too — its callers invoke it from inside `except GitError` guards."""
+
+    def boom(*a, **k):
+        raise OSError("spawn failed")
+
+    monkeypatch.setattr(verify, "_git", boom)
+    verify.worktree_prune(project.project)  # returns without raising
+
+
 def test_checkout_detach_frees_branch(project, tmp_path):
     """A worktree checked out on a branch holds that branch — git refuses to mount
     it elsewhere. Detaching the worktree's HEAD frees the branch name for a sibling

--- a/tests/test_verify_worktree.py
+++ b/tests/test_verify_worktree.py
@@ -82,6 +82,19 @@ def test_worktree_remove_dirty_needs_force(project, tmp_path):
     assert not wt.exists()
 
 
+def test_worktree_prune_swallows_git_error(project, monkeypatch):
+    """worktree_prune is best-effort and must never raise — the teardown degrade
+    paths (close_unit_workspace / discard_worktree) call it from inside their own
+    GitError guards. Since #156 `_git` can *raise* GitError on a timeout, so prune
+    must swallow it, not merely ignore the return code (gh-139)."""
+
+    def boom(*a, **k):
+        raise verify.GitError("git worktree prune timed out")
+
+    monkeypatch.setattr(verify, "_git", boom)
+    verify.worktree_prune(project.project)  # returns without raising
+
+
 def test_checkout_detach_frees_branch(project, tmp_path):
     """A worktree checked out on a branch holds that branch — git refuses to mount
     it elsewhere. Detaching the worktree's HEAD frees the branch name for a sibling


### PR DESCRIPTION
Fixes #139.

## Problem

A process left running by a just-ended session (for the reporter: pytest recreating `.pytest_cache`) can make the plain `git worktree remove` in `close_unit_workspace` fail with ENOTEMPTY. Git has by then already deleted its admin entry `.git/worktrees/<id>`, so the bare `force=True` retry fails with "is not a working tree" — and that second `GitError` propagated uncaught, crashing the whole run *after* `unit-merged` had already landed the work. `delete_branch` in the same tail was a second uncaught crash door.

## Fix

Teardown after a merge (or after a failed unit's patch capture) is housekeeping — the unit's content is already safe — so the teardown tail now never lets a `GitError` escape:

- **`close_unit_workspace`**: plain remove → `force=True` retry → fall back to `shutil.rmtree(ignore_errors=True)` + `git worktree prune` (the shape already proven in `reconcile_orphan_worktrees`). The degraded message carries **both** git errors — the ENOTEMPTY text and the "is not a working tree" fingerprint — plus a note if the dir survived the race. Branch deletion degrades the same way. A force-retry that succeeds (ordinary dirty tree) stays silent, as today.
- **Observability**: degradations surface through a new `on_teardown_degraded` callback (keeps `workspace.py` decoupled from run state); the engine journals them as `worktree-teardown-degraded` with the story key, on both the post-merge and DEFERRED close paths.
- **`discard_worktree`** gains the same rmtree fallback + prune so a stuck dir can't block the resume re-mount at the same path.
- **`verify.worktree_prune`** now honors its documented "never raises" contract: since #156, `_run_git` translates git timeouts into a *raised* `GitError`, which could have crashed straight through the new fallback (and through a pre-existing unguarded prune in engine teardown). It now swallows `GitError` at the source.

The deeper race itself — the session's process tree outliving teardown (issue's "bug 1") — is deliberately out of scope; this PR turns that class of race into a journaled warning, per the issue's own analysis.

## Tests

10 new tests against real git in `test_engine_worktree.py` / `test_verify_worktree.py`:

- the exact #139 fingerprint (admin entry dropped → both removes fail) degrades, reclaims the dir, still deletes the branch
- end-to-end: `worktree_remove` always failing → run reaches `run-complete`, merge landed, branch freed, `worktree-teardown-degraded` journaled — on both the success and DEFERRED paths
- resume re-mounts through the discard fallback with the admin entry *intact* (the case where the prune is load-bearing)
- double degradation in one teardown (remove + branch delete), ordered
- dirty-tree force-retry emits no event (behavior unchanged)
- `worktree_prune` returns cleanly when `_git` raises

Full suite: 2426 passed, 1 skipped. `trunk check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved resilience of Git worktree teardown/cleanup when admin state is missing, branches can’t be deleted, or capture diffs fail.
  - Added a best-effort fallback cleanup that prunes stale Git worktree state and safely removes leftover paths without crashing teardown.
  - Added degraded-mode journal reporting and ensured cleanup is confined to the run’s worktrees directory.
- **Tests**
  - Expanded teardown-resilience coverage (including race conditions and resume/remount recovery) and added assertions for degraded vs. clean behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->