### PR TITLE
ci(pyright): adopt basic-mode type check over src/bmad_loop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,3 +110,30 @@ jobs:
 
       - name: Trunk Check
         uses: trunk-io/trunk-action@v1
+
+  typecheck:
+    # Pyright in basic mode over src/bmad_loop (see [tool.pyright] in pyproject.toml).
+    # Basic-mode adoption (#245, assessment F-4): fences annotation drift the wider
+    # refactor program relies on. The pinned version keeps the gate reproducible.
+    name: typecheck (pyright)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.3.2
+        with:
+          enable-cache: true
+          python-version: '3.11'
+
+      - name: Install the project
+        # Populates .venv (venvPath/venv in the pyright config) so third-party and
+        # optional-extra imports (textual, pyte, httpx, …) resolve instead of being
+        # flagged as missing.
+        run: uv sync --locked --all-extras
+
+      - name: Pyright (basic mode)
+        run: uvx pyright@1.1.411

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,3 +67,18 @@ target-version = ["py311"]
 [tool.isort]
 profile = "black"
 line_length = 100
+
+[tool.pyright]
+# Stage 1 of #245 (assessment F-4): a basic-mode type-check gate so annotation
+# drift stops being invisible. Verified against pyright 1.1.411 docs.
+include = ["src/bmad_loop"]
+# data/ ships skill assets + hook scripts that are templates / stand-alone (not
+# part of the package's import graph); type-checking them is noise.
+exclude = ["src/bmad_loop/data"]
+typeCheckingMode = "basic"
+# Check against the floor of requires-python so we never lean on 3.12+ typing.
+pythonVersion = "3.11"
+# Resolve third-party imports from the uv-managed project venv (created by
+# `uv sync` locally and in CI), so optional-extra imports aren't false misses.
+venvPath = "."
+venv = ".venv"

