### PR TITLE
fix(notify): native desktop notifications on macOS/Windows + warn when inert (#231)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,16 @@ breaking changes may land in a minor release.
 
 ### Fixed
 
+- **`notify.desktop` works on macOS/Windows, and warns when it can't (#231).** The desktop
+  notification channel was `notify-send`-only, so on macOS and Windows `notify.desktop` (default
+  `true`) was silently inert — every "a human is needed" path (escalations, deferrals,
+  worktree-open failures) reached no one, leaving only the untailed `ATTENTION` file. `gates.notify`
+  now dispatches natively per platform: `osascript` (macOS), a best-effort WinRT PowerShell toast
+  (Windows), `notify-send` (Linux); the untrusted title/message are passed via environment
+  variables, never interpolated into the command string. When `notify.desktop` is set but no
+  notifier exists on the platform, `validate` emits a `notify.desktop-unavailable` warning and the
+  run start prints a one-time stderr warning plus a `notify-desktop-unavailable` journal event.
+
 - **Scrollable modal dialogs (#275).** The decision, escalation, confirm, sweep-options and
   story-checkpoint TUI dialogs now scroll their bodies and dock their action buttons, so the
   choose/action buttons stay reachable with long content down to the dialog's minimum frame

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,8 +72,9 @@ breaking changes may land in a minor release.
   `true`) was silently inert — every "a human is needed" path (escalations, deferrals,
   worktree-open failures) reached no one, leaving only the untailed `ATTENTION` file. `gates.notify`
   now dispatches natively per platform: `osascript` (macOS), a best-effort WinRT PowerShell toast
-  (Windows), `notify-send` (Linux); the untrusted title/message are passed via environment
-  variables, never interpolated into the command string. When `notify.desktop` is set but no
+  (Windows), `notify-send` (Linux); the untrusted title/message are handed to `osascript`/PowerShell
+  through environment variables and to `notify-send` as argv — never interpolated into the command
+  string. When `notify.desktop` is set but no
   notifier exists on the platform, `validate` emits a `notify.desktop-unavailable` warning and the
   run start prints a one-time stderr warning plus a `notify-desktop-unavailable` journal event.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,10 @@ breaking changes may land in a minor release.
   string. When `notify.desktop` is set but no
   notifier exists on the platform, `validate` emits a `notify.desktop-unavailable` warning and the
   run start prints a one-time stderr warning plus a `notify-desktop-unavailable` journal event.
+  Note: headless CI cannot observe a real toast/notification (there is no macOS job), so the
+  unit tests assert command construction only. To verify visual delivery, set
+  `notify.desktop = true` and trigger a notify path on each OS (macOS/Windows/Linux) — or call
+  `gates.notify` directly — and confirm a notification appears.
 
 - **Scrollable modal dialogs (#275).** The decision, escalation, confirm, sweep-options and
   story-checkpoint TUI dialogs now scroll their bodies and dock their action buttons, so the

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ session_budget_grace_s = 240     # enforce mode: seconds to wrap up after the nu
 commands = ["pytest -q", "ruff check ."]
 
 [notify]
-desktop = true             # desktop notification on gate pauses / escalations
+desktop = true             # desktop notification on gate pauses / escalations — notify-send (Linux) / osascript (macOS) / PowerShell toast (Windows), best-effort
 file = true                # append the same alerts to the run's ATTENTION file
 
 [review]

--- a/src/bmad_loop/checks.py
+++ b/src/bmad_loop/checks.py
@@ -64,6 +64,7 @@ VALIDATE_CHECKS: frozenset[str] = frozenset(
         "mux.selection",
         "mux.external-backend",
         "host.process",
+        "notify.desktop-unavailable",
         "skills.base",
         "skills.base-missing",
         "skills.base-incomplete",

--- a/src/bmad_loop/cli.py
+++ b/src/bmad_loop/cli.py
@@ -20,6 +20,7 @@ from . import (
     decisions,
     deferredwork,
     envvars,
+    gates,
     install,
     machine,
 )
@@ -257,6 +258,20 @@ def cmd_validate(args: argparse.Namespace) -> int:
         report.fail("git.probe", f"git check failed: {e}")
 
     report.extend(_platform_preflight())
+
+    # #231: notify.desktop defaults to true but only fires when a platform notifier
+    # exists (osascript/PowerShell/notify-send). When none does, the setting is
+    # silently inert — warn so it stops being a no-op nobody can see.
+    if pol is not None and pol.notify.desktop and gates.desktop_notifier_kind() is None:
+        report.warn(
+            "notify.desktop-unavailable",
+            f"notify.desktop is set but no desktop notifier is available on "
+            f"{sys.platform} — desktop notifications are silently skipped; the "
+            f"ATTENTION file in the run directory is the only alert channel "
+            f"(macOS ships osascript; Linux needs notify-send; Windows needs "
+            f"PowerShell). Install one or set notify.desktop = false.",
+            {"platform": sys.platform},
+        )
 
     for tool in dict.fromkeys(p.binary for p in profiles):
         if shutil.which(tool):

--- a/src/bmad_loop/cli.py
+++ b/src/bmad_loop/cli.py
@@ -263,13 +263,21 @@ def cmd_validate(args: argparse.Namespace) -> int:
     # exists (osascript/PowerShell/notify-send). When none does, the setting is
     # silently inert — warn so it stops being a no-op nobody can see.
     if pol is not None and pol.notify.desktop and gates.desktop_notifier_kind() is None:
+        # The ATTENTION file is only a fallback when notify.file is also on; with it
+        # off there is no alert channel left at all, so say so rather than pointing
+        # at a file that is never written.
+        channel = (
+            "the ATTENTION file in the run directory is the only alert channel left"
+            if pol.notify.file
+            else "notify.file is also off, so no alert channel is configured — "
+            "enable notify.file"
+        )
         report.warn(
             "notify.desktop-unavailable",
             f"notify.desktop is set but no desktop notifier is available on "
-            f"{sys.platform} — desktop notifications are silently skipped; the "
-            f"ATTENTION file in the run directory is the only alert channel "
-            f"(macOS ships osascript; Linux needs notify-send; Windows needs "
-            f"PowerShell). Install one or set notify.desktop = false.",
+            f"{sys.platform} — desktop notifications are silently skipped; "
+            f"{channel} (macOS ships osascript; Linux needs notify-send; Windows "
+            f"needs PowerShell). Install one or set notify.desktop = false.",
             {"platform": sys.platform},
         )
 

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -9,6 +9,7 @@ verify. All creative work happens inside disposable adapter sessions.
 from __future__ import annotations
 
 import contextlib
+import contextvars
 import functools
 import hashlib
 import shutil
@@ -173,9 +174,17 @@ def _session_task_id(story_key: str, part: str, seq: int) -> str:
     return safe_segment(f"{story_key}-{part}-{seq}")
 
 
+# Call-stack nesting depth for engine runs. A nested auto-sweep runs synchronously
+# in the same thread as its parent (see _maybe_auto_sweep), so a ContextVar carries
+# the parent's depth into the child. Tracked independently of signal ownership so an
+# off-main-thread top-level run (which cannot own signals) is still seen as depth-0.
+_run_depth: contextvars.ContextVar[int] = contextvars.ContextVar("bmad_loop_run_depth", default=0)
+
+
 class Engine:
-    # The engine that installed the process-wide stop handlers; nested
-    # auto-sweep runs (same process) see it set and let RunStopped propagate up.
+    # The engine that installed the process-wide stop handlers. Signal handling is
+    # single-owner per process; only this engine reinstalls/restores them. Run
+    # nesting is tracked separately via _run_depth (see run()).
     _stop_signals_owner: "Engine | None" = None
 
     def __init__(
@@ -238,10 +247,10 @@ class Engine:
             self.journal.append("plugins-active", plugins=self._bus.active_plugins())
         # stop-signal bookkeeping (see run())
         self._owns_signals = False
-        # True iff an outer engine already owned the stop handlers when this one
-        # started — i.e. this is a nested auto-sweep run. Distinct from
-        # _owns_signals, which is also False for a top-level engine that simply
-        # could not install handlers (e.g. off the main thread).
+        # Set authoritatively at run() entry from the _run_depth call-stack counter:
+        # True iff this engine runs nested inside another engine's run() (a nested
+        # auto-sweep). Independent of _owns_signals — a top-level run off the main
+        # thread owns no signals yet is still non-nested. Defaults False pre-run.
         self._is_nested = False
         self._stopping = False
         self._prev_handlers: dict[int, object] = {}
@@ -327,18 +336,32 @@ class Engine:
         )
 
     def run(self) -> RunSummary:
+        # Establish call-stack nesting depth before anything else: _is_nested is read
+        # by the warning gate and the stop/crash re-raise arms below. Reset in the
+        # outermost finally so a nested child's re-raise still decrements the depth.
+        depth = _run_depth.get()
+        self._is_nested = depth > 0
+        token = _run_depth.set(depth + 1)
+        try:
+            return self._run_inner()
+        finally:
+            _run_depth.reset(token)
+
+    def _run_inner(self) -> RunSummary:
         self._install_stop_signals()
         try:
             try:
+                # Warn once per top-level run before pre_run: a plugin `pause` veto in
+                # _emit_run_boundary("pre_run") raises RunPaused, which would otherwise
+                # skip the promised inert-notifier warning + journal event. Gated on
+                # `not _is_nested` (call-stack depth), not `_owns_signals`: a top-level
+                # run that could not install signal handlers (off the main thread) owns
+                # no signals yet is not nested, and must still surface the warning.
+                if not self._is_nested:
+                    self._warn_desktop_notifier_inert()
                 # target-branch setup can raise RunPaused (detached HEAD, unborn
                 # repo), so it must sit inside the pause handler, not before it.
                 self._emit_run_boundary("pre_run")
-                # Warn once per top-level run. Gate on `not _is_nested`, not
-                # `_owns_signals`: a top-level run that could not install signal
-                # handlers (off the main thread) still owns no signals yet is not
-                # nested, and must still surface the inert-notifier warning.
-                if not self._is_nested:
-                    self._warn_desktop_notifier_inert()
                 self._ensure_target_branch()
                 self._prune_preserve_refs()
                 self._loop()
@@ -492,9 +515,9 @@ class Engine:
         outermost engine in the process owns the handlers (nested auto-sweep
         runs let the exception propagate up to it); install is best-effort and
         silently skipped off the main thread (signal.signal raises there)."""
-        # capture nesting before the early return: a non-None owner here means an
-        # outer engine already installed the handlers, so we are nested.
-        self._is_nested = Engine._stop_signals_owner is not None
+        # Signal ownership is process-global and independent of run nesting (tracked
+        # via _run_depth in run()): a non-None owner means an outer engine already
+        # installed the handlers, so this engine must not reinstall them.
         if Engine._stop_signals_owner is not None:
             return
 

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -312,10 +312,17 @@ class Engine:
         if not (self.policy.notify.desktop and gates.desktop_notifier_kind() is None):
             return
         self.journal.append("notify-desktop-unavailable", platform=sys.platform)
+        # The ATTENTION file only exists as a fallback when notify.file is on; with
+        # it off there is no human channel left, so point at that rather than a file
+        # that is never written.
+        channel = (
+            f"watch the ATTENTION file in {self.run_dir}"
+            if self.policy.notify.file
+            else "notify.file is also off, so no alert channel is configured"
+        )
         print(
             f"warning: notify.desktop is set but no desktop notifier is available "
-            f"on {sys.platform}; desktop alerts are silently skipped — watch the "
-            f"ATTENTION file in {self.run_dir}.",
+            f"on {sys.platform}; desktop alerts are silently skipped — {channel}.",
             file=sys.stderr,
         )
 
@@ -326,7 +333,11 @@ class Engine:
                 # target-branch setup can raise RunPaused (detached HEAD, unborn
                 # repo), so it must sit inside the pause handler, not before it.
                 self._emit_run_boundary("pre_run")
-                if self._owns_signals:
+                # Warn once per top-level run. Gate on `not _is_nested`, not
+                # `_owns_signals`: a top-level run that could not install signal
+                # handlers (off the main thread) still owns no signals yet is not
+                # nested, and must still surface the inert-notifier warning.
+                if not self._is_nested:
                     self._warn_desktop_notifier_inert()
                 self._ensure_target_branch()
                 self._prune_preserve_refs()

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -304,6 +304,21 @@ class Engine:
 
     # ------------------------------------------------------------- top level
 
+    def _warn_desktop_notifier_inert(self) -> None:
+        """One-time run-start alert for #231: ``notify.desktop`` is requested but
+        this platform has no notifier, so every ``gates.notify`` desktop sink is a
+        silent no-op. Journalled + stderr so an unattended launch that skips
+        ``validate`` still surfaces it."""
+        if not (self.policy.notify.desktop and gates.desktop_notifier_kind() is None):
+            return
+        self.journal.append("notify-desktop-unavailable", platform=sys.platform)
+        print(
+            f"warning: notify.desktop is set but no desktop notifier is available "
+            f"on {sys.platform}; desktop alerts are silently skipped — watch the "
+            f"ATTENTION file in {self.run_dir}.",
+            file=sys.stderr,
+        )
+
     def run(self) -> RunSummary:
         self._install_stop_signals()
         try:
@@ -311,6 +326,8 @@ class Engine:
                 # target-branch setup can raise RunPaused (detached HEAD, unborn
                 # repo), so it must sit inside the pause handler, not before it.
                 self._emit_run_boundary("pre_run")
+                if self._owns_signals:
+                    self._warn_desktop_notifier_inert()
                 self._ensure_target_branch()
                 self._prune_preserve_refs()
                 self._loop()

--- a/src/bmad_loop/gates.py
+++ b/src/bmad_loop/gates.py
@@ -77,10 +77,18 @@ def _notifier_argv(kind: str, title: str, message: str) -> tuple[list[str], dict
             [pwsh, "-NoProfile", "-NonInteractive", "-Command", _WIN_TOAST_PS],
             {_TITLE_ENV: title, _MESSAGE_ENV: message},
         )
-    return (["notify-send", "--app-name=bmad-loop", title, message], {})
+    # `--` ends GLib option parsing: an untrusted title/message beginning with
+    # `-`/`--` (e.g. a plugin veto reason of `--help`) is then taken as positional
+    # SUMMARY/BODY text, not parsed as a notify-send option.
+    return (["notify-send", "--app-name=bmad-loop", "--", title, message], {})
 
 
 def notify(policy: Policy, run_dir: Path, title: str, message: str) -> None:
+    """Best-effort human notification: append the ATTENTION file (if notify.file)
+    and fire a native desktop notification (if notify.desktop). Never raises — a
+    failing notifier must not crash the run. Headless CI cannot observe a real
+    notification (no macOS job), so the native macOS/Windows paths are unit-tested
+    at the command-construction level; verify visual delivery manually per OS."""
     if policy.notify.file:
         stamp = time.strftime("%Y-%m-%d %H:%M:%S")
         with (run_dir / ATTENTION_FILE).open("a", encoding="utf-8") as f:
@@ -99,8 +107,12 @@ def notify(policy: Policy, run_dir: Path, title: str, message: str) -> None:
                     capture_output=True,
                     env={**os.environ, **env} if env else None,
                 )
-            except (subprocess.SubprocessError, OSError):
-                pass  # desktop notification is best-effort
+            except (subprocess.SubprocessError, OSError, ValueError):
+                # best-effort: a failing notifier must never crash the run. ValueError
+                # covers an embedded NUL in the untrusted title/message, which reaches
+                # argv (notify-send) or an env value (osascript/PowerShell) and makes
+                # subprocess.run raise `ValueError: embedded null byte`.
+                pass
 
 
 def pause_at_epic_boundary(policy: Policy) -> bool:

--- a/src/bmad_loop/gates.py
+++ b/src/bmad_loop/gates.py
@@ -34,7 +34,14 @@ _WIN_TOAST_PS = (
     "$x.Item(0).AppendChild($t.CreateTextNode($env:BMAD_LOOP_NOTIFY_TITLE))|Out-Null;"
     "$x.Item(1).AppendChild($t.CreateTextNode($env:BMAD_LOOP_NOTIFY_MESSAGE))|Out-Null;"
     "$n=[Windows.UI.Notifications.ToastNotification]::new($t);"
-    "[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('bmad-loop').Show($n)"
+    # Windows only shows a toast for a *registered* AppUserModelID; 'bmad-loop' has
+    # no Start-menu shortcut carrying it, so that toast would be silently dropped.
+    # Reuse Windows PowerShell's own default-registered AUMID instead (the toast is
+    # attributed to "Windows PowerShell"). Raw strings: the AUMID's backslashes must
+    # stay literal — `\v1.0` would otherwise be parsed as a vertical tab.
+    r"[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier("
+    r"'{1AC14E77-02E7-4E5D-B744-2EB1AE5198B7}\WindowsPowerShell\v1.0\powershell.exe')"
+    r".Show($n)"
 )
 
 

--- a/src/bmad_loop/gates.py
+++ b/src/bmad_loop/gates.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
+import sys
 import time
 from pathlib import Path
 
@@ -11,23 +13,87 @@ from .policy import Policy
 
 ATTENTION_FILE = "ATTENTION"
 
+# The untrusted notification title/message (story keys, `str(e)` error tails) are
+# handed to osascript/PowerShell through these environment variables rather than
+# interpolated into the command text, so quotes/newlines/AppleScript-or-PowerShell
+# metacharacters cannot break out of the string. notify-send takes them as argv,
+# which is already injection-safe.
+_TITLE_ENV = "BMAD_LOOP_NOTIFY_TITLE"
+_MESSAGE_ENV = "BMAD_LOOP_NOTIFY_MESSAGE"
+
+# WinRT ToastNotificationManager — the dependency-free toast path on Windows 10+
+# (works under both pwsh and powershell.exe). Reads title/message from $env, so no
+# PowerShell-string interpolation of user text.
+_WIN_TOAST_PS = (
+    "$ErrorActionPreference='Stop';"
+    "[Windows.UI.Notifications.ToastNotificationManager,Windows.UI.Notifications,"
+    "ContentType=WindowsRuntime]|Out-Null;"
+    "$t=[Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent("
+    "[Windows.UI.Notifications.ToastTemplateType]::ToastText02);"
+    "$x=$t.GetElementsByTagName('text');"
+    "$x.Item(0).AppendChild($t.CreateTextNode($env:BMAD_LOOP_NOTIFY_TITLE))|Out-Null;"
+    "$x.Item(1).AppendChild($t.CreateTextNode($env:BMAD_LOOP_NOTIFY_MESSAGE))|Out-Null;"
+    "$n=[Windows.UI.Notifications.ToastNotification]::new($t);"
+    "[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('bmad-loop').Show($n)"
+)
+
+
+def desktop_notifier_kind() -> str | None:
+    """The desktop notifier available on THIS platform, or ``None``. Read-only —
+    ``validate`` and the engine call it to decide whether ``notify.desktop`` can do
+    anything here. Gated on ``sys.platform`` first (not ``which`` alone): PowerShell
+    Core can exist on Linux/macOS, but only Windows should reach the toast path and
+    Linux must keep picking ``notify-send``."""
+    if sys.platform == "darwin":
+        return "osascript" if shutil.which("osascript") else None
+    if sys.platform == "win32":
+        return "powershell" if (shutil.which("pwsh") or shutil.which("powershell")) else None
+    return "notify-send" if shutil.which("notify-send") else None
+
+
+def _notifier_argv(kind: str, title: str, message: str) -> tuple[list[str], dict[str, str]]:
+    """``(argv, env-overrides)`` for ``kind``. osascript/powershell carry the
+    untrusted text via env (never argv); notify-send takes it as argv."""
+    if kind == "osascript":
+        return (
+            [
+                "osascript",
+                "-e",
+                f'display notification (system attribute "{_MESSAGE_ENV}") '
+                f'with title (system attribute "{_TITLE_ENV}")',
+            ],
+            {_TITLE_ENV: title, _MESSAGE_ENV: message},
+        )
+    if kind == "powershell":
+        pwsh = shutil.which("pwsh") or shutil.which("powershell") or "powershell"
+        return (
+            [pwsh, "-NoProfile", "-NonInteractive", "-Command", _WIN_TOAST_PS],
+            {_TITLE_ENV: title, _MESSAGE_ENV: message},
+        )
+    return (["notify-send", "--app-name=bmad-loop", title, message], {})
+
 
 def notify(policy: Policy, run_dir: Path, title: str, message: str) -> None:
     if policy.notify.file:
         stamp = time.strftime("%Y-%m-%d %H:%M:%S")
         with (run_dir / ATTENTION_FILE).open("a", encoding="utf-8") as f:
             f.write(f"[{stamp}] {title}: {message}\n")
-    # portability: notify-send is Linux-only; the shutil.which guard makes this a
-    # no-op on macOS/Windows (no desktop notification), so no platform branch needed.
-    if policy.notify.desktop and shutil.which("notify-send"):
-        try:
-            subprocess.run(
-                ["notify-send", "--app-name=bmad-loop", title, message],
-                timeout=10,
-                capture_output=True,
-            )
-        except (subprocess.SubprocessError, OSError):
-            pass  # desktop notification is best-effort
+    # Native desktop notification per platform: osascript (macOS), a best-effort
+    # WinRT PowerShell toast (Windows), notify-send (Linux). None → silently skip;
+    # `validate` and run start warn separately when notify.desktop is inert here.
+    if policy.notify.desktop:
+        kind = desktop_notifier_kind()
+        if kind:
+            argv, env = _notifier_argv(kind, title, message)
+            try:
+                subprocess.run(
+                    argv,
+                    timeout=10,
+                    capture_output=True,
+                    env={**os.environ, **env} if env else None,
+                )
+            except (subprocess.SubprocessError, OSError):
+                pass  # desktop notification is best-effort
 
 
 def pause_at_epic_boundary(policy: Policy) -> bool:

--- a/src/bmad_loop/policy.py
+++ b/src/bmad_loop/policy.py
@@ -1024,7 +1024,7 @@ session_budget_grace_s = 240 # enforce mode: seconds a tripped session gets to w
 commands = []                # e.g. ["pytest -q", "ruff check ."]
 
 [notify]
-desktop = true               # notify-send, best-effort
+desktop = true               # notify-send (Linux) / osascript (macOS) / PowerShell toast (Windows), best-effort
 file = true                  # ATTENTION file in the run dir
 
 [review]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3278,6 +3278,35 @@ def test_validate_hookless_profile_flags_missing_httpx(project, capsys, monkeypa
     assert "bmad-loop[opencode]" in text
 
 
+def test_validate_warns_when_no_desktop_notifier(project, monkeypatch, capsys):
+    """#231: notify.desktop defaults on, but when this platform resolves no
+    notifier the setting is silently inert — validate must surface it as a
+    warning finding (not a FAIL — desktop notification is best-effort)."""
+    install_bmad_config(project)
+    _write_policy(project.project)  # default notify.desktop = true
+    monkeypatch.setattr(cli.gates, "desktop_notifier_kind", lambda: None)
+    args = argparse.Namespace(project=str(project.project), spec=None, json=True)
+
+    cli.cmd_validate(args)  # rc varies by host (binary/skills) — parse the document instead
+    doc = json.loads(capsys.readouterr().out)
+    finding = next(f for f in doc["findings"] if f["check"] == "notify.desktop-unavailable")
+    assert finding["severity"] == "warning"
+    assert "notify.desktop is set" in finding["message"]
+
+
+def test_validate_silent_when_desktop_notifier_available(project, monkeypatch, capsys):
+    """The mirror case: a resolvable notifier means notify.desktop works, so no
+    notify.desktop-unavailable finding is emitted at all."""
+    install_bmad_config(project)
+    _write_policy(project.project)
+    monkeypatch.setattr(cli.gates, "desktop_notifier_kind", lambda: "osascript")
+    args = argparse.Namespace(project=str(project.project), spec=None, json=True)
+
+    cli.cmd_validate(args)
+    doc = json.loads(capsys.readouterr().out)
+    assert all(f["check"] != "notify.desktop-unavailable" for f in doc["findings"])
+
+
 OPENCODE_QUALIFIED_POLICY = '[adapter]\nname = "opencode"\nmodel = "anthropic/claude-haiku-4-5"\n'
 
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -28,7 +28,7 @@ from conftest import (
 from bmad_loop import platform_util, verify
 from bmad_loop.adapters.base import SessionResult
 from bmad_loop.adapters.mock import MockAdapter
-from bmad_loop.engine import Engine, RunPaused, RunStopped
+from bmad_loop.engine import Engine, RunPaused, RunStopped, _run_depth
 from bmad_loop.journal import Journal, load_state
 from bmad_loop.model import (
     PAUSE_EPIC_BOUNDARY,
@@ -137,6 +137,91 @@ def test_warn_desktop_notifier_inert_noop_when_available(project, monkeypatch, c
 
     engine._warn_desktop_notifier_inert()
 
+    kinds = [e["kind"] for e in engine.journal.entries()]
+    assert "notify-desktop-unavailable" not in kinds
+    assert capsys.readouterr().err == ""
+
+
+def test_warn_desktop_notifier_inert_noop_when_desktop_off(project, monkeypatch, capsys):
+    """notify.desktop off → nothing to warn about, even with no platform notifier."""
+    engine = make_engine(
+        project,
+        [],
+        policy=Policy(
+            gates=GatesPolicy(mode="none"), notify=NotifyPolicy(desktop=False, file=True)
+        ),
+    )[0]
+    monkeypatch.setattr("bmad_loop.gates.desktop_notifier_kind", lambda: None)
+
+    engine._warn_desktop_notifier_inert()
+
+    kinds = [e["kind"] for e in engine.journal.entries()]
+    assert "notify-desktop-unavailable" not in kinds
+    assert capsys.readouterr().err == ""
+
+
+def test_warn_desktop_notifier_inert_no_file_channel_guidance(project, monkeypatch, capsys):
+    """desktop requested + no notifier + notify.file off → the warning says no alert
+    channel is configured rather than pointing at an ATTENTION file never written."""
+    engine = make_engine(
+        project,
+        [],
+        policy=Policy(
+            gates=GatesPolicy(mode="none"), notify=NotifyPolicy(desktop=True, file=False)
+        ),
+    )[0]
+    monkeypatch.setattr("bmad_loop.gates.desktop_notifier_kind", lambda: None)
+
+    engine._warn_desktop_notifier_inert()
+
+    err = capsys.readouterr().err
+    assert "no alert channel is configured" in err
+    assert "ATTENTION file" not in err
+
+
+def _stub_run_side_effects(engine, monkeypatch):
+    """No-op the git/loop/session side effects of Engine.run() so a test can drive
+    the pre_run -> warn -> post_run path in isolation."""
+    monkeypatch.setattr("bmad_loop.engine.kill_session", lambda rid: None)
+    for name in ("_loop", "_ensure_target_branch", "_prune_preserve_refs", "_gc_run_worktrees"):
+        monkeypatch.setattr(engine, name, lambda *a, **k: None)
+
+
+def test_run_warns_when_toplevel_owns_no_signals(project, monkeypatch, capsys):
+    """#231/finding-4: a top-level run that owns no signals (e.g. off the main
+    thread, where signal handlers cannot install) is still depth-0 / non-nested, so
+    the inert-notifier warning fires. Guards the fix that keys the gate on _run_depth
+    rather than signal ownership (which was wrongly silencing off-main-thread runs)."""
+    engine = _notify_engine(project)
+    monkeypatch.setattr("bmad_loop.gates.desktop_notifier_kind", lambda: None)
+    _stub_run_side_effects(engine, monkeypatch)
+    monkeypatch.setattr(engine, "_install_stop_signals", lambda: None)  # owns no signals
+
+    engine.run()
+
+    assert engine._owns_signals is False
+    assert engine._is_nested is False
+    kinds = [e["kind"] for e in engine.journal.entries()]
+    assert "notify-desktop-unavailable" in kinds
+    assert "warning: notify.desktop is set" in capsys.readouterr().err
+
+
+def test_run_suppresses_warning_when_nested(project, monkeypatch, capsys):
+    """A nested run (call-stack depth > 0) suppresses the once-per-run warning even
+    with no notifier — it belongs to the owning top-level run, not the child sweep.
+    Nesting is depth-based, so it holds even when the child owns no signals."""
+    engine = _notify_engine(project)
+    monkeypatch.setattr("bmad_loop.gates.desktop_notifier_kind", lambda: None)
+    _stub_run_side_effects(engine, monkeypatch)
+    monkeypatch.setattr(engine, "_install_stop_signals", lambda: None)
+
+    token = _run_depth.set(1)  # simulate an outer engine's run() frame
+    try:
+        engine.run()
+    finally:
+        _run_depth.reset(token)
+
+    assert engine._is_nested is True
     kinds = [e["kind"] for e in engine.journal.entries()]
     assert "notify-desktop-unavailable" not in kinds
     assert capsys.readouterr().err == ""
@@ -365,11 +450,13 @@ def test_nested_engine_reraises_keyboard_interrupt(project, monkeypatch):
 
     monkeypatch.setattr(engine, "_loop", boom)
     sentinel = object()
-    Engine._stop_signals_owner = sentinel  # pretend an outer engine owns signals
+    Engine._stop_signals_owner = sentinel  # outer engine owns signals (child won't install)
+    token = _run_depth.set(1)  # ...and this run is nested inside the outer run() frame
     try:
         with pytest.raises(KeyboardInterrupt):
             engine.run()
     finally:
+        _run_depth.reset(token)
         Engine._stop_signals_owner = None
 
     assert load_state(engine.run_dir).stopped is False  # owner records it, not us
@@ -5072,11 +5159,13 @@ def test_nested_engine_reraises_runstopped(project, monkeypatch):
 
     monkeypatch.setattr(engine, "_loop", boom)
     sentinel = object()
-    Engine._stop_signals_owner = sentinel  # pretend an outer engine owns signals
+    Engine._stop_signals_owner = sentinel  # outer engine owns signals (child won't install)
+    token = _run_depth.set(1)  # ...and this run is nested inside the outer run() frame
     try:
         with pytest.raises(RunStopped):
             engine.run()
     finally:
+        _run_depth.reset(token)
         Engine._stop_signals_owner = None
 
     assert load_state(engine.run_dir).stopped is False  # owner records it, not us
@@ -5131,11 +5220,13 @@ def test_nested_engine_reraises_crash(project, monkeypatch):
 
     monkeypatch.setattr(engine, "_loop", boom)
     sentinel = object()
-    Engine._stop_signals_owner = sentinel  # pretend an outer engine owns signals
+    Engine._stop_signals_owner = sentinel  # outer engine owns signals (child won't install)
+    token = _run_depth.set(1)  # ...and this run is nested inside the outer run() frame
     try:
         with pytest.raises(RuntimeError):
             engine.run()
     finally:
+        _run_depth.reset(token)
         Engine._stop_signals_owner = None
 
     assert load_state(engine.run_dir).crashed is False  # owner records it, not us

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -108,6 +108,40 @@ def resume_engine(project, engine, script, policy=None) -> tuple[Engine, MockAda
     return new_engine, adapter
 
 
+def _notify_engine(project):
+    return make_engine(
+        project,
+        [],
+        policy=Policy(gates=GatesPolicy(mode="none"), notify=NotifyPolicy(desktop=True, file=True)),
+    )[0]
+
+
+def test_warn_desktop_notifier_inert_journals_and_prints(project, monkeypatch, capsys):
+    """#231: at run start, notify.desktop requested + no platform notifier ->
+    one journal event and a stderr warning, so an unattended launch that skipped
+    `validate` still learns the desktop channel is dead."""
+    engine = _notify_engine(project)
+    monkeypatch.setattr("bmad_loop.gates.desktop_notifier_kind", lambda: None)
+
+    engine._warn_desktop_notifier_inert()
+
+    kinds = [e["kind"] for e in engine.journal.entries()]
+    assert "notify-desktop-unavailable" in kinds
+    assert "warning: notify.desktop is set" in capsys.readouterr().err
+
+
+def test_warn_desktop_notifier_inert_noop_when_available(project, monkeypatch, capsys):
+    """A resolvable notifier means notify.desktop works here — no warning, no event."""
+    engine = _notify_engine(project)
+    monkeypatch.setattr("bmad_loop.gates.desktop_notifier_kind", lambda: "osascript")
+
+    engine._warn_desktop_notifier_inert()
+
+    kinds = [e["kind"] for e in engine.journal.entries()]
+    assert "notify-desktop-unavailable" not in kinds
+    assert capsys.readouterr().err == ""
+
+
 def test_run_session_saves_completed_session_checkpoint(project):
     """The completed session must already be on disk when post_session fires:
     a host kill inside the hooks cannot lose it."""

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -139,13 +139,48 @@ def test_notify_linux_runs_notify_send(monkeypatch, tmp_path):
     )
     calls = _capture_run(monkeypatch)
 
+    # option-shaped title/message must not be parsed as notify-send options: the `--`
+    # terminator forces GLib to treat them as positional SUMMARY/BODY text.
+    gates.notify(_policy(desktop=True, file=False), tmp_path, "--title", "--help")
+
+    assert len(calls) == 1
+    argv, kwargs = calls[0]
+    # `--` sits before the untrusted text, so a leading-dash payload stays positional
+    assert argv == ["notify-send", "--app-name=bmad-loop", "--", "--title", "--help"]
+    assert kwargs["env"] is None  # no env override for the notify-send path
+
+
+def test_notify_desktop_swallows_value_error(monkeypatch, tmp_path):
+    """An embedded NUL in the untrusted text makes subprocess.run raise ValueError
+    (not a SubprocessError, which is not a ValueError subclass); the best-effort
+    boundary must still swallow it rather than crash the run."""
+    monkeypatch.setattr(gates.sys, "platform", "linux")
+    monkeypatch.setattr(gates.shutil, "which", lambda _cmd: "/usr/bin/notify-send")
+
+    def boom(*_a, **_k):
+        raise ValueError("embedded null byte")
+
+    monkeypatch.setattr(gates.subprocess, "run", boom)
+    # must not propagate
+    gates.notify(_policy(desktop=True, file=False), tmp_path, "title", "mid\x00nul")
+
+
+def test_notify_windows_dispatches_via_pwsh_only(monkeypatch, tmp_path):
+    """PowerShell Core alone (no powershell.exe) still dispatches the toast — the
+    dispatch path must select whichever of pwsh/powershell shutil.which resolves."""
+    monkeypatch.setattr(gates.sys, "platform", "win32")
+    monkeypatch.setattr(
+        gates.shutil, "which", lambda cmd: "/usr/bin/pwsh" if cmd == "pwsh" else None
+    )
+    calls = _capture_run(monkeypatch)
+
     gates.notify(_policy(desktop=True, file=False), tmp_path, "title", "message")
 
     assert len(calls) == 1
     argv, kwargs = calls[0]
-    assert argv[:1] == ["notify-send"]
-    assert "title" in argv and "message" in argv  # notify-send takes text as argv (already safe)
-    assert kwargs["env"] is None  # no env override for the notify-send path
+    assert argv[0].endswith("pwsh")  # not powershell.exe
+    assert "-Command" in argv
+    assert kwargs["env"][gates._TITLE_ENV] == "title"
 
 
 def test_notify_desktop_noop_when_no_notifier(monkeypatch, tmp_path):

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -1,0 +1,162 @@
+"""gates.notify — the ATTENTION file sink and the cross-platform desktop
+notifier dispatch added for #231 (native macOS/Windows notifications, plus the
+untrusted-text-via-env invariant that keeps user text out of the command string)."""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from bmad_loop import gates
+from bmad_loop.policy import NotifyPolicy, Policy
+
+
+def _policy(*, desktop: bool, file: bool) -> Policy:
+    return Policy(notify=NotifyPolicy(desktop=desktop, file=file))
+
+
+def _capture_run(monkeypatch):
+    """Record every (argv, kwargs) `gates.notify` hands to `subprocess.run`."""
+    calls: list[tuple[list[str], dict]] = []
+
+    def fake_run(argv, **kwargs):
+        calls.append((argv, kwargs))
+        return subprocess.CompletedProcess(argv, 0)
+
+    monkeypatch.setattr(gates.subprocess, "run", fake_run)
+    return calls
+
+
+# ------------------------------------------------------------- file sink
+
+
+def test_notify_file_appends_attention_line(tmp_path):
+    gates.notify(_policy(desktop=False, file=True), tmp_path, "worktree-open-failed", "mount lost")
+    line = (tmp_path / gates.ATTENTION_FILE).read_text(encoding="utf-8")
+    assert line.startswith("[")  # timestamp stamp
+    assert "worktree-open-failed: mount lost" in line
+
+
+# ------------------------------------------------ desktop_notifier_kind()
+
+
+@pytest.mark.parametrize(
+    ("platform", "present", "expected"),
+    [
+        ("darwin", "osascript", "osascript"),
+        ("win32", "powershell", "powershell"),
+        ("linux", "notify-send", "notify-send"),
+    ],
+)
+def test_desktop_notifier_kind_per_platform(monkeypatch, platform, present, expected):
+    monkeypatch.setattr(gates.sys, "platform", platform)
+    monkeypatch.setattr(
+        gates.shutil, "which", lambda cmd: f"/usr/bin/{cmd}" if cmd == present else None
+    )
+    assert gates.desktop_notifier_kind() == expected
+
+
+@pytest.mark.parametrize("platform", ["darwin", "win32", "linux"])
+def test_desktop_notifier_kind_none_when_tool_absent(monkeypatch, platform):
+    monkeypatch.setattr(gates.sys, "platform", platform)
+    monkeypatch.setattr(gates.shutil, "which", lambda _cmd: None)
+    assert gates.desktop_notifier_kind() is None
+
+
+def test_desktop_notifier_kind_win32_accepts_pwsh(monkeypatch):
+    """PowerShell Core satisfies the Windows branch even without Windows PowerShell."""
+    monkeypatch.setattr(gates.sys, "platform", "win32")
+    monkeypatch.setattr(
+        gates.shutil, "which", lambda cmd: "/usr/bin/pwsh" if cmd == "pwsh" else None
+    )
+    assert gates.desktop_notifier_kind() == "powershell"
+
+
+def test_desktop_notifier_kind_linux_ignores_pwsh(monkeypatch):
+    """`sys.platform` gates first: pwsh on Linux must not divert from notify-send."""
+    monkeypatch.setattr(gates.sys, "platform", "linux")
+    monkeypatch.setattr(
+        gates.shutil, "which", lambda cmd: "/usr/bin/pwsh" if cmd == "pwsh" else None
+    )
+    assert gates.desktop_notifier_kind() is None  # notify-send absent → nothing, not pwsh
+
+
+# --------------------------------------------------- desktop dispatch
+
+
+def test_notify_macos_runs_osascript_via_env(monkeypatch, tmp_path):
+    monkeypatch.setattr(gates.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        gates.shutil, "which", lambda cmd: "/usr/bin/osascript" if cmd == "osascript" else None
+    )
+    calls = _capture_run(monkeypatch)
+
+    message = 'he said "done"\nnow'  # a quote+newline that would break AppleScript if interpolated
+    title = "story deferred: 1-2-a"
+    gates.notify(_policy(desktop=True, file=False), tmp_path, title, message)
+
+    assert len(calls) == 1
+    argv, kwargs = calls[0]
+    assert argv[0] == "osascript"
+    # untrusted text travels through env, never interpolated into the command string
+    assert kwargs["env"][gates._TITLE_ENV] == title
+    assert kwargs["env"][gates._MESSAGE_ENV] == message
+    assert not any(message in part for part in argv)
+    assert not any("1-2-a" in part for part in argv)
+
+
+def test_notify_windows_runs_powershell(monkeypatch, tmp_path):
+    monkeypatch.setattr(gates.sys, "platform", "win32")
+    monkeypatch.setattr(
+        gates.shutil, "which", lambda cmd: "C:\\powershell.exe" if cmd == "powershell" else None
+    )
+    calls = _capture_run(monkeypatch)
+
+    gates.notify(_policy(desktop=True, file=False), tmp_path, "escalation", "toast body")
+
+    assert len(calls) == 1
+    argv, kwargs = calls[0]
+    assert argv[0].lower().endswith(("powershell.exe", "pwsh"))
+    assert "-Command" in argv
+    assert kwargs["env"][gates._TITLE_ENV] == "escalation"
+    assert kwargs["env"][gates._MESSAGE_ENV] == "toast body"
+    assert not any("toast body" in part for part in argv)
+
+
+def test_notify_linux_runs_notify_send(monkeypatch, tmp_path):
+    monkeypatch.setattr(gates.sys, "platform", "linux")
+    monkeypatch.setattr(
+        gates.shutil, "which", lambda cmd: "/usr/bin/notify-send" if cmd == "notify-send" else None
+    )
+    calls = _capture_run(monkeypatch)
+
+    gates.notify(_policy(desktop=True, file=False), tmp_path, "title", "message")
+
+    assert len(calls) == 1
+    argv, kwargs = calls[0]
+    assert argv[:1] == ["notify-send"]
+    assert "title" in argv and "message" in argv  # notify-send takes text as argv (already safe)
+    assert kwargs["env"] is None  # no env override for the notify-send path
+
+
+def test_notify_desktop_noop_when_no_notifier(monkeypatch, tmp_path):
+    monkeypatch.setattr(gates.sys, "platform", "darwin")
+    monkeypatch.setattr(gates.shutil, "which", lambda _cmd: None)
+    calls = _capture_run(monkeypatch)
+
+    gates.notify(_policy(desktop=True, file=False), tmp_path, "title", "message")
+
+    assert calls == []  # no notifier resolved → subprocess.run never called
+
+
+def test_notify_desktop_swallows_errors(monkeypatch, tmp_path):
+    monkeypatch.setattr(gates.sys, "platform", "linux")
+    monkeypatch.setattr(gates.shutil, "which", lambda _cmd: "/usr/bin/notify-send")
+
+    def boom(*_a, **_k):
+        raise OSError("no dbus")
+
+    monkeypatch.setattr(gates.subprocess, "run", boom)
+    # best-effort: a failing notifier must not propagate out of notify()
+    gates.notify(_policy(desktop=True, file=False), tmp_path, "title", "message")

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -113,15 +113,23 @@ def test_notify_windows_runs_powershell(monkeypatch, tmp_path):
     )
     calls = _capture_run(monkeypatch)
 
-    gates.notify(_policy(desktop=True, file=False), tmp_path, "escalation", "toast body")
+    # both title and message carry PowerShell/shell-sensitive text that must never
+    # reach argv — they travel through env, and the -Command script reads $env:.
+    title = 'escalation `$(rm)`;"& evil'
+    message = 'toast $(bad) "body"'
+    gates.notify(_policy(desktop=True, file=False), tmp_path, title, message)
 
     assert len(calls) == 1
     argv, kwargs = calls[0]
     assert argv[0].lower().endswith(("powershell.exe", "pwsh"))
     assert "-Command" in argv
-    assert kwargs["env"][gates._TITLE_ENV] == "escalation"
-    assert kwargs["env"][gates._MESSAGE_ENV] == "toast body"
-    assert not any("toast body" in part for part in argv)
+    assert kwargs["env"][gates._TITLE_ENV] == title
+    assert kwargs["env"][gates._MESSAGE_ENV] == message
+    # neither the title nor the message is interpolated into the command string
+    assert not any(title in part for part in argv)
+    assert not any(message in part for part in argv)
+    # the toast is delivered under a registered AUMID (Windows drops unregistered ids)
+    assert any("WindowsPowerShell" in part for part in argv)
 
 
 def test_notify_linux_runs_notify_send(monkeypatch, tmp_path):

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -382,8 +382,13 @@ _FINDING_WIDTH = 96
 
 
 def render(renderable, width: int = _FINDING_WIDTH) -> str:
-    """Rich renderable -> plain text, as journal_rows does for the journal."""
-    console = Console(width=width)
+    """Rich renderable -> plain text, as journal_rows does for the journal.
+
+    ``no_color=True`` so the capture is deterministic regardless of the ambient
+    ``FORCE_COLOR``/``CLICOLOR_FORCE``: Rich otherwise honors a forced color mode
+    even into a non-tty capture buffer, and the column-alignment assertions here
+    slice raw strings that embedded ANSI escapes would shift out of position."""
+    console = Console(width=width, no_color=True)
     with console.capture() as capture:
         console.print(renderable)
     return capture.get()


### PR DESCRIPTION
Closes #231

## Problem

`notify.desktop` defaults to `true`, but the only desktop channel was `notify-send` (Linux-only). On macOS/Windows the `shutil.which("notify-send")` guard made the call a **silent no-op** — the setting was enabled, valid, and did nothing, with no indication anywhere. Since `gates.notify` is the single choke every "a human is needed" path funnels through (escalations, deferrals, worktree-open failures, run-finished), an unattended macOS/Windows run that needed a human had no channel but the untailed `ATTENTION` file in `.bmad-loop/`.

## Fix

A small notifier-resolution seam in `gates.py`, consumed by `notify`, `validate`, and the engine:

- **Native per-platform dispatch** in `gates.notify`: `osascript` (macOS), a best-effort WinRT `ToastNotificationManager` PowerShell toast (Windows, dependency-free), `notify-send` (Linux). Resolution is gated on `sys.platform` first (not `which` alone) so PowerShell Core on Linux can't divert Linux off `notify-send`. Windows stays strictly best-effort inside the existing try/except — a failure only ever no-ops.
- **Untrusted title/message are passed via environment variables** (`system attribute` / `$env:`), never interpolated into the osascript/PowerShell command string, so quotes/newlines/metacharacters in story keys or error tails can't break out. `notify-send` keeps taking them as argv (already injection-safe). A test proves the raw text lands in `env`, not `argv`.
- **Honest warning when inert**, in two places so unattended launches that skip `validate` still surface it:
  - `validate` emits a `notify.desktop-unavailable` **warning** finding when `notify.desktop` is set but no notifier resolves on the platform.
  - Run start prints a one-time stderr `warning:` line and journals a `notify-desktop-unavailable` event (gated by `_owns_signals` so nested auto-sweeps don't repeat it).

No new policy field — reuses the existing `notify.desktop` / `notify.file`.

## Tests

- New `tests/test_gates.py`: file sink; `desktop_notifier_kind` per platform + `None`; osascript/PowerShell/notify-send argv+env dispatch; the untrusted-text-via-env-not-argv assertion; no-op when no notifier; error swallow.
- `tests/test_cli.py`: `validate` warns when no notifier / silent when one is available.
- `tests/test_engine.py`: `_warn_desktop_notifier_inert` journals + prints when inert / no-ops when a notifier is present.

Full suite green (2928 passed, 1 skipped); `trunk check --no-fix` clean. The Windows toast path is unverifiable on this repo's Linux/macOS CI and is best-effort by design.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Desktop notifications now use platform-native delivery on macOS, Windows, and Linux (best-effort).
  * Untrusted notification title/message text is handled safely to avoid unsafe command construction.
  * Added validation and one-time startup warnings when desktop notifications are enabled but unavailable, with guidance pointing to the run-directory alert behavior.
* **Documentation**
  * Expanded `[notify] desktop = true` policy documentation to reflect platform-specific mechanisms.
* **Tests**
  * Added/updated tests for notifier dispatch, selection behavior, and the new unavailable-notifier warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->