### PR TITLE
fix(tui): scrollable modal dialogs so action buttons stay reachable (#275)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,11 @@ breaking changes may land in a minor release.
 
 ### Fixed
 
+- **Scrollable modal dialogs (#275).** The decision, escalation, confirm, sweep-options and
+  story-checkpoint TUI dialogs now scroll their bodies, so the choose/action buttons stay
+  reachable with long content on any terminal size (previously the lowest button could be clipped
+  off-screen with no scrollbar).
+
 - **A finished story whose session omitted `## Auto Run Result` no longer livelocks and
   DEFER-drops (#224).** The review HALT intermittently finalizes the spec's frontmatter to
   `status: done` without appending the terminal marker the harvest scan keys on; every Stop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,9 +68,11 @@ breaking changes may land in a minor release.
 ### Fixed
 
 - **Scrollable modal dialogs (#275).** The decision, escalation, confirm, sweep-options and
-  story-checkpoint TUI dialogs now scroll their bodies, so the choose/action buttons stay
-  reachable with long content on any terminal size (previously the lowest button could be clipped
-  off-screen with no scrollbar).
+  story-checkpoint TUI dialogs now scroll their bodies and dock their action buttons, so the
+  choose/action buttons stay reachable with long content down to the dialog's minimum frame
+  height (previously the lowest button could be clipped off-screen with no scrollbar). Safety
+  warnings that gate an enabled Resume/Re-arm are docked with the buttons so they cannot scroll
+  out of view, and the Resume confirm re-checks engine liveness at click time.
 
 - **A finished story whose session omitted `## Auto Run Result` no longer livelocks and
   DEFER-drops (#224).** The review HALT intermittently finalizes the spec's frontmatter to

--- a/src/bmad_loop/tui/app.py
+++ b/src/bmad_loop/tui/app.py
@@ -364,14 +364,12 @@ class BmadLoopApp(App[None]):
         engine_alive = _engine_possibly_live(run_dir)
 
         def done(ok: bool | None) -> None:
-            if not ok:
-                return
-            try:
-                launch.resume_detached(self.project, run_id)
-            except launch.LaunchError as e:
-                self.notify(str(e), severity="error")
-                return
-            self.notify(f"resume of {run_id} launched (control session {launch.CTL_SESSION})")
+            # Re-check liveness at confirm time via the shared guard — the modal's
+            # warning is display-only and sampled at open time, so route through
+            # _do_resume (like the e/viewer and re-arm paths) rather than launching
+            # blind; a newly-live engine is caught even if the user confirmed.
+            if ok:
+                self._do_resume(run_id)
 
         self.push_screen(ConfirmResumeModal(run_id, state, engine_alive), done)
 

--- a/src/bmad_loop/tui/screens/modals.py
+++ b/src/bmad_loop/tui/screens/modals.py
@@ -38,6 +38,13 @@ class BaseDialog(ModalScreen):
     }
     BaseDialog #dialog {
         width: 64;
+        /* height is intentionally auto (not a definite %). Two-tier by design:
+           list-heavy modals (Decision/Escalation/StartRun/...) override #dialog
+           with a definite height + a 1fr body; the bounded modals (Confirm/
+           StartSweep/StoryCheckpoint) keep this auto so short content stays
+           compact and only long bodies grow to the #body max-height cap. Giving
+           #dialog a definite % here would balloon a one-line confirm to ~90% of
+           the screen — see test_short_confirm_modal_stays_compact. */
         height: auto;
         max-height: 90%;
         padding: 1 2;

--- a/src/bmad_loop/tui/screens/modals.py
+++ b/src/bmad_loop/tui/screens/modals.py
@@ -210,18 +210,26 @@ class StartSweepModal(BaseDialog):
     """Options for `bmad-loop sweep` → {no_prompt, decisions_only,
     max_bundles, dry_run}."""
 
+    DEFAULT_CSS = """
+    StartSweepModal #body {
+        height: auto;
+        max-height: 70%;
+    }
+    """
+
     def compose(self) -> ComposeResult:
         with Vertical(id="dialog"):
             yield Label("start sweep", classes="title")
-            yield Checkbox("unattended (--no-prompt): skip decisions", id="no-prompt")
-            yield Checkbox("decisions only: triage + answer, no bundles", id="decisions-only")
-            yield Input(
-                placeholder="max bundles — blank for policy default",
-                type="integer",
-                valid_empty=True,
-                id="max-bundles",
-            )
-            yield Checkbox("dry run (list open entries, spawn nothing)", id="dry-run")
+            with VerticalScroll(id="body"):
+                yield Checkbox("unattended (--no-prompt): skip decisions", id="no-prompt")
+                yield Checkbox("decisions only: triage + answer, no bundles", id="decisions-only")
+                yield Input(
+                    placeholder="max bundles — blank for policy default",
+                    type="integer",
+                    valid_empty=True,
+                    id="max-bundles",
+                )
+                yield Checkbox("dry run (list open entries, spawn nothing)", id="dry-run")
             with Horizontal(classes="buttons"):
                 yield Button("start", variant="primary", id="ok")
                 yield Button("cancel", id="cancel")
@@ -243,6 +251,13 @@ class StartSweepModal(BaseDialog):
 class ConfirmModal(BaseDialog):
     """Generic confirmation → dismiss(True) on confirm, None otherwise."""
 
+    DEFAULT_CSS = """
+    ConfirmModal #body {
+        height: auto;
+        max-height: 60%;
+    }
+    """
+
     def __init__(
         self,
         title: str,
@@ -260,9 +275,10 @@ class ConfirmModal(BaseDialog):
     def compose(self) -> ComposeResult:
         with Vertical(id="dialog"):
             yield Label(self._title, classes="title")
-            yield Static(self._body)
-            if self._warning:
-                yield Static(Text(f"⚠ {self._warning}", style="bold red"))
+            with VerticalScroll(id="body"):
+                yield Static(self._body)
+                if self._warning:
+                    yield Static(Text(f"⚠ {self._warning}", style="bold red"))
             with Horizontal(classes="buttons"):
                 yield Button(self._confirm_label, variant="warning", id="ok")
                 yield Button("cancel", id="cancel")
@@ -343,12 +359,12 @@ class DecisionModal(BaseDialog):
     DEFAULT_CSS = """
     DecisionModal #dialog {
         width: 86;
-        height: auto;
-        max-height: 90%;
+        height: 90%;
     }
-    DecisionModal #context {
-        height: auto;
-        max-height: 40%;
+    DecisionModal #body {
+        height: 1fr;
+    }
+    DecisionModal .context {
         margin-bottom: 1;
     }
     DecisionModal .opt {
@@ -369,22 +385,22 @@ class DecisionModal(BaseDialog):
         title.append(f"{d.id} — answer this decision", style="bold")
         with Vertical(id="dialog"):
             yield Static(title, classes="title")
-            yield Static(Text(d.question))
-            if d.context:
-                with VerticalScroll(id="context"):
-                    yield Static(Text(d.context, style="dim"))
-            for opt in d.options:
-                head = Text()
-                head.append(f"[{opt.key}] ", style="bold")
-                head.append(opt.label)
-                head.append(f"  · {opt.effect}", style="cyan")
-                if opt.key == d.recommendation:
-                    head.append("  (recommended)", style="green")
-                yield Static(head, classes="opt")
-                detail = opt.intent or opt.resolution
-                if detail:
-                    yield Static(Text(f"    {detail}", style="dim"), classes="opt-detail")
-                yield Button(f"choose {opt.key}", id=f"opt-{opt.key}")
+            with VerticalScroll(id="body"):
+                yield Static(Text(d.question))
+                if d.context:
+                    yield Static(Text(d.context, style="dim"), classes="context")
+                for opt in d.options:
+                    head = Text()
+                    head.append(f"[{opt.key}] ", style="bold")
+                    head.append(opt.label)
+                    head.append(f"  · {opt.effect}", style="cyan")
+                    if opt.key == d.recommendation:
+                        head.append("  (recommended)", style="green")
+                    yield Static(head, classes="opt")
+                    detail = opt.intent or opt.resolution
+                    if detail:
+                        yield Static(Text(f"    {detail}", style="dim"), classes="opt-detail")
+                    yield Button(f"choose {opt.key}", id=f"opt-{opt.key}")
             with Horizontal(classes="buttons"):
                 yield Button("skip", id="cancel")
 
@@ -477,6 +493,13 @@ class StoryCheckpointModal(BaseDialog):
     count) and token totals. Dismisses with 'continue' (resume the schedule) or
     'stop' (mark the run stopped), None on close/escape."""
 
+    DEFAULT_CSS = """
+    StoryCheckpointModal #body {
+        height: auto;
+        max-height: 70%;
+    }
+    """
+
     def __init__(
         self,
         *,
@@ -498,16 +521,17 @@ class StoryCheckpointModal(BaseDialog):
         head.append(f"story checkpoint — {self._story_key}", style="bold")
         with Vertical(id="dialog"):
             yield Label(head, classes="title")
-            if self._title:
-                yield Static(Text(self._title))
-            card = Text()
-            card.append("\ncommit  ", style="dim")
-            card.append(self._commit or "(none)", style="green")
-            card.append("\nverify  ", style="dim")
-            card.append(self._verify_line)
-            card.append("\ntokens  ", style="dim")
-            card.append(self._tokens, style="dim")
-            yield Static(card)
+            with VerticalScroll(id="body"):
+                if self._title:
+                    yield Static(Text(self._title))
+                card = Text()
+                card.append("\ncommit  ", style="dim")
+                card.append(self._commit or "(none)", style="green")
+                card.append("\nverify  ", style="dim")
+                card.append(self._verify_line)
+                card.append("\ntokens  ", style="dim")
+                card.append(self._tokens, style="dim")
+                yield Static(card)
             with Horizontal(classes="buttons"):
                 yield Button("Continue run", variant="primary", id="act-continue")
                 yield Button("Stop run", variant="warning", id="act-stop")
@@ -529,12 +553,13 @@ class EscalationModal(BaseDialog):
     DEFAULT_CSS = """
     EscalationModal #dialog {
         width: 90;
-        height: auto;
-        max-height: 90%;
+        height: 90%;
+    }
+    EscalationModal #body {
+        height: 1fr;
     }
     EscalationModal #blocking {
         height: auto;
-        max-height: 40%;
         margin-top: 1;
         border: solid $primary-darken-2;
         padding: 0 1;
@@ -568,47 +593,50 @@ class EscalationModal(BaseDialog):
         head.append(f"escalation — {self._story_key}", style="bold red")
         with Vertical(id="dialog"):
             yield Label(head, classes="title")
-            if self._title:
-                yield Static(Text(self._title, style="bold"))
-            if self._description:
-                yield Static(Text(self._description, style="dim"))
-            if self._sentinel_kind:
-                yield Static(
-                    Text(
-                        f"⚠ pre-planning-halt sentinel ({self._sentinel_kind}) — "
-                        "re-arm deletes it (a copy is preserved) for a clean re-dispatch",
+            with VerticalScroll(id="body"):
+                if self._title:
+                    yield Static(Text(self._title, style="bold"))
+                if self._description:
+                    yield Static(Text(self._description, style="dim"))
+                if self._sentinel_kind:
+                    yield Static(
+                        Text(
+                            f"⚠ pre-planning-halt sentinel ({self._sentinel_kind}) — "
+                            "re-arm deletes it (a copy is preserved) for a clean re-dispatch",
+                            style="yellow",
+                        )
+                    )
+                with Vertical(id="blocking"):
+                    body = self._blocking.strip()
+                    yield Static(
+                        Text(body)
+                        if body
+                        else Text("(no blocking condition recorded)", style="dim")
+                    )
+                if self._engine_live:
+                    yield Static(
+                        Text("engine may still be live — stop it before resolving", style="yellow")
+                    )
+                hint = Text()
+                if self._restore_recorded:
+                    # honoring the latch from here would be unsafe (a stale marker is
+                    # indistinguishable from a fresh one), so Re-arm stays a plain
+                    # from-scratch re-drive — but never a silent drop of the decision.
+                    hint.append(
+                        "⚠ the resolution records a restore patch — Re-arm here re-drives "
+                        "from scratch and drops it; run `bmad-loop resolve` to honor the "
+                        "restore",
                         style="yellow",
                     )
-                )
-            with VerticalScroll(id="blocking"):
-                body = self._blocking.strip()
-                yield Static(
-                    Text(body) if body else Text("(no blocking condition recorded)", style="dim")
-                )
-            if self._engine_live:
-                yield Static(
-                    Text("engine may still be live — stop it before resolving", style="yellow")
-                )
-            hint = Text()
-            if self._restore_recorded:
-                # honoring the latch from here would be unsafe (a stale marker is
-                # indistinguishable from a fresh one), so Re-arm stays a plain
-                # from-scratch re-drive — but never a silent drop of the decision.
-                hint.append(
-                    "⚠ the resolution records a restore patch — Re-arm here re-drives "
-                    "from scratch and drops it; run `bmad-loop resolve` to honor the "
-                    "restore",
-                    style="yellow",
-                )
-            elif self._resolution_ready:
-                hint.append("resolution recorded — re-arm & resume when ready", style="green")
-            else:
-                hint.append(
-                    "resolve opens an interactive agent to fix the frozen spec; "
-                    "re-arm unlocks once it records a resolution",
-                    style="dim",
-                )
-            yield Static(hint)
+                elif self._resolution_ready:
+                    hint.append("resolution recorded — re-arm & resume when ready", style="green")
+                else:
+                    hint.append(
+                        "resolve opens an interactive agent to fix the frozen spec; "
+                        "re-arm unlocks once it records a resolution",
+                        style="dim",
+                    )
+                yield Static(hint)
             with Horizontal(classes="buttons"):
                 yield Button(
                     "Resolve", variant="primary", id="act-resolve", disabled=self._engine_live

--- a/src/bmad_loop/tui/screens/modals.py
+++ b/src/bmad_loop/tui/screens/modals.py
@@ -277,8 +277,10 @@ class ConfirmModal(BaseDialog):
             yield Label(self._title, classes="title")
             with VerticalScroll(id="body"):
                 yield Static(self._body)
-                if self._warning:
-                    yield Static(Text(f"⚠ {self._warning}", style="bold red"))
+            # The warning gates an enabled, destructive confirm, so it is docked
+            # outside #body (never scrolled off) — directly above the button row.
+            if self._warning:
+                yield Static(Text(f"⚠ {self._warning}", style="bold red"), id="warning")
             with Horizontal(classes="buttons"):
                 yield Button(self._confirm_label, variant="warning", id="ok")
                 yield Button("cancel", id="cancel")
@@ -617,26 +619,28 @@ class EscalationModal(BaseDialog):
                     yield Static(
                         Text("engine may still be live — stop it before resolving", style="yellow")
                     )
-                hint = Text()
-                if self._restore_recorded:
-                    # honoring the latch from here would be unsafe (a stale marker is
-                    # indistinguishable from a fresh one), so Re-arm stays a plain
-                    # from-scratch re-drive — but never a silent drop of the decision.
-                    hint.append(
-                        "⚠ the resolution records a restore patch — Re-arm here re-drives "
-                        "from scratch and drops it; run `bmad-loop resolve` to honor the "
-                        "restore",
-                        style="yellow",
-                    )
-                elif self._resolution_ready:
-                    hint.append("resolution recorded — re-arm & resume when ready", style="green")
-                else:
-                    hint.append(
-                        "resolve opens an interactive agent to fix the frozen spec; "
-                        "re-arm unlocks once it records a resolution",
-                        style="dim",
-                    )
-                yield Static(hint)
+            # The restore-discard branch below gates an enabled Re-arm, so the hint
+            # is docked outside #body (never scrolled off) — directly above the buttons.
+            hint = Text()
+            if self._restore_recorded:
+                # honoring the latch from here would be unsafe (a stale marker is
+                # indistinguishable from a fresh one), so Re-arm stays a plain
+                # from-scratch re-drive — but never a silent drop of the decision.
+                hint.append(
+                    "⚠ the resolution records a restore patch — Re-arm here re-drives "
+                    "from scratch and drops it; run `bmad-loop resolve` to honor the "
+                    "restore",
+                    style="yellow",
+                )
+            elif self._resolution_ready:
+                hint.append("resolution recorded — re-arm & resume when ready", style="green")
+            else:
+                hint.append(
+                    "resolve opens an interactive agent to fix the frozen spec; "
+                    "re-arm unlocks once it records a resolution",
+                    style="dim",
+                )
+            yield Static(hint, id="hint")
             with Horizontal(classes="buttons"):
                 yield Button(
                     "Resolve", variant="primary", id="act-resolve", disabled=self._engine_live

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1232,6 +1232,122 @@ async def test_answer_decisions_none_notifies(project):
         await until(pilot, lambda: any("no unanswered decisions" in m for m in notifications(app)))
 
 
+# ------------------------------------- #275 modal bodies scroll, buttons stay
+
+
+def _on_screen(app, w) -> bool:
+    """A widget's laid-out region is non-empty and fully inside the screen —
+    i.e. the button is reachable, not clipped off the visible area (#275)."""
+    r = w.region
+    return r.width > 0 and r.height > 0 and app.screen.region.contains_region(r)
+
+
+def _long_decision():
+    from bmad_loop.sweep import Decision, DecisionOption
+
+    options = tuple(
+        DecisionOption(
+            key=str(i),
+            label=f"option {i} — " + "a wordy option label that keeps going " * 3,
+            effect="build",
+            intent="a long intent describing what building this bundle would do " * 2,
+        )
+        for i in range(1, 9)
+    )
+    return Decision(
+        id="DW-1",
+        question="a decision question that is itself fairly wordy " * 3,
+        context="\n".join(f"context line {i} with some detail" for i in range(60)),
+        options=options,
+        recommendation="1",
+    )
+
+
+async def test_decision_modal_scrolls_when_content_long(project):
+    """A long question + 60-line context + 8 options overflow the dialog, but the
+    body scrolls so the docked skip button stays reachable and every per-option
+    choose button is present."""
+    app = BmadLoopApp(project.project)
+    async with app.run_test(size=(90, 16)) as pilot:
+        await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
+        app.push_screen(DecisionModal(_long_decision()))
+        await until(pilot, lambda: isinstance(app.screen, DecisionModal))
+        body = await ready(pilot, "#body")
+        assert body.max_scroll_y > 0  # content overflows yet scrolls
+        assert _on_screen(app, app.screen.query_one("#cancel", Button))  # skip reachable
+        assert app.screen.query_one("#opt-8", Button)  # last option present in the DOM
+
+
+async def test_escalation_modal_scrolls_when_description_long(project):
+    """A long escalation description overflows; the body scrolls and both the
+    Resolve and close buttons stay on-screen."""
+    app = BmadLoopApp(project.project)
+    async with app.run_test(size=(90, 16)) as pilot:
+        await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
+        app.push_screen(
+            EscalationModal(
+                story_key="e-1-s",
+                title="t",
+                description="X\n" * 80,
+                blocking="b",
+                sentinel_kind="",
+                resolution_ready=False,
+                engine_live=False,
+            )
+        )
+        await until(pilot, lambda: isinstance(app.screen, EscalationModal))
+        body = await ready(pilot, "#body")
+        assert body.max_scroll_y > 0
+        assert _on_screen(app, app.screen.query_one("#act-resolve", Button))
+        assert _on_screen(app, app.screen.query_one("#cancel", Button))
+
+
+async def test_confirm_modal_scrolls_long_body(project):
+    """A ConfirmModal (covers ConfirmResumeModal by inheritance) with a long body
+    scrolls it so the confirm/cancel buttons stay reachable."""
+    app = BmadLoopApp(project.project)
+    async with app.run_test(size=(64, 12)) as pilot:
+        await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
+        app.push_screen(ConfirmModal("t", "line\n" * 80, warning="w"))
+        await until(pilot, lambda: isinstance(app.screen, ConfirmModal))
+        body = await ready(pilot, "#body")
+        assert body.max_scroll_y > 0
+        assert _on_screen(app, app.screen.query_one("#ok", Button))
+        assert _on_screen(app, app.screen.query_one("#cancel", Button))
+
+
+async def test_start_sweep_and_checkpoint_buttons_reachable(project):
+    """On a short terminal the bounded modals keep their docked action buttons
+    on-screen: the body scrolls to absorb the overflow instead of pushing the
+    button row off the bottom. The height (14) sits just above the frame floor —
+    a thick-bordered dialog with a title and a 3-row button row needs ~13 rows
+    before any body content — so the assertion isolates the body-scroll fix."""
+    app = BmadLoopApp(project.project)
+    async with app.run_test(size=(64, 14)) as pilot:
+        await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
+        app.push_screen(StartSweepModal())
+        await until(pilot, lambda: isinstance(app.screen, StartSweepModal))
+        body = await ready(pilot, "#body")
+        assert body.max_scroll_y > 0  # options overflow the shrunk body, so it scrolls
+        assert _on_screen(app, app.screen.query_one("#ok", Button))
+        assert _on_screen(app, app.screen.query_one("#cancel", Button))
+        app.pop_screen()
+
+        app.push_screen(
+            StoryCheckpointModal(
+                story_key="e-1-s",
+                title="t",
+                commit="abc123",
+                verify_line="v",
+                tokens="0",
+            )
+        )
+        await until(pilot, lambda: isinstance(app.screen, StoryCheckpointModal))
+        await ready(pilot, "#body")
+        assert _on_screen(app, app.screen.query_one("#act-continue", Button))
+        assert _on_screen(app, app.screen.query_one("#cancel", Button))
+
+
 def test_cli_tui_hint_without_textual(project, monkeypatch, capsys):
     """`bmad-loop tui` prints the install hint when the extra is missing."""
     import builtins

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1265,17 +1265,26 @@ def _long_decision():
 
 async def test_decision_modal_scrolls_when_content_long(project):
     """A long question + 60-line context + 8 options overflow the dialog, but the
-    body scrolls so the docked skip button stays reachable and every per-option
-    choose button is present."""
+    body scrolls so the docked skip button stays reachable AND the last option can
+    be scrolled into view and activated — proving real access, not just overflow."""
     app = BmadLoopApp(project.project)
+    chosen: list = []
     async with app.run_test(size=(90, 16)) as pilot:
         await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
-        app.push_screen(DecisionModal(_long_decision()))
+        app.push_screen(DecisionModal(_long_decision()), chosen.append)
         await until(pilot, lambda: isinstance(app.screen, DecisionModal))
         body = await ready(pilot, "#body")
         assert body.max_scroll_y > 0  # content overflows yet scrolls
         assert _on_screen(app, app.screen.query_one("#cancel", Button))  # skip reachable
-        assert app.screen.query_one("#opt-8", Button)  # last option present in the DOM
+        # the last option starts below the fold; scroll it in, confirm it is on
+        # screen, then click it — the whole point of the scroll fix.
+        opt8 = app.screen.query_one("#opt-8", Button)
+        opt8.scroll_visible(animate=False)
+        await pilot.pause()
+        assert _on_screen(app, opt8)
+        await pilot.click("#opt-8")
+        await until(pilot, lambda: bool(chosen))
+        assert chosen[0].key == "8"  # the eighth option was actually returned
 
 
 async def test_escalation_modal_scrolls_when_description_long(project):
@@ -1304,16 +1313,22 @@ async def test_escalation_modal_scrolls_when_description_long(project):
 
 async def test_confirm_modal_scrolls_long_body(project):
     """A ConfirmModal (covers ConfirmResumeModal by inheritance) with a long body
-    scrolls it so the confirm/cancel buttons stay reachable."""
+    scrolls it so the confirm/cancel buttons stay reachable, and the ⚠ warning is
+    docked outside the scroll region so it stays on-screen with the buttons — a
+    warning that gates the enabled confirm must never scroll off (#280 review)."""
     app = BmadLoopApp(project.project)
-    async with app.run_test(size=(64, 12)) as pilot:
+    # height 16 clears the frame floor now that the warning is a docked row (a
+    # sibling of #body); the 80-line body still overflows the 60%-capped #body.
+    async with app.run_test(size=(64, 16)) as pilot:
         await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
         app.push_screen(ConfirmModal("t", "line\n" * 80, warning="w"))
         await until(pilot, lambda: isinstance(app.screen, ConfirmModal))
         body = await ready(pilot, "#body")
-        assert body.max_scroll_y > 0
+        assert body.max_scroll_y > 0  # the long body still overflows and scrolls
         assert _on_screen(app, app.screen.query_one("#ok", Button))
         assert _on_screen(app, app.screen.query_one("#cancel", Button))
+        # the warning is a sibling of #body, not a child — visible whenever #ok is
+        assert _on_screen(app, app.screen.query_one("#warning", Static))
 
 
 async def test_start_sweep_and_checkpoint_buttons_reachable(project):
@@ -1333,19 +1348,79 @@ async def test_start_sweep_and_checkpoint_buttons_reachable(project):
         assert _on_screen(app, app.screen.query_one("#cancel", Button))
         app.pop_screen()
 
+        # genuinely long checkpoint content (not just a tiny terminal): the body
+        # must scroll to absorb it while the action buttons stay docked on-screen.
         app.push_screen(
             StoryCheckpointModal(
                 story_key="e-1-s",
-                title="t",
+                title="t\n" * 80,
                 commit="abc123",
                 verify_line="v",
                 tokens="0",
             )
         )
         await until(pilot, lambda: isinstance(app.screen, StoryCheckpointModal))
-        await ready(pilot, "#body")
+        body = await ready(pilot, "#body")
+        assert body.max_scroll_y > 0  # the long title overflows and the body scrolls
         assert _on_screen(app, app.screen.query_one("#act-continue", Button))
         assert _on_screen(app, app.screen.query_one("#cancel", Button))
+
+
+async def test_escalation_rearm_warning_stays_on_screen(project):
+    """When a restore patch is recorded the escalation warns that Re-arm re-drives
+    from scratch and drops it. Re-arm is enabled, so that warning must stay docked
+    on-screen (a sibling of #body) even when a long description scrolls the body
+    (#280 review — the warning must not be reachable-only by scrolling)."""
+    app = BmadLoopApp(project.project)
+    async with app.run_test(size=(90, 16)) as pilot:
+        await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
+        app.push_screen(
+            EscalationModal(
+                story_key="e-1-s",
+                title="t",
+                description="X\n" * 80,
+                blocking="b",
+                sentinel_kind="",
+                resolution_ready=True,
+                engine_live=False,
+                restore_recorded=True,
+            )
+        )
+        await until(pilot, lambda: isinstance(app.screen, EscalationModal))
+        body = await ready(pilot, "#body")
+        assert body.max_scroll_y > 0  # the long description overflows and scrolls
+        rearm = app.screen.query_one("#act-rearm", Button)
+        assert not rearm.disabled  # the destructive action is clickable...
+        assert _on_screen(app, rearm)
+        assert _on_screen(
+            app, app.screen.query_one("#hint", Static)
+        )  # ...so its warning is visible
+
+
+async def test_resume_confirm_rechecks_liveness(project, monkeypatch):
+    """The resume confirm callback re-checks engine liveness at click time rather
+    than launching blind: with a possibly-live engine (unknown liveness + a pid),
+    confirming resume is refused and never calls resume_detached (#280 review)."""
+    calls: list = []
+    monkeypatch.setattr(launch, "mux_available", lambda: True)
+    monkeypatch.setattr(launch, "resume_detached", lambda proj, rid: calls.append(rid))
+    monkeypatch.setattr(data, "liveness", lambda run_dir: "unknown")
+    run_dir = make_run(
+        project.project,
+        "20260611-100000-aaaa",
+        paused_stage="DEV_VERIFY",
+        paused_reason="verify failed",
+    )
+    (run_dir / "engine.pid").write_text("4242 123.0", encoding="utf-8")
+    app = BmadLoopApp(project.project)
+    async with app.run_test() as pilot:
+        await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
+        await until(pilot, lambda: dashboard(app).selected_run_id is not None)
+        await pilot.press("e")
+        await until(pilot, lambda: isinstance(app.screen, ConfirmResumeModal))
+        await pilot.click(await ready(pilot, "#ok"))
+        await until(pilot, lambda: any("may still be live" in m for m in notifications(app)))
+        assert calls == []  # the callback re-checked and refused; nothing launched
 
 
 def test_cli_tui_hint_without_textual(project, monkeypatch, capsys):

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1366,6 +1366,22 @@ async def test_start_sweep_and_checkpoint_buttons_reachable(project):
         assert _on_screen(app, app.screen.query_one("#cancel", Button))
 
 
+async def test_short_confirm_modal_stays_compact(project):
+    """The bounded modals keep BaseDialog #dialog at height: auto on purpose, so a
+    short body sizes to content instead of filling the screen. Guards the compact
+    tier against the #280 CodeRabbit suggestion of a definite `#dialog` height: on
+    a tall terminal a one-line confirm must stay a handful of rows, not balloon to
+    the 90% cap (a definite height took this from 7 → 23 rows when measured)."""
+    app = BmadLoopApp(project.project)
+    async with app.run_test(size=(64, 40)) as pilot:
+        await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
+        app.push_screen(ConfirmModal("t", "Stop the run?"))
+        await until(pilot, lambda: isinstance(app.screen, ConfirmModal))
+        dialog = await ready(pilot, "#dialog")
+        # content-driven height, nowhere near the 90% cap (36 rows at this size)
+        assert dialog.region.height < 12
+
+
 async def test_escalation_rearm_warning_stays_on_screen(project):
     """When a restore patch is recorded the escalation warns that Re-arm re-drives
     from scratch and drops it. Re-arm is enabled, so that warning must stay docked


### PR DESCRIPTION
Closes #275.

## Problem

The TUI "Decision Panel" (`DecisionModal`) — and several sibling run-control modals — rendered their body content **and** their action buttons as direct children of a non-scrolling `Vertical(id="dialog")` capped at `max-height: 90%`. When the LLM-written decision/escalation text or option list was long, the dialog hit its cap and the plain `Vertical` **clipped** the overflow with no scrollbar and no scroll key, so the lowest `choose`/`skip` (or Resolve/Re-arm/close) button became unreachable. This is a pure Textual layout bug — OS-independent (macOS in #275 was just where it surfaced); it reproduces on any terminal short enough that content exceeds 90% of the height.

## Fix — the repo's own docked-buttons pattern, in two tiers

The codebase already endorses the correct pattern (`modals.py:108`, used by `StartRunModal`/`DeferredEntryModal`/`SpecReviewModal`/`ValidateFindingsModal`/`TextOutputModal`): a `VerticalScroll` body region + a docked `Horizontal(classes="buttons")` row that never scrolls off.

- **Tier 1 — action modals with frequently-long content (`DecisionModal`, `EscalationModal`).** Switch `#dialog` to a definite `height: 90%` and wrap all growable content in `VerticalScroll(id="body") { height: 1fr }`; the button row stays docked outside. (A `1fr` child needs a definite parent height — hence the fixed `#dialog` height.)
- **Tier 2 — bounded modals (`ConfirmModal` → also `ConfirmResumeModal`, `StartSweepModal`, `StoryCheckpointModal`).** Keep `#dialog { height: auto; max-height: 90% }` so small dialogs still hug their content, and wrap the variable body in `VerticalScroll(id="body") { height: auto; max-height: N% }` (grows to content, scrolls past the cap — the same mechanism the old `#context`/`#blocking` boxes used). No visual change in the common short case; the docked buttons can no longer be pushed off-bottom by an unexpectedly long body (e.g. an engine-written `paused_reason`).

All widget ids are preserved verbatim (tests click by id), and all user/LLM strings stay wrapped in `rich.Text`. The five already-correct modals and `BaseDialog`'s shared CSS are untouched.

## Tests

Adds four regression tests to `tests/test_tui_app.py` that push each modal directly with long content and assert (a) the `#body` scrolls (`max_scroll_y > 0`) and (b) the docked action buttons are fully on-screen (`screen.region.contains_region(...)`). The sweep/checkpoint test runs at height 14 — just above the modal frame floor (a thick-bordered dialog with a title and a 3-row button row needs ~13 rows before any body content), so the body-scroll fix is what keeps the buttons reachable.

## Verification

- `uv run pytest -q tests/test_tui_app.py` — 135 passed (new + existing modal tests, including the `#opt-1`/`#act-resolve`/`#act-rearm` click paths).
- `uv run pytest -q` — full suite green (the 2 `test_module_skills_sync` failures are pre-existing local-install drift; those tests skip on a clean checkout/CI and are unrelated to this change).
- `uvx pyright@1.1.411` clean; `trunk fmt` + `trunk check` clean.
- Manual: on a short terminal, press `d` with a long pending decision (or open an escalation) — the body scrolls (wheel/arrows/Tab) and every button stays reachable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved modal dialogs on small terminal screens so long content scrolls while action buttons remain visible and reachable.
  * Kept important safety warnings visible while scrolling, including Resume and Re-arm confirmations.
  * Resume confirmations now re-check engine status before proceeding, preventing unsafe resume attempts.
* **Documentation**
  * Added changelog entries describing the modal scrolling and resume-safety improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->