--- a/src/bmad_loop/adapters/generic.py
+++ b/src/bmad_loop/adapters/generic.py
@@ -88,6 +88,10 @@ class _ResultFileMixin:
     any adapter whose skill writes ``tasks/<task_id>/result.json``; needs
     only ``self.tasks_dir``."""
 
+    # Set by the concrete adapter's __init__; bare annotation (no runtime effect)
+    # tells the type checker the host attribute this mixin reads.
+    tasks_dir: Path
+
     def _result_json(self, handle: SessionHandle, spec: SessionSpec, *, wait: bool) -> dict | None:
         """Acquire this session's result dict. Base behavior: read the
         skill-written ``result.json`` (briefly awaiting it on the Stop event,
@@ -875,6 +879,11 @@ class _DevSynthesisMixin(_ResultFileMixin):
     synthesizes the legacy result dict via :mod:`devcontract`. Hosts provide
     ``self.paths`` (a :class:`ProjectPaths`), the ``self.policy`` knobs read
     by ``_configure_dev_knobs``, and the ``_probe_alive`` liveness seam."""
+
+    # Set by the concrete adapter's __init__ (see docstring); bare annotations
+    # (no runtime effect) tell the type checker the host attributes this reads.
+    paths: ProjectPaths
+    policy: Policy
 
     def _configure_dev_knobs(self) -> None:
         """Override the base result-file knobs for the bmad-dev-auto contract;

--- a/src/bmad_loop/cli.py
+++ b/src/bmad_loop/cli.py
@@ -12,6 +12,7 @@ import sys
 import time
 from enum import IntEnum
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from . import (
     __version__,
@@ -78,6 +79,11 @@ from .runsetup import mux_reason_label as _mux_reason_label
 from .runsetup import platform_preflight as _platform_preflight
 from .stories_engine import StoriesEngine
 from .sweep import SweepEngine
+
+if TYPE_CHECKING:
+    # Type-only: annotate the profile-lookup map without a module-level adapter
+    # import (cli.py imports the adapter package lazily inside functions).
+    from .adapters.profile import CLIProfile
 
 POLICY_FILE = policy_mod.POLICY_FILE
 
@@ -193,7 +199,7 @@ def cmd_validate(args: argparse.Namespace) -> int:
     from .adapters.profile import ProfileError, get_profile
 
     profiles = []
-    profile_by_name: dict[str, object] = {}
+    profile_by_name: dict[str, CLIProfile] = {}
     pol = None
     try:
         pol = policy_mod.load(_policy_path(project))

--- a/src/bmad_loop/diagnostics.py
+++ b/src/bmad_loop/diagnostics.py
@@ -397,7 +397,13 @@ def summarize_journal(
         kind_histogram=dict(kinds),
         first_ts=first_ts,
         last_ts=last_ts,
-        duration_s=(round(last_ts - first_ts, 3) if first_ts is not None else None),
+        # first_ts/last_ts are set together (both None iff no timestamps), so the
+        # first_ts guard also proves last_ts is not None here.
+        duration_s=(
+            round(last_ts - first_ts, 3)  # pyright: ignore[reportOptionalOperand]
+            if first_ts is not None
+            else None
+        ),
         escalation_count=kinds.get("story-escalated", 0) + kinds.get("preference-escalation", 0),
         defer_count=kinds.get("story-deferred", 0),
         plugin_error_count=kinds.get("plugin-error", 0),

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -18,7 +18,7 @@ import time
 import traceback
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
 
 from . import deferredwork, devcontract, gates, verify
 from .adapters.base import CodingCLIAdapter, SessionResult, SessionSpec
@@ -58,6 +58,10 @@ from .workspace import (
     open_unit_workspace,
     unit_worktrees_dir,
 )
+
+if TYPE_CHECKING:
+    # Type-only: the worktree-provisioning helpers speak in CLI profiles.
+    from .adapters.profile import CLIProfile
 
 
 class RunPaused(Exception):
@@ -461,7 +465,9 @@ class Engine:
     def _restore_stop_signals(self) -> None:
         for sig, prev in self._prev_handlers.items():
             try:
-                signal.signal(sig, prev)
+                # prev is a prior OS handler from signal.signal(); the dict is
+                # object-typed to avoid importing the private stdlib _HANDLER alias.
+                signal.signal(sig, prev)  # pyright: ignore[reportArgumentType]
             except (ValueError, TypeError):
                 pass
         self._prev_handlers.clear()
@@ -527,11 +533,11 @@ class Engine:
         self.journal.append("target-branch", branch=self.state.target_branch)
         self._save()
 
-    def _worktree_profiles(self):
+    def _worktree_profiles(self) -> list[CLIProfile]:
         """The distinct CLI profiles of the dev + review adapters, for provisioning
         their skills/hooks into a worktree. Adapters without a `profile` (e.g. test
         fakes) contribute nothing, so provisioning is a no-op for them."""
-        seen: dict[str, object] = {}
+        seen: dict[str, CLIProfile] = {}
         for adapter in (self.adapters["dev"], self.adapters["review"]):
             profile = getattr(adapter, "profile", None)
             if profile is not None and profile.name not in seen:
@@ -2712,10 +2718,13 @@ class Engine:
             "post_session",
             task,
             role=role,
-            session_status=result.status,
-            result_json=result.result_json,
+            # Reaching here means `adapter.run` returned (a non-None SessionResult)
+            # rather than raising past the finally, but pyright can't prove that
+            # through the try/finally, so it keeps `result` widened to | None.
+            session_status=result.status,  # pyright: ignore[reportOptionalMemberAccess]
+            result_json=result.result_json,  # pyright: ignore[reportOptionalMemberAccess]
         )
-        return result
+        return result  # pyright: ignore[reportReturnType]
 
     def _dev_prompt(self, task: StoryTask, feedback: Path | None) -> str:
         return self._generic_dev_prompt(task, feedback)

--- a/src/bmad_loop/machine.py
+++ b/src/bmad_loop/machine.py
@@ -117,7 +117,8 @@ def emit_document(rendered: str) -> None:
     # a TextIOWrapper at all. Falling through leaves the pre-#200 behaviour, which
     # is a crash with stdout still empty — permitted by the contract above.
     if hasattr(sys.stdout, "reconfigure"):
-        sys.stdout.reconfigure(encoding="utf-8")
+        # hasattr-guarded: reconfigure exists on TextIOWrapper, not the TextIO base.
+        sys.stdout.reconfigure(encoding="utf-8")  # pyright: ignore[reportAttributeAccessIssue]
     print(document)
 
 

--- a/src/bmad_loop/plugins/registry.py
+++ b/src/bmad_loop/plugins/registry.py
@@ -67,7 +67,11 @@ def _instantiate(manifest: PluginManifest, settings: dict) -> Plugin:
     cls_name = manifest.python.cls  # type: ignore[union-attr]
     cls = getattr(module, cls_name, None)
     if cls is None:
-        raise AttributeError(f"plugin module {manifest.python.module!r} has no {cls_name!r}")
+        # manifest.python is validated non-None before this loader runs (mirrors
+        # the manifest.python.cls access above).
+        raise AttributeError(
+            f"plugin module {manifest.python.module!r} has no {cls_name!r}"  # pyright: ignore[reportOptionalMemberAccess]
+        )
     if not (isinstance(cls, type) and issubclass(cls, Plugin)):
         raise TypeError(f"{cls_name!r} must subclass plugins.Plugin")
     return cls(manifest, settings)

--- a/src/bmad_loop/runsetup.py
+++ b/src/bmad_loop/runsetup.py
@@ -50,6 +50,8 @@ if TYPE_CHECKING:
     from .adapters.base import CodingCLIAdapter
     from .engine import Engine
     from .policy import Policy
+    from .stories_engine import StoriesEngine
+    from .sweep import SweepEngine
 
 
 # The three adapter roles a run wires. Defined here (the composition layer that
@@ -103,10 +105,11 @@ def make_adapters(project: Path, run_dir: Path, policy) -> dict[str, CodingCLIAd
                     stop_without_result_nudges=cfg.stop_without_result_nudges,
                 )
                 try:
+                    # heterogeneous **kwargs: pyright unions the dict values; per-arg error is spurious
                     by_cfg[key] = (
                         OpencodeDevAdapter(**common, paths=paths)
                         if synthesizes
-                        else OpencodeHttpAdapter(**common)
+                        else OpencodeHttpAdapter(**common)  # pyright: ignore[reportArgumentType]
                     )
                 except OpencodeServerError as e:
                     raise SystemExit(f"error: {e}") from e
@@ -135,10 +138,11 @@ def make_adapters(project: Path, run_dir: Path, policy) -> dict[str, CodingCLIAd
                     stop_without_result_nudges=cfg.stop_without_result_nudges,
                     mux=mux,
                 )
+                # heterogeneous **kwargs: pyright unions the dict values; per-arg error is spurious
                 by_cfg[key] = (
                     GenericDevAdapter(**common, paths=paths)
                     if synthesizes
-                    else GenericAdapter(**common)
+                    else GenericAdapter(**common)  # pyright: ignore[reportArgumentType]
                 )
         adapters[role] = by_cfg[key]
     return adapters
@@ -342,7 +346,7 @@ def compose_run(
     sweep_factory: Callable[[str], None],
     make_adapters: Callable[[Path, Path, Policy], dict[str, CodingCLIAdapter]],
     engine_cls: type[Engine],
-    stories_engine_cls: type[Engine],
+    stories_engine_cls: type[StoriesEngine],
 ) -> ComposedRun:
     """Stand up a run: allocate the run dir, persist state + pid, build the
     adapters, and wire the engine — everything ``cmd_run`` did inline between its
@@ -388,10 +392,11 @@ def compose_run(
         story_filter=story_filter,
         sweep_factory=sweep_factory,
     )
+    # heterogeneous **kwargs: pyright unions the dict values; per-arg error is spurious
     engine: Engine = (
         stories_engine_cls(**common, spec_folder=spec_folder)
         if stories_on
-        else engine_cls(**common)
+        else engine_cls(**common)  # pyright: ignore[reportArgumentType]
     )
     return ComposedRun(engine=engine, run_id=run_id, run_dir=run_dir, state=state, journal=journal)
 
@@ -409,7 +414,7 @@ def compose_sweep(
     max_cycles: int | None,
     trigger: str,
     make_adapters: Callable[[Path, Path, Policy], dict[str, CodingCLIAdapter]],
-    sweep_engine_cls: type[Engine],
+    sweep_engine_cls: type[SweepEngine],
 ) -> ComposedRun:
     """Stand up a sweep run: allocate the run dir, persist state + pid, record the
     sweep options, build the adapters, and wire the ``SweepEngine`` — everything
@@ -478,8 +483,8 @@ def compose_resume(
     sweep_factory: Callable[[str], None],
     make_adapters: Callable[[Path, Path, Policy], dict[str, CodingCLIAdapter]],
     engine_cls: type[Engine],
-    stories_engine_cls: type[Engine],
-    sweep_engine_cls: type[Engine],
+    stories_engine_cls: type[StoriesEngine],
+    sweep_engine_cls: type[SweepEngine],
 ) -> ComposedRun:
     """Rebuild the engine for a paused/interrupted run and return it ready to
     :meth:`run` — the adapter build + engine selection ``cli._resume_paused_run``
@@ -540,10 +545,11 @@ def compose_resume(
         )
         # stories mode is pinned in run state at launch, so resume rebuilds the
         # same picker (StoriesEngine) without any flag.
+        # heterogeneous **kwargs: pyright unions the dict values; per-arg error is spurious
         engine = (
             stories_engine_cls(**story_common, spec_folder=state.spec_folder)
             if state.source == "stories"
-            else engine_cls(**story_common)
+            else engine_cls(**story_common)  # pyright: ignore[reportArgumentType]
         )
     return ComposedRun(
         engine=engine, run_id=run_dir.name, run_dir=run_dir, state=state, journal=journal

--- a/src/bmad_loop/tui/app.py
+++ b/src/bmad_loop/tui/app.py
@@ -328,12 +328,20 @@ class BmadLoopApp(App[None]):
         self.push_screen(DecisionModal(decision), on_choice)
 
     def _record_decision(self, decision: object, option: object) -> bool:
+        # decision/option cross the widget boundary as `object`; their runtime types
+        # are the Decision/DecisionOption that apply_pre_answer and `.id` expect.
         try:
             decisions.apply_pre_answer(
-                self.project, decision, option, date=time.strftime("%Y-%m-%d")
+                self.project,
+                decision,  # pyright: ignore[reportArgumentType]
+                option,  # pyright: ignore[reportArgumentType]
+                date=time.strftime("%Y-%m-%d"),
             )
         except (OSError, bmadconfig.BmadConfigError) as e:
-            self.notify(f"failed to record {decision.id}: {e}", severity="error")
+            self.notify(
+                f"failed to record {decision.id}: {e}",  # pyright: ignore[reportAttributeAccessIssue]
+                severity="error",
+            )
             return False
         return True
 
@@ -406,6 +414,9 @@ class BmadLoopApp(App[None]):
         ok, argv = self._mux_guarded(lambda: runs.attach_target_argv(target))
         if not ok:
             return
+        # argv is None only when `ok` is False (they are a pair); past this guard it
+        # is a real argv, but pyright can't correlate the two — hence the
+        # reportArgumentType ignores on the subprocess.call/shlex.join uses below.
         # Backend-honest inside-the-multiplexer probe (current_return_target()
         # is None outside): inside, attach_target_argv returned the
         # fire-and-forget switch/focus form, so no suspend is needed.
@@ -417,7 +428,7 @@ class BmadLoopApp(App[None]):
             # session.
             if return_window is not None:
                 launch.set_return_pane(return_window, ret)
-            subprocess.call(argv)
+            subprocess.call(argv)  # pyright: ignore[reportArgumentType]
             return
         # Outside tmux we attach a throwaway client (under suspend). The ctl
         # session keeps its own shell window, so a closed run window would leave
@@ -428,10 +439,10 @@ class BmadLoopApp(App[None]):
             launch.set_return_pane(return_window, launch.RETURN_DETACH)
         try:
             with self.suspend():
-                subprocess.call(argv)
+                subprocess.call(argv)  # pyright: ignore[reportArgumentType]
         except SuspendNotSupported:
             self.notify(
-                f"cannot suspend here — run manually: {shlex.join(argv)}",
+                f"cannot suspend here — run manually: {shlex.join(argv)}",  # pyright: ignore[reportArgumentType]
                 severity="warning",
                 timeout=10,
             )
@@ -556,7 +567,8 @@ class BmadLoopApp(App[None]):
         }
         spec_path, spec_text = self._paused_spec(state)
         modal = SpecReviewModal(
-            title=f"{labels.get(state.paused_stage, 'gate')} — review the finalized spec",
+            # paused_stage may be None; dict.get tolerates a None key (returns the default).
+            title=f"{labels.get(state.paused_stage, 'gate')} — review the finalized spec",  # pyright: ignore[reportArgumentType, reportCallIssue]
             subtitle=self._story_subtitle(state),
             spec_path=spec_path,
             spec_text=spec_text,

--- a/src/bmad_loop/tui/data.py
+++ b/src/bmad_loop/tui/data.py
@@ -364,7 +364,8 @@ def _render_row(row: dict) -> Text:
         ch = row[x]
         key = (ch.fg, ch.bg, ch.bold, ch.italics, ch.underscore, ch.strikethrough, ch.reverse)
         if key != prev_key and run:
-            text.append("".join(run), _char_style(prev_key))
+            # prev_key is non-None whenever `run` is non-empty (a prior cell was buffered).
+            text.append("".join(run), _char_style(prev_key))  # pyright: ignore[reportArgumentType]
             run.clear()
         prev_key = key
         run.append(ch.data)
@@ -622,7 +623,13 @@ class LogView:
             # marker bytes; the log_pos->line mapping is already approximate)
             end = start + len(piece)
             self._offset = base + (consumed if end >= total else round(end / total * consumed))
-            line = top.dropped + len(top) + self._screen.cursor.y
+            # pyte types history.top as base deque; bmad-loop installs a _CountingDeque
+            # (see class below) that adds `.dropped`.
+            line = (
+                top.dropped  # pyright: ignore[reportAttributeAccessIssue]
+                + len(top)
+                + self._screen.cursor.y
+            )
             self._checkpoints.append((self._offset, line))
         self._offset = base + consumed
         # When a chunk is entirely an unterminated trailing CSI, consumed == 0 and
@@ -633,7 +640,12 @@ class LogView:
         # only risk eating a legitimately split sequence by forcing it through).
         # drop checkpoints whose lines evicted past the history horizon;
         # their offsets would clamp to line 0 anyway
-        while len(self._checkpoints) > 1 and self._checkpoints[1][1] <= top.dropped:
+        # `.dropped` is on the _CountingDeque bmad-loop installs as history.top.
+        while (
+            len(self._checkpoints) > 1
+            and self._checkpoints[1][1]
+            <= top.dropped  # pyright: ignore[reportAttributeAccessIssue]
+        ):
             self._checkpoints.pop(0)
         return consumed > 0
 
@@ -663,7 +675,10 @@ class LogView:
             rows.pop()
         front_drop = max(0, len(rows) - self._history)
         del rows[:front_drop]
-        self._render_base = screen.history.top.dropped + front_drop
+        # `.dropped` is on the _CountingDeque bmad-loop installs as history.top.
+        self._render_base = (
+            screen.history.top.dropped + front_drop  # pyright: ignore[reportAttributeAccessIssue]
+        )
         self._render_len = len(rows)
         return Text("\n").join(rows)
 

--- a/src/bmad_loop/tui/screens/settings_screen.py
+++ b/src/bmad_loop/tui/screens/settings_screen.py
@@ -403,7 +403,11 @@ class SettingsScreen(Screen[None]):
                 return False
             return True
         if isinstance(desired, list):
-            return [str(item) for item in current] != desired
+            # `current` pairs with a list `desired` here; its static type is the
+            # heterogeneous `object` setting supertype, but at runtime it is a list.
+            return [
+                str(item) for item in current  # pyright: ignore[reportGeneralTypeIssues]
+            ] != desired
         return current != desired
 
     def _save_enabled(self) -> None:

--- a/src/bmad_loop/tui/settings.py
+++ b/src/bmad_loop/tui/settings.py
@@ -67,7 +67,9 @@ class PolicyDoc:
             if stage and table is not None and len(table) == 0:
                 del self._doc[parent][stage]
             return
-        self._table(section, create=True)[key] = value
+        # _table(create=True) never returns None (it creates missing tables), but
+        # its return type is Any | None.
+        self._table(section, create=True)[key] = value  # pyright: ignore[reportOptionalSubscript]
 
     def validate(
         self,

--- a/src/bmad_loop/verify.py
+++ b/src/bmad_loop/verify.py
@@ -641,7 +641,17 @@ def worktree_add(
     another worktree — git refuses that.
     """
     if create:
-        rc, out = _git(repo, "worktree", "add", "-b", branch, str(path), base)
+        # base is the caller-supplied start-point when create=True; None would fail
+        # in git, so callers pass a real ref — not narrowed by the signature here.
+        rc, out = _git(
+            repo,
+            "worktree",
+            "add",
+            "-b",
+            branch,
+            str(path),
+            base,  # pyright: ignore[reportArgumentType]
+        )
     else:
         rc, out = _git(repo, "worktree", "add", str(path), branch)
     if rc != 0:

--- a/src/bmad_loop/verify.py
+++ b/src/bmad_loop/verify.py
@@ -635,23 +635,19 @@ def worktree_add(
 ) -> None:
     """Check `branch` out in a new worktree at `path` (which must not exist).
 
-    create=True (default) cuts a fresh `branch` at `base`. create=False mounts an
+    create=True (default) cuts a fresh `branch` at `base`, or from HEAD when
+    `base` is None (git's own default start-point). create=False mounts an
     existing `branch` (used to re-mount a shared run branch across serial units);
     `base` is ignored. Either way the branch must not already be checked out in
     another worktree — git refuses that.
     """
     if create:
-        # base is the caller-supplied start-point when create=True; None would fail
-        # in git, so callers pass a real ref — not narrowed by the signature here.
-        rc, out = _git(
-            repo,
-            "worktree",
-            "add",
-            "-b",
-            branch,
-            str(path),
-            base,  # pyright: ignore[reportArgumentType]
-        )
+        # `git worktree add -b <branch> <path> [<base>]`: cut the new branch at the
+        # caller's start-point, or from HEAD when none is given (git's own default).
+        cmd = ["worktree", "add", "-b", branch, str(path)]
+        if base is not None:
+            cmd.append(base)
+        rc, out = _git(repo, *cmd)
     else:
         rc, out = _git(repo, "worktree", "add", str(path), branch)
     if rc != 0:

--- a/tests/test_verify_worktree.py
+++ b/tests/test_verify_worktree.py
@@ -63,6 +63,18 @@ def test_worktree_add_list_remove(project, tmp_path):
     assert wt.resolve() not in [p.resolve() for p in verify.worktree_list(repo)]
 
 
+def test_worktree_add_create_defaults_to_head(project, tmp_path):
+    """create=True with no `base` cuts the branch from HEAD (git's own default)
+    instead of passing None into git and crashing."""
+    repo = project.project
+    head = verify.rev_parse_head(repo)
+    wt = tmp_path / "wt-head"
+
+    verify.worktree_add(repo, wt, "feat", create=True)
+    assert verify.branch_exists(repo, "feat")
+    assert verify.rev_parse_head(wt) == head
+
+
 def test_worktree_add_existing_path_raises(project, tmp_path):
     wt = tmp_path / "wt"
     wt.mkdir()


### PR DESCRIPTION
Closes #245 — Stage 1 (basic mode) of assessment finding F-4.

## Why

No type checker existed anywhere (no pyright/mypy config in `pyproject.toml`, `.trunk/`, or CI). Annotations are pervasive but were unverified, so annotation drift was invisible and the wider refactor program's code moves had no cheap safety net. This lands a **basic-mode pyright gate** that fences those moves.

## Spike result (the go/no-go)

Ran pyright **1.1.411** (verified current via npm/pip) in basic mode over `src/bmad_loop`, excluding `data/`, with imports resolved against the uv-managed venv:

| stage | errors |
|---|---|
| initial spike (basic) | **89** |
| after cheap annotation fixes | 22 |
| after targeted suppressions | **0** |

89 is well under the ~200 threshold, so the gate lands here rather than proposing a per-module rollout. (Notably, only **1** error fell in a Stage-2 "pure" module — `machine.py` — a good omen for Stage 2.)

## What's in the change

**Config** — `[tool.pyright]` in `pyproject.toml`: `typeCheckingMode = "basic"`, `include = ["src/bmad_loop"]`, `exclude = ["src/bmad_loop/data"]`, `pythonVersion = "3.11"` (the `requires-python` floor), `venvPath="."`/`venv=".venv"` so optional-extra imports (textual, pyte, httpx, …) resolve instead of reading as missing.

**CI** — a `typecheck (pyright)` job mirroring the existing job structure: checkout → install uv → `uv sync --locked --all-extras` (populates `.venv` for import resolution) → pinned `uvx pyright@1.1.411`.

**Cheap fixes** — real annotation drift the gate caught, all type-only:
- `runsetup`: the injected `stories_engine_cls` / `sweep_engine_cls` were typed `type[Engine]`, but the real classes are `StoriesEngine` / `SweepEngine`. Retyping them clears the "No parameter named `spec_folder`/`triage_adapter`/…" errors — the gate literally caught the annotations lying about the DI seam.
- `cli` / `engine`: `dict[str, object]` profile maps retyped to `dict[str, CLIProfile]` (+ a `-> list[CLIProfile]` return annotation on `_worktree_profiles`).
- `adapters/generic`: bare class annotations declare the host attributes the `_ResultFileMixin` / `_DevSynthesisMixin` mixins read (bare annotations = no runtime effect).

**Targeted suppressions** — the rest, each with a one-line reason. Categories: heterogeneous `**dict` splats (pyright unions the values and flags every kwarg); narrowing gaps pyright can't prove (the `try/finally` `result` is non-None past the finally, coupled `first_ts`/`last_ts` sentinels, `object`-typed values at widget boundaries); and stdlib/third-party stub shapes (`TextIO.reconfigure`, the signal-handler dict, a pyte `deque` subclass that adds `.dropped`).

## Notes

- **No runtime behavior changes.** Suppressions are comments; fixes are annotations / bare class attributes / behavior-preserving reformats.
- The gate surfaced a **latent gap, now fixed** (2nd commit): `verify.worktree_add(create=True)` passed a possibly-`None` `base` straight into `_git`, where `None` would raise in subprocess (unreachable today — the sole caller types `base: str` — but the signature was dishonest). Now mirrors git's own CLI: the start-point is appended only when supplied, else git cuts from HEAD. Drops that one suppression and adds a regression test.
- **Full suite green** locally (2724 passed, 1 skipped). The 2 `test_module_skills_sync` failures are pre-existing local install-copy drift (`module_version 0.8.1` vs canonical `0.9.0` in gitignored `.agents`/`.claude`), unrelated to this change and absent on a fresh CI checkout.
- No CHANGELOG entry (per request).

Stage 2 (per-module strict on the pure modules) is a separate follow-up that requires this merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved document output reliability in environments where standard output does not support UTF-8 reconfiguration.

* **Quality Improvements**
  * Added automated static type checking to the CI workflow.
  * Strengthened type validation across core workflows, plugin handling, diagnostics, and terminal interfaces.
  * Improved handling and rendering of terminal history checkpoints without changing existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
