### PR TITLE
test(tui): de-flake cleanup-session summary toast assertion

### DIFF
--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1728,7 +1728,10 @@ async def test_cleanup_unknown_sessions_notifies(project, monkeypatch):
         await until(pilot, lambda: isinstance(app.screen, ConfirmModal))
         await pilot.click(await ready(pilot, "#ok"))
         await until(pilot, lambda: any("unverifiable engine pid" in m for m in notifications(app)))
-        assert any("removed 1 session(s)" in m for m in notifications(app))
+        # `until`, not a bare assert: the summary toast is marshalled from the
+        # worker AFTER the pid warning, so waiting on the earlier one does not
+        # guarantee this one has reached the message pump yet (Windows flake).
+        await until(pilot, lambda: any("removed 1 session(s)" in m for m in notifications(app)))
 
 
 async def test_cleanup_sessions_mux_error_notifies(project, monkeypatch):
@@ -1760,7 +1763,10 @@ async def test_cleanup_sessions_mux_error_notifies(project, monkeypatch):
         # the ctl-window failure is surfaced, but the session pruning that already
         # completed is still reported — not swallowed by an early return
         await until(pilot, lambda: any("unverifiable engine pid" in m for m in notifications(app)))
-        assert any("removed 1 session(s)" in m for m in notifications(app))
+        # `until`, not a bare assert: the summary toast is marshalled from the
+        # worker AFTER the pid warning, so waiting on the earlier one does not
+        # guarantee this one has reached the message pump yet (Windows flake).
+        await until(pilot, lambda: any("removed 1 session(s)" in m for m in notifications(app)))
         assert isinstance(app.screen, DashboardScreen)  # worker failed soft, no crash
 
 


### PR DESCRIPTION
Follow-up to the 0.9.0 release (#247). De-flakes a Windows-only CI failure — **not a code regression**; v0.9.0 shipped fine.

### The failure
On the #247 merge commit, `test (windows, py3.11)` failed:

```
tests/test_tui_app.py::test_cleanup_sessions_mux_error_notifies
>   assert any("removed 1 session(s)" in m for m in notifications(app))
E   assert False
```

The identical tree **passed** this exact job in the PR's own CI — same code, passed once / failed once = a timing flake.

### Root cause
`_cleanup_sessions_worker` (app.py) marshals two toasts from the worker thread via separate `call_from_thread` hops, in this order: the `unverifiable engine pid` **warning**, then the `removed N session(s)` **summary**. Both cleanup tests waited `until` the *earlier* warning appeared, then did a **bare** `assert` on the *later* summary — so on slow Windows timing the summary toast hadn't reached the message pump yet and the assert raced it.

### Fix
Wrap the summary check in the same `until()` poll the surrounding waits already use, in both `test_cleanup_unknown_sessions_notifies` and `test_cleanup_sessions_mux_error_notifies`. Test-only; no production code touched.

### Verification
- `pytest tests/test_tui_app.py -k cleanup` → 2 passed locally.
- trunk pre-commit hook clean.
