### PR TITLE
refactor(cli): codify the machine-output (--json) contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,12 @@ breaking changes may land in a minor release.
 
 ### Changed
 
+- **Machine-output (`--json`) contract codified in `machine.py`.** The pure-document conventions
+  from #190 — one JSON object on stdout, inline `schema_version`, additive-only evolution,
+  errors → stderr with empty stdout — now live in one module with shared `emit`/`add_json_flag`
+  helpers; `status --json` uses them (output byte-identical) and the duplicated token-total math
+  folded into `_run_token_totals`. `diagnose`/`probe-adapter --json` keep their older
+  report+fenced-block form for now (#195); `--json` adoption on more commands is tracked in #196.
 - **Backend-neutral naming for the seam-backed helpers and operator messages.** The multiplexer
   seam has non-tmux backends now, so the helpers that wrap it drop their legacy tmux names —
   `launch.tmux_available` → `mux_available`, `app._tmux_missing` → `_mux_missing`,

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -183,7 +183,7 @@ See [README.md](../README.md) for the narrative overview and [setup-guide.md](se
 - `bmad-loop resolve <run-id>` — resolve a CRITICAL escalation, then re-arm + resume (`--story`, `--no-interactive`, `--restore-patch <path>` for intent-gap patch-restore, `--resume`/`--no-resume`).
 - `bmad-loop decisions` — answer deferred-work decisions past sweeps left unanswered (`--list` to just show them).
 - `bmad-loop list` (`ls`) — list every run/sweep with its short ref, type, and status.
-- `bmad-loop status [<run-id>]` — run + sprint summary with per-story token totals, cost-weighted with the raw count alongside. `--json` instead emits a stable machine-readable document (schema-versioned; run state, snapshot `cache_read_weight`, per-story phase/attempt/review-cycle/tokens/commit/defer-reason) — the supported surface for scripts; the text output is best-effort.
+- `bmad-loop status [<run-id>]` — run + sprint summary with per-story token totals, cost-weighted with the raw count alongside. `--json` instead emits a stable machine-readable document (schema-versioned; run state, snapshot `cache_read_weight`, per-story phase/attempt/review-cycle/tokens/commit/defer-reason) per the [contract below](#machine-readable-output---json) — the supported surface for scripts; the text output is best-effort.
 - `bmad-loop diagnose [<run-id>]` (`diag`) — emit a sanitized diagnostic dump of a run/sweep to hand maintainers (histograms, counts, env, file sizes — no code/spec/prompts/paths/PII); a stray pseudonymized identifier is auto-substituted with its alias (disclosed in the report), while PII/secret hits still refuse to emit; defaults to the latest run (`--all`, `--out`, `--json`, `--max-journal-entries`).
 - `bmad-loop attach [<run-id>]` — tmux-attach to a run's live agent session.
 - `bmad-loop stop <run-id>` — stop a live run (engine + agent session).
@@ -194,3 +194,7 @@ See [README.md](../README.md) for the narrative overview and [setup-guide.md](se
 - `bmad-loop tui` — the interactive dashboard (`--low-frame-rate` for slow/SSH links).
 - `bmad-loop probe-adapter <cli>` (`collect-adapter-data`) — collect + sanitize adapter-finalization data for a CLI profile; default zero-launch scan, opt-in `--probe` live capture.
 - Every command takes `--project <dir>` (default: current directory). Any `<run-id>` accepts a partial — the tail after the last `-`, shortened to any unique prefix.
+
+### Machine-readable output (`--json`)
+
+A command's `--json` mode emits exactly one JSON object on stdout and nothing else — no trailers, no fenced blocks. Every document carries an inline integer `schema_version` owned by that command; evolution is additive-only, and anything breaking bumps the version. Errors never produce a partial or error document: the message goes to stderr, stdout stays empty, and the exit code is nonzero — so stdout is always either one complete valid document or empty. The contract is codified in `src/bmad_loop/machine.py`. Exception: `diagnose --json` and `probe-adapter --json` predate the contract and append a fenced JSON block to their text report instead; unifying them is tracked in [#195](https://github.com/bmad-code-org/bmad-loop/issues/195).

--- a/src/bmad_loop/cli.py
+++ b/src/bmad_loop/cli.py
@@ -18,6 +18,7 @@ from . import (
     decisions,
     deferredwork,
     install,
+    machine,
 )
 from . import policy as policy_mod
 from . import (
@@ -1422,17 +1423,33 @@ def cmd_decisions(args: argparse.Namespace) -> int:
 STATUS_SCHEMA_VERSION = 1
 
 
+def _run_token_totals(state: RunState) -> tuple[int, int, float]:
+    """Run-level token totals as ``(raw, weighted, weight)``.
+
+    The weight is the run's persisted snapshot — never live policy — so the
+    figures match what the run actually enforced; the TUI and the run summary
+    agree (see Engine.summary). Weighted is the sum of per-task weighted
+    totals (sum-of-rounds), never a weighted_total of the summed counters:
+    two tasks of 101 cache reads at weight 0.5 weigh 50 + 50 = 100, not
+    round(202 * 0.5) = 101.
+    """
+    weight = state.cache_read_weight()
+    raw = sum(t.tokens.total for t in state.tasks.values())
+    weighted = sum(t.tokens.weighted_total(weight) for t in state.tasks.values())
+    return raw, weighted, weight
+
+
 def _status_document(state: RunState) -> dict[str, object]:
     """The `status --json` document: the stable machine-readable contract.
 
-    Unlike the human-readable status text (best-effort, free to change), this
-    shape is an API: changes must be additive; anything breaking bumps
-    STATUS_SCHEMA_VERSION (same convention as diagnostics.SCHEMA_VERSION).
-    Everything here is derived from state.json alone — never from live policy
-    or other project files — so a consumer can reproduce the document, and the
-    weight matches what the run actually enforced (see Engine.summary).
+    Obeys the pure-document contract in machine.py (additive-only evolution;
+    anything breaking bumps STATUS_SCHEMA_VERSION), unlike the human-readable
+    status text, which is best-effort and free to change. Everything here is
+    derived from state.json alone — never from live policy or other project
+    files — so a consumer can reproduce the document, and the weight matches
+    what the run actually enforced (see _run_token_totals).
     """
-    weight = state.cache_read_weight()
+    raw_total, weighted_total, weight = _run_token_totals(state)
     if state.finished:
         status = "finished"
     elif state.paused:
@@ -1476,10 +1493,8 @@ def _status_document(state: RunState) -> dict[str, object]:
         "paused_story_key": state.paused_story_key,
         "cache_read_weight": weight,
         "tokens": {
-            "raw": sum(t.tokens.total for t in state.tasks.values()),
-            # Per-task summation, same as Engine.summary: sum-of-rounds, never
-            # a weighted_total of the summed counters.
-            "weighted": sum(t.tokens.weighted_total(weight) for t in state.tasks.values()),
+            "raw": raw_total,
+            "weighted": weighted_total,
         },
         "tasks": tasks,
     }
@@ -1500,7 +1515,7 @@ def cmd_status(args: argparse.Namespace) -> int:
         return 1
     state = load_state(run_dir)
     if args.json:
-        print(json.dumps(_status_document(state), indent=2))
+        machine.emit(_status_document(state))
         return 0
     kind = f" [{state.run_type}]" if state.run_type != "story" else ""
     print(f"run {state.run_id}{kind}  started {state.started_at}")
@@ -1510,12 +1525,8 @@ def cmd_status(args: argparse.Namespace) -> int:
         print(f"status: PAUSED ({state.paused_stage}) — {state.paused_reason}")
     else:
         print("status: in progress (or interrupted)")
-    # From the run's persisted snapshot, so this matches the TUI and the run
-    # summary exactly (see Engine.summary). Per-task summation, same reason.
-    weight = state.cache_read_weight()
-    raw_total = sum(t.tokens.total for t in state.tasks.values())
+    raw_total, weighted_total, weight = _run_token_totals(state)
     if raw_total:
-        weighted_total = sum(t.tokens.weighted_total(weight) for t in state.tasks.values())
         print(
             f"tokens: {weighted_total:,} weighted "
             f"({raw_total:,} raw incl. cache reads, cache_read_weight {weight})"
@@ -2184,11 +2195,7 @@ def main(argv: list[str] | None = None) -> int:
 
     status_p = add("status", cmd_status, "show run + sprint state")
     status_p.add_argument("run_id", nargs="?")
-    status_p.add_argument(
-        "--json",
-        action="store_true",
-        help="emit a machine-readable JSON document instead of text",
-    )
+    machine.add_json_flag(status_p, "run state")
 
     diag_p = add(
         "diagnose",

--- a/src/bmad_loop/machine.py
+++ b/src/bmad_loop/machine.py
@@ -1,0 +1,39 @@
+"""The machine-readable output contract for CLI ``--json`` modes.
+
+``--json`` in its pure-document form means exactly one JSON object on stdout
+and nothing else — no trailers, no fenced blocks, no log lines. Every document
+carries an inline integer ``schema_version``; each command owns its own version
+constant (e.g. ``cli.STATUS_SCHEMA_VERSION``) so the documents evolve
+independently, the same convention as ``diagnostics.SCHEMA_VERSION``. Evolution
+is additive-only: new fields may appear, but anything breaking — removing or
+renaming a field, changing a type or the meaning of a value — bumps that
+command's version.
+
+Errors never produce a partial or error document: the message goes to stderr,
+stdout stays empty, and the exit code is nonzero. Consumers may rely on
+"stdout is either one complete valid document or empty".
+
+``diagnose --json`` and ``probe-adapter --json`` predate this contract — they
+append a fenced JSON block to a markdown/text report instead of emitting a
+pure document. Unifying them is tracked in
+https://github.com/bmad-code-org/bmad-loop/issues/195.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+
+def emit(doc: dict[str, object]) -> None:
+    """The single stdout write in JSON mode."""
+    print(json.dumps(doc, indent=2))
+
+
+def add_json_flag(parser: argparse.ArgumentParser, what: str) -> None:
+    """Register ``--json`` with the standard help text."""
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help=f"emit a stable machine-readable JSON document ({what}) instead of text",
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -536,14 +536,20 @@ def test_status_stories_mode_bad_manifest_is_soft(project, capsys):
     assert "no stories.yaml found" in capsys.readouterr().out
 
 
-def _status_json(project, capsys, *extra_args):
-    """Run `status --json` and parse the WHOLE of stdout — parsing the full
-    stream (not a substring) is itself the assertion that nothing but the
-    document is printed."""
-    assert cli.main(["status", "--project", str(project.project), "--json", *extra_args]) == 0
+def _machine_json(argv, capsys):
+    """Run a `--json` CLI command and parse the WHOLE of stdout — parsing the
+    full stream (not a substring) is itself the assertion that nothing but the
+    document is printed (the machine.py purity contract)."""
+    assert cli.main(argv) == 0
     out, err = capsys.readouterr()
     assert err == ""
     return json.loads(out)
+
+
+def _status_json(project, capsys, *extra_args):
+    return _machine_json(
+        ["status", "--project", str(project.project), "--json", *extra_args], capsys
+    )
 
 
 def test_status_json_emits_pure_document(project, capsys):


### PR DESCRIPTION
## Summary

Phase 1 of the `--json` standardization plan: codify the machine-output contract with **no behavior change**. (Phase 2, `list --json` closing #192, follows on top of this.)

- **New thin module `src/bmad_loop/machine.py`** — the single home of the pure-document `--json` contract: exactly one JSON object on stdout, inline integer `schema_version` per command, additive-only evolution (breaking changes bump the command's version), errors → stderr + empty stdout + exit ≠ 0. Two shared helpers: `emit(doc)` and `add_json_flag(parser, what)`. These conventions previously lived only in `_status_document`'s docstring and test idioms.
- **`status --json` switches to `machine.emit` / `machine.add_json_flag`**, and the token-total math duplicated between `cmd_status`'s text/JSON branches and `_status_document` folds into one `_run_token_totals` helper — snapshot weight, sum-of-per-task-rounds, semantics pinned by the existing `test_status_json_weight_from_snapshot_and_per_task_rounding` (101+101@0.5→100).
- **Tests**: the JSON-purity assertion core (exit 0, empty stderr, `json.loads` of the *entire* stdout) is extracted from `_status_json` into a shared `_machine_json` helper; `_status_json` keeps its signature and every `test_status_json_*` test is unmodified.
- **Docs**: FEATURES.md gains a "Machine-readable output (`--json`)" contract blurb, referenced from the `status` line, noting that `diagnose --json` / `probe-adapter --json` are the older report+embedded-fenced-block form.
- **Follow-ups filed**: #195 (unify `diagnose`/`probe-adapter --json` with the pure-document contract — cited in `machine.py` and FEATURES.md), #196 (tracking `--json` adoption on `decisions --list`, `clean`/`cleanup --dry-run`, `validate`).

The only user-visible delta is `status --help`'s `--json` line, which now uses the standard wording ("emit a stable machine-readable JSON document (run state) instead of text").

## Test plan

- Full suite: 2521 passed, 1 skipped (`.venv/bin/python -m pytest`), `test_status_json_*` untouched.
- Byte-diff smoke: `bmad-loop status --json` and the text mode captured on a fixture project (two tasks, tokens, defer reason, snapshot weight 0.5) before and after the refactor — byte-identical.
- `trunk check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Standardized `status --json` output as a single machine-readable JSON document with an inline schema version.
  * Errors now produce no JSON on stdout and report details through stderr.
  * Improved consistency of raw and weighted token totals across status views.
  * JSON output can evolve additively without breaking existing fields.

* **Documentation**
  * Added the machine-readable output contract and clarified text-output behavior.
  * Documented that `diagnose --json` and `probe-adapter --json` retain their existing formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->