### PR TITLE
feat(tui): render validate --json in a findings modal (#210)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,16 @@ breaking changes may land in a minor release.
 
 ### Changed
 
+- **The TUI's validate modal (`v`) renders `validate --json` instead of the text output (#210).**
+  One row per check — glyph, stable `check` id, message — with the verdict taken from the
+  document's `ok` rather than the exit code, which cannot tell "the checks failed" from "the
+  command broke". A check's `detail` is now reachable at all: inline for warnings and problems,
+  and `d` toggles it on for everything, so `mux.backends-detected` expands to a row per backend
+  instead of the text's `tmux*, psmux (unavailable)`. A failure adds a footer noting the gates
+  are chained — the later gates emit nothing after one fails, so a short list is not a short
+  list of problems. An unrenderable document (a newer schema, unparseable stdout) re-runs
+  validate in text mode and shows the old modal unchanged.
+
 - **BREAKING: `probe-adapter` now runs `diagnose`'s egress leak self-check, and captured hook
   payloads ship as a schema instead of scrubbed values (#199).** The rendered report re-scans
   itself before emitting (the guard moved to `sanitize.guard`, one audited implementation for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,6 +201,16 @@ breaking changes may land in a minor release.
   list of problems. An unrenderable document (a newer schema, unparseable stdout) re-runs
   validate in text mode and shows the old modal unchanged.
 
+- **`validate` reports a failed external mux backend as a warning, not a note (#210).** The
+  `mux.external-backend` finding has always read as a failure — "external mux backend 'x'
+  failed to load: …" — while carrying severity `ok`, so it counted as a passing check; it is
+  now `warning`, matching what `bmad-loop mux` has always printed for the same condition. It
+  stays below `problem` deliberately: selection degrades past a broken external, so the verdict
+  and exit code are unchanged. On an affected host `validate --json`'s `counts` shift by one
+  (`warning` +1, `ok` −1) while `ok` and rc do not; the schema version is deliberately
+  unchanged, since the document contracts each `check` id, not a given check's outcome. The
+  text line gains the doubled `ok:   warning:` prefix that `render()` preserves by design.
+
 - **BREAKING: `probe-adapter` now runs `diagnose`'s egress leak self-check, and captured hook
   payloads ship as a schema instead of scrubbed values (#199).** The rendered report re-scans
   itself before emitting (the guard moved to `sanitize.guard`, one audited implementation for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -290,6 +290,13 @@ PATH)`, the TUI notifies `multiplexer backend unavailable — launch/attach disa
 
 ### Fixed
 
+- **A dry run the TUI cannot spawn opens a modal instead of taking the app down (#210).** The
+  `run --dry-run` / `sweep --dry-run` workers called `run_captured` unguarded, and
+  `@work(thread=True)` defaults to `exit_on_error=True` — so an `OSError` from the spawn itself
+  (a venv deleted out from under `sys.executable`, `EAGAIN` off a loaded process table) escaped
+  the worker and killed the whole app rather than the one modal. Both workers and the validate
+  degrade now share a guard that reports the reason in the modal body.
+
 - **`--json` output survives a console that cannot encode it (#200).** A JSON document is not
   necessarily ASCII: `diagnostics.render_json` serializes with `ensure_ascii=False` so its leak
   guard can scan values unescaped (#195, below), which lets a _non_-sensitive non-ASCII field —

--- a/docs/tui-guide.md
+++ b/docs/tui-guide.md
@@ -277,7 +277,7 @@ Journal kinds are styled by substring, first match wins:
 | `D`      | delete the selected run's directory (confirm modal)                        |
 | `A`      | archive the selected run to `.bmad-loop/archive` (confirm modal)           |
 | `c`      | clean up tmux sessions/windows for finished & stopped runs (confirm modal) |
-| `v`      | run `bmad-loop validate`, output in a modal                                |
+| `v`      | run `bmad-loop validate`, findings in a modal (`d` toggles detail)         |
 | `g`      | settings editor for `.bmad-loop/policy.toml`                               |
 | `M`      | toggle theme (light/dark mode)                                             |
 | `y`      | copy the active Log/Attention pane to the clipboard                        |
@@ -482,10 +482,25 @@ modal to leave that one for later. The same set is available on the CLI via
 
 ## Validate (`v`)
 
-Runs `bmad-loop validate --project <project>` in the background and shows the
-combined output in a scrollable modal titled `validate — ok` (or
-`exit <code>`). Same preflight as the CLI: config, sprint-status, git, tmux,
-CLI binary, hooks.
+Runs `bmad-loop validate --project <project> --json` in the background and
+renders the document in a scrollable modal: a verdict header with the
+per-severity counts and the queue mode, then one row per check — glyph, the
+stable `check` id, and the message. Same preflight as the CLI: config,
+sprint-status, git, tmux, CLI binary, hooks.
+
+The verdict is the document's own `ok`, not the exit code, which cannot tell
+"the checks failed" from "the command broke". A check's `detail` — the data it
+knew before flattening itself into a sentence, like every detected mux backend
+rather than the text mode's `tmux*, psmux (unavailable)` — shows inline for
+warnings and problems, and `d` toggles it on for everything. When anything
+failed, a footer notes that the gates are **chained**: a policy failure leaves
+the later gates emitting nothing at all, so a short findings list after a
+failure is not a short list of problems.
+
+If the document cannot be rendered — a schema newer than this TUI, or output
+that is not a document at all — `v` silently re-runs validate in text mode and
+shows the combined output in a modal titled `validate — ok` (or `exit <code>`),
+exactly as it did before.
 
 ## Settings editor (`g`)
 

--- a/src/bmad_loop/cli.py
+++ b/src/bmad_loop/cli.py
@@ -310,14 +310,20 @@ def _platform_preflight() -> list[Finding]:
             )
         )
 
-    # Advisory, not a problem: selection already degraded past the broken
-    # package (a failed external can never be the selected backend), so the
-    # preflight outcome above is authoritative — this line explains the absence.
+    # A warning, not a problem and not a note: an installed package the operator
+    # asked for did not load, which is a real failure — but selection already
+    # degraded past it (a failed external can never be the selected backend), so
+    # the preflight outcome above is authoritative and the verdict must not flip.
+    # `cmd_mux` has always printed this same condition as `warning:`; validate was
+    # the outlier, pinned to "ok" because promoting inserts "  warning: " into the
+    # text (render() keeps the double prefix by design) and the TUI rendered that
+    # text verbatim. Since #210 the TUI reads `validate --json` and styles from the
+    # severity field, so the severity is free to say what the message already does.
     for ep_name, reason in sorted(external_backend_errors().items()):
         found.append(
             Finding(
                 "mux.external-backend",
-                "ok",
+                "warning",
                 f"external mux backend '{ep_name}' failed to load: {reason}",
                 {"entry_point": ep_name, "error": reason},
             )

--- a/src/bmad_loop/tui/app.py
+++ b/src/bmad_loop/tui/app.py
@@ -2,7 +2,9 @@
 
 Observer/launcher only: the TUI never runs engines in-process. Run control
 (r/s/e) launches detached bmad-loop processes in the bmad-loop-ctl tmux
-session via tui.launch; validate and dry runs are captured into a modal.
+session via tui.launch. Dry runs are captured into a text modal; validate
+renders its `--json` document into a findings modal (falling back to the text
+one), so the verdict is the document's `ok` rather than an exit code.
 The g binding opens the policy.toml settings editor.
 """
 
@@ -36,7 +38,7 @@ from ..model import (
 from ..policy import POLICY_FILE
 from ..process_host import ProcessHostError
 from ..runs import RUNS_DIR, RearmError, StopRunError
-from . import data, launch
+from . import data, launch, widgets
 from .screens.dashboard import DashboardScreen
 from .screens.modals import (
     ConfirmModal,
@@ -48,6 +50,7 @@ from .screens.modals import (
     StartSweepModal,
     StoryCheckpointModal,
     TextOutputModal,
+    ValidateFindingsModal,
 )
 from .screens.settings_screen import SettingsScreen
 from .settings import PolicyDoc
@@ -950,7 +953,46 @@ class BmadLoopApp(App[None]):
         )
 
     def action_validate(self) -> None:
-        self._show_captured("validate", ["validate", "--project", str(self.project)])
+        self._show_validate()
+
+    @work(thread=True, exclusive=True, group="captured")
+    def _show_validate(self) -> None:
+        """Preflight in a findings modal, degrading to the text one (#210).
+
+        A sibling of _show_captured rather than a change to it: that worker still
+        serves the two dry runs, which have no document to parse.
+
+        The transport is the subprocess and `--json`, not documents.py's builders
+        in-process, which its module docstring otherwise asks a non-CLI frontend
+        to prefer. Knowing exception: cmd_validate imports third-party mux entry
+        points and probes httpx, so the subprocess quarantines a broken plugin's
+        import side effects and leaves the TUI's own lru_cached mux selection
+        undisturbed. Extracting an in-process builder is a follow-up.
+
+        The body is guarded because @work(thread=True) defaults to
+        exit_on_error=True: a JSONDecodeError or a KeyError escaping here would
+        take the whole app down, not just this modal. exit_on_error=False is not
+        the fix — that trades the crash for pressing `v` and nothing happening.
+
+        The degrade **re-runs validate in text mode** rather than showing the
+        captured JSON. Dumping the document would withhold a perfectly good human
+        rendering at the exact moment the structural one failed, and hand the
+        reader a wall of `{"schema_version": ...}` instead. One sub-second
+        subprocess on a path that should never fire buys a degrade that is
+        byte-for-byte the pre-#210 behavior.
+        """
+        tail = ["validate", "--project", str(self.project)]
+        try:
+            _rc, out, _err = launch.run_captured_streams([*tail, "--json"])
+            doc = widgets.validate_document(out)
+        except Exception:  # noqa: BLE001 — a JSON-leg failure degrades, never kills the app
+            doc = None
+        if doc is None:
+            rc, merged = launch.run_captured(tail)
+            screen = TextOutputModal("validate", rc, merged)
+        else:
+            screen = ValidateFindingsModal(doc)
+        self.call_from_thread(self.push_screen, screen)
 
     @work(thread=True, exclusive=True, group="captured")
     def _show_captured(self, title: str, tail: list[str]) -> None:

--- a/src/bmad_loop/tui/app.py
+++ b/src/bmad_loop/tui/app.py
@@ -980,6 +980,12 @@ class BmadLoopApp(App[None]):
         reader a wall of `{"schema_version": ...}` instead. One sub-second
         subprocess on a path that should never fire buys a degrade that is
         byte-for-byte the pre-#210 behavior.
+
+        That re-run goes through _run_captured_guarded rather than calling
+        run_captured directly: the except above does not cover it, and the two
+        legs spawn the same subprocess, so a failure to spawn at all is not a
+        JSON-leg failure a text re-run recovers from — it is the same failure
+        twice, the second one escaping into exit_on_error.
         """
         tail = ["validate", "--project", str(self.project)]
         try:
@@ -988,15 +994,33 @@ class BmadLoopApp(App[None]):
         except Exception:  # noqa: BLE001 — a JSON-leg failure degrades, never kills the app
             doc = None
         if doc is None:
-            rc, merged = launch.run_captured(tail)
+            rc, merged = self._run_captured_guarded(tail)
             screen = TextOutputModal("validate", rc, merged)
         else:
             screen = ValidateFindingsModal(doc)
         self.call_from_thread(self.push_screen, screen)
 
+    def _run_captured_guarded(self, tail: list[str]) -> tuple[int, str]:
+        """run_captured, with a failure to spawn rendered as output, not raised.
+
+        Every caller is a @work(thread=True) body, and that decorator defaults to
+        exit_on_error=True: an OSError out of subprocess.run — a deleted venv
+        under sys.executable, EAGAIN off a loaded process table — would escape
+        the worker and take the whole app down rather than this one modal.
+
+        The reason goes in the body rather than a notify() because the modal is
+        already opening; a blank panel over an `exit 1` header would say only
+        that something went wrong. The header carries which command it was, so
+        the body does not repeat it.
+        """
+        try:
+            return launch.run_captured(tail)
+        except Exception as exc:  # noqa: BLE001 — a failed spawn is a modal, not a crash
+            return 1, f"could not run: {exc}"
+
     @work(thread=True, exclusive=True, group="captured")
     def _show_captured(self, title: str, tail: list[str]) -> None:
-        rc, out = launch.run_captured(tail)
+        rc, out = self._run_captured_guarded(tail)
         self.call_from_thread(self.push_screen, TextOutputModal(title, rc, out))
 
     def action_settings(self) -> None:

--- a/src/bmad_loop/tui/launch.py
+++ b/src/bmad_loop/tui/launch.py
@@ -357,13 +357,45 @@ def start_resolve_detached(project: Path, run_id: str) -> str | None:
     )
 
 
+def run_captured_streams(argv_tail: list[str]) -> tuple[int, str, str]:
+    """Run a fast read-only command (validate, --dry-run) and capture its output
+    with the two streams kept **apart**.
+
+    Separation is the whole point of this seam. Anything parsing stdout as a
+    whole document — a ``--json`` command, whose contract in :mod:`bmad_loop.machine`
+    is that stdout is one JSON object and nothing else — cannot use the merged
+    form: :func:`run_captured` appends stderr *after* stdout, so a single
+    ``DeprecationWarning`` written to the child's stderr by any dependency turns
+    ``json.loads`` into ``Extra data:``. That failure is environment-dependent —
+    it needs the right interpreter, the right installed versions, the right
+    warning filters — so it would pass everywhere it was tested and silently
+    degrade the JSON path to the text one on a user's machine. A caller that
+    genuinely wants one blob merges them itself; a caller that parses must never
+    have been handed the option.
+
+    Decoding is pinned to UTF-8 with ``errors="replace"`` rather than
+    ``text=True``, which decodes with the *locale* encoding at ``errors="strict"``
+    — the #200 family of failure already fixed CLI-side in :mod:`bmad_loop.machine`.
+    A console in a non-UTF-8 code page must not turn a perfectly good document
+    into a ``UnicodeDecodeError`` on the way in.
+    """
+    proc = subprocess.run(
+        cli_argv(*argv_tail), capture_output=True, encoding="utf-8", errors="replace"
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
 def run_captured(argv_tail: list[str]) -> tuple[int, str]:
     """Run a fast read-only command (validate, --dry-run) and capture its
-    combined output for display."""
-    proc = subprocess.run(cli_argv(*argv_tail), capture_output=True, text=True)
-    out = proc.stdout
-    if proc.stderr:
+    combined output for display.
+
+    For text display only. Anything that parses the output must call
+    :func:`run_captured_streams` — see its docstring on why the merge is
+    unparseable.
+    """
+    rc, out, err = run_captured_streams(argv_tail)
+    if err:
         if out and not out.endswith("\n"):
             out += "\n"
-        out += proc.stderr
-    return proc.returncode, out
+        out += err
+    return rc, out

--- a/src/bmad_loop/tui/screens/modals.py
+++ b/src/bmad_loop/tui/screens/modals.py
@@ -21,7 +21,7 @@ from textual.widgets import Button, Checkbox, Input, Label, Select, Static
 
 from ... import stories
 from ...model import RunState
-from .. import data
+from .. import data, widgets
 
 
 def _int_or_none(value: str) -> int | None:
@@ -626,8 +626,72 @@ class EscalationModal(BaseDialog):
         self.dismiss(bid[len("act-") :] if bid.startswith("act-") else None)
 
 
+class ValidateFindingsModal(BaseDialog):
+    """`validate --json` rendered structurally: verdict, then one row per finding.
+
+    The text mode this replaces made severity a string prefix and the verdict an
+    exit code, and had already flattened away what each check knew. Here the
+    verdict is the document's own ``ok`` — which, unlike ``rc``, separates "the
+    checks failed" from "the command broke" — severities are styled, and
+    ``detail`` is renderable: inline for warnings and problems, and one ``d``
+    away for everything else.
+
+    Everything user-controlled (a ``spec_folder``, a check's ``message``) arrives
+    as rich ``Text`` built in :mod:`bmad_loop.tui.widgets`, never as markup: both
+    ``Static`` and ``Label`` default to ``markup=True``, so a spec folder named
+    ``docs/[wip]-epic-3`` interpolated into an f-string title would be a
+    ``MarkupError``.
+
+    ``__init__`` deliberately does nothing but store the document. The worker
+    that builds this screen runs on a **thread**; composing is the app's job, on
+    the main thread. ``TextOutputModal`` is the precedent.
+    """
+
+    DEFAULT_CSS = """
+    ValidateFindingsModal #dialog {
+        width: 96;
+        height: 80%;
+    }
+    ValidateFindingsModal #findings {
+        height: 1fr;
+    }
+    """
+
+    # BaseDialog's escape binding is inherited: Textual collects BINDINGS from
+    # the whole MRO, so this list adds to it rather than replacing it.
+    BINDINGS = [Binding("d", "toggle_detail", "detail")]
+
+    def __init__(self, doc: dict):
+        super().__init__()
+        self._doc = doc
+        self._details = False
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="dialog"):
+            yield Static(widgets.validate_header(self._doc), classes="title")
+            with VerticalScroll(id="findings"):
+                yield Static(widgets.validate_findings(self._doc, details=self._details), id="grid")
+            yield Static(Text("d — toggle detail on every finding", style="dim"))
+            with Horizontal(classes="buttons"):
+                yield Button("close", variant="primary", id="ok")
+
+    def action_toggle_detail(self) -> None:
+        self._details = not self._details
+        self.query_one("#grid", Static).update(
+            widgets.validate_findings(self._doc, details=self._details)
+        )
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        self.dismiss(None)
+
+
 class TextOutputModal(BaseDialog):
-    """Scrollable captured command output (validate, dry runs)."""
+    """Scrollable captured command output (dry runs, and the validate degrade).
+
+    Still the validate path's fallback: when the JSON document is unrenderable,
+    the app re-runs validate in text mode and shows it here, byte-for-byte the
+    pre-#210 behavior. See ``BmadLoopApp._show_validate``.
+    """
 
     DEFAULT_CSS = """
     TextOutputModal #dialog {

--- a/src/bmad_loop/tui/widgets.py
+++ b/src/bmad_loop/tui/widgets.py
@@ -7,6 +7,7 @@ interpreted as markup.
 
 from __future__ import annotations
 
+import json
 import time
 from pathlib import Path
 from typing import Any, Callable
@@ -258,6 +259,281 @@ class JournalEntryOption(Option):
 def _short(value: Any, limit: int = 60) -> str:
     s = str(value)
     return s if len(s) <= limit else s[: limit - 1] + "…"
+
+
+# --------------------------------------------------------- validate findings
+#
+# A structural rendering of the `validate --json` document (documents.py), for
+# the TUI's validate modal. The text mode's severities are string prefixes and
+# its verdict is an exit code; here both are fields, and the `detail` each check
+# carried before it flattened itself into a sentence is renderable.
+
+# The document schema version this renderer was written against — a HAND-WRITTEN
+# literal, deliberately *not* an import of documents.VALIDATE_SCHEMA_VERSION.
+#
+# This is load-bearing. An import would auto-follow a CLI schema bump, and the
+# fields read below would very likely still resolve against a v2 document, so
+# the result would not be a refusal — it would be a quietly wrong modal in a
+# user's terminal, with the suite green. Pinning the literal makes a bump a
+# deliberate edit *here*, after re-reading this renderer against the new
+# document, and a tripwire test fails the moment the two diverge.
+_RENDERS_VALIDATE_SCHEMA = 1
+
+# Finding severities (checks.py: ok/warning/problem). A DIFFERENT vocabulary
+# from _SEVERITY_STYLES further down, which styles deferred-work items
+# (critical/high/medium/low) — separate maps on purpose, no reuse. Both are
+# read through .get() with a fallback: severity arrives from a subprocess
+# document, so an unrecognised string must render neutrally, never KeyError.
+_FINDING_STYLES = {
+    "ok": "green",
+    "warning": "yellow",
+    "problem": "bold red",
+}
+
+_FINDING_GLYPHS = {
+    "ok": "✓",
+    "warning": "!",
+    "problem": "✖",
+}
+
+# Row-grid geometry, mirroring the journal's. The check column is wide enough
+# for the longest id in checks.VALIDATE_CHECKS ("queue.sprint-status-unknown-keys")
+# so ids do not fold in practice; it folds rather than truncates if one grows.
+# The message column's left edge is the sum of everything before it, and the
+# alignment test derives its indent from these same constants so the two cannot
+# silently drift apart.
+_FINDING_GLYPH_WIDTH = 1
+_FINDING_CHECK_WIDTH = 32
+_FINDING_COL_PAD = 1  # per-column right pad in the row grid
+
+
+def validate_document(stdout: str) -> dict | None:
+    """Parse `validate --json` stdout into a document this renderer can draw.
+
+    Returns ``None`` — **never raises** — for anything undrawable: unparseable
+    stdout, a schema version this renderer was not written against, or a
+    document whose shape is not the one the renderer walks. The caller's
+    degrade is then a value check rather than an exception, which matters
+    because the caller runs on a worker thread where an escaping exception
+    takes the app down.
+
+    The version check is an equality, not a ``>=``: a *newer* document is
+    exactly the case that must degrade rather than be half-rendered.
+    """
+    try:
+        doc = json.loads(stdout)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(doc, dict):
+        return None
+    if doc.get("schema_version") != _RENDERS_VALIDATE_SCHEMA:
+        return None
+    if not isinstance(doc.get("findings"), list):
+        return None
+    if not isinstance(doc.get("counts"), dict):
+        return None
+    return doc
+
+
+def _is_scalar(value: Any) -> bool:
+    return value is None or isinstance(value, (str, int, float, bool))
+
+
+def _detail_scalar(value: Any) -> str:
+    """One leaf as text, in JSON's spelling — ``true``/``null``, not Python's
+    ``True``/``None`` — so a rendered detail reads as the document it came from."""
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)
+
+
+def _detail_pairs(mapping: dict) -> str:
+    return ", ".join(f"{k}={_detail_scalar(v)}" for k, v in mapping.items())
+
+
+def _json_leaf(value: Any) -> str:
+    """A value too deep or too odd for the depth-2 walk, as JSON.
+
+    Never ``str()``: that prints a Python repr (``{'dev': 'claude'}``) at the
+    user, which is the exact tell that a renderer met a shape it did not model.
+    """
+    try:
+        return json.dumps(value, ensure_ascii=False, default=str)
+    except (TypeError, ValueError):  # unreachable for json.loads output; this renders, never raises
+        return str(value)
+
+
+def _detail_lines(detail: Any) -> list[str]:
+    """A finding's ``detail`` as flat text rows: **depth-2, not recursive.**
+
+    The real shapes, enumerated from every check site (cli.py's validate gates
+    and platform preflight, install.py's skill probes): ``detail`` is one dict
+    whose values are a scalar (``str``/``int``/``bool``/``None`` — ``mux.backend``'s
+    ``version`` is ``str | None``), a list of scalars (``missing_markers``,
+    ``unknown_keys``, ``trees``), a dict of scalars (``policy``'s ``adapters`` —
+    a nested dict, on the *passing* path, in every successful validate), or a
+    list of dicts of scalars (``mux.backends-detected``, six keys per backend).
+    Two levels covers all of them.
+
+    Anything deeper or otherwise unmodelled falls back to :func:`_json_leaf`
+    rather than recursing: recursion is more machinery than this data justifies
+    and is unbounded for a payload nobody has written yet, whereas the fallback
+    is correct for any depth and still legible.
+    """
+    if not isinstance(detail, dict):
+        # detail is `dict | None` by contract; anything else still renders.
+        return [] if detail is None else [_json_leaf(detail)]
+    lines: list[str] = []
+    for key, value in detail.items():
+        if _is_scalar(value):
+            lines.append(f"{key}: {_detail_scalar(value)}")
+        elif isinstance(value, list) and all(_is_scalar(v) for v in value):
+            lines.append(f"{key}: {', '.join(_detail_scalar(v) for v in value) or '—'}")
+        elif isinstance(value, dict) and all(_is_scalar(v) for v in value.values()):
+            lines.append(f"{key}: {_detail_pairs(value) or '—'}")
+        elif isinstance(value, list) and all(
+            isinstance(v, dict) and all(_is_scalar(x) for x in v.values()) for v in value
+        ):
+            # list[dict] gets a line per entry, so six-key backend rows stay
+            # readable instead of becoming one unreadable joined string.
+            lines.append(f"{key}:")
+            lines.extend(f"  {_detail_pairs(v) or '—'}" for v in value)
+        else:
+            lines.append(f"{key}: {_json_leaf(value)}")
+    return lines
+
+
+def _finding_rows(finding: Any, *, details: bool) -> list[tuple[Text, Text, Text]]:
+    """One finding as its grid rows: the finding itself, then its detail lines.
+
+    Detail shows inline for ``warning`` and ``problem`` — the findings someone
+    opened the modal to act on — and for everything when ``details``. One
+    severity rule, and zero matching on ``check`` ids: ids are the contracted
+    identity, but keying layout off them would make every new check a renderer
+    edit.
+    """
+    if not isinstance(finding, dict):
+        raise TypeError("finding is not a dict")
+    severity = finding.get("severity")
+    if not isinstance(severity, str):
+        severity = ""
+    style = _FINDING_STYLES.get(severity, "")
+    check = finding.get("check")
+    rows = [
+        (
+            Text(_FINDING_GLYPHS.get(severity, "?"), style=style),
+            Text("?" if check is None else str(check), style=style),
+            Text(str(finding.get("message", ""))),
+        )
+    ]
+    if details or severity in ("warning", "problem"):
+        rows += [
+            (Text(""), Text(""), Text(line, style="dim"))
+            for line in _detail_lines(finding.get("detail"))
+        ]
+    return rows
+
+
+def validate_findings(doc: dict, *, details: bool) -> Table:
+    """Every finding as **one** grid: glyph, ``check`` id, message + detail rows.
+
+    One grid for all findings rather than one per finding, which is what buys
+    column alignment *across* findings — the check ids line up into a readable
+    column instead of each row sizing itself. (journal_line builds a grid per
+    row for the mirror-image reason: there each row is alone and only its own
+    columns need to align.)
+
+    Two separate mechanisms keep it legible, both load-bearing:
+
+    - **The grid itself** handles multi-line messages. ``message`` may carry
+      newlines — the config, sprint-status and stories loaders put a PyYAML
+      ``MarkedYAMLError`` straight into ``str(e)`` — and in a flat ``Text`` an
+      embedded newline returns to column 0, destroying the alignment of every
+      row below it. In a cell it stays inside its column.
+    - **``overflow="fold"``** handles the long *unbroken* runs that wrapping
+      cannot break: absolute paths, joined marker lists, a ``check`` id longer
+      than its column. Folding wraps them; the default would truncate with an
+      ellipsis, silently dropping the end of a path someone needs to read.
+
+    Defensive **per finding**: a finding that is not a dict, or whose fields
+    are not what this walks, costs its own placeholder row and nothing more.
+    One malformed entry must not blank the modal a reader is using to find out
+    what is wrong.
+    """
+    grid = Table.grid(padding=(0, _FINDING_COL_PAD, 0, 0))
+    grid.add_column(width=_FINDING_GLYPH_WIDTH)
+    grid.add_column(width=_FINDING_CHECK_WIDTH, overflow="fold")
+    grid.add_column(overflow="fold")
+    findings = doc.get("findings")
+    if not isinstance(findings, list):
+        findings = []
+    for finding in findings:
+        try:
+            rows = _finding_rows(finding, details=details)
+        except Exception:  # noqa: BLE001 — a bad finding costs its row, never the modal
+            rows = [
+                (
+                    Text("?", style="dim"),
+                    Text("?", style="dim"),
+                    Text("(unreadable finding)", style="dim"),
+                )
+            ]
+        for row in rows:
+            grid.add_row(*row)
+    return grid
+
+
+def validate_header(doc: dict) -> Text:
+    """The verdict line, built from the document's ``ok`` — never from the
+    subprocess exit code, which conflates "checks failed" with "the command
+    broke". The document is the thing that actually knows which happened.
+
+    When any problem is present, a dim footer says the gates are chained. That
+    puts documents.py's "absence is not a pass" on screen: a policy failure
+    leaves the binary, hook and skill gates emitting *nothing at all*, so a
+    short findings list after a failure is not a short list of problems. It is
+    the one thing this rendering can teach that the text mode cannot.
+    """
+    ok = doc.get("ok")
+    text = Text()
+    if ok is True:
+        text.append("✓ validate passed", style="green")
+    elif ok is False:
+        text.append("✖ validate failed", style="bold red")
+    else:
+        text.append("? validate verdict unknown", style="dim")
+
+    counts = doc.get("counts")
+    if not isinstance(counts, dict):
+        counts = {}
+    tallies = [
+        f"{counts[severity]} {severity}"
+        for severity in ("ok", "warning", "problem")
+        if isinstance(counts.get(severity), int) and not isinstance(counts.get(severity), bool)
+    ]
+    if tallies:
+        text.append("  " + " · ".join(tallies), style="dim")
+
+    meta = []
+    mode = doc.get("mode")
+    if isinstance(mode, str) and mode:
+        meta.append(f"mode: {mode}")
+    # spec_folder is user-controlled; it goes into a Text, never into markup.
+    spec_folder = doc.get("spec_folder")
+    if isinstance(spec_folder, str) and spec_folder:
+        meta.append(f"spec: {spec_folder}")
+    if meta:
+        text.append("\n" + " · ".join(meta), style="dim")
+
+    problems = counts.get("problem")
+    if isinstance(problems, int) and not isinstance(problems, bool) and problems > 0:
+        text.append(
+            "\ngates are chained — checks after a failure may not have run",
+            style="dim italic",
+        )
+    return text
 
 
 # ------------------------------------------------------------- sprint tree

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,9 +13,10 @@ from pathlib import Path
 import pytest
 import yaml
 
-from bmad_loop import cli
+from bmad_loop import cli, documents
 from bmad_loop.adapters.base import SessionResult, SessionSpec
 from bmad_loop.bmadconfig import ProjectPaths
+from bmad_loop.checks import ValidationReport
 from bmad_loop.journal import save_state
 from bmad_loop.model import PAUSE_ESCALATION, Phase, RunState, SessionRecord, StoryTask
 from bmad_loop.verify import finalize_commit, rev_parse_head
@@ -161,6 +162,28 @@ def machine_json(argv, capsys, *, rc: int = 0, err_contains: str | None = None):
     else:
         assert err_contains in err
     return json.loads(out)
+
+
+def make_validate_document(findings, *, stories_on: bool = False, spec_folder: str = ""):
+    """Build a REAL `validate --json` document from (check, severity, message,
+    detail) tuples, for tests that need to *stub* one rather than run validate.
+
+    A sibling of machine_json, not an extension of it: that helper drives
+    cli.main + capsys to assert stdout purity, so it can only ever produce the
+    document a real run happens to emit on the host. Callers here need a chosen
+    document (a specific severity mix, a specific detail shape) and no
+    subprocess.
+
+    It is built by driving the same ValidationReport -> _validate_document path
+    the CLI drives, so the shape cannot drift from the contract by being
+    hand-written. Going through ValidationReport.add also means its assert
+    (checks.py) rejects invented check ids: a test cannot quietly pin behaviour
+    to a check that does not exist.
+    """
+    report = ValidationReport()
+    for check, severity, message, detail in findings:
+        report.add(check, severity, message, detail)
+    return documents._validate_document(report, stories_on, spec_folder)
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3223,6 +3223,53 @@ def test_validate_json_every_emitted_check_is_registered(project, capsys, monkey
     assert emitted <= VALIDATE_CHECKS
 
 
+@pytest.mark.parametrize("passing", [True, False], ids=["rc-0", "rc-1"])
+def test_tui_renderer_draws_every_detail_shape_a_real_validate_emits(
+    project, capsys, monkeypatch, passing
+):
+    """The bridge between the `--json` document and the TUI's renderer (#210), run
+    against a REAL validate rather than a fixture.
+
+    It lives in this file, not test_tui_app.py, because everything that produces a
+    real document — _make_validate_pass and the failure setups — is here; the
+    renderer is the thing imported. Its value is zero fixture maintenance: it draws
+    whatever shapes validate actually emits today, so a check site that starts
+    carrying a new `detail` shape is covered the moment it ships, rather than when
+    someone remembers to update a fixture.
+
+    Both legs matter: `ok`-severity detail shapes never appear on a failing run.
+    """
+    from rich.console import Console
+
+    from bmad_loop.tui import widgets
+
+    if passing:
+        _make_validate_pass(project, monkeypatch, capsys)
+        doc = machine_json(["validate", "--project", str(project.project), "--json"], capsys)
+    else:
+        _write_policy(project.project, CLAUDE_ONLY_POLICY)  # no BMAD config -> real problems
+        doc = machine_json(["validate", "--project", str(project.project), "--json"], capsys, rc=1)
+    assert doc["findings"], "the leg under test emitted findings"
+
+    console = Console(width=96)  # the width the modal is laid out for
+    with console.capture() as capture:
+        console.print(widgets.validate_findings(doc, details=True))
+    rendered = capture.get()
+
+    for finding in doc["findings"]:
+        assert finding["check"] in rendered
+    # The nested-dict trap: `policy`'s detail is {"adapters": {"dev": ...}}, emitted
+    # on the *passing* path. A renderer that str()s a shape it did not model prints
+    # a Python repr, and this is the tell.
+    assert "{'" not in rendered
+    policy = next(f for f in doc["findings"] if f["check"] == "policy")
+    assert policy["detail"]["adapters"], "policy still carries the nested adapters dict"
+    assert "adapters: dev=claude" in rendered
+
+    # and the document the CLI just emitted is one this renderer accepts at all
+    assert widgets.validate_document(json.dumps(doc)) == doc
+
+
 def test_validate_json_mux_detail_keeps_the_rows_the_text_flattens(mux_registry, capsys):
     """The text line ("alpha*, beta (unavailable)") makes a consumer parse a trailing
     `*` to learn which backend is selected. The detail keeps all six MuxBackendInfo

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3312,6 +3312,33 @@ def test_platform_preflight_selection_detail_keeps_the_raw_reason(mux_registry, 
     assert "forced by BMAD_LOOP_MUX_BACKEND" in selection.message  # prose stays in the message
 
 
+def test_external_backend_failure_is_a_warning_not_a_note(mux_registry, monkeypatch, capsys):
+    """A package the operator installed did not load — a real failure, so it carries
+    `warning`, matching what `cmd_mux` has always printed for the same condition.
+
+    It stays below `problem` on purpose: selection degraded past it, so the verdict
+    and rc must not flip. Held at `ok` until #210 only because promoting inserts
+    `  warning: ` into the text (render() keeps the double prefix by design) and the
+    TUI rendered that text verbatim; the second assert is that now-shipping line.
+    """
+    from bmad_loop.checks import ValidationReport
+
+    monkeypatch.setattr(mux_registry, "_EXTERNAL_ERRORS", {"brokenmux": "ImportError: no ghost"})
+    monkeypatch.setattr(mux_registry, "_EXTERNALS_LOADED", True)  # no rescan over the stub
+
+    finding = next(f for f in cli._platform_preflight() if f.check == "mux.external-backend")
+    assert finding.severity == "warning"
+    assert finding.detail == {"entry_point": "brokenmux", "error": "ImportError: no ghost"}
+
+    report = ValidationReport()
+    report.extend([finding])
+    report.render()
+    assert capsys.readouterr().out == (
+        "  ok:   warning: external mux backend 'brokenmux' failed to load: "
+        "ImportError: no ghost\n"
+    )
+
+
 def test_validate_without_a_json_attribute_still_renders_text(project, capsys):
     """cmd_validate reads `getattr(args, "json", False)`, not `args.json`: it is called
     directly with hand-built Namespaces that predate the flag (every validate test

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -8,12 +8,13 @@ bindings drive modals into tui.launch calls (monkeypatched — no real tmux)."""
 from __future__ import annotations
 
 import dataclasses
+import json
 import os
 import tomllib
 from pathlib import Path
 
 import pytest
-from conftest import install_bmad_config, write_sprint
+from conftest import install_bmad_config, make_validate_document, write_sprint
 from rich.console import Console
 from rich.text import Text
 from textual.events import MouseMove
@@ -31,12 +32,13 @@ from textual.widgets import (
     TabbedContent,
 )
 
+from bmad_loop import documents
 from bmad_loop import policy as policy_mod
 from bmad_loop.adapters.multiplexer import MultiplexerError
 from bmad_loop.journal import Journal, save_state
 from bmad_loop.model import Phase, RunState, StoryTask, TokenUsage
 from bmad_loop.runs import RUNS_DIR
-from bmad_loop.tui import data, launch
+from bmad_loop.tui import data, launch, widgets
 from bmad_loop.tui.app import BmadLoopApp
 from bmad_loop.tui.screens.dashboard import (
     _MIN_DETAIL,
@@ -57,6 +59,9 @@ from bmad_loop.tui.screens.modals import (
     TextOutputModal,
 )
 from bmad_loop.tui.widgets import (
+    _FINDING_CHECK_WIDTH,
+    _FINDING_COL_PAD,
+    _FINDING_GLYPH_WIDTH,
     _JOURNAL_CLOCK_WIDTH,
     _JOURNAL_COL_PAD,
     _JOURNAL_KIND_WIDTH,
@@ -363,6 +368,217 @@ def test_journal_line_wraps_fields_with_hanging_indent():
         assert line[:indent] == " " * indent
     # and the wrapped fields carry real content past the indent
     assert any(line[indent:].strip() for line in lines[1:])
+
+
+# ------------------------------------------------ #210: validate --json renderer
+#
+# The pure seams: parsing a validate document and rendering it. No app is
+# mounted here — these are the pieces the validate modal is built out of.
+
+# The width the modal is laid out for.
+_FINDING_WIDTH = 96
+
+
+def render(renderable, width: int = _FINDING_WIDTH) -> str:
+    """Rich renderable -> plain text, as journal_rows does for the journal."""
+    console = Console(width=width)
+    with console.capture() as capture:
+        console.print(renderable)
+    return capture.get()
+
+
+def test_renderer_pins_the_current_validate_schema_version():
+    """Deliberate duplication: the TUI renderer must NOT import
+    documents.VALIDATE_SCHEMA_VERSION — an import would auto-follow a CLI bump and
+    silently render a v2 document as v1. On failure, re-read the renderer against
+    the new document, then bump the literal."""
+    assert widgets._RENDERS_VALIDATE_SCHEMA == documents.VALIDATE_SCHEMA_VERSION
+
+
+def test_validate_document_accepts_a_real_document():
+    doc = make_validate_document([("git.worktree-clean", "ok", "git worktree clean", None)])
+    assert widgets.validate_document(json.dumps(doc)) == doc
+
+
+@pytest.mark.parametrize(
+    ("stdout", "why"),
+    [
+        ("", "empty stdout — the command produced no document at all"),
+        ("not json{", "unparseable"),
+        ("[]", "a JSON array is not a document"),
+        ('"a string"', "a JSON scalar is not a document"),
+        ('{"schema_version": 2, "ok": true, "counts": {}, "findings": []}', "a newer schema"),
+        ('{"ok": true, "counts": {}, "findings": []}', "no schema_version at all"),
+        (
+            '{"schema_version": 1, "ok": true, "counts": {}, "findings": "nope"}',
+            "findings not a list",
+        ),
+        ('{"schema_version": 1, "ok": true, "counts": [], "findings": []}', "counts not a dict"),
+    ],
+)
+def test_validate_document_returns_none_for_anything_undrawable(stdout, why):
+    """Never raises — the caller runs this on a worker thread, where an escaping
+    exception takes the app down. Undrawable is a value, so the degrade is an
+    `is None` check. A *newer* schema is the important row: it parses fine and its
+    fields resolve, so only the version pin catches it."""
+    assert widgets.validate_document(stdout) is None, why
+
+
+def test_validate_findings_renders_every_detail_shape():
+    """Depth-2 covers every shape the real check sites emit, and none of them
+    reach the renderer as a Python repr.
+
+    The shapes are taken from cli.py's validate gates and platform preflight and
+    install.py's skill probes; the ids are real, so ValidationReport.add's assert
+    would reject this fixture if one were invented."""
+    doc = make_validate_document(
+        [
+            # dict of scalars, and a str
+            ("bmad-config", "problem", "BMAD config OK", {"implementation_artifacts": "/a/b"}),
+            # NESTED dict — the passing path's shape, the one that breaks naive renderers
+            ("policy", "ok", "policy OK", {"gates_mode": "strict", "adapters": {"dev": "claude"}}),
+            # ints
+            ("queue.sprint-status", "ok", "sprint-status OK", {"stories": 4, "actionable": 2}),
+            # bool + str|None
+            (
+                "mux.backend",
+                "ok",
+                "mux ok",
+                {"backend": "Tmux", "available": True, "version": None},
+            ),
+            # list[dict], six keys per row
+            (
+                "mux.backends-detected",
+                "ok",
+                "mux backends: tmux*",
+                {
+                    "backends": [
+                        {
+                            "name": "tmux",
+                            "matches_platform": True,
+                            "available": True,
+                            "version": "3.4",
+                            "selected": True,
+                            "reason": "default",
+                        }
+                    ]
+                },
+            ),
+            # list[str]
+            ("skills.base-incomplete", "problem", "incomplete", {"missing_markers": ["a", "b"]}),
+            # None detail
+            ("git.probe", "problem", "git check failed", None),
+        ]
+    )
+    out = render(widgets.validate_findings(doc, details=True))
+
+    assert "{'" not in out, "a Python repr leaked — some shape was str()'d, not modelled"
+    assert "adapters: dev=claude" in out  # the nested dict, as readable pairs
+    assert "stories: 4" in out
+    assert "version: null" in out and "available: true" in out  # JSON's spelling, not Python's
+    assert "missing_markers: a, b" in out
+    assert "name=tmux" in out and "reason=default" in out  # list[dict], one line per entry
+    for finding in doc["findings"]:
+        assert finding["check"] in out
+
+
+def test_validate_findings_detail_is_gated_on_severity_not_check_id():
+    """Inline detail for warning/problem — what a reader opened the modal to act
+    on — and everything under `details`. One severity rule, zero id matching."""
+    doc = make_validate_document(
+        [
+            ("host.process", "ok", "process host: Posix", {"host": "PosixProcessHost"}),
+            ("adapter.binary", "problem", "codex not found", {"binary": "codex"}),
+            ("policy.model-qualified", "warning", "bare model", {"model": "haiku"}),
+        ]
+    )
+    inline = render(widgets.validate_findings(doc, details=False))
+    assert "binary: codex" in inline and "model: haiku" in inline
+    assert "host: PosixProcessHost" not in inline, "an ok finding's detail is not inline"
+
+    expanded = render(widgets.validate_findings(doc, details=True))
+    assert "host: PosixProcessHost" in expanded
+
+
+def test_validate_findings_survives_a_malformed_finding():
+    """One bad finding costs its own row, not the modal. The document arrives from
+    a subprocess, so 'this cannot happen' is not available."""
+    doc = make_validate_document([("git.worktree-clean", "ok", "git worktree clean", None)])
+    doc["findings"] = [
+        "not a dict",
+        None,
+        {"check": "policy", "severity": "made-up", "message": "unknown severity is neutral"},
+        *doc["findings"],
+    ]
+    out = render(widgets.validate_findings(doc, details=True))
+
+    assert out.count("(unreadable finding)") == 2  # the string and the None
+    assert "unknown severity is neutral" in out  # rendered, just without a style
+    assert "git worktree clean" in out, "a good finding after a bad one still renders"
+
+
+def test_validate_findings_multiline_message_keeps_column_alignment():
+    """The fold trap: several problems are a bare str(e) carrying a PyYAML
+    MarkedYAMLError, so `message` is multi-line. In a flat Text an embedded
+    newline returns to column 0 and destroys every row below it; folding inside
+    the message column is what keeps the grid a grid."""
+    doc = make_validate_document(
+        [
+            ("policy", "problem", "while parsing a block\n  in policy.toml, line 3\n    ^", None),
+            ("git.worktree-clean", "ok", "git worktree clean", None),
+        ]
+    )
+    lines = render(widgets.validate_findings(doc, details=False)).splitlines()
+
+    indent = _FINDING_GLYPH_WIDTH + _FINDING_COL_PAD + _FINDING_CHECK_WIDTH + _FINDING_COL_PAD
+    body = [ln for ln in lines if "in policy.toml" in ln or "^" in ln]
+    assert body, "the continuation lines rendered"
+    for line in body:
+        assert line[:indent] == " " * indent
+        assert line[indent:].strip()
+    # the row after the multi-line message is still in its own columns
+    assert any(ln[indent:].startswith("git worktree clean") for ln in lines)
+
+
+def test_validate_header_verdict_comes_from_ok_with_the_chained_gates_note():
+    """The verdict is doc["ok"], never an exit code — rc conflates 'checks failed'
+    with 'the command broke'. The chained-gates footer appears only when something
+    failed, because that is when absence stops meaning 'passed'."""
+    passing = make_validate_document([("git.worktree-clean", "ok", "clean", None)])
+    failing = make_validate_document([("adapter.binary", "problem", "codex not found", None)])
+
+    good = render(widgets.validate_header(passing))
+    assert "validate passed" in good
+    assert "1 ok" in good and "0 problem" in good
+    assert "gates are chained" not in good
+
+    bad = render(widgets.validate_header(failing))
+    assert "validate failed" in bad
+    assert "gates are chained" in bad
+
+
+def test_validate_header_shows_mode_and_spec_folder_without_markup():
+    """spec_folder is user-controlled and reaches a Static that defaults to
+    markup=True, so it must arrive as Text. A folder with brackets would be a
+    MarkupError if it were ever interpolated into a markup string."""
+    doc = make_validate_document(
+        [("git.worktree-clean", "ok", "clean", None)],
+        stories_on=True,
+        spec_folder="docs/[wip]-epic-3",
+    )
+    header = widgets.validate_header(doc)
+    assert isinstance(header, Text)
+    out = render(header)
+    assert "mode: stories" in out
+    assert "docs/[wip]-epic-3" in out, "brackets survive verbatim — nothing interpreted them"
+
+
+def test_validate_header_tolerates_a_gutted_document():
+    """validate_document gates the shape, but the header still never raises on a
+    field that is present and of the wrong type."""
+    out = render(widgets.validate_header({"ok": None, "counts": {"problem": "lots"}}))
+    assert "verdict unknown" in out
+    assert "gates are chained" not in out  # a non-int count is not a problem count
 
 
 async def test_log_pane_shows_emulated_content(project):

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1457,6 +1457,32 @@ async def test_dry_run_shows_captured_output(project, monkeypatch):
         await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
 
 
+async def test_dry_run_worker_survives_a_raising_subprocess(project, monkeypatch):
+    """The twin of test_validate_worker_survives_a_raising_subprocess: this worker
+    is a @work(thread=True) body too, so a subprocess that cannot be spawned takes
+    the whole app down unless run_captured is guarded. Both go through
+    _run_captured_guarded, and this is the leg that proves the shared guard."""
+    monkeypatch.setattr(launch, "mux_available", lambda: True)
+    monkeypatch.setattr(
+        launch,
+        "run_captured_streams",
+        lambda tail: (_ for _ in ()).throw(OSError("no such file")),
+    )
+    app = BmadLoopApp(project.project)
+    async with app.run_test() as pilot:
+        await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
+        await pilot.press("r")
+        await until(pilot, lambda: isinstance(app.screen, StartRunModal))
+        await ready(pilot, "#ok")
+        app.screen.query_one("#dry-run", Checkbox).value = True
+        await pilot.click("#ok")
+        await until(pilot, lambda: isinstance(app.screen, TextOutputModal))
+        await ready(pilot, "#output Static")
+        body = render(app.screen.query_one("#output Static").content)
+        assert "no such file" in body, "the modal carries the reason, not a blank panel"
+        assert app.is_running, "the app survived a dry run it could not spawn"
+
+
 # ---------------------------------------------------------- #210: validate wiring
 #
 # `v` renders the --json document; anything undrawable degrades to the text modal.
@@ -1604,19 +1630,28 @@ async def test_validate_worker_survives_a_raising_subprocess(project, monkeypatc
     """@work(thread=True) defaults to exit_on_error=True, so anything escaping the
     worker body takes the whole app down rather than this one modal. The guard is
     an except, not a set of condition checks — the raise here is not a shape the
-    checks could have caught."""
+    checks could have caught.
+
+    Only run_captured_streams is stubbed, on purpose: run_captured *calls* it, so
+    a spawn failure is not a JSON-leg failure that the text re-run recovers from
+    — it is the same failure twice. Stubbing the two legs to opposite outcomes
+    would model a split production cannot produce, and would leave the degrade's
+    own raise escaping the worker unnoticed. It raises in place of the spawn, so
+    no real subprocess runs either."""
     monkeypatch.setattr(
         launch,
         "run_captured_streams",
         lambda tail: (_ for _ in ()).throw(OSError("no such file")),
     )
-    monkeypatch.setattr(launch, "run_captured", lambda tail: (1, "FAIL: no policy\n"))
     app = BmadLoopApp(project.project)
     async with app.run_test() as pilot:
         await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
         await pilot.press("v")
         await until(pilot, lambda: isinstance(app.screen, TextOutputModal))
-        assert app.is_running, "the app survived; only the JSON leg failed"
+        await ready(pilot, "#output Static")
+        body = render(app.screen.query_one("#output Static").content)
+        assert "no such file" in body, "the modal carries the reason, not a blank panel"
+        assert app.is_running, "the app survived a failure BOTH legs hit"
 
 
 async def test_resume_confirm_launches(project, monkeypatch):

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -57,6 +57,7 @@ from bmad_loop.tui.screens.modals import (
     StartSweepModal,
     StoryCheckpointModal,
     TextOutputModal,
+    ValidateFindingsModal,
 )
 from bmad_loop.tui.widgets import (
     _FINDING_CHECK_WIDTH,
@@ -1456,16 +1457,166 @@ async def test_dry_run_shows_captured_output(project, monkeypatch):
         await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
 
 
-async def test_validate_shows_output_modal(project, monkeypatch):
+# ---------------------------------------------------------- #210: validate wiring
+#
+# `v` renders the --json document; anything undrawable degrades to the text modal.
+# These tests mix real documents (via the conftest builder, for what actually gets
+# rendered) with hand-rolled stdout strings (for the degrades) on purpose, not out
+# of inconsistency: the builder goes through ValidationReport, so it can only ever
+# produce a *valid* document, and every degrade case is by definition one it cannot
+# express.
+
+
+def stub_validate(monkeypatch, *, stdout: str = "", rc: int = 0, text: str = "FAIL: no policy\n"):
+    """Stub **both** legs and record which ran.
+
+    Stubbing only run_captured_streams leaves the degrade's run_captured live, so
+    every degrade test would spawn a real `bmad-loop validate` subprocess — slow,
+    and asserting the host's preflight rather than the code under test."""
+    seen: dict[str, list[str]] = {}
+
+    def fake_streams(tail):
+        seen["json_tail"] = tail
+        return rc, stdout, ""
+
+    def fake_captured(tail):
+        seen["text_tail"] = tail
+        return rc, text
+
+    monkeypatch.setattr(launch, "run_captured_streams", fake_streams)
+    monkeypatch.setattr(launch, "run_captured", fake_captured)
+    return seen
+
+
+def grid_text(app: BmadLoopApp) -> str:
+    """The findings grid as it draws at the modal's width."""
+    return render(app.screen.query_one("#grid", Static).content)
+
+
+async def test_validate_shows_findings_modal(project, monkeypatch):
+    """The migrated test_validate_shows_output_modal. `v` renders the document
+    now, so the old run_captured stub is dead — and a dead stub is a real
+    subprocess, not a failure."""
+    doc = make_validate_document(
+        [
+            ("git.worktree-clean", "ok", "git worktree clean", None),
+            ("adapter.binary", "problem", "codex not found on PATH", {"binary": "codex"}),
+        ]
+    )
+    seen = stub_validate(monkeypatch, stdout=json.dumps(doc), rc=1)
+    app = BmadLoopApp(project.project)
+    async with app.run_test() as pilot:
+        await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
+        await pilot.press("v")
+        await until(pilot, lambda: isinstance(app.screen, ValidateFindingsModal))
+        await ready(pilot, "#grid")
+        assert "--json" in seen["json_tail"]
+        assert "text_tail" not in seen, "the JSON leg drew it; nothing re-ran in text mode"
+
+        body = grid_text(app)
+        assert "git.worktree-clean" in body and "adapter.binary" in body
+        assert "binary: codex" in body, "a problem's detail is inline"
+        header = str(app.screen.query_one(".title", Static).content)
+        assert "validate failed" in header
+
+        await pilot.press("escape")
+        await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
+
+
+async def test_validate_detail_toggle_expands_every_finding(project, monkeypatch):
+    """`d` re-renders the same document with detail on."""
+    doc = make_validate_document(
+        [("host.process", "ok", "process host: Posix", {"host": "PosixProcessHost"})]
+    )
+    stub_validate(monkeypatch, stdout=json.dumps(doc))
+    app = BmadLoopApp(project.project)
+    async with app.run_test() as pilot:
+        await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
+        await pilot.press("v")
+        await until(pilot, lambda: isinstance(app.screen, ValidateFindingsModal))
+        await ready(pilot, "#grid")
+        assert "host: PosixProcessHost" not in grid_text(app), "an ok detail starts collapsed"
+
+        await pilot.press("d")
+        await until(pilot, lambda: "host: PosixProcessHost" in grid_text(app))
+        await pilot.press("d")
+        await until(pilot, lambda: "host: PosixProcessHost" not in grid_text(app))
+
+
+async def test_validate_verdict_comes_from_the_document_not_the_exit_code(project, monkeypatch):
+    """rc conflates "checks failed" with "the command broke"; the document's `ok`
+    does not. Both legs are rendered here with rc deliberately disagreeing with
+    what the old code would have inferred from it."""
+    failing = make_validate_document([("adapter.binary", "problem", "codex not found", None)])
+    stub_validate(monkeypatch, stdout=json.dumps(failing), rc=1)
+    app = BmadLoopApp(project.project)
+    async with app.run_test() as pilot:
+        await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
+        await pilot.press("v")
+        await until(pilot, lambda: isinstance(app.screen, ValidateFindingsModal))
+        await ready(pilot, "#grid")
+        header = str(app.screen.query_one(".title", Static).content)
+        assert "validate failed" in header
+        assert "gates are chained" in header, "a failure says the later gates may not have run"
+
+    # A passing document at rc 0 — same wiring, opposite verdict, and the header
+    # says so without the modal ever seeing the exit code.
+    passing = make_validate_document([("git.worktree-clean", "ok", "git worktree clean", None)])
+    stub_validate(monkeypatch, stdout=json.dumps(passing), rc=0)
+    app = BmadLoopApp(project.project)
+    async with app.run_test() as pilot:
+        await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
+        await pilot.press("v")
+        await until(pilot, lambda: isinstance(app.screen, ValidateFindingsModal))
+        await ready(pilot, "#grid")
+        header = str(app.screen.query_one(".title", Static).content)
+        assert "validate passed" in header
+        assert "gates are chained" not in header
+
+
+@pytest.mark.parametrize(
+    ("stdout", "why"),
+    [
+        ("", "the command produced no document at all"),
+        ("not json{", "unparseable stdout"),
+        ('{"schema_version": 2, "ok": true, "counts": {}, "findings": []}', "a newer schema"),
+        ('{"schema_version": 1, "ok": true, "counts": {}, "findings": "nope"}', "wrong shape"),
+    ],
+)
+async def test_validate_degrades_to_the_text_modal(project, monkeypatch, stdout, why):
+    """Every undrawable document RE-RUNS validate in text mode. Showing the
+    captured JSON instead would hand the reader a wall of `{"schema_version": ...}`
+    at the exact moment the structural rendering failed; re-running costs one
+    subprocess and makes the degrade byte-for-byte the pre-#210 behavior."""
+    seen = stub_validate(monkeypatch, stdout=stdout, rc=1)
+    app = BmadLoopApp(project.project)
+    async with app.run_test() as pilot:
+        await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
+        await pilot.press("v")
+        await until(pilot, lambda: isinstance(app.screen, TextOutputModal), timeout=10.0)
+        await ready(pilot, "Label")  # body mounts a tick after the screen swaps
+        labels = app.screen.query("Label")
+        assert any("exit 1" in str(label.content) for label in labels), why
+        assert "--json" not in seen["text_tail"], "the text re-run is the plain command"
+
+
+async def test_validate_worker_survives_a_raising_subprocess(project, monkeypatch):
+    """@work(thread=True) defaults to exit_on_error=True, so anything escaping the
+    worker body takes the whole app down rather than this one modal. The guard is
+    an except, not a set of condition checks — the raise here is not a shape the
+    checks could have caught."""
+    monkeypatch.setattr(
+        launch,
+        "run_captured_streams",
+        lambda tail: (_ for _ in ()).throw(OSError("no such file")),
+    )
     monkeypatch.setattr(launch, "run_captured", lambda tail: (1, "FAIL: no policy\n"))
     app = BmadLoopApp(project.project)
     async with app.run_test() as pilot:
         await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
         await pilot.press("v")
         await until(pilot, lambda: isinstance(app.screen, TextOutputModal))
-        await ready(pilot, "Label")  # body mounts a tick after the screen swaps
-        labels = app.screen.query("Label")
-        assert any("exit 1" in str(label.content) for label in labels)
+        assert app.is_running, "the app survived; only the JSON leg failed"
 
 
 async def test_resume_confirm_launches(project, monkeypatch):

--- a/tests/test_tui_launch.py
+++ b/tests/test_tui_launch.py
@@ -9,6 +9,7 @@ path still shells out from ``launch`` itself."""
 
 from __future__ import annotations
 
+import json
 import shlex
 import subprocess
 import sys
@@ -595,7 +596,12 @@ def test_run_captured_merges_streams(monkeypatch):
     def fake(argv, **kwargs):
         assert argv[:3] == [sys.executable, "-m", "bmad_loop.cli"]
         assert argv[3:] == ["validate", "--project", "/p"]
-        assert kwargs.get("capture_output") and kwargs.get("text")
+        # encoding= puts subprocess in text mode without setting the `text`
+        # kwarg, so assert on the decoding that is actually pinned. UTF-8 at
+        # errors="replace" is the point: text=True would decode with the
+        # locale encoding at errors="strict" (the #200 failure family).
+        assert kwargs.get("capture_output")
+        assert kwargs.get("encoding") == "utf-8" and kwargs.get("errors") == "replace"
         return subprocess.CompletedProcess(argv, 1, stdout="ok line", stderr="FAIL line\n")
 
     monkeypatch.setattr(launch.subprocess, "run", fake)
@@ -604,8 +610,40 @@ def test_run_captured_merges_streams(monkeypatch):
     assert out == "ok line\nFAIL line\n"
 
 
+def test_run_captured_streams_keeps_stderr_off_stdout(monkeypatch):
+    """The reason the seam exists: a caller parsing stdout as one JSON document
+    must not receive a dependency's stderr warning appended to it. Merged, this
+    is exactly the input that makes json.loads raise "Extra data"."""
+    payload = '{"schema_version": 1, "ok": true}'
+
+    def fake(argv, **kwargs):
+        return subprocess.CompletedProcess(
+            argv, 0, stdout=payload, stderr="DeprecationWarning: whatever\n"
+        )
+
+    monkeypatch.setattr(launch.subprocess, "run", fake)
+    rc, out, err = launch.run_captured_streams(["validate", "--project", "/p", "--json"])
+    assert rc == 0
+    assert out == payload
+    assert "DeprecationWarning" in err
+    assert json.loads(out) == {"schema_version": 1, "ok": True}
+    # and the merging caller still gets the blob it wants, from the same call
+    assert launch.run_captured(["validate", "--project", "/p"])[1] == (
+        payload + "\nDeprecationWarning: whatever\n"
+    )
+
+
 def test_run_captured_real_subprocess():
     """End-to-end: the module really is invocable as `python -m bmad_loop.cli`."""
     rc, out = launch.run_captured(["--version"])
     assert rc == 0
     assert "bmad-loop" in out
+
+
+def test_run_captured_streams_real_subprocess():
+    """The separated form against the real CLI: a `--json` document parses off
+    stdout alone, with stderr empty (the machine.py purity contract)."""
+    rc, out, err = launch.run_captured_streams(["--version"])
+    assert rc == 0
+    assert "bmad-loop" in out
+    assert err == ""


### PR DESCRIPTION
Closes #210.

Pressing `v` in the TUI ran `bmad-loop validate` in **text** mode and dropped the captured
blob into `TextOutputModal`, with the verdict inferred from the exit code. That meant severity
was a string prefix, the verdict conflated "the checks failed" with "the command broke", and
every check's `detail` — the data it knew before flattening itself into a sentence — was
already gone by the time the TUI saw it. This moves the modal onto the schema-v1 document from
#205 and renders it structurally.

Three commits, each self-contained:

| | |
|---|---|
| `609a567` | Phase 1 — the pure seams (no user-visible change) |
| `55bdd43` | Phase 2 — the modal and the wiring |
| _this_ | Phase 3 — promote `mux.external-backend` to `warning` |

## Phase 1 — seams

- `launch.run_captured_streams(argv_tail) -> (rc, stdout, stderr)`. `run_captured` merges the
  child's stderr onto stdout *after* it, so `json.loads` on the merged string raises
  `Extra data:` — one `DeprecationWarning` from any dependency would have silently degraded
  the feature to the text modal on some machines and not others. `run_captured` now delegates
  to the new function and merges, so there is still exactly one `subprocess.run`.
  `encoding="utf-8", errors="replace"` rather than `text=True`: `text=True` decodes with the
  *locale* encoding at `errors='strict'`, which is the #200 family of failure the JSON path
  already fixed CLI-side.
- `widgets.validate_document()` (parse + version pin + shape gate, returns `None` rather than
  raising), `validate_findings()` (one `Table.grid`, so columns align *across* findings) and
  `validate_header()`.
- `widgets._RENDERS_VALIDATE_SCHEMA = 1` is a **hand-written literal, deliberately not an
  import** of `documents.VALIDATE_SCHEMA_VERSION` — an import would auto-follow a CLI bump and
  silently render a v2 document as v1. A tripwire test asserts the two are equal, since
  otherwise a mismatch would first surface as a silent degrade in a user's terminal with CI
  green.

## Phase 2 — modal and wiring

`ValidateFindingsModal` + a new `_show_validate` worker. `_show_captured` is untouched — the
`run --dry-run` and `sweep --dry-run` modals still use it.

- Verdict from `doc["ok"]`, never rc.
- Detail inline for `warning`/`problem`, `d` toggles it for everything. One severity rule, zero
  check-id matching (`message` is not contracted; `check` is). Rendering all detail inline
  would make a passing modal ~3.6× longer than today's while restating messages already on
  screen.
- Detail rendering is depth-2 with a `json.dumps` leaf fallback, not recursive: `detail` is not
  flat — the passing path emits `{"gates_mode": str, "adapters": {"dev": ...}}` as the second
  finding of every successful validate, and a scalar-only renderer prints a Python repr. The
  bridge test drives a **live** `validate --json` and asserts `"{'" not in rendered`, so it
  cannot rot against a fixture.
- When any `problem` exists the header appends a dim footer noting the gates are chained. That
  puts `documents.py`'s "absence is not a pass" on screen, and is the one thing the structural
  renderer can teach that the text cannot: a short findings list is not a short list of
  problems.
- The worker body is wrapped in `try/except`. `@work(thread=True)` defaults to
  `exit_on_error=True` (Textual 8.2.7), so an unguarded `JSONDecodeError`/`KeyError` in the new
  parse-and-render body would take down the whole app. Not `exit_on_error=False` — that turns a
  crash into pressing `v` and nothing happening.
- **The degrade re-runs in text mode rather than dumping the captured JSON.** If stdout was
  non-empty but unrenderable, showing the merged blob means a wall of `{"schema_version": 2, …}`
  in a modal titled `validate — exit 1`, withholding a perfectly good human rendering at the
  exact moment the structural one failed. Re-running costs one sub-second subprocess on a path
  that should never fire, and makes the claim trivially reviewable: the degrade is
  byte-for-byte the pre-#210 behavior.

Transport is subprocess + `--json`, which is a knowing exception to `documents.py`'s "a non-CLI
frontend should import the builders directly and never parse CLI stdout" — the TUI *is* such a
frontend. The justification is in the worker's docstring: `cmd_validate` loads third-party mux
entry points and probes `httpx`, so the subprocess quarantines a broken plugin's import side
effects and leaves the TUI's own `lru_cache`d mux selection undisturbed. Extracting an
in-process `build_validation_report()` is worth filing as a follow-up.

## Phase 3 — `mux.external-backend` → `warning`

The finding has always read as a failure — "external mux backend 'x' failed to load: …" — while
carrying severity `ok`, so it counted as a *passing* check. It was pinned there only because
promoting it inserts `warning:` into shipped text the TUI rendered verbatim; the TUI no longer
does. `bmad-loop mux` has always printed this same condition as `warning:`, so validate was the
outlier. It stays below `problem` deliberately: selection degrades past a broken external (a
failed external can never be the selected backend), so the verdict and rc must not flip. The
comment at the site argued the finding was advisory; it now says that.

Two things worth stating rather than leaving implicit:

**1. No schema bump — a decision, not an oversight.** On an affected host the promotion flips
`counts` (`warning` +1, `ok` −1) but leaves `ok` and rc alone. `machine.py` says changing "the
meaning of a value" bumps, and someone could reasonably read a changed count that way. The
counter-argument is that `documents.py` contracts the **`check` id** as the matchable identity,
not any given check's outcome — a consumer branching on `mux.external-backend` still finds it,
and one reading `counts` is reading a tally of severities that was always free to move as
checks changed their minds. Under a bump-on-any-count-change reading, every future severity
adjustment would be a breaking change, which is not what the additive-only rule is protecting.
Happy to bump if you disagree — it is cheap now and expensive later.

**2. The CLI text still changes, and gets uglier.** That line becomes:

```
  ok:   warning: external mux backend 'x' failed to load: ...
```

because `render()` preserves the double prefix by design (the warning sites stored
`"  warning: " + msg` into the same list the `  ok: ` printer walked). #210 unblocks the TUI
half of the freeze, not the CLI half. `test_validation_report_renders_each_severity_verbatim`
is the byte-exact lock and stays green — it builds its own findings and never touches this
check — and the new test asserts the now-shipping line at the real site, so the consequence is
pinned rather than incidental.

## Two UI notes

1. The dashboard's `Footer` shows through beneath every modal, so while this one is open the
   footer still reads `d  decisions`. That is pre-existing for all modals, not new here; the
   in-modal `d — toggle detail on every finding` hint covers discoverability, and the modal's
   binding wins since it holds focus.
2. Detail sub-rows sit in the same column as folded message continuations, distinguished only
   by dim styling. Legible in a real terminal, but if you want a visual marker that is a
   Phase-1 renderer change, so I left it alone.

## Testing

Full suite green, full `trunk check` (no filter) clean.

Nothing asserted `mux.external-backend`'s severity before this — `test_external_backends.py`
only covers `external_backend_errors()` contents — so Phase 3 adds a test pinning the severity,
the detail, and the rendered text.

The degrade path was verified live during Phase 2 — forcing `validate_document` to `None`
reproduces the old modal exactly. The rest is covered by the automated cases: the four degrade
shapes, the `d` toggle, a raising subprocess (the `exit_on_error` trap), and both verdicts with
rc deliberately disagreeing with what the old code would have inferred from it. Worth a look at
96 columns by a second pair of eyes before merge.

Docs: `docs/tui-guide.md` described the replaced behavior verbatim in two places.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The TUI Validate view now presents structured, per-check findings from `validate --json`, including verdict-derived summaries, severity counts, check IDs/messages, and an expandable details toggle.
  - Validation mode (`v`) and its on-screen guidance were refreshed to match the new structured renderer.

- **Bug Fixes**
  - If the JSON output can’t be rendered, the TUI automatically falls back to the prior text-based validate modal.
  - External multiplexer backend load failures are now reported as **warnings** (and validation counts/output reflect the change).
  - Dry-run spawn failures now show an error modal instead of crashing the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->