### PR TITLE
fix(teardown): wait for the session's process tree before worktree teardown (#183)

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -144,7 +144,7 @@ See [README.md](../README.md) for the narrative overview and [setup-guide.md](se
 
 - Single policy file written by `init`, snapshotted at run start (applies to new runs and resumes; editable live from the TUI).
 - Sections: `[gates]`, `[limits]`, `[verify]`, `[notify]`, `[review]`, `[adapter]` (+ per-stage), `[sweep]`, `[scm]` (worktree isolation + merge-back), `[cleanup]` (run-dir retention + disk reclamation), `[plugins]` (trust allowlist + per-plugin `[plugins.<name>]` config — e.g. the opt-in game-engine layer via `[plugins.unity]`, off by default), `[tui]` (`low_frame_rate` for slow/SSH links; persisted dashboard pane sizes).
-- Tunable limits: `max_review_cycles`, `max_dev_attempts`, `max_followup_reviews`, `session_timeout_min`, `git_timeout_s`, `teardown_grace_s`, `stop_without_result_nudges`, `dev_stall_grace_s`, `dev_stall_nudges`, `dev_stall_nudges_cap`, `workflow_stall_nudges_cap`, `max_tokens_per_story`.
+- Tunable limits: `max_review_cycles`, `max_dev_attempts`, `max_followup_reviews`, `session_timeout_min`, `git_timeout_s`, `teardown_grace_s` (one shared budget bounding the verified window kill _and_ the follow-on reap of any straggler descendant the session detached — e.g. a `setsid` background writer — combined; whatever remains after the window dies is what the straggler reap gets, before the worktree is merged and removed), `stop_without_result_nudges`, `dev_stall_grace_s`, `dev_stall_nudges`, `dev_stall_nudges_cap`, `workflow_stall_nudges_cap`, `max_tokens_per_story`.
 
 ### TUI dashboard
 

--- a/src/bmad_loop/adapters/generic.py
+++ b/src/bmad_loop/adapters/generic.py
@@ -22,18 +22,22 @@ import json
 import shlex
 import time
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from .. import devcontract, gates, runs
 from ..bmadconfig import ProjectPaths
 from ..journal import LOGS_DIR
 from ..model import TokenUsage
 from ..policy import Policy
-from ..process_host import get_process_host
+from ..process_host import ProcessHostError, get_process_host
 from ..signals import SignalWatcher
 from ..tokens import read_usage as tally_usage
 from .base import CodingCLIAdapter, SessionHandle, SessionResult, SessionSpec
 from .multiplexer import MultiplexerError, TerminalMultiplexer, get_multiplexer
 from .profile import CLIProfile
+
+if TYPE_CHECKING:
+    from ..process_host import ProcessHost
 
 # Pane geometry for agent windows; mirrored in tui.data for log emulation.
 PANE_COLUMNS = 220
@@ -690,40 +694,130 @@ class GenericAdapter(_ResultFileMixin, CodingCLIAdapter):
         self.mux.send_text(handle.native_id, text)
 
     def kill(self, handle: SessionHandle) -> None:
-        # First strike stays the plain best-effort window kill; everything below
-        # verifies it landed. teardown_grace_s = 0 restores this line alone.
-        self.mux.kill_window(handle.native_id)
         grace = float(self.policy.limits.teardown_grace_s)
         if grace <= 0:
+            # Legacy single strike: no harvest, no wait, no pid reads. grace 0 is the
+            # documented opt-out — teardown stays exactly today's best-effort kill.
+            self.mux.kill_window(handle.native_id)
             return
+        try:
+            host = get_process_host()
+        except ProcessHostError:
+            # An explicit-but-bogus BMAD_LOOP_PROCESS_HOST override raises loudly
+            # (deliberate doctrine — never silently mis-signal). But the lookup now
+            # precedes the first strike, so the window must not be left alive behind
+            # the raise: strike once (today's teardown), then re-raise.
+            self.mux.kill_window(handle.native_id)
+            raise
+        # Harvest the pane roots AND their whole descendant tree NOW, while the
+        # window is provably alive, stamping a pid-reuse identity per member. This
+        # pre-kill snapshot is load-bearing (#183): once the window dies a detached
+        # straggler (setsid, a double-fork survivor) reparents to init and is no
+        # longer reachable from the pane pids, and a late-read pid risks reuse — so
+        # every destructive strike below is identity-guarded via alive_and_ours,
+        # never a bare pid. The snapshot is a point-in-time read: a process that
+        # detached (double-fork/setsid) BEFORE the harvest — or in the TOCTOU window
+        # AFTER it, before/around kill_window — has no pane-pid ancestor to be found
+        # by, so it is out of reach by construction (accepted, documented #183 limit).
+        # An empty list = the backend offers no pids (herdr) → degrade to the window
+        # kill alone.
+        tree: dict[int, float | None] = {}
+        for pid in self.mux.window_pane_pids(handle.native_id):
+            tree.setdefault(pid, host.identity(pid))
+            for child in host.descendants(pid):
+                tree.setdefault(child, host.identity(child))
+        # First strike stays the plain best-effort window kill; everything below
+        # verifies it landed and chases the harvested tree.
+        self.mux.kill_window(handle.native_id)
         deadline = time.monotonic() + grace
         while True:
             try:
-                if not self._window_alive(handle):
-                    return  # normal case: dead on the first probe
+                dead = not self._window_alive(handle)
             except MultiplexerError:
-                pass  # transport hiccup — liveness unknown this tick, keep polling
+                dead = False  # transport hiccup — liveness unknown this tick, keep polling
+            if dead:
+                # Window died within grace (the normal case): reap any harvested
+                # straggler that outlived the pane pgid, sharing this deadline.
+                self._reap_straggler_tree(handle, host, tree, deadline)
+                return
             if time.monotonic() >= deadline:
                 break
             time.sleep(KILL_POLL_S)
-        # The window outlived the grace: the kill was ignored (a wedged CLI, a
-        # shell that trapped the hangup). Harvest the pane pids NOW, while the
-        # window is provably still alive, so a reused pid can never be signalled.
-        # [] = capability not offered / unknown — degrade to the re-kill alone.
-        pids = self.mux.window_pane_pids(handle.native_id)
-        self._note_lifecycle(handle.task_id, "kill-escalated", pids=pids)
-        host = get_process_host()
-        for pid in pids:
+        # The window outlived the grace: the kill was ignored (a wedged CLI, a shell
+        # that trapped the hangup). Re-read the pane pids (freshest view; the live
+        # Popen-free window pins them, so they are safe to force-kill directly) and
+        # force-kill them, plus every harvested descendant still alive-and-ours. The
+        # descendant force-kill is identity-guarded AND skips members with no recorded
+        # identity: alive_and_ours(pid, None) degrades to bare is_alive, so a reused
+        # pid would pass — the ProcessHost contract forbids force-killing it, exactly
+        # like the clean-path reap below. Then re-strike the window.
+        repane = self.mux.window_pane_pids(handle.native_id)
+        self._note_lifecycle(handle.task_id, "kill-escalated", pids=repane)
+        for pid in repane:
             try:
                 host.force_kill(pid)
             except Exception:  # noqa: BLE001  # nosec B110 - already-gone races are fine
                 pass
+        for pid, identity in tree.items():
+            if pid not in repane and identity is not None and host.alive_and_ours(pid, identity):
+                try:
+                    host.force_kill(pid)
+                except Exception:  # noqa: BLE001  # nosec B110 - already-gone races are fine
+                    pass
         self.mux.kill_window(handle.native_id)
         try:
             alive: bool | None = self._window_alive(handle)
         except MultiplexerError:
             alive = None  # unknown is not dead — record it honestly
         self._note_lifecycle(handle.task_id, "kill-outcome", alive=alive, escalated=True)
+
+    def _reap_straggler_tree(
+        self,
+        handle: SessionHandle,
+        host: ProcessHost,
+        tree: dict[int, float | None],
+        deadline: float,
+    ) -> None:
+        """Reap harvested straggler pids the window death left behind — a
+        setsid/double-fork survivor escapes the pane pgid, so the window's death is
+        not the tree's. Filter to still-alive-and-ours members, then terminate →
+        poll → force-kill within the SAME grace ``deadline`` (one budget, two
+        phases): terminate first so a mid-write process can flush before SIGKILL. A
+        member whose recorded identity is None is unconfirmable (a possible reuse),
+        so it is polled via the bare-liveness degrade but NEVER force-killed. No
+        survivors → silent return: the clean-end path leaves no breadcrumb."""
+        survivors = [pid for pid, identity in tree.items() if host.alive_and_ours(pid, identity)]
+        if not survivors:
+            return
+        self._note_lifecycle(handle.task_id, "straggler-reap", pids=survivors)
+        for pid in survivors:
+            try:
+                host.terminate(pid)
+            except OSError:
+                pass  # already-gone race — the poll below settles it
+        while True:
+            survivors = [
+                pid for pid, identity in tree.items() if host.alive_and_ours(pid, identity)
+            ]
+            if not survivors or time.monotonic() >= deadline:
+                break
+            time.sleep(KILL_POLL_S)
+        forced: list[int] = []
+        for pid in survivors:
+            if tree[pid] is None:
+                continue  # unconfirmable identity: refuse to force-kill a possible reuse
+            try:
+                host.force_kill(pid)
+                forced.append(pid)
+            except Exception:  # noqa: BLE001  # nosec B110 - already-gone races are fine
+                pass
+        unreaped = [pid for pid, identity in tree.items() if host.alive_and_ours(pid, identity)]
+        # Distinct field name (`unreaped`, a pid list) from the wedged branch's
+        # `alive` (bool|None): reusing `alive` for both would give one key an
+        # unstable type across kill-outcome lines — a footgun for jsonl tailers.
+        self._note_lifecycle(
+            handle.task_id, "kill-outcome", reaped=True, forced=forced, unreaped=unreaped
+        )
 
     def _sample_weighted_usage(self, transcript_path: str, spec: SessionSpec) -> int | None:
         """Cumulative weighted spend of the live session's transcript, or None

--- a/src/bmad_loop/adapters/generic.py
+++ b/src/bmad_loop/adapters/generic.py
@@ -721,8 +721,10 @@ class GenericAdapter(_ResultFileMixin, CodingCLIAdapter):
         # by, so it is out of reach by construction (accepted, documented #183 limit).
         # An empty list = the backend offers no pids (herdr) → degrade to the window
         # kill alone.
-        # Descendant identities ride along from the enumeration itself (the same
-        # /proc read / psutil Process object — no post-hoc stamp to race a reuse);
+        # Descendant identities ride along from the enumeration itself — the same
+        # /proc read (Linux) or the same psutil Process object, revalidated against
+        # its construction-bound ident (macOS/win32), so no post-hoc stamp can race
+        # a reuse;
         # only the pane ROOT is stamped separately, which is safe: the live window
         # pins the root pid until kill_window below, so it cannot be recycled here.
         tree: dict[int, float | None] = {}

--- a/src/bmad_loop/adapters/generic.py
+++ b/src/bmad_loop/adapters/generic.py
@@ -721,11 +721,15 @@ class GenericAdapter(_ResultFileMixin, CodingCLIAdapter):
         # by, so it is out of reach by construction (accepted, documented #183 limit).
         # An empty list = the backend offers no pids (herdr) → degrade to the window
         # kill alone.
+        # Descendant identities ride along from the enumeration itself (the same
+        # /proc read / psutil Process object — no post-hoc stamp to race a reuse);
+        # only the pane ROOT is stamped separately, which is safe: the live window
+        # pins the root pid until kill_window below, so it cannot be recycled here.
         tree: dict[int, float | None] = {}
         for pid in self.mux.window_pane_pids(handle.native_id):
             tree.setdefault(pid, host.identity(pid))
-            for child in host.descendants(pid):
-                tree.setdefault(child, host.identity(child))
+            for child, identity in host.descendants(pid).items():
+                tree.setdefault(child, identity)
         # First strike stays the plain best-effort window kill; everything below
         # verifies it landed and chases the harvested tree.
         self.mux.kill_window(handle.native_id)
@@ -780,37 +784,48 @@ class GenericAdapter(_ResultFileMixin, CodingCLIAdapter):
     ) -> None:
         """Reap harvested straggler pids the window death left behind — a
         setsid/double-fork survivor escapes the pane pgid, so the window's death is
-        not the tree's. Filter to still-alive-and-ours members, then terminate →
-        poll → force-kill within the SAME grace ``deadline`` (one budget, two
-        phases): terminate first so a mid-write process can flush before SIGKILL. A
-        member whose recorded identity is None is unconfirmable (a possible reuse),
-        so it is polled via the bare-liveness degrade but NEVER force-killed. No
-        survivors → silent return: the clean-end path leaves no breadcrumb."""
-        survivors = [pid for pid, identity in tree.items() if host.alive_and_ours(pid, identity)]
-        if not survivors:
-            return
-        self._note_lifecycle(handle.task_id, "straggler-reap", pids=survivors)
-        for pid in survivors:
-            try:
-                host.terminate(pid)
-            except OSError:
-                pass  # already-gone race — the poll below settles it
-        while True:
-            survivors = [
-                pid for pid, identity in tree.items() if host.alive_and_ours(pid, identity)
+        not the tree's. Filter to still-alive-and-ours identity-CONFIRMED members,
+        then terminate → poll → force-kill within the SAME grace ``deadline`` (one
+        budget, two phases): terminate first so a mid-write process can flush
+        before SIGKILL. A member whose recorded identity is None is unconfirmable
+        (a possible reuse), so it is never signalled AT ALL — not terminated, not
+        polled against the deadline, not force-killed; even a SIGTERM to a recycled
+        pid kills an innocent process. It only surfaces in the ``unreaped`` field
+        via the bare-liveness degrade. Nothing alive at all → silent return: the
+        clean-end path leaves no breadcrumb."""
+
+        def _confirmed_survivors() -> list[int]:
+            return [
+                pid
+                for pid, identity in tree.items()
+                if identity is not None and host.alive_and_ours(pid, identity)
             ]
-            if not survivors or time.monotonic() >= deadline:
-                break
-            time.sleep(KILL_POLL_S)
+
+        survivors = _confirmed_survivors()
+        unconfirmed = [
+            pid for pid, identity in tree.items() if identity is None and host.is_alive(pid)
+        ]
+        if not survivors and not unconfirmed:
+            return
         forced: list[int] = []
-        for pid in survivors:
-            if tree[pid] is None:
-                continue  # unconfirmable identity: refuse to force-kill a possible reuse
-            try:
-                host.force_kill(pid)
-                forced.append(pid)
-            except Exception:  # noqa: BLE001  # nosec B110 - already-gone races are fine
-                pass
+        if survivors:
+            self._note_lifecycle(handle.task_id, "straggler-reap", pids=survivors)
+            for pid in survivors:
+                try:
+                    host.terminate(pid)
+                except OSError:
+                    pass  # already-gone race — the poll below settles it
+            while True:
+                survivors = _confirmed_survivors()
+                if not survivors or time.monotonic() >= deadline:
+                    break
+                time.sleep(KILL_POLL_S)
+            for pid in survivors:
+                try:
+                    host.force_kill(pid)
+                    forced.append(pid)
+                except Exception:  # noqa: BLE001  # nosec B110 - already-gone races are fine
+                    pass
         unreaped = [pid for pid, identity in tree.items() if host.alive_and_ours(pid, identity)]
         # Distinct field name (`unreaped`, a pid list) from the wedged branch's
         # `alive` (bool|None): reusing `alive` for both would give one key an

--- a/src/bmad_loop/adapters/opencode_http.py
+++ b/src/bmad_loop/adapters/opencode_http.py
@@ -93,7 +93,7 @@ from ..bmadconfig import ProjectPaths
 from ..journal import LOGS_DIR
 from ..model import TokenUsage
 from ..policy import Policy
-from ..process_host import get_process_host
+from ..process_host import ProcessHostError, get_process_host
 from .base import CodingCLIAdapter, SessionHandle, SessionResult, SessionSpec
 from .generic import (
     BUDGET_NUDGE_TEXT,
@@ -991,15 +991,33 @@ class OpencodeHttpAdapter(_ResultFileMixin, CodingCLIAdapter):
         process = sess.process
         if process.poll() is not None:
             return
-        host = get_process_host()
-        # Harvest the server's descendant tree + pid-reuse identities BEFORE the
-        # first signal, while the tree is intact (#183): a tool subprocess the
-        # server detached (setsid, a double-fork) outlives the root's SIGTERM and
-        # would keep writing into the worktree the engine is about to merge/remove.
-        # Post-kill it reparents to init and is unreachable, so snapshot it now; the
-        # reap below is identity-guarded via alive_and_ours, never a bare (reusable)
-        # pid. [] = no descendants / psutil absent → the root ladder alone, as before.
-        tree = {pid: host.identity(pid) for pid in host.descendants(process.pid)}
+        try:
+            host = get_process_host()
+        except ProcessHostError:
+            # An explicit-but-bogus BMAD_LOOP_PROCESS_HOST override raises loudly
+            # (deliberate doctrine — never silently mis-signal). But the lookup
+            # precedes the first signal, so the server must not be left alive
+            # behind the raise: one legacy Popen root strike (no host → no tree
+            # kill; the win32 kill() reaps only the .cmd wrapper — an accepted
+            # degrade on a loud config error), then re-raise. Mirrors the tmux
+            # adapter's kill().
+            try:
+                if sys.platform == "win32":
+                    process.kill()
+                else:
+                    process.terminate()
+            except OSError:
+                pass
+            raise
+        # Harvest the server's descendant tree BEFORE the first signal, while the
+        # tree is intact (#183): a tool subprocess the server detached (setsid, a
+        # double-fork) outlives the root's SIGTERM and would keep writing into the
+        # worktree the engine is about to merge/remove. Post-kill it reparents to
+        # init and is unreachable, so snapshot it now; each member's pid-reuse
+        # identity rides along from the enumeration itself, and the reap below is
+        # identity-guarded via alive_and_ours, never a bare (reusable) pid. {} =
+        # no descendants / psutil absent → the root ladder alone, as before.
+        tree = host.descendants(process.pid)
         # The live Popen handle pins the pid (win32 handle / unreaped POSIX
         # child), so signalling it cannot hit a reused pid — the identity
         # confirmation force_kill's contract asks for.
@@ -1034,11 +1052,20 @@ class OpencodeHttpAdapter(_ResultFileMixin, CodingCLIAdapter):
     def _reap_descendants(self, host: ProcessHost, tree: dict[int, float | None]) -> None:
         """Reap harvested straggler descendants the root signal missed — a detached
         tool subprocess that escaped the server's process group. Terminate → bounded
-        wait ≤ ``kill_wait_s`` → force-kill, identity-guarded (a None identity is
-        polled via the bare-liveness degrade, never force-killed, to sidestep a pid
-        reuse). Same already-gone swallow as the root ladder; best-effort, never a
-        teardown gate."""
-        survivors = [pid for pid, identity in tree.items() if host.alive_and_ours(pid, identity)]
+        wait ≤ ``kill_wait_s`` → force-kill, identity-guarded: a None identity is
+        unconfirmable (a possible pid reuse), so it is never signalled or polled at
+        all — even a SIGTERM to a recycled pid kills an innocent process (the tmux
+        adapter's straggler doctrine, mirrored). Same already-gone swallow as the
+        root ladder; best-effort, never a teardown gate."""
+
+        def _survivors() -> list[int]:
+            return [
+                pid
+                for pid, identity in tree.items()
+                if identity is not None and host.alive_and_ours(pid, identity)
+            ]
+
+        survivors = _survivors()
         if not survivors:
             return
         for pid in survivors:
@@ -1048,15 +1075,11 @@ class OpencodeHttpAdapter(_ResultFileMixin, CodingCLIAdapter):
                 pass
         deadline = time.monotonic() + self.kill_wait_s
         while True:
-            survivors = [
-                pid for pid, identity in tree.items() if host.alive_and_ours(pid, identity)
-            ]
+            survivors = _survivors()
             if not survivors or time.monotonic() >= deadline:
                 break
             time.sleep(REAP_POLL_S)
         for pid in survivors:
-            if tree[pid] is None:
-                continue
             try:
                 host.force_kill(pid)
             except Exception:  # noqa: BLE001  # nosec B110 - already-gone races are fine

--- a/src/bmad_loop/adapters/opencode_http.py
+++ b/src/bmad_loop/adapters/opencode_http.py
@@ -86,7 +86,7 @@ import threading
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from .. import gates
 from ..bmadconfig import ProjectPaths
@@ -105,6 +105,9 @@ from .generic import (
 )
 from .profile import CLIProfile
 
+if TYPE_CHECKING:
+    from ..process_host import ProcessHost
+
 # Spawn/readiness defaults; per-instance attributes so tests shrink them.
 HEALTH_TIMEOUT_S = 30.0
 HEALTH_POLL_S = 0.25
@@ -112,6 +115,10 @@ SSE_READ_TIMEOUT_S = 30.0  # server heartbeats ~10s; 3 misses = stream is gone
 SILENCE_THRESHOLD_S = 30.0
 RECONNECT_SLEEP_S = 1.0
 KILL_WAIT_S = 5.0
+# Straggler-reap poll cadence. Independent of generic's KILL_POLL_S: this teardown
+# budgets waits at kill_wait_s scale (seconds), not the tmux grace scale, so a
+# tight fixed poll keeps the reap responsive without a per-instance knob.
+REAP_POLL_S = 0.1
 SPAWN_ATTEMPTS = 3
 POLL_TICK_S = 5.0  # max event-queue wait per loop tick (generic's cadence)
 
@@ -985,6 +992,14 @@ class OpencodeHttpAdapter(_ResultFileMixin, CodingCLIAdapter):
         if process.poll() is not None:
             return
         host = get_process_host()
+        # Harvest the server's descendant tree + pid-reuse identities BEFORE the
+        # first signal, while the tree is intact (#183): a tool subprocess the
+        # server detached (setsid, a double-fork) outlives the root's SIGTERM and
+        # would keep writing into the worktree the engine is about to merge/remove.
+        # Post-kill it reparents to init and is unreachable, so snapshot it now; the
+        # reap below is identity-guarded via alive_and_ours, never a bare (reusable)
+        # pid. [] = no descendants / psutil absent → the root ladder alone, as before.
+        tree = {pid: host.identity(pid) for pid in host.descendants(process.pid)}
         # The live Popen handle pins the pid (win32 handle / unreaped POSIX
         # child), so signalling it cannot hit a reused pid — the identity
         # confirmation force_kill's contract asks for.
@@ -1013,6 +1028,38 @@ class OpencodeHttpAdapter(_ResultFileMixin, CodingCLIAdapter):
             try:
                 process.wait(timeout=self.kill_wait_s)
             except subprocess.TimeoutExpired:
+                pass
+        self._reap_descendants(host, tree)
+
+    def _reap_descendants(self, host: ProcessHost, tree: dict[int, float | None]) -> None:
+        """Reap harvested straggler descendants the root signal missed — a detached
+        tool subprocess that escaped the server's process group. Terminate → bounded
+        wait ≤ ``kill_wait_s`` → force-kill, identity-guarded (a None identity is
+        polled via the bare-liveness degrade, never force-killed, to sidestep a pid
+        reuse). Same already-gone swallow as the root ladder; best-effort, never a
+        teardown gate."""
+        survivors = [pid for pid, identity in tree.items() if host.alive_and_ours(pid, identity)]
+        if not survivors:
+            return
+        for pid in survivors:
+            try:
+                host.terminate(pid)
+            except OSError:
+                pass
+        deadline = time.monotonic() + self.kill_wait_s
+        while True:
+            survivors = [
+                pid for pid, identity in tree.items() if host.alive_and_ours(pid, identity)
+            ]
+            if not survivors or time.monotonic() >= deadline:
+                break
+            time.sleep(REAP_POLL_S)
+        for pid in survivors:
+            if tree[pid] is None:
+                continue
+            try:
+                host.force_kill(pid)
+            except Exception:  # noqa: BLE001  # nosec B110 - already-gone races are fine
                 pass
 
     def _atexit_sweep(self) -> None:

--- a/src/bmad_loop/process_host.py
+++ b/src/bmad_loop/process_host.py
@@ -292,16 +292,36 @@ def _linux_descendants(pid: int) -> dict[int, float | None]:
 
 def _psutil_descendants(pid: int) -> dict[int, float | None]:
     """Transitive descendants via psutil (non-Linux POSIX + Windows), each stamped
-    with the ``create_time()`` of the SAME enumerated ``Process`` object — psutil
-    binds identity at construction, so a pid reaped-and-reused mid-walk raises a
-    ``NoSuchProcess`` instead of authenticating the newcomer, and that member is
-    omitted. Blanket-except → ``{}`` so a missing psutil or an already-gone pid
-    degrades silently — the never-raise contract the kill escalation depends on."""
+    with the ``create_time()`` of the SAME enumerated ``Process`` object and then
+    REVALIDATED against that object's construction-bound identity before it is
+    recorded.
+
+    The revalidation is load-bearing, not belt-and-braces — ``create_time()`` alone
+    is NOT reuse-safe here. Per ``psutil.Process._get_ident`` (7.2.2), only the
+    ``WINDOWS`` branch pre-populates the epoch cache (``self._create_time =
+    create_time(fast_only=True)``); the ``LINUX or NETBSD or OSX`` branch binds a
+    *monotonic* starttime and leaves ``self._create_time`` unset. So on macOS our
+    ``create_time()`` is the FIRST call — a raw call-time kernel read, and
+    ``create_time()`` does not consult ``_raise_if_pid_reused()``. A pid reaped and
+    reused between ``children()`` and the stamp would therefore hand back the
+    NEWCOMER's identity, which teardown would then authenticate successfully and
+    signal (#184 review). ``is_running()`` closes that window: it compares the
+    ident captured at construction against a freshly built ``Process``, so a
+    generation change reads as not-running and the member is omitted.
+
+    Order matters — read the identity, THEN validate, THEN record; validating first
+    would reopen the same TOCTOU gap. A member whose identity can't be confirmed is
+    OMITTED, never returned unstamped. Blanket-except → ``{}`` so a missing psutil
+    or an already-gone pid degrades silently — the never-raise contract the kill
+    escalation depends on."""
     out: dict[int, float | None] = {}
     try:
         for child in _psutil().Process(pid).children(recursive=True):
             try:
-                out[child.pid] = child.create_time()
+                identity = child.create_time()
+                if not child.is_running():  # generation changed under us — don't stamp it
+                    continue
+                out[child.pid] = identity
             except Exception:  # noqa: BLE001  # nosec B112 - gone/reused mid-walk: omit it
                 continue
     except Exception:  # noqa: BLE001 - the kill-path seam must never raise

--- a/src/bmad_loop/process_host.py
+++ b/src/bmad_loop/process_host.py
@@ -103,6 +103,21 @@ class ProcessHost(ABC):
             return "unknown"
         return "dead"
 
+    def descendants(self, pid: int) -> list[int]:
+        """Transitive descendant pids of ``pid`` (children, grandchildren, …), for
+        the teardown reap that must chase a session's whole process tree, not just
+        the pane root — a detached straggler (setsid, a double-fork survivor)
+        escapes the pane pgid the window kill signals.
+
+        NEVER raises: ``[]`` on an unsupported platform, a missing psutil, a gone
+        pid, or any read error — this feeds the kill escalation, which must never be
+        the thing that raises. The default enumerates via psutil (macOS/Windows);
+        the Linux host overrides it with a psutil-free ``/proc`` scan so the core
+        stays dep-free there."""
+        if pid <= 0:
+            return []
+        return _psutil_descendants(pid)
+
     def shell_quote(self, arg: str) -> str:
         """Quote ``arg`` for the shell that runs this host's hook commands, so the
         argument-quoting axis sits behind the same seam as ``hook_interpreter``. Not
@@ -151,6 +166,13 @@ class PosixProcessHost(ProcessHost):
             return _psutil().Process(pid).create_time()
         except Exception:
             return None
+
+    def descendants(self, pid: int) -> list[int]:
+        if pid <= 0:
+            return []
+        if sys.platform.startswith("linux"):
+            return _linux_descendants(pid)  # psutil-free: keeps the Linux core dep-free
+        return super().descendants(pid)  # macOS: psutil, guarded by the seam's never-raise
 
     def hook_interpreter(self) -> str:
         return "python3"
@@ -216,6 +238,50 @@ def _proc_starttime(pid: int) -> float | None:
         return float(after_comm[19])  # field 22 = index 19 after the comm token
     except (ValueError, IndexError):
         return None
+
+
+def _linux_descendants(pid: int) -> list[int]:
+    """Transitive descendants of ``pid`` from a single pass over ``/proc/*/stat``
+    (Linux only, psutil-free). Build the ppid→children map from field 4 (ppid) —
+    index 1 after the comm token, split on the last ``)`` exactly as
+    :func:`_proc_starttime` does — then BFS out from ``pid``. Best-effort: a process
+    that exits mid-scan simply drops out of the map, and any error yields ``[]`` so
+    the kill seam never raises. A ``seen`` set guards against a pid-reuse race
+    fabricating a cycle."""
+    try:
+        children: dict[int, list[int]] = {}
+        for entry in Path("/proc").iterdir():  # portability: Linux-only, guarded by caller
+            if not entry.name.isdigit():
+                continue
+            try:
+                stat = (entry / "stat").read_text(encoding="utf-8")
+                ppid = int(stat[stat.rindex(")") + 1 :].split()[1])  # field 4 = ppid
+            except (OSError, ValueError, IndexError):
+                continue  # vanished mid-scan / unparsable line — just skip it
+            children.setdefault(ppid, []).append(int(entry.name))
+    except OSError:
+        return []
+    out: list[int] = []
+    seen: set[int] = set()
+    stack = list(children.get(pid, ()))
+    while stack:
+        child = stack.pop()
+        if child in seen:
+            continue
+        seen.add(child)
+        out.append(child)
+        stack.extend(children.get(child, ()))
+    return out
+
+
+def _psutil_descendants(pid: int) -> list[int]:
+    """Transitive descendants via psutil (non-Linux POSIX + Windows). Blanket-except
+    → ``[]`` so a missing psutil or an already-gone pid degrades silently — the
+    never-raise contract the kill escalation depends on."""
+    try:
+        return [child.pid for child in _psutil().Process(pid).children(recursive=True)]
+    except Exception:  # noqa: BLE001 - the kill-path seam must never raise
+        return []
 
 
 def _psutil():

--- a/src/bmad_loop/process_host.py
+++ b/src/bmad_loop/process_host.py
@@ -103,19 +103,26 @@ class ProcessHost(ABC):
             return "unknown"
         return "dead"
 
-    def descendants(self, pid: int) -> list[int]:
-        """Transitive descendant pids of ``pid`` (children, grandchildren, …), for
-        the teardown reap that must chase a session's whole process tree, not just
-        the pane root — a detached straggler (setsid, a double-fork survivor)
-        escapes the pane pgid the window kill signals.
+    def descendants(self, pid: int) -> dict[int, float | None]:
+        """Transitive descendants of ``pid`` (children, grandchildren, …) as a
+        pid → :meth:`identity` snapshot, for the teardown reap that must chase a
+        session's whole process tree, not just the pane root — a detached straggler
+        (setsid, a double-fork survivor) escapes the pane pgid the window kill
+        signals. The identity is captured DURING enumeration — from the same
+        ``/proc`` read (Linux) or the same enumerated psutil ``Process`` object —
+        so a pid reaped-and-reused after enumeration can never be authenticated by
+        a later lookup; a member whose identity can't be captured is OMITTED, never
+        returned unstamped. ``None`` values are reserved for platforms that
+        genuinely can't stamp one — consumers must treat ``None`` as unconfirmable
+        (never signal it).
 
-        NEVER raises: ``[]`` on an unsupported platform, a missing psutil, a gone
+        NEVER raises: ``{}`` on an unsupported platform, a missing psutil, a gone
         pid, or any read error — this feeds the kill escalation, which must never be
         the thing that raises. The default enumerates via psutil (macOS/Windows);
         the Linux host overrides it with a psutil-free ``/proc`` scan so the core
         stays dep-free there."""
         if pid <= 0:
-            return []
+            return {}
         return _psutil_descendants(pid)
 
     def shell_quote(self, arg: str) -> str:
@@ -167,9 +174,9 @@ class PosixProcessHost(ProcessHost):
         except Exception:
             return None
 
-    def descendants(self, pid: int) -> list[int]:
+    def descendants(self, pid: int) -> dict[int, float | None]:
         if pid <= 0:
-            return []
+            return {}
         if sys.platform.startswith("linux"):
             return _linux_descendants(pid)  # psutil-free: keeps the Linux core dep-free
         return super().descendants(pid)  # macOS: psutil, guarded by the seam's never-raise
@@ -240,28 +247,37 @@ def _proc_starttime(pid: int) -> float | None:
         return None
 
 
-def _linux_descendants(pid: int) -> list[int]:
-    """Transitive descendants of ``pid`` from a single pass over ``/proc/*/stat``
-    (Linux only, psutil-free). Build the ppid→children map from field 4 (ppid) —
-    index 1 after the comm token, split on the last ``)`` exactly as
-    :func:`_proc_starttime` does — then BFS out from ``pid``. Best-effort: a process
-    that exits mid-scan simply drops out of the map, and any error yields ``[]`` so
-    the kill seam never raises. A ``seen`` set guards against a pid-reuse race
-    fabricating a cycle."""
+def _linux_descendants(pid: int) -> dict[int, float | None]:
+    """Transitive descendants of ``pid``, with their pid-reuse identities, from a
+    single pass over ``/proc/*/stat`` (Linux only, psutil-free). Each entry's ppid
+    (field 4, index 1 after the comm token) AND starttime identity (field 22,
+    index 19 — the very value :func:`_proc_starttime` reads) come from ONE read of
+    the same ``stat`` line, split on the last ``)`` exactly as
+    :func:`_proc_starttime` does — so ancestry and identity are captured atomically
+    per process and a pid reused after the scan can never be authenticated by a
+    later lookup. BFS out from ``pid``. Best-effort: a process that exits mid-scan
+    simply drops out of the map, an unparsable line is omitted (never
+    authenticated), and any error yields ``{}`` so the kill seam never raises. A
+    ``seen`` set guards against a pid-reuse race fabricating a cycle."""
     try:
         children: dict[int, list[int]] = {}
+        identities: dict[int, float] = {}
         for entry in Path("/proc").iterdir():  # portability: Linux-only, guarded by caller
             if not entry.name.isdigit():
                 continue
             try:
                 stat = (entry / "stat").read_text(encoding="utf-8")
-                ppid = int(stat[stat.rindex(")") + 1 :].split()[1])  # field 4 = ppid
+                after_comm = stat[stat.rindex(")") + 1 :].split()
+                ppid = int(after_comm[1])  # field 4 = ppid
+                starttime = float(after_comm[19])  # field 22 = starttime, the identity
             except (OSError, ValueError, IndexError):
                 continue  # vanished mid-scan / unparsable line — just skip it
-            children.setdefault(ppid, []).append(int(entry.name))
+            child = int(entry.name)
+            children.setdefault(ppid, []).append(child)
+            identities[child] = starttime
     except OSError:
-        return []
-    out: list[int] = []
+        return {}
+    out: dict[int, float | None] = {}
     seen: set[int] = set()
     stack = list(children.get(pid, ()))
     while stack:
@@ -269,19 +285,28 @@ def _linux_descendants(pid: int) -> list[int]:
         if child in seen:
             continue
         seen.add(child)
-        out.append(child)
+        out[child] = identities[child]
         stack.extend(children.get(child, ()))
     return out
 
 
-def _psutil_descendants(pid: int) -> list[int]:
-    """Transitive descendants via psutil (non-Linux POSIX + Windows). Blanket-except
-    → ``[]`` so a missing psutil or an already-gone pid degrades silently — the
-    never-raise contract the kill escalation depends on."""
+def _psutil_descendants(pid: int) -> dict[int, float | None]:
+    """Transitive descendants via psutil (non-Linux POSIX + Windows), each stamped
+    with the ``create_time()`` of the SAME enumerated ``Process`` object — psutil
+    binds identity at construction, so a pid reaped-and-reused mid-walk raises a
+    ``NoSuchProcess`` instead of authenticating the newcomer, and that member is
+    omitted. Blanket-except → ``{}`` so a missing psutil or an already-gone pid
+    degrades silently — the never-raise contract the kill escalation depends on."""
+    out: dict[int, float | None] = {}
     try:
-        return [child.pid for child in _psutil().Process(pid).children(recursive=True)]
+        for child in _psutil().Process(pid).children(recursive=True):
+            try:
+                out[child.pid] = child.create_time()
+            except Exception:  # noqa: BLE001  # nosec B112 - gone/reused mid-walk: omit it
+                continue
     except Exception:  # noqa: BLE001 - the kill-path seam must never raise
-        return []
+        return {}
+    return out
 
 
 def _psutil():

--- a/tests/test_generic_tmux.py
+++ b/tests/test_generic_tmux.py
@@ -226,10 +226,18 @@ class _RecordingHost:
         self.terminated: list[int] = []
 
     def descendants(self, pid):
-        return list(self.descendants_map.get(pid, ()))
+        # The real seam stamps identity during enumeration; the fake mirrors that,
+        # still emitting None for no_identity pids so the adapter's unconfirmable
+        # guard stays exercised (the contract allows None where no stamp exists).
+        return {child: self.identity(child) for child in self.descendants_map.get(pid, ())}
 
     def identity(self, pid):
         return None if pid in self.no_identity else float(pid)
+
+    def is_alive(self, pid):
+        # Bare existence — a recycled pid still reads alive here (that's the point:
+        # the reap must not treat this as licence to signal an unconfirmable pid).
+        return pid in self.alive
 
     def alive_and_ours(self, pid, identity):
         if pid in self.reused or pid not in self.alive:
@@ -311,10 +319,13 @@ def test_kill_clean_end_no_stragglers_leaves_no_breadcrumb(tmp_path, monkeypatch
     assert _lifecycle_lines(adapter) == []
 
 
-def test_kill_never_force_kills_identity_none_straggler(tmp_path, monkeypatch):
-    """A harvested straggler whose identity could not be read (None) is polled via
-    the bare-liveness degrade and terminated, but NEVER force-killed — a None
-    identity can't rule out pid reuse. It rides out the grace still alive."""
+def test_kill_never_signals_identity_none_straggler(tmp_path, monkeypatch):
+    """A harvested straggler whose identity could not be read (None) is
+    unconfirmable — a possible pid reuse — so it is never signalled AT ALL: no
+    terminate, no force-kill, and no poll burning the grace deadline (even a
+    SIGTERM to a recycled pid kills an innocent process). It rides out the grace
+    untouched, recorded honestly as unreaped; with nothing actually signalled
+    there is no straggler-reap breadcrumb, only the kill-outcome."""
     monkeypatch.setattr(generic, "KILL_POLL_S", 0)
     host = _RecordingHost(
         alive={200}, descendants_map={100: [200]}, ignore_terminate={200}, no_identity={200}
@@ -323,12 +334,12 @@ def test_kill_never_force_kills_identity_none_straggler(tmp_path, monkeypatch):
     mux = _TeardownMux(survives_kills=0, pids=[100])
     adapter = make_adapter(tmp_path, mux=mux, teardown_grace_s=0.05)
     adapter.kill(_kill_handle())
-    assert host.terminated == [200]
-    assert host.force_killed == []  # identity None → refuse to force-kill a possible reuse
+    assert host.terminated == []  # identity None → never signalled (possible reuse)
+    assert host.force_killed == []
     events = _lifecycle_lines(adapter)
-    assert [e["event"] for e in events] == ["straggler-reap", "kill-outcome"]
-    assert events[1]["forced"] == []
-    assert events[1]["unreaped"] == [200]  # unconfirmable → left alive, recorded honestly
+    assert [e["event"] for e in events] == ["kill-outcome"]
+    assert events[0]["forced"] == []
+    assert events[0]["unreaped"] == [200]  # unconfirmable → left alive, recorded honestly
 
 
 def test_kill_reap_skips_reused_harvested_pid(tmp_path, monkeypatch):

--- a/tests/test_generic_tmux.py
+++ b/tests/test_generic_tmux.py
@@ -205,11 +205,45 @@ class _TeardownMux:
 
 
 class _RecordingHost:
-    def __init__(self):
+    """A tiny process-tree model for the reap path. ``alive`` is the set of live
+    pids; ``descendants_map`` gives each pid's transitive children (the pre-kill
+    harvest reads it); ``ignore_terminate`` pids survive SIGTERM so a force_kill is
+    required (the terminate-precedes-force-kill case); ``no_identity`` pids report
+    identity ``None`` (the unconfirmable case). terminate/force_kill record the call
+    and — unless ignored — drop the pid from ``alive``, so the reap's poll converges."""
+
+    def __init__(
+        self, alive=(), descendants_map=None, ignore_terminate=(), no_identity=(), reused=()
+    ):
+        self.alive = set(alive)
+        self.descendants_map = dict(descendants_map or {})
+        self.ignore_terminate = set(ignore_terminate)
+        self.no_identity = set(no_identity)
+        # pids recycled to a different process since harvest: still alive, but the
+        # recorded identity no longer matches — alive_and_ours must read them not-ours.
+        self.reused = set(reused)
         self.force_killed: list[int] = []
+        self.terminated: list[int] = []
+
+    def descendants(self, pid):
+        return list(self.descendants_map.get(pid, ()))
+
+    def identity(self, pid):
+        return None if pid in self.no_identity else float(pid)
+
+    def alive_and_ours(self, pid, identity):
+        if pid in self.reused or pid not in self.alive:
+            return False  # recycled pid or gone → not ours
+        return identity is None or identity == self.identity(pid)  # None → bare-liveness degrade
+
+    def terminate(self, pid):
+        self.terminated.append(pid)
+        if pid not in self.ignore_terminate:
+            self.alive.discard(pid)
 
     def force_kill(self, pid):
         self.force_killed.append(pid)
+        self.alive.discard(pid)
 
 
 def _kill_handle() -> SessionHandle:
@@ -230,8 +264,153 @@ def test_kill_returns_on_first_dead_probe_without_escalating(tmp_path, monkeypat
     adapter.kill(_kill_handle())
     assert mux.kill_windows == 1
     assert mux.liveness_probes == 1
-    assert mux.pane_pid_reads == 0
-    assert _lifecycle_lines(adapter) == []  # the normal path leaves no breadcrumbs
+    # #183: the clean end now reads the pane pids exactly ONCE (the pre-harvest
+    # snapshot), yet — no straggler and the window dead on probe 1 — it still
+    # performs no window re-kill and no escalation, leaving no breadcrumb.
+    assert mux.pane_pid_reads == 1
+    assert _lifecycle_lines(adapter) == []
+
+
+def test_kill_reaps_clean_end_straggler(tmp_path, monkeypatch):
+    """Clean end (window dead on probe 1) with a detached straggler harvested
+    pre-kill: it is terminated, then force-killed (it ignored SIGTERM), all within
+    the grace. terminate must precede force_kill so a mid-write process can flush."""
+    monkeypatch.setattr(generic, "KILL_POLL_S", 0)
+    # pane root 100 dies with the window; the setsid child 200 (a harvested child of
+    # 100, its own session at runtime) survives the pane-pgid kill and must be reaped.
+    host = _RecordingHost(alive={200}, descendants_map={100: [200]}, ignore_terminate={200})
+    monkeypatch.setattr(generic, "get_process_host", lambda: host)
+    mux = _TeardownMux(survives_kills=0, pids=[100])
+    adapter = make_adapter(tmp_path, mux=mux, teardown_grace_s=0.05)
+    adapter.kill(_kill_handle())
+    assert mux.pane_pid_reads == 1  # harvested once, pre-kill
+    assert mux.kill_windows == 1  # window died on the first strike — no re-kill
+    assert host.terminated == [200]
+    assert host.force_killed == [200]  # ignored SIGTERM → force-killed within grace
+    events = _lifecycle_lines(adapter)
+    assert [e["event"] for e in events] == ["straggler-reap", "kill-outcome"]
+    assert events[0]["pids"] == [200]
+    assert events[1]["forced"] == [200]
+    assert events[1]["unreaped"] == []  # reaped clean (distinct key from the wedged `alive`)
+
+
+def test_kill_clean_end_no_stragglers_leaves_no_breadcrumb(tmp_path, monkeypatch):
+    """Clean end, harvested tree already dead: the pane pids are read once and the
+    window killed once, but the reap finds nothing — no terminate, no force_kill, no
+    breadcrumb (the #157 clean path, now with a one-time pre-harvest read)."""
+    monkeypatch.setattr(generic, "KILL_POLL_S", 0)
+    host = _RecordingHost(alive=set(), descendants_map={100: [200]})
+    monkeypatch.setattr(generic, "get_process_host", lambda: host)
+    mux = _TeardownMux(survives_kills=0, pids=[100])
+    adapter = make_adapter(tmp_path, mux=mux, teardown_grace_s=0.05)
+    adapter.kill(_kill_handle())
+    assert mux.pane_pid_reads == 1
+    assert mux.kill_windows == 1
+    assert host.terminated == []
+    assert host.force_killed == []
+    assert _lifecycle_lines(adapter) == []
+
+
+def test_kill_never_force_kills_identity_none_straggler(tmp_path, monkeypatch):
+    """A harvested straggler whose identity could not be read (None) is polled via
+    the bare-liveness degrade and terminated, but NEVER force-killed — a None
+    identity can't rule out pid reuse. It rides out the grace still alive."""
+    monkeypatch.setattr(generic, "KILL_POLL_S", 0)
+    host = _RecordingHost(
+        alive={200}, descendants_map={100: [200]}, ignore_terminate={200}, no_identity={200}
+    )
+    monkeypatch.setattr(generic, "get_process_host", lambda: host)
+    mux = _TeardownMux(survives_kills=0, pids=[100])
+    adapter = make_adapter(tmp_path, mux=mux, teardown_grace_s=0.05)
+    adapter.kill(_kill_handle())
+    assert host.terminated == [200]
+    assert host.force_killed == []  # identity None → refuse to force-kill a possible reuse
+    events = _lifecycle_lines(adapter)
+    assert [e["event"] for e in events] == ["straggler-reap", "kill-outcome"]
+    assert events[1]["forced"] == []
+    assert events[1]["unreaped"] == [200]  # unconfirmable → left alive, recorded honestly
+
+
+def test_kill_reap_skips_reused_harvested_pid(tmp_path, monkeypatch):
+    """A harvested pid recycled to an unrelated process since the pre-kill snapshot
+    reads not-alive-and-ours at reap (identity mismatch) and is never signalled —
+    only the genuinely-ours straggler is reaped."""
+    monkeypatch.setattr(generic, "KILL_POLL_S", 0)
+    # 200 is still ours (reaped); 300 was reused by the OS for an unrelated process.
+    host = _RecordingHost(
+        alive={200, 300}, descendants_map={100: [200, 300]}, ignore_terminate={200}, reused={300}
+    )
+    monkeypatch.setattr(generic, "get_process_host", lambda: host)
+    mux = _TeardownMux(survives_kills=0, pids=[100])
+    adapter = make_adapter(tmp_path, mux=mux, teardown_grace_s=0.05)
+    adapter.kill(_kill_handle())
+    assert host.terminated == [200]  # 300 never touched — its identity no longer matches
+    assert host.force_killed == [200]
+    events = _lifecycle_lines(adapter)
+    assert events[0]["event"] == "straggler-reap"
+    assert events[0]["pids"] == [200]
+
+
+def test_kill_wedged_escalation_also_force_kills_harvested_descendants(tmp_path, monkeypatch):
+    """A wedged window (outlives grace) force-kills the re-read pane pids AND every
+    harvested descendant still alive-and-ours — the setsid child the pane-pid
+    escalation alone would miss. A descendant that no longer reads alive-and-ours (a
+    reused/gone pid) is skipped."""
+    monkeypatch.setattr(generic, "KILL_POLL_S", 0)
+    # pane root 100 (re-read at escalation) + harvested descendants 200 (still
+    # alive-and-ours) and 300 (gone → not alive_and_ours, must be skipped).
+    host = _RecordingHost(alive={100, 200}, descendants_map={100: [200, 300]})
+    monkeypatch.setattr(generic, "get_process_host", lambda: host)
+    mux = _TeardownMux(survives_kills=99, pids=[100])
+    adapter = make_adapter(tmp_path, mux=mux, teardown_grace_s=0.05)
+    adapter.kill(_kill_handle())
+    assert host.force_killed == [100, 200]  # 300 skipped: not alive_and_ours
+    assert mux.kill_windows == 2
+    events = _lifecycle_lines(adapter)
+    assert [e["event"] for e in events] == ["kill-escalated", "kill-outcome"]
+    assert events[0]["pids"] == [100]
+    assert events[1]["alive"] is True
+    assert events[1]["escalated"] is True
+
+
+def test_kill_wedged_escalation_never_force_kills_identity_none_descendant(tmp_path, monkeypatch):
+    """A wedged window must NOT force-kill a harvested descendant whose recorded
+    identity is None: alive_and_ours(pid, None) degrades to bare is_alive, so a
+    reused pid would pass — the ProcessHost contract forbids force-killing it. Only
+    the pane pid (pinned by the live window) and the identity-confirmed descendant
+    are struck."""
+    monkeypatch.setattr(generic, "KILL_POLL_S", 0)
+    # 200 is identity-confirmed (force-killed); 400 is alive but unconfirmable
+    # (identity None) → must be left untouched even under the wedged escalation.
+    host = _RecordingHost(
+        alive={100, 200, 400}, descendants_map={100: [200, 400]}, no_identity={400}
+    )
+    monkeypatch.setattr(generic, "get_process_host", lambda: host)
+    mux = _TeardownMux(survives_kills=99, pids=[100])
+    adapter = make_adapter(tmp_path, mux=mux, teardown_grace_s=0.05)
+    adapter.kill(_kill_handle())
+    assert host.force_killed == [100, 200]  # 400 refused: None identity
+    assert 400 not in host.force_killed
+
+
+def test_kill_strikes_window_before_reraising_bad_host_override(tmp_path, monkeypatch):
+    """The process-host lookup now precedes the first strike; an explicit-but-bogus
+    BMAD_LOOP_PROCESS_HOST must still raise loudly (never silently mis-signal), but
+    the window must not be left alive behind the raise — kill_window fires once, then
+    ProcessHostError propagates and the harvest is never reached."""
+    from bmad_loop.process_host import ProcessHostError, get_process_host
+
+    monkeypatch.setenv("BMAD_LOOP_PROCESS_HOST", "bogus-host-name")
+    get_process_host.cache_clear()
+    mux = _TeardownMux(survives_kills=0)
+    adapter = make_adapter(tmp_path, mux=mux, teardown_grace_s=0.05)
+    try:
+        with pytest.raises(ProcessHostError):
+            adapter.kill(_kill_handle())
+        assert mux.kill_windows == 1  # struck once before the raise
+        assert mux.pane_pid_reads == 0  # never reached the harvest
+    finally:
+        get_process_host.cache_clear()
 
 
 def test_kill_escalates_to_pane_pid_force_kill(tmp_path, monkeypatch):

--- a/tests/test_opencode_http.py
+++ b/tests/test_opencode_http.py
@@ -10,6 +10,7 @@ Everything binds 127.0.0.1; no real opencode binary or network access anywhere.
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import os
 import queue
@@ -39,7 +40,7 @@ from bmad_loop.adapters.profile import get_profile
 from bmad_loop.bmadconfig import ProjectPaths
 from bmad_loop.model import TokenUsage
 from bmad_loop.policy import LimitsPolicy, NotifyPolicy, Policy
-from bmad_loop.process_host import get_process_host
+from bmad_loop.process_host import ProcessHostError, get_process_host
 
 # A pinned example timestamp from the pins file (§4): OpenCode `time.*` values
 # are epoch MILLISECONDS. The proof-of-work floor must live in the same unit —
@@ -529,23 +530,35 @@ def test_kill_unknown_handle_is_a_noop(tmp_path):
     adapter.kill(SessionHandle(task_id="never-started", native_id="ses_x"))
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="setsid + os.kill(0) reap probe is POSIX")
+@pytest.mark.skipif(sys.platform == "win32", reason="os.kill(0) reap probe is POSIX")
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux") and importlib.util.find_spec("psutil") is None,
+    reason="descendant discovery off Linux needs psutil (the non-linux extra)",
+)
 def test_kill_process_reaps_detached_descendant(tmp_path):
     """#183 mirror on the HTTP transport, deterministic without a real opencode
     binary: a focused _kill_process test with a real Popen server whose body
-    `setsid`-detaches a child (its own session — the root SIGTERM cannot reach it)
-    against the REAL process host. After _kill_process the detached child is reaped,
-    proving the pre-signal descendant harvest + reap covers a straggler the pane/pgid
-    kill would leak (a live opencode binary is not required, and the live-server
-    harness cannot easily be made to detach a child — noted in the report)."""
+    detaches a child into its own session (``start_new_session=True`` — Python's
+    portable setsid; macOS ships no setsid(1) utility, so the root SIGTERM cannot
+    reach it) against the REAL process host. After _kill_process the detached child
+    is reaped, proving the pre-signal descendant harvest + reap covers a straggler
+    the pane/pgid kill would leak (a live opencode binary is not required, and the
+    live-server harness cannot easily be made to detach a child — noted in the
+    report)."""
     adapter = make_adapter(tmp_path)
     adapter.kill_wait_s = 3.0
     child_pid_file = tmp_path / "detached.pid"
-    # The "server" backgrounds a setsid child (records its pid), then idles so it is
-    # provably alive at harvest — the server (process.pid) is the parent of the
-    # detached child, so host.descendants(server) finds it before the SIGTERM.
-    script = f"setsid sleep 300 & echo $! > {child_pid_file}; sleep 300"
-    process = subprocess.Popen(["sh", "-c", script])
+    # The "server" detaches a session-leader child (records its pid), then idles so
+    # it is provably alive at harvest — the server (process.pid) is the parent of
+    # the detached child, so host.descendants(server) finds it before the SIGTERM.
+    server_body = (
+        "import subprocess, sys, time\n"
+        "p = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(300)'],"
+        " start_new_session=True)\n"
+        f"open({str(child_pid_file)!r}, 'w', encoding='utf-8').write(str(p.pid))\n"
+        "time.sleep(300)\n"
+    )
+    process = subprocess.Popen([sys.executable, "-c", server_body])
     detached_pid = None
     try:
         deadline = time.monotonic() + 10
@@ -582,6 +595,45 @@ def test_kill_process_reaps_detached_descendant(tmp_path):
             pass
 
 
+def test_kill_process_strikes_root_before_reraising_bad_host_override(tmp_path, monkeypatch):
+    """The process-host lookup precedes the first signal; an explicit-but-bogus
+    BMAD_LOOP_PROCESS_HOST must still raise loudly (never silently mis-signal), but
+    the server must not be left alive behind the raise — one legacy Popen root
+    strike fires, then ProcessHostError propagates (the tmux adapter's
+    strike-before-reraise doctrine, mirrored)."""
+
+    class _FakePopen:
+        pid = 4242
+
+        def __init__(self):
+            self.terminated = 0
+            self.killed = 0
+
+        def poll(self):
+            return None  # alive → _kill_process must not early-return
+
+        def terminate(self):
+            self.terminated += 1
+
+        def kill(self):
+            self.killed += 1
+
+    adapter = make_adapter(tmp_path)
+    process = _FakePopen()
+    sess = _ServerSession(process=process, port=0, base_url="", password="", log_fh=None)
+    monkeypatch.setenv("BMAD_LOOP_PROCESS_HOST", "bogus-host-name")
+    get_process_host.cache_clear()
+    try:
+        with pytest.raises(ProcessHostError):
+            adapter._kill_process(sess)
+        if sys.platform == "win32":
+            assert process.killed == 1  # the win32 legacy strike is Popen.kill()
+        else:
+            assert process.terminated == 1  # struck once before the raise
+    finally:
+        get_process_host.cache_clear()
+
+
 class _ReapRecordingHost:
     """Minimal host for the reap-gate unit test: nobody dies on SIGTERM, so the
     force-kill loop is what settles survivors — proving the identity gate, not
@@ -609,17 +661,18 @@ class _ReapRecordingHost:
         self.alive.discard(pid)
 
 
-def test_reap_descendants_refuses_to_force_kill_none_identity(tmp_path):
-    """_reap_descendants terminates every surviving straggler but force-kills only
-    the identity-confirmed one; a None-identity survivor (a possible pid reuse) is
-    polled via the bare-liveness degrade and NEVER force-killed — the ProcessHost
-    contract, mirrored on the HTTP teardown (opencode_http.py:_reap_descendants)."""
+def test_reap_descendants_never_signals_none_identity(tmp_path):
+    """_reap_descendants signals only identity-confirmed stragglers; a
+    None-identity survivor (a possible pid reuse) is never signalled AT ALL — no
+    terminate, no force-kill, no poll burn (even a SIGTERM to a recycled pid kills
+    an innocent process) — the ProcessHost contract, mirrored on the HTTP teardown
+    (opencode_http.py:_reap_descendants)."""
     adapter = make_adapter(tmp_path)
     adapter.kill_wait_s = 0.1  # bound the poll: nobody dies on terminate here
     host = _ReapRecordingHost(alive={200, 400}, no_identity={400})
     tree = {200: 200.0, 400: None}  # 200 identity-confirmed at harvest, 400 unconfirmable
     adapter._reap_descendants(host, tree)
-    assert host.terminated == [200, 400]  # both asked to stop
+    assert host.terminated == [200]  # the unconfirmable 400 is never asked to stop
     assert host.force_killed == [200]  # only the confirmed pid escalated
     assert 400 not in host.force_killed
 

--- a/tests/test_opencode_http.py
+++ b/tests/test_opencode_http.py
@@ -11,7 +11,10 @@ Everything binds 127.0.0.1; no real opencode binary or network access anywhere.
 from __future__ import annotations
 
 import json
+import os
 import queue
+import signal
+import subprocess
 import sys
 import time
 from pathlib import Path
@@ -524,6 +527,101 @@ def test_missing_binary_is_a_clean_error(tmp_path):
 def test_kill_unknown_handle_is_a_noop(tmp_path):
     adapter = make_adapter(tmp_path)
     adapter.kill(SessionHandle(task_id="never-started", native_id="ses_x"))
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="setsid + os.kill(0) reap probe is POSIX")
+def test_kill_process_reaps_detached_descendant(tmp_path):
+    """#183 mirror on the HTTP transport, deterministic without a real opencode
+    binary: a focused _kill_process test with a real Popen server whose body
+    `setsid`-detaches a child (its own session — the root SIGTERM cannot reach it)
+    against the REAL process host. After _kill_process the detached child is reaped,
+    proving the pre-signal descendant harvest + reap covers a straggler the pane/pgid
+    kill would leak (a live opencode binary is not required, and the live-server
+    harness cannot easily be made to detach a child — noted in the report)."""
+    adapter = make_adapter(tmp_path)
+    adapter.kill_wait_s = 3.0
+    child_pid_file = tmp_path / "detached.pid"
+    # The "server" backgrounds a setsid child (records its pid), then idles so it is
+    # provably alive at harvest — the server (process.pid) is the parent of the
+    # detached child, so host.descendants(server) finds it before the SIGTERM.
+    script = f"setsid sleep 300 & echo $! > {child_pid_file}; sleep 300"
+    process = subprocess.Popen(["sh", "-c", script])
+    detached_pid = None
+    try:
+        deadline = time.monotonic() + 10
+        while not child_pid_file.is_file() and time.monotonic() < deadline:
+            time.sleep(0.05)
+        assert child_pid_file.is_file(), "server never recorded its detached child"
+        detached_pid = int(child_pid_file.read_text(encoding="utf-8").strip())
+        # sanity: the recorded pid is the setsid'd process and is currently alive
+        os.kill(detached_pid, 0)
+
+        sess = _ServerSession(process=process, port=0, base_url="", password="", log_fh=None)
+        adapter._kill_process(sess)
+
+        assert process.poll() is not None  # root server reaped
+        reap_deadline = time.monotonic() + 10
+        while True:
+            try:
+                os.kill(detached_pid, 0)
+            except ProcessLookupError:
+                break  # detached child reaped by the descendant sweep
+            assert time.monotonic() < reap_deadline, f"detached child {detached_pid} survived"
+            time.sleep(0.05)
+    finally:
+        for pid in (detached_pid, process.pid):
+            if pid is None:
+                continue
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except OSError:
+                pass
+        try:
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            pass
+
+
+class _ReapRecordingHost:
+    """Minimal host for the reap-gate unit test: nobody dies on SIGTERM, so the
+    force-kill loop is what settles survivors — proving the identity gate, not
+    terminate, decides who gets force-killed. identity is None for ``no_identity``."""
+
+    def __init__(self, alive=(), no_identity=()):
+        self.alive = set(alive)
+        self.no_identity = set(no_identity)
+        self.terminated: list[int] = []
+        self.force_killed: list[int] = []
+
+    def identity(self, pid):
+        return None if pid in self.no_identity else float(pid)
+
+    def alive_and_ours(self, pid, identity):
+        if pid not in self.alive:
+            return False
+        return identity is None or identity == self.identity(pid)
+
+    def terminate(self, pid):
+        self.terminated.append(pid)  # deliberately does NOT kill — force_kill settles it
+
+    def force_kill(self, pid):
+        self.force_killed.append(pid)
+        self.alive.discard(pid)
+
+
+def test_reap_descendants_refuses_to_force_kill_none_identity(tmp_path):
+    """_reap_descendants terminates every surviving straggler but force-kills only
+    the identity-confirmed one; a None-identity survivor (a possible pid reuse) is
+    polled via the bare-liveness degrade and NEVER force-killed — the ProcessHost
+    contract, mirrored on the HTTP teardown (opencode_http.py:_reap_descendants)."""
+    adapter = make_adapter(tmp_path)
+    adapter.kill_wait_s = 0.1  # bound the poll: nobody dies on terminate here
+    host = _ReapRecordingHost(alive={200, 400}, no_identity={400})
+    tree = {200: 200.0, 400: None}  # 200 identity-confirmed at harvest, 400 unconfirmable
+    adapter._reap_descendants(host, tree)
+    assert host.terminated == [200, 400]  # both asked to stop
+    assert host.force_killed == [200]  # only the confirmed pid escalated
+    assert 400 not in host.force_killed
 
 
 def test_read_usage_returns_stash_by_session_id(tmp_path):

--- a/tests/test_process_host.py
+++ b/tests/test_process_host.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import os
+import signal
+import subprocess
 import sys
+import time
 
 import pytest
 
@@ -137,6 +140,93 @@ def test_liveness_of_legacy_identity_degrades_to_is_alive(host, monkeypatch):
     assert host.liveness_of(4242, None) == "alive"
     assert host.liveness_of(9999, None) == "dead"
     assert host.liveness_of(0, None) == "dead"
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"), reason="descendants /proc walk is exercised on Linux"
+)
+def test_descendants_enumerates_transitively(host, tmp_path):
+    """A child-of-child (grandchild) is found: the /proc walk is transitive, not
+    just direct children. The outer sh backgrounds an inner sh that itself
+    backgrounds a sleep and records that grandchild's pid; descendants(outer) must
+    contain it. The whole tree runs in its own session so the finally can nuke it
+    with a single killpg even if the assertion fails."""
+    gc_file = tmp_path / "gc.pid"
+    # outer sh -> inner sh (stays a shell: compound body, not exec'd) -> grandchild sleep
+    script = f"sh -c 'sleep 300 & echo $! > {gc_file}; wait' & sleep 300"
+    proc = subprocess.Popen(["sh", "-c", script], start_new_session=True)
+    try:
+        deadline = time.monotonic() + 10
+        while not gc_file.is_file() and time.monotonic() < deadline:
+            time.sleep(0.05)
+        assert gc_file.is_file(), "grandchild pid was never recorded"
+        gc_pid = int(gc_file.read_text(encoding="utf-8").strip())
+        kids = host.descendants(proc.pid)
+        assert gc_pid in kids, f"grandchild {gc_pid} not in transitive descendants {kids}"
+    finally:
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        except (ProcessLookupError, OSError):
+            pass
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            pass
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"), reason="descendants /proc walk is exercised on Linux"
+)
+def test_descendants_dead_or_unknown_pid_is_empty(host):
+    """The seam contract: a reaped pid, a never-allocated high pid, and a
+    non-positive pid all enumerate to [] rather than raising."""
+    proc = subprocess.Popen(["true"])
+    proc.wait(timeout=10)  # reap it — its pid is now gone
+    assert host.descendants(proc.pid) == []
+    assert host.descendants(2**31 - 1) == []  # never allocated
+    assert host.descendants(0) == []
+    assert host.descendants(-1) == []
+
+
+def test_psutil_descendants_maps_children_and_never_raises(monkeypatch):
+    """The non-Linux/Windows descendant path maps ``Process.children(recursive=True)``
+    to pids, and any failure (a raising Process, or a missing-psutil ProcessHostError
+    from ``_psutil()`` itself) degrades to [] — the never-raise seam contract that the
+    Linux ``/proc`` walk cannot exercise on Linux CI."""
+
+    class _FakeChild:
+        def __init__(self, pid):
+            self.pid = pid
+
+    class _FakeProc:
+        def __init__(self, pid):
+            self.pid = pid
+
+        def children(self, recursive=False):
+            assert recursive is True  # transitive tree, not just direct children
+            return [_FakeChild(11), _FakeChild(22)]
+
+    class _FakePsutil:
+        Process = _FakeProc
+
+    monkeypatch.setattr(process_host, "_psutil", lambda: _FakePsutil)
+    assert process_host._psutil_descendants(123) == [11, 22]
+
+    class _BoomProc:
+        def __init__(self, pid):
+            raise RuntimeError("no such process")  # psutil.NoSuchProcess analogue
+
+    class _BoomPsutil:
+        Process = _BoomProc
+
+    monkeypatch.setattr(process_host, "_psutil", lambda: _BoomPsutil)
+    assert process_host._psutil_descendants(123) == []
+
+    def _missing():
+        raise process_host.ProcessHostError("psutil missing")
+
+    monkeypatch.setattr(process_host, "_psutil", _missing)
+    assert process_host._psutil_descendants(123) == []
 
 
 def test_default_host_matches_platform(monkeypatch):

--- a/tests/test_process_host.py
+++ b/tests/test_process_host.py
@@ -163,6 +163,9 @@ def test_descendants_enumerates_transitively(host, tmp_path):
         gc_pid = int(gc_file.read_text(encoding="utf-8").strip())
         kids = host.descendants(proc.pid)
         assert gc_pid in kids, f"grandchild {gc_pid} not in transitive descendants {kids}"
+        # The identity rides along from the SAME /proc read the ancestry came from
+        # and must equal the canonical per-pid stamp (the /proc starttime).
+        assert kids[gc_pid] == process_host._proc_starttime(gc_pid)
     finally:
         try:
             os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
@@ -179,24 +182,29 @@ def test_descendants_enumerates_transitively(host, tmp_path):
 )
 def test_descendants_dead_or_unknown_pid_is_empty(host):
     """The seam contract: a reaped pid, a never-allocated high pid, and a
-    non-positive pid all enumerate to [] rather than raising."""
+    non-positive pid all enumerate to {} rather than raising."""
     proc = subprocess.Popen(["true"])
     proc.wait(timeout=10)  # reap it — its pid is now gone
-    assert host.descendants(proc.pid) == []
-    assert host.descendants(2**31 - 1) == []  # never allocated
-    assert host.descendants(0) == []
-    assert host.descendants(-1) == []
+    assert host.descendants(proc.pid) == {}
+    assert host.descendants(2**31 - 1) == {}  # never allocated
+    assert host.descendants(0) == {}
+    assert host.descendants(-1) == {}
 
 
 def test_psutil_descendants_maps_children_and_never_raises(monkeypatch):
     """The non-Linux/Windows descendant path maps ``Process.children(recursive=True)``
-    to pids, and any failure (a raising Process, or a missing-psutil ProcessHostError
-    from ``_psutil()`` itself) degrades to [] — the never-raise seam contract that the
-    Linux ``/proc`` walk cannot exercise on Linux CI."""
+    to a pid → create_time identity snapshot stamped from the SAME enumerated
+    ``Process`` objects, and any failure (a raising Process, or a missing-psutil
+    ProcessHostError from ``_psutil()`` itself) degrades to {} — the never-raise
+    seam contract that the Linux ``/proc`` walk cannot exercise on Linux CI."""
 
     class _FakeChild:
-        def __init__(self, pid):
+        def __init__(self, pid, created):
             self.pid = pid
+            self._created = created
+
+        def create_time(self):
+            return self._created
 
     class _FakeProc:
         def __init__(self, pid):
@@ -204,13 +212,13 @@ def test_psutil_descendants_maps_children_and_never_raises(monkeypatch):
 
         def children(self, recursive=False):
             assert recursive is True  # transitive tree, not just direct children
-            return [_FakeChild(11), _FakeChild(22)]
+            return [_FakeChild(11, 111.0), _FakeChild(22, 222.0)]
 
     class _FakePsutil:
         Process = _FakeProc
 
     monkeypatch.setattr(process_host, "_psutil", lambda: _FakePsutil)
-    assert process_host._psutil_descendants(123) == [11, 22]
+    assert process_host._psutil_descendants(123) == {11: 111.0, 22: 222.0}
 
     class _BoomProc:
         def __init__(self, pid):
@@ -220,13 +228,48 @@ def test_psutil_descendants_maps_children_and_never_raises(monkeypatch):
         Process = _BoomProc
 
     monkeypatch.setattr(process_host, "_psutil", lambda: _BoomPsutil)
-    assert process_host._psutil_descendants(123) == []
+    assert process_host._psutil_descendants(123) == {}
 
     def _missing():
         raise process_host.ProcessHostError("psutil missing")
 
     monkeypatch.setattr(process_host, "_psutil", _missing)
-    assert process_host._psutil_descendants(123) == []
+    assert process_host._psutil_descendants(123) == {}
+
+
+def test_psutil_descendants_omits_pid_reused_before_identity_capture(monkeypatch):
+    """PID-generation rollover between enumeration and the identity stamp: the
+    child enumerates as generation A, but by the time its identity is read the
+    pid is gone (or reused as generation B) and psutil raises — its ``Process``
+    objects bind identity at construction, so ``create_time()`` on a recycled pid
+    is a ``NoSuchProcess`` analogue, never generation B's stamp. The snapshot must
+    OMIT that pid — a member it cannot authenticate — while keeping confirmable
+    siblings, and still never raise."""
+
+    class _GoneChild:
+        pid = 11
+
+        def create_time(self):
+            raise RuntimeError("process no longer exists")  # NoSuchProcess analogue
+
+    class _OkChild:
+        pid = 22
+
+        def create_time(self):
+            return 222.0
+
+    class _FakeProc:
+        def __init__(self, pid):
+            self.pid = pid
+
+        def children(self, recursive=False):
+            return [_GoneChild(), _OkChild()]
+
+    class _FakePsutil:
+        Process = _FakeProc
+
+    monkeypatch.setattr(process_host, "_psutil", lambda: _FakePsutil)
+    assert process_host._psutil_descendants(123) == {22: 222.0}
 
 
 def test_default_host_matches_platform(monkeypatch):

--- a/tests/test_process_host.py
+++ b/tests/test_process_host.py
@@ -206,6 +206,9 @@ def test_psutil_descendants_maps_children_and_never_raises(monkeypatch):
         def create_time(self):
             return self._created
 
+        def is_running(self):
+            return True  # same generation we enumerated — identity confirmed
+
     class _FakeProc:
         def __init__(self, pid):
             self.pid = pid
@@ -238,13 +241,22 @@ def test_psutil_descendants_maps_children_and_never_raises(monkeypatch):
 
 
 def test_psutil_descendants_omits_pid_reused_before_identity_capture(monkeypatch):
-    """PID-generation rollover between enumeration and the identity stamp: the
-    child enumerates as generation A, but by the time its identity is read the
-    pid is gone (or reused as generation B) and psutil raises — its ``Process``
-    objects bind identity at construction, so ``create_time()`` on a recycled pid
-    is a ``NoSuchProcess`` analogue, never generation B's stamp. The snapshot must
-    OMIT that pid — a member it cannot authenticate — while keeping confirmable
-    siblings, and still never raise."""
+    """PID-generation rollover between enumeration and the identity stamp, in BOTH
+    shapes psutil actually produces — the snapshot must OMIT any member it cannot
+    authenticate, keep confirmable siblings, and never raise.
+
+    ``_GoneChild`` is the easy shape: the pid vanished and was not reused, so
+    ``create_time()`` raises a ``NoSuchProcess`` analogue.
+
+    ``_ReusedChild`` is the shape that actually bites on macOS and the reason the
+    ``is_running()`` revalidation exists (#184 review). Per
+    ``psutil.Process._get_ident``, the ``LINUX or NETBSD or OSX`` branch binds a
+    *monotonic* ident and leaves ``self._create_time`` unset, so ``create_time()``
+    is a raw call-time read that happily returns the RECYCLED process's stamp — no
+    exception at all. Stamping that would let teardown authenticate and signal an
+    unrelated process. Only ``is_running()`` (construction-bound ident vs. a fresh
+    ``Process``) reports the generation change. An exception-only fake would pass
+    against the buggy code, so this case is what makes the test a regression test."""
 
     class _GoneChild:
         pid = 11
@@ -252,24 +264,46 @@ def test_psutil_descendants_omits_pid_reused_before_identity_capture(monkeypatch
         def create_time(self):
             raise RuntimeError("process no longer exists")  # NoSuchProcess analogue
 
+        def is_running(self):  # pragma: no cover - create_time raises first
+            raise AssertionError("must not be reached: identity read comes first")
+
+    class _ReusedChild:
+        """Enumerated as generation A; the pid was recycled before the stamp, so
+        ``create_time()`` returns generation B's identity WITHOUT raising."""
+
+        pid = 33
+
+        def create_time(self):
+            return 999.0  # generation B's stamp — plausible, and utterly wrong
+
+        def is_running(self):
+            return False  # construction-bound ident no longer matches this pid
+
     class _OkChild:
         pid = 22
 
         def create_time(self):
             return 222.0
 
+        def is_running(self):
+            return True
+
     class _FakeProc:
         def __init__(self, pid):
             self.pid = pid
 
         def children(self, recursive=False):
-            return [_GoneChild(), _OkChild()]
+            return [_GoneChild(), _ReusedChild(), _OkChild()]
 
     class _FakePsutil:
         Process = _FakeProc
 
     monkeypatch.setattr(process_host, "_psutil", lambda: _FakePsutil)
-    assert process_host._psutil_descendants(123) == {22: 222.0}
+    snapshot = process_host._psutil_descendants(123)
+    assert snapshot == {22: 222.0}
+    # The recycled pid must be absent outright, not stamped with the newcomer's
+    # identity — a stamped entry authenticates at teardown and gets signalled.
+    assert 33 not in snapshot
 
 
 def test_default_host_matches_platform(monkeypatch):

--- a/tests/test_stories_e2e.py
+++ b/tests/test_stories_e2e.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import signal
 import subprocess
 import sys
 import time
@@ -201,6 +202,47 @@ sleep 100000 &
 child=$!
 printf '%s\n' "$child" > "$rd/tasks/$tid/fake-child.pid"
 wait "$child"
+"""
+
+# A fake CLI that ends CLEANLY (writes a `done` spec + Stop, then idles like a real
+# interactive session) but first `setsid`-detaches a straggler into its OWN session.
+# Unlike the :185-204 same-pgid child (which tmux's SIGHUP reaps), a setsid child
+# escapes the pane pgid entirely — the #183/#139 repro the pre-harvest descendant
+# reap must cover before the worktree is merged and removed. Sprint mode: writes the
+# id-keyed done spec + a real code change so the run merges and tears the worktree down.
+DETACHED_WRITER_FAKE_CLI = r"""#!/usr/bin/env bash
+set -e
+rd="$BMAD_LOOP_RUN_DIR"; tid="$BMAD_LOOP_TASK_ID"; story="$BMAD_LOOP_STORY_KEY"
+ts=$(date +%s%N)
+mkdir -p "$rd/events"
+printf '{"ts": %s, "event": "SessionStart", "task_id": "%s", "session_id": "fake-1"}' \
+    "$ts" "$tid" > "$rd/events/$ts-$tid-SessionStart.json"
+baseline=$(git rev-parse HEAD)
+
+# Detach a straggler into a NEW session (setsid): $! is the setsid'd process itself
+# (a non-interactive shell runs background jobs in its own pgrp, so setsid does not
+# fork) — it now leads its own session and survives the pane pgid's SIGHUP.
+setsid sleep 100000 &
+child=$!
+printf '%s\n' "$child" > "$rd/tasks/$tid/fake-child.pid"
+
+# Sprint-mode result: a real code change + the id-keyed done spec the dev synthesis
+# reads back (written under the worktree cwd in isolation mode).
+impl="_bmad-output/implementation-artifacts"
+mkdir -p "$impl"
+echo "impl for $story" >> src.txt
+printf -- '---\ntitle: %s\nstatus: done\nbaseline_commit: %s\n---\n\n## Intent\n\nx\n\n## Auto Run Result\n\n- Status: done\n\nSummary: sprint.\n' \
+    "$story" "$baseline" > "$impl/spec-$story.md"
+
+ts2=$(( ts + 1 ))
+printf '{"ts": %s, "event": "Stop", "task_id": "%s", "session_id": "fake-1"}' \
+    "$ts2" "$tid" > "$rd/events/$ts2-$tid-Stop.json"
+# Stay alive like an idle interactive session so the pane shell is still live when
+# the engine kills it: the harvest sees the detached child as our descendant only
+# while we (its parent) are still around. Long enough to outlast Stop -> kill_window
+# on a loaded CI host (the window kill terminates this sleep anyway, so it costs
+# nothing) — else the shell could exit first, reparenting the child to init.
+sleep 600
 """
 
 
@@ -642,6 +684,74 @@ def test_e2e_session_timeout_teardown(tmp_path, monkeypatch):
             break  # dead and reaped — teardown covered the descendant
         assert time.monotonic() < deadline, f"sleep child {fake_pid} survived teardown"
         time.sleep(0.1)
+
+
+def test_e2e_detached_writer_reaped_before_worktree_teardown(tmp_path):
+    """#183/#139 end to end: a dev session `setsid`-detaches a straggler into its own
+    session (escaping the pane pgid tmux's SIGHUP reaps), then ends CLEANLY via a
+    Stop + done spec. The verified-kill reap must chase the harvested descendant tree
+    and reap the straggler BEFORE the worktree is merged and removed — so the
+    detached pid is dead, the worktree is gone, and no `worktree-teardown-degraded`
+    fires (the #139 signature). Worktree isolation makes the teardown real."""
+    root = tmp_path / "sbx"
+    story = "1-1-detach"
+    _scaffold_sprint(
+        root,
+        story,
+        fake_cli=DETACHED_WRITER_FAKE_CLI,
+        extra_policy=(
+            '\n[scm]\nisolation = "worktree"\n\n'
+            "[limits]\nmax_dev_attempts = 1\nteardown_grace_s = 10\n"
+        ),
+    )
+    detached_pid: int | None = None
+    try:
+        proc = _run(root, "run", timeout=120)
+        assert proc.returncode == 0, proc.stderr or proc.stdout
+
+        run_id = _run_id(root)
+        run_dir = root / ".bmad-loop" / "runs" / run_id
+
+        # (1) clean end: the story landed done and merged, not a timeout/stall
+        assert _sprint_status(root, story) == "done"
+        journal = [
+            json.loads(ln)
+            for ln in (run_dir / "journal.jsonl").read_text(encoding="utf-8").splitlines()
+            if ln.strip()
+        ]
+        kinds = [j["kind"] for j in journal]
+        assert "unit-merged" in kinds, kinds
+        # (2) the #139 failure signature is ABSENT — the worktree teardown was clean
+        assert "worktree-teardown-degraded" not in kinds, kinds
+
+        # (3) no unit worktree survives (git sees only the main checkout)
+        wt = subprocess.run(
+            ["git", "-C", str(root), "worktree", "list", "--porcelain"],
+            capture_output=True,
+            text=True,
+        )
+        mounts = [ln for ln in wt.stdout.splitlines() if ln.startswith("worktree ")]
+        assert len(mounts) == 1, wt.stdout  # only the primary checkout remains
+
+        # (4) the detached straggler was reaped within the grace: kill-0 -> gone.
+        pid_files = list((run_dir / "tasks").glob("*/fake-child.pid"))
+        assert pid_files, "fake CLI never recorded its setsid child"
+        detached_pid = int(pid_files[0].read_text(encoding="utf-8").strip())
+        deadline = time.monotonic() + 10
+        while True:
+            try:
+                os.kill(detached_pid, 0)
+            except ProcessLookupError:
+                break  # reaped by the descendant sweep before teardown
+            assert time.monotonic() < deadline, f"detached child {detached_pid} survived teardown"
+            time.sleep(0.1)
+    finally:
+        # never leak the detached sleep if the test fails before the reap check
+        if detached_pid is not None:
+            try:
+                os.kill(detached_pid, signal.SIGKILL)
+            except OSError:
+                pass
 
 
 def test_e2e_sweep_intent_gap_patch_restore(tmp_path):

--- a/tests/test_stories_e2e.py
+++ b/tests/test_stories_e2e.py
@@ -45,8 +45,11 @@ import pytest
 import yaml
 from conftest import install_dev_base_skills
 
-HAVE_TMUX = sys.platform != "win32" and shutil.which("tmux") is not None
-pytestmark = pytest.mark.skipif(not HAVE_TMUX, reason="stories E2E needs real tmux")
+# Linux-only, not merely non-win32: every fake CLI below is bash + GNU coreutils
+# (`date +%s%N`; the detached-writer fake also needs setsid(1)) — BSD/macOS date
+# has no %N and macOS ships no setsid utility, so skipping honestly beats failing.
+HAVE_TMUX = sys.platform.startswith("linux") and shutil.which("tmux") is not None
+pytestmark = pytest.mark.skipif(not HAVE_TMUX, reason="stories E2E needs real tmux on Linux")
 
 # The fake CLI: reads the story id + spec folder from the session env (as the real
 # folder+id adapter does), writes the id-keyed story spec BEFORE the Stop event so


### PR DESCRIPTION
Closes #183. Follow-up to #139/#182: that PR made a lost teardown race *degrade* instead of crash; this one removes the race itself.

## Mechanism

A process spawned inside a session (backgrounded pytest, a `setsid`/double-forked runner) escapes the pane's process group, so `tmux kill-window`'s SIGHUP never reaches it — and the #157 verified kill only harvested pane pids when the *window* outlived `teardown_grace_s`. A session that ended cleanly (window dead on the first probe) never had any pids read at all, leaving stragglers free to write into the worktree while the engine merged and deleted it.

## Fix

- **`GenericAdapter.kill`** — when `teardown_grace_s > 0`, harvest the pane pids **plus their transitive descendants** (each stamped with a pid-reuse identity) *before* the first kill strike, while the tree is provably alive. After the window dies, `_reap_straggler_tree` terminates → polls → force-kills identity-confirmed survivors within the same grace deadline (one budget, two phases; terminate first so a mid-write straggler can flush). The wedged-window escalation also force-kills harvested descendants, with the same None-identity refusal as the clean path. `grace = 0` remains the legacy single strike, byte-for-byte.
- **`ProcessHost.descendants(pid)`** — new seam capability: transitive descendants as a `dict[int, float | None]` (pid → pid-reuse identity captured DURING enumeration, so there is no post-hoc stamp to race a reuse); a member whose identity can't be confirmed is OMITTED rather than returned unstamped. Never raises, `{}` degrade. Linux uses a one-pass `/proc` ppid map + BFS, taking ppid and starttime from the SAME `stat` read (the core stays psutil-free); macOS/win32 go through the existing lazy `_psutil()`, revalidating each child via `is_running()` before stamping it — `create_time()` is only construction-bound on the WINDOWS branch of psutil's `_get_ident`, so on macOS it is a call-time read that would otherwise return a recycled pid's identity.
- **`opencode_http._kill_process`** — mirrored pre-signal harvest + reap bounded by `kill_wait_s` (kept as its own copy per the adapter's teardown convention; these sessions have no tmux window, so the process-tree wait is the only teardown signal there).
- A misconfigured `BMAD_LOOP_PROCESS_HOST` override still strikes the window once before the loud `ProcessHostError` re-raise, so a config error can never leak a live window.

Accepted limitations (documented at the harvest site): a double-fork orphan that reparented *before* the harvest, or a process detached in the harvest→kill TOCTOU window, is unfindable by construction; macOS without the `non-linux` extra degrades to today's behavior.

## Verification

- New E2E (`test_e2e_detached_writer_reaped_before_worktree_teardown`) automates the issue's acceptance sketch: a fake CLI `setsid`-detaches a writer and ends cleanly; the writer is reaped within the grace, the worktree removes cleanly, and **no** `worktree-teardown-degraded` fires. (The existing #157 fake child shares the pane pgid and dies via SIGHUP — it cannot reproduce this bug.)
- Kill-path units extended: clean-end straggler reap (terminate precedes force-kill), None-identity never signalled at all on either branch (no terminate, no poll, no force-kill), reused-pid skip, no-pids backend degrade, bad-host-override strike; `test_kill_returns_on_first_dead_probe_without_escalating`'s `pane_pid_reads == 0` assertion is deliberately inverted to `== 1` — the old assertion encoded the bug.
- `descendants` seam: real grandchild `/proc` enumeration + monkeypatched-psutil never-raise contract, plus a psutil pid-rollover unit (`create_time()` returning the recycled generation while `is_running()` reports False — that pid must be omitted, verified to fail without the fix); opencode mirror: real Popen `setsid` descendant reaped, None-identity refusal unit.
- Full suite: **2446 passed, 1 skipped** (win32-only); full `trunk check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved teardown to more reliably harvest and reap detached/descendant processes within the grace window, including wedged escalation cases.
  - Added identity-verified reaping so unverified/unconfirmable PIDs are never signaled, reducing risks from PID reuse.
  - Enhanced failure handling so the tmux window is struck before errors surface, improving consistency across teardown paths.
  - Strengthened end-to-end behavior to confirm detached processes are reaped before worktree merge/removal.
- **Documentation**
  - Clarified that the teardown grace period bounds both window termination and the subsequent descendant-process reap.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
