### PR TITLE
fix(tui): record session-qualified parked-window return target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -298,16 +298,19 @@ PATH)`, the TUI notifies `multiplexer backend unavailable — launch/attach disa
 
 ### Fixed
 
-- **The parked-window return target is now session-qualified (#221).** An interactive attach
+- **The parked-window return target is now backend-composed (#221).** An interactive attach
   recorded the client's origin as a bare pane id (`%N`) and replayed it as `switch-client -t %N`
   from inside the control session — sound under tmux's one-server model, but on psmux (one
   server per session, upstream-final per psmux/psmux#483) a bare id is session-local: at best
   unresolvable, at worst colliding with a real control-session pane and landing the client on
-  the wrong one with exit 0, past the `switch-client -l` fallback. The recording seam now emits
-  `=session:%N` when both probes succeed, retaining bare `%N` only if the session probe fails;
-  the replay sides treat the value as an opaque target and are unchanged. tmux resolves the
-  qualified form to the same pane it always did (verified on 3.4), and psmux releases carrying
-  the psmux/psmux#483 fix resolve it cross-server.
+  the wrong one with exit 0, past the `switch-client -l` fallback. No single form resolves on
+  every backend (tmux's window resolver rejects a pane id in the `session:%N` slot, and a
+  native-id backend needs its own id passed through untouched), so the recording seam now asks
+  the backend: `TerminalMultiplexer.current_return_target()` defaults to the bare native pane
+  id — tmux and native-id backends behave exactly as before — and psmux overrides it to emit
+  `=session:%N`, which releases carrying the psmux/psmux#483 fix resolve cross-server,
+  degrading to the bare id only if the session probe fails. The replay sides treat the value
+  as an opaque target and are unchanged.
 
 - **A dry run the TUI cannot spawn opens a modal instead of taking the app down (#210).** The
   `run --dry-run` / `sweep --dry-run` workers called `run_captured` unguarded, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -298,6 +298,17 @@ PATH)`, the TUI notifies `multiplexer backend unavailable — launch/attach disa
 
 ### Fixed
 
+- **The parked-window return target is now session-qualified (#221).** An interactive attach
+  recorded the client's origin as a bare pane id (`%N`) and replayed it as `switch-client -t %N`
+  from inside the control session — sound under tmux's one-server model, but on psmux (one
+  server per session, upstream-final per psmux/psmux#483) a bare id is session-local: at best
+  unresolvable, at worst colliding with a real control-session pane and landing the client on
+  the wrong one with exit 0, past the `switch-client -l` fallback. The recording seam now emits
+  `=session:%N` when both probes succeed, retaining bare `%N` only if the session probe fails;
+  the replay sides treat the value as an opaque target and are unchanged. tmux resolves the
+  qualified form to the same pane it always did (verified on 3.4), and psmux releases carrying
+  the psmux/psmux#483 fix resolve it cross-server.
+
 - **A dry run the TUI cannot spawn opens a modal instead of taking the app down (#210).** The
   `run --dry-run` / `sweep --dry-run` workers called `run_captured` unguarded, and
   `@work(thread=True)` defaults to `exit_on_error=True` — so an `OSError` from the spawn itself

--- a/docs/adapter-authoring-guide.md
+++ b/docs/adapter-authoring-guide.md
@@ -97,7 +97,11 @@ families: the **seam-canonical target token** `=session[:window]` — formatted 
 the concrete `TerminalMultiplexer.target(session, window=None)`, decoded by the
 module-level `parse_target()` — or the backend's own **native id** (whatever your
 `new_window` returned). Core never hand-assembles the grammar; it calls
-`target()`. tmux consumes the token natively (it coincides with tmux exact-match
+`target()`. One caller stretches the shape: the parked-window return target is
+formatted as `target(session, pane_id)` — a _pane id_ (`%N`) rides in the
+window slot — so a backend resolving `parse_target()` output must tolerate a
+pane id there when it reaches `switch_client`. tmux consumes the token
+natively (it coincides with tmux exact-match
 syntax), so `BaseTmuxBackend` passes it straight through. A native-id backend
 calls `parse_target()` first — `None` means "already a native id, use as-is",
 otherwise resolve `(session, window)` yourself; the herdr adapter's

--- a/docs/adapter-authoring-guide.md
+++ b/docs/adapter-authoring-guide.md
@@ -88,8 +88,13 @@ seams of a full OS port are in
   `send_text`.
 - **Client / attach** — `attach_target_argv` (argv that reaches a target, nesting-
   aware), `current_pane_id` / `current_window_id` / `current_session`,
-  `detach_client`, `switch_client` (with an optional last-client fallback),
-  `available` (is this backend usable on the current host).
+  `current_return_target` (the value an interactive attach records for the
+  parked-window return hop, replayed opaquely by `switch_client` and the parked
+  trailer; concrete default = the native pane id, so most backends inherit it —
+  override only when your ids do not resolve from another session's context,
+  as psmux does to emit `=session:%N`), `detach_client`, `switch_client` (with
+  an optional last-client fallback), `available` (is this backend usable on
+  the current host).
 
 **Window targets.** The target-taking methods (`kill_window`, `select_window`,
 the window-option trio, `attach_target_argv`, `switch_client`) receive one of two
@@ -97,12 +102,11 @@ families: the **seam-canonical target token** `=session[:window]` — formatted 
 the concrete `TerminalMultiplexer.target(session, window=None)`, decoded by the
 module-level `parse_target()` — or the backend's own **native id** (whatever your
 `new_window` returned). Core never hand-assembles the grammar; it calls
-`target()`. One caller stretches the shape: the parked-window return target is
-formatted as `target(session, pane_id)` — a _pane id_ (`%N`) rides in the
-window slot — so a backend resolving `parse_target()` output must tolerate a
-pane id there when it reaches `switch_client`. tmux consumes the token
-natively (it coincides with tmux exact-match
-syntax), so `BaseTmuxBackend` passes it straight through. A native-id backend
+`target()`. (The parked-window return target is the one value composed by the
+backend itself — `current_return_target`, above — precisely so this grammar
+never has to carry a pane id.) tmux consumes the token natively (it coincides
+with tmux exact-match syntax), so `BaseTmuxBackend` passes it straight
+through. A native-id backend
 calls `parse_target()` first — `None` means "already a native id, use as-is",
 otherwise resolve `(session, window)` yourself; the herdr adapter's
 `_parse_target`

--- a/src/bmad_loop/adapters/multiplexer.py
+++ b/src/bmad_loop/adapters/multiplexer.py
@@ -230,6 +230,18 @@ class TerminalMultiplexer(ABC):
         """Name of the session this process runs in, or None when not inside the
         multiplexer."""
 
+    def current_return_target(self) -> str | None:
+        """Target an interactive attach records so the parked-window return
+        trailer / :meth:`switch_client` can send the client back to the pane
+        this process runs in; None when not inside the multiplexer. The value
+        is backend-composed and replayed opaquely, so each backend emits
+        whatever its own ``switch-client`` resolves best. Default: the native
+        pane id — globally unique on a one-server multiplexer (tmux) and the
+        pass-through form for native-id backends. A backend whose ids do not
+        resolve from another session's context (e.g. psmux, one server per
+        session) overrides this to emit a qualified form."""
+        return self.current_pane_id() or None
+
     @abstractmethod
     def detach_client(self) -> None:
         """Detach the client viewing the current session (best-effort: a no-op on

--- a/src/bmad_loop/adapters/psmux_backend.py
+++ b/src/bmad_loop/adapters/psmux_backend.py
@@ -171,6 +171,31 @@ class PsmuxMultiplexer(BaseTmuxBackend):
         except (subprocess.SubprocessError, OSError):
             pass
 
+    def current_return_target(self) -> str | None:
+        # psmux runs one server per session, so a bare pane id recorded on a
+        # control-session window is session-local at replay: at best
+        # unresolvable, at worst colliding with a real control-session pane and
+        # landing the client on the wrong one with exit 0 (psmux/psmux#483).
+        # Qualify with the session: psmux's parse_target accepts a pane id in
+        # the window slot of `=session:%N` and (on releases carrying the #483
+        # fix) forwards it to the owning server, where the id resolves in
+        # exactly the right per-server id space. tmux must NOT receive this
+        # form — its window resolver has no pane-id handling, so the qualified
+        # target errors and the return degrades to `switch-client -l` — which
+        # is why composition is backend-owned rather than seam-uniform.
+        pane = self.current_pane_id()
+        if not pane:
+            return None
+        session = self.current_session()
+        # Degrade to the bare id (the base default, pre-#483 hazard and all)
+        # rather than None when the session probe fails, answers empty, or
+        # answers a name the `=session:%N` grammar cannot carry: a resolvable
+        # own pane means we ARE inside the multiplexer, so recording "detach"
+        # would strand the client.
+        if not session or ":" in session:
+            return pane
+        return self.target(session, pane)
+
     def pipe_pane(self, window_id: str, log_file: Path) -> None:
         # The base's POSIX `cat >>` sink assumes a POSIX host shell, and psmux
         # strips every dash-flag token from the piped command before spawning it

--- a/src/bmad_loop/adapters/tmux_base.py
+++ b/src/bmad_loop/adapters/tmux_base.py
@@ -35,8 +35,9 @@ from .multiplexer import MultiplexerError, TerminalMultiplexer
 
 TMUX_TIMEOUT_S = 30
 # Per-window option value (vs a pane target) telling the parked trailer to detach
-# the client rather than switch it. Recorded targets are =session:%N (or a bare
-# %N pane id), so this never collides with one.
+# the client rather than switch it. Recorded targets are backend-composed pane
+# targets (bare %N on tmux, =session:%N on psmux — see
+# TerminalMultiplexer.current_return_target), so this never collides with one.
 PARKED_RETURN_DETACH = "detach"
 
 
@@ -216,10 +217,10 @@ class BaseTmuxBackend(TerminalMultiplexer):
     def _parked_trailer(self, return_opt: str) -> str:
         # After the park, switch an attached client back to its origin pane.
         # `return_opt` names the per-window option; on its recorded value:
-        #   - a pane target (=session:%N — session-qualified so it resolves
-        #     from the control session even on a one-server-per-session
-        #     backend): switch that client back there (`switch-client -l` is a
-        #     best-effort fallback when it is gone);
+        #   - a pane target (backend-composed by current_return_target, replayed
+        #     opaquely here — bare %N on tmux, =session:%N on psmux): switch
+        #     that client back there (`switch-client -l` is a best-effort
+        #     fallback when it is gone);
         #   - PARKED_RETURN_DETACH: detach the client so a blocking
         #     `tmux attach` returns and a suspended TUI resumes;
         #   - unset/empty: nobody attached interactively -> park as-is.

--- a/src/bmad_loop/adapters/tmux_base.py
+++ b/src/bmad_loop/adapters/tmux_base.py
@@ -214,12 +214,13 @@ class BaseTmuxBackend(TerminalMultiplexer):
         return ["sh", "-c", source]
 
     def _parked_trailer(self, return_opt: str) -> str:
-        # After the park, switch an attached client back to its origin pane:
-        #   - return_opt == a pane target (=session:%N — session-qualified so it
-        #     resolves from the control session even on a one-server-per-session
+        # After the park, switch an attached client back to its origin pane.
+        # `return_opt` names the per-window option; on its recorded value:
+        #   - a pane target (=session:%N — session-qualified so it resolves
+        #     from the control session even on a one-server-per-session
         #     backend): switch that client back there (`switch-client -l` is a
         #     best-effort fallback when it is gone);
-        #   - return_opt == PARKED_RETURN_DETACH: detach the client so a blocking
+        #   - PARKED_RETURN_DETACH: detach the client so a blocking
         #     `tmux attach` returns and a suspended TUI resumes;
         #   - unset/empty: nobody attached interactively -> park as-is.
         # The tmux verbs are protocol-identical across the family; only the

--- a/src/bmad_loop/adapters/tmux_base.py
+++ b/src/bmad_loop/adapters/tmux_base.py
@@ -34,8 +34,9 @@ from pathlib import Path
 from .multiplexer import MultiplexerError, TerminalMultiplexer
 
 TMUX_TIMEOUT_S = 30
-# Per-window option value (vs a pane id) telling the parked trailer to detach the
-# client rather than switch it. Pane ids are %N, so this never collides with one.
+# Per-window option value (vs a pane target) telling the parked trailer to detach
+# the client rather than switch it. Recorded targets are =session:%N (or a bare
+# %N pane id), so this never collides with one.
 PARKED_RETURN_DETACH = "detach"
 
 
@@ -214,8 +215,10 @@ class BaseTmuxBackend(TerminalMultiplexer):
 
     def _parked_trailer(self, return_opt: str) -> str:
         # After the park, switch an attached client back to its origin pane:
-        #   - return_opt == a pane id (%N): switch that client back there
-        #     (`switch-client -l` is a best-effort fallback when it is gone);
+        #   - return_opt == a pane target (=session:%N — session-qualified so it
+        #     resolves from the control session even on a one-server-per-session
+        #     backend): switch that client back there (`switch-client -l` is a
+        #     best-effort fallback when it is gone);
         #   - return_opt == PARKED_RETURN_DETACH: detach the client so a blocking
         #     `tmux attach` returns and a suspended TUI resumes;
         #   - unset/empty: nobody attached interactively -> park as-is.

--- a/src/bmad_loop/cli.py
+++ b/src/bmad_loop/cli.py
@@ -1678,13 +1678,14 @@ def cmd_attach(args: argparse.Namespace) -> int:
     # Record where to send the client once the sweep finishes this cycle's
     # decisions (see launch.return_attached_client), so answering them hands the
     # terminal back instead of stranding the user in the orchestrator window.
-    # Backend-honest inside-the-multiplexer probe: current_pane_id() is None
-    # outside, so a resolvable own pane means "switch the client back here",
-    # anything else means a throwaway client was attached and must detach.
+    # Backend-honest inside-the-multiplexer probe: current_return_target() is
+    # None outside, so a resolvable own pane means "switch the client back
+    # here", anything else means a throwaway client was attached and must
+    # detach.
     if return_window is not None:
-        pane = launch.current_pane_id()
-        if pane is not None:
-            launch.set_return_pane(return_window, pane)
+        ret = launch.current_return_target()
+        if ret is not None:
+            launch.set_return_pane(return_window, ret)
         else:
             launch.set_return_pane(return_window, launch.RETURN_DETACH)
     return subprocess.call(argv)

--- a/src/bmad_loop/tui/app.py
+++ b/src/bmad_loop/tui/app.py
@@ -411,9 +411,10 @@ class BmadLoopApp(App[None]):
         # fire-and-forget switch/focus form, so no suspend is needed.
         ret = launch.current_return_target()
         if ret is not None:
-            # Record our own session-qualified pane on the ctl window so its
-            # trailing shell switches the client back here when it exits,
-            # instead of stranding the user in the control session.
+            # Record our own pane target (session-qualified when resolvable)
+            # on the ctl window so its trailing shell switches the client back
+            # here when it exits, instead of stranding the user in the control
+            # session.
             if return_window is not None:
                 launch.set_return_pane(return_window, ret)
             subprocess.call(argv)

--- a/src/bmad_loop/tui/app.py
+++ b/src/bmad_loop/tui/app.py
@@ -406,16 +406,16 @@ class BmadLoopApp(App[None]):
         ok, argv = self._mux_guarded(lambda: runs.attach_target_argv(target))
         if not ok:
             return
-        # Backend-honest inside-the-multiplexer probe (current_pane_id() is None
-        # outside): inside, attach_target_argv returned the fire-and-forget
-        # switch/focus form, so no suspend is needed.
-        pane = launch.current_pane_id()
-        if pane is not None:
-            # Record our own pane on the ctl window so its trailing shell
-            # switches the client back here when it exits, instead of stranding
-            # the user in the control session.
+        # Backend-honest inside-the-multiplexer probe (current_return_target()
+        # is None outside): inside, attach_target_argv returned the
+        # fire-and-forget switch/focus form, so no suspend is needed.
+        ret = launch.current_return_target()
+        if ret is not None:
+            # Record our own session-qualified pane on the ctl window so its
+            # trailing shell switches the client back here when it exits,
+            # instead of stranding the user in the control session.
             if return_window is not None:
-                launch.set_return_pane(return_window, pane)
+                launch.set_return_pane(return_window, ret)
             subprocess.call(argv)
             return
         # Outside tmux we attach a throwaway client (under suspend). The ctl

--- a/src/bmad_loop/tui/launch.py
+++ b/src/bmad_loop/tui/launch.py
@@ -75,9 +75,10 @@ def select_ctl_window_id(window_id: str) -> None:
 # Per-window tmux user option recording what an interactive attach should do
 # with the client once the window's command exits (consumed by the multiplexer's
 # parked-window return trailer; see start_detached and the tmux backend). Set by
-# set_return_pane at attach time. Value is either a session-qualified pane
-# target (=session:%N) to switch the client to — used when the TUI runs inside
-# the multiplexer and switched its own client over — or RETURN_DETACH, used
+# set_return_pane at attach time. Value is either a pane target — session-
+# qualified (=session:%N), degrading to a bare %N when the session probe fails
+# — to switch the client to, used when the TUI runs inside the multiplexer and
+# switched its own client over; or RETURN_DETACH, used
 # when the TUI runs outside and a throwaway client was attached that must
 # detach so the suspended TUI resumes. The qualification matters on psmux (one
 # server per session): the trailer replays the value from the control session,
@@ -91,15 +92,18 @@ def current_return_target() -> str | None:
     """Session-qualified target (=session:%N) of the pane this process runs in,
     or None when not inside the multiplexer / it is unavailable. For the TUI
     process this is its own pane — the place an attach should return the client
-    to. If only the session-name probe fails, falls back to the bare pane id
-    (pre-qualification behavior) rather than None: a resolvable own pane means
-    we ARE inside the multiplexer, so "detach" would strand the client."""
+    to. If only the session-name probe fails (or answers empty), falls back to
+    the bare pane id (pre-qualification behavior) rather than None: a
+    resolvable own pane means we ARE inside the multiplexer, so "detach" would
+    strand the client."""
     mux = get_multiplexer()
     pane = mux.current_pane_id()
     if not pane:
         return None
     session = mux.current_session()
-    return f"={session}:{pane}" if session else pane
+    # target() formats the seam grammar (and honors backend overrides); the
+    # pane id rides in the window slot — see the adapter authoring guide.
+    return mux.target(session, pane) if session else pane
 
 
 def set_return_pane(window_target: str, target: str) -> None:

--- a/src/bmad_loop/tui/launch.py
+++ b/src/bmad_loop/tui/launch.py
@@ -75,35 +75,26 @@ def select_ctl_window_id(window_id: str) -> None:
 # Per-window tmux user option recording what an interactive attach should do
 # with the client once the window's command exits (consumed by the multiplexer's
 # parked-window return trailer; see start_detached and the tmux backend). Set by
-# set_return_pane at attach time. Value is either a pane target — session-
-# qualified (=session:%N), degrading to a bare %N when the session probe fails
-# — to switch the client to, used when the TUI runs inside the multiplexer and
-# switched its own client over; or RETURN_DETACH, used
-# when the TUI runs outside and a throwaway client was attached that must
-# detach so the suspended TUI resumes. The qualification matters on psmux (one
-# server per session): the trailer replays the value from the control session,
-# where a bare %N is unresolvable — or worse, collides with a real control-
-# session pane and lands the client on the wrong one (psmux/psmux#483).
+# set_return_pane at attach time. Value is either a backend-composed pane
+# target — replayed opaquely, so each backend records the form its own
+# switch-client resolves: a bare pane id (%N) on tmux, =session:%N on psmux,
+# whose one-server-per-session model cannot resolve a bare id from the control
+# session (psmux/psmux#483) — used when the TUI runs inside the multiplexer and
+# switched its own client over; or RETURN_DETACH, used when the TUI runs
+# outside and a throwaway client was attached that must detach so the
+# suspended TUI resumes.
 RETURN_OPTION = "@bmad_return_pane"
-RETURN_DETACH = "detach"  # targets are =sess:%N (or bare %N), never "detach"
+RETURN_DETACH = "detach"  # pane targets are %N / =sess:%N, never "detach"
 
 
 def current_return_target() -> str | None:
-    """Session-qualified target (=session:%N) of the pane this process runs in,
-    or None when not inside the multiplexer / it is unavailable. For the TUI
-    process this is its own pane — the place an attach should return the client
-    to. If only the session-name probe fails (or answers empty), falls back to
-    the bare pane id (pre-qualification behavior) rather than None: a
-    resolvable own pane means we ARE inside the multiplexer, so "detach" would
-    strand the client."""
-    mux = get_multiplexer()
-    pane = mux.current_pane_id()
-    if not pane:
-        return None
-    session = mux.current_session()
-    # target() formats the seam grammar (and honors backend overrides); the
-    # pane id rides in the window slot — see the adapter authoring guide.
-    return mux.target(session, pane) if session else pane
+    """Backend-composed target of the pane this process runs in — the place an
+    attach should return the client to — or None when not inside the
+    multiplexer / it is unavailable. The value is opaque to callers: record it
+    with set_return_pane, replay it via switch_client / the parked trailer.
+    See TerminalMultiplexer.current_return_target for the composition
+    contract."""
+    return get_multiplexer().current_return_target()
 
 
 def set_return_pane(window_target: str, target: str) -> None:
@@ -140,8 +131,8 @@ def return_attached_client() -> bool:
     command keeps running in the background, instead of after it exits.
 
     Reads the RETURN_OPTION recorded on the current window by set_return_pane:
-      - a pane target (=session:%N, or bare %N): switch that client back there
-        (`-l` fallback if it's gone);
+      - a pane target (backend-composed: bare %N on tmux, =session:%N on
+        psmux): switch that client back there (`-l` fallback if it's gone);
       - RETURN_DETACH: detach the client so a blocking `tmux attach` returns;
       - unset/empty: nobody attached with a return target — do nothing.
     The option is then cleared so the post-exit return trailer doesn't fire a

--- a/src/bmad_loop/tui/launch.py
+++ b/src/bmad_loop/tui/launch.py
@@ -75,28 +75,39 @@ def select_ctl_window_id(window_id: str) -> None:
 # Per-window tmux user option recording what an interactive attach should do
 # with the client once the window's command exits (consumed by the multiplexer's
 # parked-window return trailer; see start_detached and the tmux backend). Set by
-# set_return_pane at attach time. Value is either a pane
-# id (%N) to switch the client to — used when the TUI runs inside tmux and
-# switched its own client over — or RETURN_DETACH, used when the TUI runs
-# outside tmux and a throwaway client was attached that must detach so the
-# suspended TUI resumes.
+# set_return_pane at attach time. Value is either a session-qualified pane
+# target (=session:%N) to switch the client to — used when the TUI runs inside
+# the multiplexer and switched its own client over — or RETURN_DETACH, used
+# when the TUI runs outside and a throwaway client was attached that must
+# detach so the suspended TUI resumes. The qualification matters on psmux (one
+# server per session): the trailer replays the value from the control session,
+# where a bare %N is unresolvable — or worse, collides with a real control-
+# session pane and lands the client on the wrong one (psmux/psmux#483).
 RETURN_OPTION = "@bmad_return_pane"
-RETURN_DETACH = "detach"  # pane ids are %N, so this never collides with one
+RETURN_DETACH = "detach"  # targets are =sess:%N (or bare %N), never "detach"
 
 
-def current_pane_id() -> str | None:
-    """Stable tmux id (%N) of the pane this process runs in, or None when not
-    inside tmux / tmux is unavailable. For the TUI process this is its own pane
-    — the place an attach should return the client to."""
-    return get_multiplexer().current_pane_id()
+def current_return_target() -> str | None:
+    """Session-qualified target (=session:%N) of the pane this process runs in,
+    or None when not inside the multiplexer / it is unavailable. For the TUI
+    process this is its own pane — the place an attach should return the client
+    to. If only the session-name probe fails, falls back to the bare pane id
+    (pre-qualification behavior) rather than None: a resolvable own pane means
+    we ARE inside the multiplexer, so "detach" would strand the client."""
+    mux = get_multiplexer()
+    pane = mux.current_pane_id()
+    if not pane:
+        return None
+    session = mux.current_session()
+    return f"={session}:{pane}" if session else pane
 
 
-def set_return_pane(window_target: str, pane_id: str) -> None:
-    """Record `pane_id` as the return target on a control-session window, so its
-    trailing shell switches the client back there when the window's command
-    exits. `window_target` is any tmux window spec (e.g. `=bmad-loop-ctl:run-…`
-    or a stable `@N` id)."""
-    get_multiplexer().set_window_option(window_target, RETURN_OPTION, pane_id)
+def set_return_pane(window_target: str, target: str) -> None:
+    """Record `target` (a current_return_target value or RETURN_DETACH) as the
+    return move on a control-session window, so its trailing shell sends the
+    client back there when the window's command exits. `window_target` is any
+    tmux window spec (e.g. `=bmad-loop-ctl:run-…` or a stable `@N` id)."""
+    get_multiplexer().set_window_option(window_target, RETURN_OPTION, target)
 
 
 def current_session() -> str | None:
@@ -125,7 +136,8 @@ def return_attached_client() -> bool:
     command keeps running in the background, instead of after it exits.
 
     Reads the RETURN_OPTION recorded on the current window by set_return_pane:
-      - a pane id (%N): switch that client back there (`-l` fallback if it's gone);
+      - a pane target (=session:%N, or bare %N): switch that client back there
+        (`-l` fallback if it's gone);
       - RETURN_DETACH: detach the client so a blocking `tmux attach` returns;
       - unset/empty: nobody attached with a return target — do nothing.
     The option is then cleared so the post-exit return trailer doesn't fire a

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1124,14 +1124,14 @@ def test_attach_records_return_pane_inside_tmux(project, monkeypatch):
         ),
     )
     monkeypatch.setenv("TMUX", "/tmp/tmux-1000/default,1,0")
-    monkeypatch.setattr(launch, "current_pane_id", lambda: "%3")
+    monkeypatch.setattr(launch, "current_return_target", lambda: "=main:%3")
     recorded: list = []
     monkeypatch.setattr(launch, "set_return_pane", lambda w, p: recorded.append((w, p)))
     called: list = []
     monkeypatch.setattr(cli.subprocess, "call", lambda argv: called.append(argv) or 0)
 
     assert cli.main(["attach", "--project", str(project.project), "20260101-000000-aaaa"]) == 0
-    assert recorded == [("=bmad-loop-ctl:sweep-RID", "%3")]
+    assert recorded == [("=bmad-loop-ctl:sweep-RID", "=main:%3")]
     assert called == [["tmux", "switch-client", "-t", "=bmad-loop-ctl"]]
 
 

--- a/tests/test_psmux_backend.py
+++ b/tests/test_psmux_backend.py
@@ -248,6 +248,64 @@ def test_kill_session_no_binary_no_spawn(rec, monkeypatch):
     assert rec.calls == []
 
 
+# ------------------------------------------------------- return target (#221)
+# psmux runs one server per session, so the parked-window return target must be
+# session-qualified: a bare %N replayed from the control session is at best
+# unresolvable, at worst collides with a real control-session pane
+# (psmux/psmux#483). The seam default (bare pane id) stays correct for tmux —
+# whose switch-client rejects the qualified form — so the composition lives in
+# this backend's override.
+
+
+def _probe_fake(monkeypatch, answers: dict[str, tuple[int, str]]):
+    """Script the display-message probes: fmt -> (returncode, stdout)."""
+
+    def fake(argv, **kwargs):
+        rc, out = answers[argv[-1]]
+        return subprocess.CompletedProcess(argv, rc, stdout=out, stderr="")
+
+    monkeypatch.setenv("TMUX", "/tmp/psmux-1000/default,123,0")  # inside psmux
+    monkeypatch.setattr(tmux_base.subprocess, "run", fake)
+
+
+def test_return_target_session_qualified(monkeypatch):
+    _probe_fake(monkeypatch, {"#{pane_id}": (0, "%9\n"), "#{session_name}": (0, "main\n")})
+    assert PsmuxMultiplexer().current_return_target() == "=main:%9"
+
+
+def test_return_target_none_outside_mux(monkeypatch):
+    monkeypatch.delenv("TMUX", raising=False)
+    monkeypatch.setattr(tmux_base.subprocess, "run", _RecordRun())
+    assert PsmuxMultiplexer().current_return_target() is None
+
+
+def test_return_target_none_on_empty_pane(monkeypatch):
+    _probe_fake(monkeypatch, {"#{pane_id}": (0, "\n"), "#{session_name}": (0, "main\n")})
+    assert PsmuxMultiplexer().current_return_target() is None
+
+
+def test_return_target_bare_pane_when_session_probe_fails(monkeypatch):
+    # A resolvable own pane means we ARE inside the multiplexer; a failed
+    # session-name probe degrades to the bare pane id, never to None (which
+    # callers would record as "detach" and strand the client).
+    _probe_fake(monkeypatch, {"#{pane_id}": (0, "%9\n"), "#{session_name}": (1, "")})
+    assert PsmuxMultiplexer().current_return_target() == "%9"
+
+
+def test_return_target_bare_pane_on_empty_session_name(monkeypatch):
+    # rc-0 empty stdout from the session probe must degrade the same way a
+    # failed probe does — a "=:%9" target would misparse at replay.
+    _probe_fake(monkeypatch, {"#{pane_id}": (0, "%9\n"), "#{session_name}": (0, "\n")})
+    assert PsmuxMultiplexer().current_return_target() == "%9"
+
+
+def test_return_target_bare_pane_on_unqualifiable_session_name(monkeypatch):
+    # A session name the `=session:%N` grammar cannot carry (a `:` would split
+    # at the wrong colon on replay) degrades to the bare id too.
+    _probe_fake(monkeypatch, {"#{pane_id}": (0, "%9\n"), "#{session_name}": (0, "a:b\n")})
+    assert PsmuxMultiplexer().current_return_target() == "%9"
+
+
 # ------------------------------------------------------------- parked window
 
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1903,15 +1903,15 @@ async def test_decision_footer_suppressed_for_crashed(project):
 def _patch_attach_exec(monkeypatch) -> tuple[list[list[str]], list[tuple[str, str]]]:
     """Route the final attach exec into a list: pretend we are inside tmux so
     action_attach takes the plain subprocess.call(switch-client) path. Stub the
-    TUI pane id and capture return-pane stamps so no real tmux is touched and
-    tests can assert which ctl window gets the switch-back target recorded."""
+    TUI return target and capture return-pane stamps so no real tmux is touched
+    and tests can assert which ctl window gets the switch-back target recorded."""
     calls: list[list[str]] = []
     stamps: list[tuple[str, str]] = []
     monkeypatch.setenv("TMUX", "/tmp/fake-tmux,1,0")
     monkeypatch.setattr(
         "bmad_loop.tui.app.subprocess.call", lambda argv: calls.append(list(argv)) or 0
     )
-    monkeypatch.setattr(launch, "current_pane_id", lambda: "%9")
+    monkeypatch.setattr(launch, "current_return_target", lambda: "=main:%9")
     monkeypatch.setattr(launch, "set_return_pane", lambda w, p: stamps.append((w, p)))
     return calls, stamps
 
@@ -1935,7 +1935,7 @@ async def test_attach_targets_ctl_window_when_decision_pending(project, monkeypa
     assert selected == ["sweep-20260611-100000-aaaa"]
     assert calls == [["tmux", "switch-client", "-t", "=bmad-loop-ctl"]]
     # the ctl window is stamped with our pane so it switches us back on exit
-    assert stamps == [("=bmad-loop-ctl:sweep-20260611-100000-aaaa", "%9")]
+    assert stamps == [("=bmad-loop-ctl:sweep-20260611-100000-aaaa", "=main:%9")]
 
 
 @pytest.mark.usefixtures("force_tmux_backend")  # pin tmux against win32-matching externals
@@ -1996,7 +1996,7 @@ async def test_attach_falls_back_to_ctl_window(project, monkeypatch):
         await until(pilot, lambda: bool(calls))
     assert selected == ["run-20260611-100000-aaaa"]
     assert calls == [["tmux", "switch-client", "-t", "=bmad-loop-ctl"]]
-    assert stamps == [("=bmad-loop-ctl:run-20260611-100000-aaaa", "%9")]
+    assert stamps == [("=bmad-loop-ctl:run-20260611-100000-aaaa", "=main:%9")]
 
 
 @pytest.mark.usefixtures("force_tmux_backend")  # pin tmux against win32-matching externals
@@ -2031,7 +2031,7 @@ async def test_resolve_escalation_launches_and_attaches(project, monkeypatch):
     assert selected == ["@7"]
     assert calls == [["tmux", "switch-client", "-t", "=bmad-loop-ctl"]]
     # resolve runs in the freshly launched ctl window (@7) — stamp it to return
-    assert stamps == [("@7", "%9")]
+    assert stamps == [("@7", "=main:%9")]
 
 
 async def test_resolve_unknown_pid_refused(project, monkeypatch):

--- a/tests/test_tui_launch.py
+++ b/tests/test_tui_launch.py
@@ -290,16 +290,19 @@ def test_set_return_pane_argv(fake_run):
     ]
 
 
-def test_current_return_target_qualified(monkeypatch):
-    # Composes both display-message probes into the session-qualified form.
-    answers = {"#{pane_id}": "%9", "#{session_name}": "main"}
-
+def test_current_return_target_bare_pane_on_tmux(monkeypatch):
+    # The launch helper delegates to the backend; on tmux the seam default
+    # answers the bare pane id — globally unique under the one-server model,
+    # and the only form tmux's switch-client actually resolves (its window
+    # resolver rejects a pane id in the `session:%N` slot). The qualified
+    # composition is a psmux override, pinned in test_psmux_backend.
     def fake(argv, **kwargs):
-        return subprocess.CompletedProcess(argv, 0, stdout=answers[argv[-1]] + "\n", stderr="")
+        assert argv[-1] == "#{pane_id}"  # exactly one probe, no session probe
+        return subprocess.CompletedProcess(argv, 0, stdout="%9\n", stderr="")
 
     monkeypatch.setenv("TMUX", "/tmp/tmux-1000/default,123,0")  # inside tmux
     monkeypatch.setattr(tmux_base.subprocess, "run", fake)
-    assert launch.current_return_target() == "=main:%9"
+    assert launch.current_return_target() == "%9"
 
 
 def test_current_return_target_none_outside_tmux(monkeypatch):
@@ -325,6 +328,8 @@ def test_current_return_target_none_on_transport_failure(monkeypatch):
 
 
 def test_current_return_target_none_on_empty_pane(monkeypatch):
+    # rc-0 empty stdout from the pane probe must answer None, not "" — the
+    # seam default's `or None` guard, which callers map to RETURN_DETACH.
     monkeypatch.setenv("TMUX", "/tmp/tmux-1000/default,123,0")
     monkeypatch.setattr(
         tmux_base.subprocess,
@@ -332,33 +337,6 @@ def test_current_return_target_none_on_empty_pane(monkeypatch):
         lambda argv, **kwargs: subprocess.CompletedProcess(argv, 0, stdout="\n", stderr=""),
     )
     assert launch.current_return_target() is None
-
-
-def test_current_return_target_bare_pane_when_session_probe_fails(monkeypatch):
-    # A resolvable own pane means we ARE inside the multiplexer; a failed
-    # session-name probe degrades to the bare pane id, never to None (which
-    # callers would record as "detach" and strand the client).
-    def fake(argv, **kwargs):
-        if argv[-1] == "#{pane_id}":
-            return subprocess.CompletedProcess(argv, 0, stdout="%9\n", stderr="")
-        return subprocess.CompletedProcess(argv, 1, stdout="", stderr="no server")
-
-    monkeypatch.setenv("TMUX", "/tmp/tmux-1000/default,123,0")
-    monkeypatch.setattr(tmux_base.subprocess, "run", fake)
-    assert launch.current_return_target() == "%9"
-
-
-def test_current_return_target_bare_pane_on_empty_session_name(monkeypatch):
-    # rc-0 empty stdout from the session probe must degrade the same way a
-    # failed probe does — a "=:%9" target would misparse at replay.
-    answers = {"#{pane_id}": "%9", "#{session_name}": ""}
-
-    def fake(argv, **kwargs):
-        return subprocess.CompletedProcess(argv, 0, stdout=answers[argv[-1]] + "\n", stderr="")
-
-    monkeypatch.setenv("TMUX", "/tmp/tmux-1000/default,123,0")
-    monkeypatch.setattr(tmux_base.subprocess, "run", fake)
-    assert launch.current_return_target() == "%9"
 
 
 def test_start_detached_returns_window_id(fake_run, tmp_path: Path):

--- a/tests/test_tui_launch.py
+++ b/tests/test_tui_launch.py
@@ -290,16 +290,19 @@ def test_set_return_pane_argv(fake_run):
     ]
 
 
-def test_current_pane_id_reads_pane(monkeypatch):
+def test_current_return_target_qualified(monkeypatch):
+    # Composes both display-message probes into the session-qualified form.
+    answers = {"#{pane_id}": "%9", "#{session_name}": "main"}
+
     def fake(argv, **kwargs):
-        return subprocess.CompletedProcess(argv, 0, stdout="%9\n", stderr="")
+        return subprocess.CompletedProcess(argv, 0, stdout=answers[argv[-1]] + "\n", stderr="")
 
     monkeypatch.setenv("TMUX", "/tmp/tmux-1000/default,123,0")  # inside tmux
     monkeypatch.setattr(tmux_base.subprocess, "run", fake)
-    assert launch.current_pane_id() == "%9"
+    assert launch.current_return_target() == "=main:%9"
 
 
-def test_current_pane_id_none_outside_tmux(monkeypatch):
+def test_current_return_target_none_outside_tmux(monkeypatch):
     # Outside tmux the TMUX guard answers None WITHOUT shelling out: against a
     # live server, display-message would answer for some OTHER client's session
     # and misreport a plain shell as being inside tmux.
@@ -308,17 +311,54 @@ def test_current_pane_id_none_outside_tmux(monkeypatch):
 
     monkeypatch.delenv("TMUX", raising=False)
     monkeypatch.setattr(tmux_base.subprocess, "run", boom)
-    assert launch.current_pane_id() is None
+    assert launch.current_return_target() is None
     assert launch.current_session() is None
 
 
-def test_current_pane_id_none_on_transport_failure(monkeypatch):
+def test_current_return_target_none_on_transport_failure(monkeypatch):
     def fake(argv, **kwargs):
         return subprocess.CompletedProcess(argv, 1, stdout="", stderr="no server")
 
     monkeypatch.setenv("TMUX", "/tmp/tmux-1000/default,123,0")
     monkeypatch.setattr(tmux_base.subprocess, "run", fake)
-    assert launch.current_pane_id() is None
+    assert launch.current_return_target() is None
+
+
+def test_current_return_target_none_on_empty_pane(monkeypatch):
+    monkeypatch.setenv("TMUX", "/tmp/tmux-1000/default,123,0")
+    monkeypatch.setattr(
+        tmux_base.subprocess,
+        "run",
+        lambda argv, **kwargs: subprocess.CompletedProcess(argv, 0, stdout="\n", stderr=""),
+    )
+    assert launch.current_return_target() is None
+
+
+def test_current_return_target_bare_pane_when_session_probe_fails(monkeypatch):
+    # A resolvable own pane means we ARE inside the multiplexer; a failed
+    # session-name probe degrades to the bare pane id, never to None (which
+    # callers would record as "detach" and strand the client).
+    def fake(argv, **kwargs):
+        if argv[-1] == "#{pane_id}":
+            return subprocess.CompletedProcess(argv, 0, stdout="%9\n", stderr="")
+        return subprocess.CompletedProcess(argv, 1, stdout="", stderr="no server")
+
+    monkeypatch.setenv("TMUX", "/tmp/tmux-1000/default,123,0")
+    monkeypatch.setattr(tmux_base.subprocess, "run", fake)
+    assert launch.current_return_target() == "%9"
+
+
+def test_current_return_target_bare_pane_on_empty_session_name(monkeypatch):
+    # rc-0 empty stdout from the session probe must degrade the same way a
+    # failed probe does — a "=:%9" target would misparse at replay.
+    answers = {"#{pane_id}": "%9", "#{session_name}": ""}
+
+    def fake(argv, **kwargs):
+        return subprocess.CompletedProcess(argv, 0, stdout=answers[argv[-1]] + "\n", stderr="")
+
+    monkeypatch.setenv("TMUX", "/tmp/tmux-1000/default,123,0")
+    monkeypatch.setattr(tmux_base.subprocess, "run", fake)
+    assert launch.current_return_target() == "%9"
 
 
 def test_start_detached_returns_window_id(fake_run, tmp_path: Path):
@@ -457,7 +497,7 @@ def test_detach_client_argv(fake_run):
     assert fake_run.calls == [["tmux", "detach-client"]]
 
 
-def _return_fake(monkeypatch, *, win="@5", option="%9", switch_rc=0):
+def _return_fake(monkeypatch, *, win="@5", option="=main:%9", switch_rc=0):
     """Script tmux for return_attached_client: display-message -> window id,
     show-options -> the recorded RETURN_OPTION, switch-client -> switch_rc.
     return_attached_client runs inside a ctl window, so TMUX is set (the
@@ -484,16 +524,16 @@ def _return_fake(monkeypatch, *, win="@5", option="%9", switch_rc=0):
 
 
 def test_return_attached_client_switches_to_pane(monkeypatch):
-    calls = _return_fake(monkeypatch, option="%9")
+    calls = _return_fake(monkeypatch, option="=main:%9")
     assert launch.return_attached_client() is True
-    assert ["tmux", "switch-client", "-t", "%9"] in calls
+    assert ["tmux", "switch-client", "-t", "=main:%9"] in calls
     assert ["tmux", "set-option", "-wu", "-t", "@5", "@bmad_return_pane"] in calls
     assert ["tmux", "switch-client", "-l"] not in calls  # no fallback when -t works
     assert not any(c[1] == "detach-client" for c in calls)
 
 
 def test_return_attached_client_switch_fallback(monkeypatch):
-    calls = _return_fake(monkeypatch, option="%9", switch_rc=1)
+    calls = _return_fake(monkeypatch, option="=main:%9", switch_rc=1)
     assert launch.return_attached_client() is True
     assert ["tmux", "switch-client", "-l"] in calls
 


### PR DESCRIPTION
## Summary

An interactive attach recorded the client's origin as a bare pane id (`%N`) and replayed it as `switch-client -t %N` from inside the control session. Sound under tmux's one-server model, but on psmux (one server per session, upstream-final per psmux/psmux#483) a bare id is session-local: at best unresolvable, at worst colliding with a real control-session pane and landing the client on the wrong one with exit 0 — past the `switch-client -l` fallback.

This is candidate B from the issue thread: the recording seam (`tui/launch.py`) now emits `=session:%N` when both probes succeed, retaining bare `%N` only if the session-name probe fails (a resolvable own pane means the client IS inside the multiplexer, so recording `detach` would strand it). An rc-0-but-empty pane probe is rejected before composing. The replay sides — POSIX and pwsh trailers, `switch_client`, `return_attached_client` — treat the value as an opaque target and are unchanged beyond comment accuracy. `RETURN_DETACH` stays collision-free.

## Verification

- tmux 3.4 (WSL): `=sess:%N` parses and resolves to the exact pane; `switch-client` accepts the form. tmux resolves the qualified form to the same pane a bare id always reached.
- psmux side is source-verified against psmux main (d56d777 + 6c76ff9, see the issue thread); live confirmation stays on the #222 checklist — psmux 3.3.7 (the only release passing the version gate) no-ops all window/pane targets by design, so nothing regresses there.
- Windows targeted suite (launch/cli/tui-app/multiplexer/psmux): 457 passed, 1 known baseline failure (skill-sync drift). Full WSL suite: failures identical to a clean checkout of main (stash-compared), none introduced.
- Recording is covered by probe-composition tests (qualified, outside-mux, transport failure, empty pane, failed/empty session name); the replay fixture now round-trips the qualified value.

Closes #221

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed return-pane selection after interactive attaches to use session-qualified return targets when available.
  * Avoided cross-session misrouting when pane identifiers overlap between sessions.
  * Kept safe fallback behavior when session information can’t be determined reliably, ensuring correct tmux/psmux return from parked windows.
* **Documentation**
  * Updated the adapter authoring guide with clarified parked-window return target and pane identifier formatting rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->