### PR TITLE
fix(cli): emit --json documents to a UTF-8 stdout (#200)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -257,6 +257,19 @@ PATH)`, the TUI notifies `multiplexer backend unavailable — launch/attach disa
 
 ### Fixed
 
+- **`--json` output survives a console that cannot encode it (#200).** A JSON document is not
+  necessarily ASCII: `diagnostics.render_json` serializes with `ensure_ascii=False` so its leak
+  guard can scan values unescaped (#195, below), which lets a _non_-sensitive non-ASCII field —
+  a localized `platform.release()`, say — reach stdout verbatim. Printing it to a console whose
+  encoding could not carry it raised `UnicodeEncodeError`, in practice a legacy non-UTF-8
+  Windows one. It failed safe rather than silently — the encode runs before any write, so
+  stdout stayed empty instead of half-written — but `diagnose --json` still died on a machine
+  where `--out FILE` would have worked. `machine.emit_document` now switches stdout to UTF-8
+  before writing. Re-serializing the document as escaped ASCII would have been the smaller
+  change and the wrong one: the leak check verified the unescaped bytes, and emitting anything
+  re-derived from them is what that helper exists to prevent. `--out FILE` was never affected;
+  it has always written `encoding="utf-8"`.
+
 - **Leak self-check now matches JSON-escaped values (#195).** Two evasions became reachable
   the moment `diagnose --json` stopped also rendering the markdown report, since that raw-text
   pass was what had been catching them: `json.dumps` doubles backslashes, so a Windows home

--- a/src/bmad_loop/machine.py
+++ b/src/bmad_loop/machine.py
@@ -52,12 +52,19 @@ Two ways in, by what the caller already holds:
 
 :func:`write_document` is the ``--out`` sibling of :func:`emit_document`, taking
 the same already-serialized string to a file instead of stdout.
+
+The serializer flags differ by family on purpose and are not to be unified: the
+renderers behind :func:`emit_document` sort their keys (a diff-stable dump is
+worth more than field order there) while :func:`emit`'s dicts are built in the
+order they are meant to be read, and ``diagnostics.render_json`` alone passes
+``ensure_ascii=False`` because its leak guard has to scan the values unescaped.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import sys
 from pathlib import Path
 
 
@@ -93,8 +100,25 @@ def emit_document(rendered: str) -> None:
     Raises :class:`ValueError` on a malformed document — a bug in the caller's
     renderer, and far better surfaced as a crash with empty stdout (which the
     contract permits) than as a half-parsable stream a consumer has to diagnose.
+
+    stdout is switched to UTF-8 first, because a document is not necessarily
+    ASCII — ``diagnostics.render_json`` dumps with ``ensure_ascii=False`` so its
+    leak guard can scan the values unescaped, which lets a non-sensitive
+    non-ASCII field (a localized ``platform.release()``, say) through to here
+    verbatim. Encoding it for a legacy non-UTF-8 console then raised
+    :class:`UnicodeEncodeError` before a byte was written (#200). Escaping the
+    output instead would have been the smaller change and the wrong one: it
+    breaks the invariant this function exists for, since the guard verified the
+    unescaped bytes. So the stream is made able to carry the document rather
+    than the document cut down to fit the stream.
     """
-    print(_validated(rendered))
+    document = _validated(rendered)
+    # Guarded: a substituted stdout (pytest capture, an exotic stream) may not be
+    # a TextIOWrapper at all. Falling through leaves the pre-#200 behaviour, which
+    # is a crash with stdout still empty — permitted by the contract above.
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8")
+    print(document)
 
 
 def write_document(path: Path, rendered: str) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,9 @@
 """CLI command tests — init policy-derived profiles and per-stage dry-run."""
 
 import argparse
+import io
 import json
+import sys
 
 import pytest
 import yaml
@@ -720,6 +722,47 @@ def test_emit_document_verifies_without_altering_the_bytes(capsys):
     with pytest.raises(ValueError, match="malformed JSON document"):
         machine.emit_document('{"truncated": ')
     assert capsys.readouterr().out == ""  # refused before writing anything
+
+
+def test_emit_document_writes_utf8_to_a_console_that_cannot_encode_the_document():
+    """A document is not necessarily ASCII: `diagnostics.render_json` dumps with
+    ensure_ascii=False so its leak guard can scan values unescaped, which lets a
+    non-sensitive non-ASCII field through to stdout verbatim. On a console that
+    cannot encode it — a legacy non-UTF-8 Windows one — that used to take the
+    whole command down with UnicodeEncodeError before a byte was written (#200).
+
+    The stream is widened to fit the document, not the document narrowed to fit
+    the stream: re-dumping with ensure_ascii=True would emit bytes the leak
+    check never saw, which is the one thing emit_document exists to prevent."""
+    from bmad_loop import machine
+
+    raw = io.BytesIO()
+    # newline="" so the assertion below is byte-exact on Windows too, where the
+    # default would translate print's \n to \r\n. Matches pytest's own CaptureIO.
+    ascii_console = io.TextIOWrapper(raw, encoding="ascii", newline="")
+    original = '{\n  "os_release": "5.15-café"\n}'
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(sys, "stdout", ascii_console)
+        machine.emit_document(original)
+        ascii_console.flush()
+
+    written = raw.getvalue().decode("utf-8")
+    assert written == original + "\n"  # verbatim, as on any other stream
+    assert json.loads(written)["os_release"] == "5.15-café"
+
+
+def test_emit_document_survives_a_stdout_that_cannot_be_reconfigured(capsys):
+    """The UTF-8 switch is hasattr-guarded: a substituted stdout need not be a
+    TextIOWrapper, and StringIO — no reconfigure, and no encoding to fail on —
+    is the shape that proves the guard does not itself become the crash."""
+    from bmad_loop import machine
+
+    sink = io.StringIO()
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(sys, "stdout", sink)
+        machine.emit_document('{"a": "café"}')
+    assert sink.getvalue() == '{"a": "café"}\n'
+    assert capsys.readouterr().out == ""  # nothing leaked to the real stdout
 
 
 def test_write_document_matches_the_stdout_bytes_and_validates(tmp_path, capsys):


### PR DESCRIPTION
Closes #200.

## The bug

`diagnose --json` could die with `UnicodeEncodeError` on a console whose encoding cannot carry a non-ASCII character in the document:

```
$ PYTHONIOENCODING=ascii python -c "from bmad_loop import machine; machine.emit_document('{\"os_release\": \"5.15-café\"}')"
UnicodeEncodeError: 'ascii' codec can't encode character '\xe9' in position 24: ordinal not in range(128)
```

The exposure arrived with #195, which changed `diagnostics.render_json` to `ensure_ascii=False`. That flag is a safety requirement, not cosmetics — with the default, a non-ASCII sensitive value is escaped to `\uXXXX` *before* `sanitize.assert_no_leak` scans the rendered bytes, so the guard misses it entirely. The guard needs the raw form. The only open question was what gets *written* afterwards.

Narrow and fail-safe as filed: it needs non-ASCII that survived the guard (so a non-sensitive value — a localized `platform.release()`) **and** a stdout encoding that cannot represent it, in practice a legacy non-UTF-8 Windows console. `str.encode` runs before any write, so stdout stayed empty rather than half-written — a contract-permitted error shape. But `diagnose --json` still died on a machine where `--json --out FILE` would have worked.

## The fix

Option (2) from the issue: `machine.emit_document` switches stdout to UTF-8 before the write, guarded by `hasattr` since a substituted stdout (pytest capture, an exotic stream) need not be a `TextIOWrapper`. On that fallback the pre-existing crash-with-empty-stdout is what the contract already permits.

Rejected alternatives, and why:

- **Guard on the raw form, emit the escaped form** (option 3). Smaller, no encoding risk at all, and escaping provably cannot introduce content. But it breaks the "emit exactly the bytes the leak check verified" invariant that `emit_document` exists to enforce, which is worth more than this edge costs.
- **Write `sys.stdout.buffer` directly** (option 1). Deterministic, but bypasses `sys.stdout` and so breaks `capsys` across every `--json` test.
- **Reverting `ensure_ascii=False`.** Reopens the leak-guard evasion #195 closed.

`reconfigure(encoding=...)` preserves `newline`, `line_buffering` and `write_through`, so it changes nothing but the codec — verified against CPython 3.13 before adopting it.

`write_document` needed no change: `--out FILE` has always written `encoding="utf-8"`. `diagnostics.py:524` already asserted the document "is only ever written with `encoding=\"utf-8\"` … or printed to a UTF-8 stream" — this makes the second half true rather than assumed.

Also adds a note to `machine.py`'s module docstring recording that the per-family serializer flags (`sort_keys`, `ensure_ascii`) differ **on purpose** and are not to be unified: the `emit_document` renderers sort keys for a diff-stable dump, `emit`'s dicts are built in the order they are meant to be read, and only `diagnostics.render_json` needs `ensure_ascii=False`.

## Tests

`test_emit_document_writes_utf8_to_a_console_that_cannot_encode_the_document` drives the emit path against a `TextIOWrapper(encoding="ascii")` stdout with a non-ASCII value, and asserts the bytes decode as UTF-8 to the verbatim document. It fails pre-fix with exactly the reported `UnicodeEncodeError` (confirmed by stashing only `machine.py`), and the issue's original `PYTHONIOENCODING=ascii` subprocess repro now round-trips through a real pipe.

`test_emit_document_survives_a_stdout_that_cannot_be_reconfigured` covers the `hasattr` fallback with a `StringIO` — the shape that proves the guard does not itself become the crash.

The `machine_json` conftest helper stays the purity net for the normal path; it is untouched.

Full suite green (2579 passed, 1 skipped), `trunk check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `diagnose --json` failures on consoles that cannot encode non-ASCII characters.
  - JSON output now writes UTF-8 content reliably while preserving non-ASCII characters.
  - Output redirected to a file continues to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->