### PR TITLE
fix(adapters): session-qualify psmux window ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,19 @@ story <id>`, the same annotation a sweep bundle writes. Both sprint and stories 
 
 ### Fixed
 
+- **psmux window ids are now session-qualified (#254).** psmux mints window ids per server (one
+  server per session), so the bare `@N` the backend returned from `new_window` routed by the
+  caller's `$TMUX` when replayed as a `-t` target — from a `bmad-loop-ctl` pane that is the ctl
+  server, not the agent's. The log sink then bound to the engine's own window (empty run logs,
+  dead activity signal), stop/stall nudges were typed into the engine's own pane, and session
+  teardown harvested and killed the engine's window instead of the agent's. `new_window` and
+  `list_window_ids` now emit the `session:@N` form symmetrically (endorsed in psmux/psmux#483 as
+  the permanent model boundary), so every target the engine replays — `pipe_pane`, `send_text`,
+  `kill_window`, `window_pane_pids` — routes to the owning server unambiguously, and the
+  `window_alive` membership check keeps matching the minted form. Degrades to the bare id when
+  the session name contains `:` (the #221 rule); the tmux backend is untouched (its ids are
+  server-global).
+
 - **A session's read-back could adopt another story's spec (#261).** The generic dev/review
   read-back located "the artifact this session produced" by scanning the implementation-artifacts
   dir for the most-recently-modified qualifying `*.md`, with nothing tying the match to the story

--- a/docs/adapter-authoring-guide.md
+++ b/docs/adapter-authoring-guide.md
@@ -108,9 +108,11 @@ module-level `parse_target()` — or the backend's own **native id** (whatever y
 `target()`. (Two values are composed by the backend itself rather than by
 `target()`, precisely so the seam grammar never has to carry a pane or window
 id: the parked-window return target — `current_return_target`, above — and the
-native window id, which psmux qualifies to `session:@N` at both minting seams
-because its ids are per-server. Both are replayed opaquely; neither is parsed by
-core.) tmux consumes the token natively (it coincides with tmux exact-match
+native window id, which psmux qualifies to `session:@N` across the
+`new_window`/`list_window_ids` pair because its ids are per-server (falling back
+to the bare id where that grammar would not survive — the backend owns those
+conditions, and applies them to both halves of the pair so the symmetry rule
+still holds). Both are replayed opaquely; neither is parsed by core.) tmux consumes the token natively (it coincides with tmux exact-match
 syntax), so `BaseTmuxBackend` passes it straight through. A native-id backend
 calls `parse_target()` first — `None` means "already a native id, use as-is",
 otherwise resolve `(session, window)` yourself; the herdr adapter's

--- a/docs/adapter-authoring-guide.md
+++ b/docs/adapter-authoring-guide.md
@@ -82,7 +82,10 @@ seams of a full OS port are in
   (run a command, then _park_ on a keypress so the exit status stays inspectable,
   then return any attached client to its origin — the POSIX `sh -c` recipe is
   composed from the base's overridable shell-dialect hooks, so a non-POSIX
-  backend swaps the dialect fragments, not the method body), `list_window_ids`, `list_windows` (selected fields per window),
+  backend swaps the dialect fragments, not the method body), `list_window_ids`
+  (which MUST emit the same id form your `new_window` returns — `window_alive` is
+  a membership test over it, so qualifying one side and not the other reads every
+  live window as dead), `list_windows` (selected fields per window),
   `window_alive`, `kill_window`, `select_window`, `set_window_option`,
   `unset_window_option`, `show_window_option`, `pipe_pane` (tee a pane to a log),
   `send_text`.
@@ -102,11 +105,13 @@ families: the **seam-canonical target token** `=session[:window]` — formatted 
 the concrete `TerminalMultiplexer.target(session, window=None)`, decoded by the
 module-level `parse_target()` — or the backend's own **native id** (whatever your
 `new_window` returned). Core never hand-assembles the grammar; it calls
-`target()`. (The parked-window return target is the one value composed by the
-backend itself — `current_return_target`, above — precisely so this grammar
-never has to carry a pane id.) tmux consumes the token natively (it coincides
-with tmux exact-match syntax), so `BaseTmuxBackend` passes it straight
-through. A native-id backend
+`target()`. (Two values are composed by the backend itself rather than by
+`target()`, precisely so the seam grammar never has to carry a pane or window
+id: the parked-window return target — `current_return_target`, above — and the
+native window id, which psmux qualifies to `session:@N` at both minting seams
+because its ids are per-server. Both are replayed opaquely; neither is parsed by
+core.) tmux consumes the token natively (it coincides with tmux exact-match
+syntax), so `BaseTmuxBackend` passes it straight through. A native-id backend
 calls `parse_target()` first — `None` means "already a native id, use as-is",
 otherwise resolve `(session, window)` yourself; the herdr adapter's
 `_parse_target`

--- a/src/bmad_loop/adapters/multiplexer.py
+++ b/src/bmad_loop/adapters/multiplexer.py
@@ -129,6 +129,15 @@ class TerminalMultiplexer(ABC):
         """Create a window running ``command`` (with ``env`` layered on) in
         ``session``, rooted at ``cwd``. Returns the backend-native window id.
 
+        That id is **opaque to core**: it is replayed verbatim as the ``-t``
+        target of :meth:`pipe_pane`, :meth:`send_text`, :meth:`kill_window` and
+        :meth:`window_pane_pids`, and membership-tested against
+        :meth:`list_window_ids` — never parsed, and never re-composed through
+        :meth:`target`. So a backend MAY return an already-qualified target
+        instead of a bare id (psmux returns ``session:@N``), provided
+        :meth:`list_window_ids` emits the identical form — see its symmetry
+        rule.
+
         ``command`` is a POSIX shlex-joined argv string, not a shell line:
         shell-operator behavior (``&&``, ``|``, ...) is backend-defined —
         one backend may hand the string to a shell, another may shlex
@@ -146,6 +155,15 @@ class TerminalMultiplexer(ABC):
     @abstractmethod
     def list_window_ids(self, session: str) -> list[str]:
         """Native ids of every window in ``session`` (empty if it is gone).
+
+        SYMMETRY RULE: these must be the *same id form* :meth:`new_window` and
+        :meth:`new_parked_window` return, because :meth:`window_alive` is a
+        membership test over this list. A backend that qualifies one side and
+        not the other reads every live window as instantly dead. The form
+        itself is the backend's own — psmux emits ``session:@N`` because its
+        ids are minted per server (one server per session), so a bare ``@N``
+        replayed as a ``-t`` target routes by the *caller's* server instead of
+        the owning one.
 
         Raises :class:`MultiplexerError` if the transport itself fails (timeout /
         missing binary): an empty list means "no windows" and must not be

--- a/src/bmad_loop/adapters/multiplexer.py
+++ b/src/bmad_loop/adapters/multiplexer.py
@@ -156,14 +156,19 @@ class TerminalMultiplexer(ABC):
     def list_window_ids(self, session: str) -> list[str]:
         """Native ids of every window in ``session`` (empty if it is gone).
 
-        SYMMETRY RULE: these must be the *same id form* :meth:`new_window` and
-        :meth:`new_parked_window` return, because :meth:`window_alive` is a
-        membership test over this list. A backend that qualifies one side and
-        not the other reads every live window as instantly dead. The form
-        itself is the backend's own — psmux emits ``session:@N`` because its
-        ids are minted per server (one server per session), so a bare ``@N``
-        replayed as a ``-t`` target routes by the *caller's* server instead of
-        the owning one.
+        SYMMETRY RULE: these must be the *same id form* :meth:`new_window`
+        returns, because :meth:`window_alive` is a membership test over this
+        list. A backend that qualifies one side and not the other reads every
+        live window as instantly dead. The form itself is the backend's own —
+        psmux emits ``session:@N`` because its ids are minted per server (one
+        server per session), so a bare ``@N`` replayed as a ``-t`` target
+        routes by the *caller's* server instead of the owning one.
+
+        :meth:`new_parked_window` is deliberately *outside* the rule: nothing
+        membership-tests a parked id — it is only replayed as a ``-t`` target,
+        by the TUI — so a backend MAY mint it in a form this list never
+        carries. psmux keeps it bare, because the qualified grammar is not
+        accepted by the verbs the parked path uses (#291).
 
         Raises :class:`MultiplexerError` if the transport itself fails (timeout /
         missing binary): an empty list means "no windows" and must not be

--- a/src/bmad_loop/adapters/psmux_backend.py
+++ b/src/bmad_loop/adapters/psmux_backend.py
@@ -11,7 +11,10 @@ pane, ``kill-session`` ignores the ``=name`` exact-match form, a quoted
 command string does not survive psmux's outer re-parse (so shell source
 travels as ``pwsh -EncodedCommand``), and ``pipe-pane`` strips every
 dash-flag token from the piped command (so the log sink travels as a
-positional sidecar ``.ps1``). ``available()`` additionally gates on
+positional sidecar ``.ps1``). Window ids are minted per server (one
+server per session), so ``new_window``/``list_window_ids`` hand back
+session-qualified ``session:@N`` ids that route to the owning server from
+any caller (psmux/psmux#483). ``available()`` additionally gates on
 the reported version: psmux releases up to 3.3.6 kill recycled PIDs during
 pane/session teardown without a process-identity check, which can take down
 an unrelated long-lived process mid-run. See :mod:`.multiplexer` for the
@@ -170,6 +173,39 @@ class PsmuxMultiplexer(BaseTmuxBackend):
             self._run(["kill-session", "-t", name], check=False)
         except (subprocess.SubprocessError, OSError):
             pass
+
+    @staticmethod
+    def _qualified_window_id(session: str, window_id: str) -> str:
+        # psmux mints window ids per server (one server per session), so a bare
+        # `@N` replayed as a `-t` target routes by the caller's $TMUX — from a
+        # ctl pane that is the wrong server entirely (#254). A `session:@N`
+        # target routes by the session's port file instead (psmux/psmux#483:
+        # qualified targets are at full parity; bare ids are a permanent model
+        # boundary). Degrade to the bare id when the session name contains `:`
+        # (it would split at the wrong colon) — the #221 rule — or when the id
+        # is falsy (a failure sentinel must pass through unchanged).
+        if not window_id or ":" in session:
+            return window_id
+        return f"{session}:{window_id}"
+
+    def new_window(
+        self, session: str, name: str, cwd: Path, env: dict[str, str], command: str
+    ) -> str:
+        # Session-qualify the minted id (see _qualified_window_id) so every
+        # downstream `-t` consumer inherits an unambiguous target. Post-process
+        # the base's return rather than reformatting `-F` so the argv stays
+        # byte-identical to the base's.
+        window_id = super().new_window(session, name, cwd, env, command)
+        return self._qualified_window_id(session, window_id)
+
+    def list_window_ids(self, session: str) -> list[str]:
+        # psmux's list-windows emits bare `@N` lines; qualify them identically
+        # to new_window or window_alive's membership check (native_id in
+        # list_window_ids) would read every window as dead.
+        return [
+            self._qualified_window_id(session, window_id)
+            for window_id in super().list_window_ids(session)
+        ]
 
     def current_return_target(self) -> str | None:
         # psmux runs one server per session, so a bare pane id recorded on a

--- a/src/bmad_loop/adapters/psmux_backend.py
+++ b/src/bmad_loop/adapters/psmux_backend.py
@@ -14,7 +14,10 @@ dash-flag token from the piped command (so the log sink travels as a
 positional sidecar ``.ps1``). Window ids are minted per server (one
 server per session), so ``new_window``/``list_window_ids`` hand back
 session-qualified ``session:@N`` ids that route to the owning server from
-any caller (psmux/psmux#483). ``available()`` additionally gates on
+any caller (psmux/psmux#483) — the TUI-side mint/list surfaces
+(``new_parked_window``, ``list_windows`` field ids) deliberately still hand
+back bare ids, a different process context tracked in #291.
+``available()`` additionally gates on
 the reported version: psmux releases up to 3.3.6 kill recycled PIDs during
 pane/session teardown without a process-identity check, which can take down
 an unrelated long-lived process mid-run. See :mod:`.multiplexer` for the
@@ -184,6 +187,12 @@ class PsmuxMultiplexer(BaseTmuxBackend):
         # boundary). Degrade to the bare id when the session name contains `:`
         # (it would split at the wrong colon) — the #221 rule — or when the id
         # is falsy (a failure sentinel must pass through unchanged).
+        #
+        # Composed here rather than via self.target() — which would emit
+        # `=session:@N`, and does parse (psmux strips the `=`) — because the
+        # seam requires target() to stay a stable *by-name* token and `@N` is
+        # an id. Do not "unify" the two grammars: current_return_target's
+        # `=session:%N` is a target(), this is not.
         if not window_id or ":" in session:
             return window_id
         return f"{session}:{window_id}"

--- a/tests/test_psmux_backend.py
+++ b/tests/test_psmux_backend.py
@@ -157,6 +157,69 @@ def test_new_window_env_values_stay_inert_literals(rec, tmp_path):
     assert source.replace("''", "").count("'") % 2 == 0
 
 
+# ------------------------------------------- session-qualified window ids (#254)
+# psmux mints window ids per server (one server per session), so a bare `@N`
+# replayed as a `-t` target routes by the caller's $TMUX — the wrong server
+# from a ctl pane. new_window and list_window_ids must therefore emit the
+# `session:@N` form symmetrically (psmux/psmux#483), or window_alive's
+# membership check reads every window as dead.
+
+
+def _window_fake(monkeypatch, new_window_id: str = "@2\n", listed: str = "@1\n@2\n"):
+    """Script new-window to print an id and list-windows to list ids."""
+
+    def fake(argv, **kwargs):
+        out = new_window_id if argv[1] == "new-window" else listed
+        return subprocess.CompletedProcess(argv, 0, stdout=out, stderr="")
+
+    monkeypatch.setattr(tmux_base.subprocess, "run", fake)
+
+
+def test_new_window_returns_session_qualified_id(monkeypatch, tmp_path):
+    _window_fake(monkeypatch)
+    assert PsmuxMultiplexer().new_window("s", "n", tmp_path, {}, "prog") == "s:@2"
+
+
+def test_list_window_ids_returns_session_qualified_ids(monkeypatch):
+    _window_fake(monkeypatch)
+    assert PsmuxMultiplexer().list_window_ids("s") == ["s:@1", "s:@2"]
+
+
+def test_qualification_degrades_to_bare_on_colon_session(monkeypatch, tmp_path):
+    # A `:` in the session name would split the target at the wrong colon on
+    # replay — both methods degrade to the bare id identically (the #221 rule).
+    _window_fake(monkeypatch)
+    mux = PsmuxMultiplexer()
+    assert mux.new_window("a:b", "n", tmp_path, {}, "prog") == "@2"
+    assert mux.list_window_ids("a:b") == ["@1", "@2"]
+
+
+def test_new_window_falsy_id_passes_through_unqualified(monkeypatch, tmp_path):
+    # An empty minted id is a failure sentinel, not a target — qualifying it
+    # would forge "s:" out of nothing.
+    _window_fake(monkeypatch, new_window_id="")
+    assert PsmuxMultiplexer().new_window("s", "n", tmp_path, {}, "prog") == ""
+
+
+def test_window_alive_accepts_new_window_id(monkeypatch, tmp_path):
+    # Symmetry is the whole contract: the id new_window mints must be found by
+    # list_window_ids, or the engine's liveness probe declares an instant crash.
+    _window_fake(monkeypatch)
+    mux = PsmuxMultiplexer()
+    assert mux.window_alive("s", mux.new_window("s", "n", tmp_path, {}, "prog")) is True
+
+
+def test_list_window_ids_transport_failure_still_raises(monkeypatch):
+    # Qualification must not soften the liveness contract: a transport failure
+    # raises rather than answering [] (which would read as "session crashed").
+    def timeout(*_a, **_k):
+        raise subprocess.TimeoutExpired(["psmux"], 30)
+
+    monkeypatch.setattr(tmux_base.subprocess, "run", timeout)
+    with pytest.raises(MultiplexerError):
+        PsmuxMultiplexer().list_window_ids("s")
+
+
 # --------------------------------------------------------------- new_session
 
 

--- a/tests/test_psmux_backend.py
+++ b/tests/test_psmux_backend.py
@@ -209,6 +209,16 @@ def test_window_alive_accepts_new_window_id(monkeypatch, tmp_path):
     assert mux.window_alive("s", mux.new_window("s", "n", tmp_path, {}, "prog")) is True
 
 
+def test_qualified_id_reaches_the_pipe_pane_target(rec, tmp_path):
+    # #254 is about the `-t` argv, not the return value: the consumer must replay
+    # the minted id verbatim, and this backend's pipe_pane override (the one verb
+    # it reimplements) must not re-derive a bare target of its own.
+    rec.stdout = "@2\n"
+    mux = PsmuxMultiplexer()
+    mux.pipe_pane(mux.new_window("s", "n", tmp_path, {}, "prog"), tmp_path / "run.log")
+    assert rec.argv[1:4] == ["pipe-pane", "-t", "s:@2"]
+
+
 def test_list_window_ids_transport_failure_still_raises(monkeypatch):
     # Qualification must not soften the liveness contract: a transport failure
     # raises rather than answering [] (which would read as "session crashed").


### PR DESCRIPTION
## Summary

psmux mints window ids per server (one server per session), so the bare `@N` returned by `new_window` routed by the caller's `$TMUX` when replayed as a `-t` target — from a `bmad-loop-ctl` pane that is the ctl server, not the agent's. The log sink then bound to the engine's own window (empty run logs, dead activity signal), stop/stall nudges were typed into the engine's own pane, and session teardown harvested and killed the engine's window instead of the agent's.

`PsmuxMultiplexer` now returns `session:@N` from `new_window` and emits the identical form from `list_window_ids`. The symmetry is load-bearing: the engine's liveness probe is a membership check (`native_id in list_window_ids(session)`), so qualifying only one side would read every window as instantly dead. With both sides qualified, every target the engine replays — `pipe_pane`, `send_text`, `kill_window`, `window_pane_pids` — routes to the owning server with zero changes to the generic adapter. The tmux path is untouched (its ids are server-global), and the id degrades to bare `@N` when the session name contains `:` (the #221 rule).

This is option 2 from the issue, with the qualification done by post-processing the base methods' return values so the argv construction (and its byte-identity tests) stays untouched.

## How the target grammar was verified (not assumed)

The #483 target-forwarding fixes on psmux main are **not** in the 3.3.7 release, so every form used here was verified against stock 3.3.7 independently:

1. **Source audit at the release tag.** psmux `v3.3.7` (tag == installed binary `05cc5d4`): a `session:`-prefixed target picks the server by the session's `.port` file and forwards the full target out-of-band to that server, where `@N` resolves by window id. Resolution is uniform across `send-keys`, `kill-window`, `capture-pane`, `pipe-pane`, and `list-windows` (a single `parse_target` + temp-focus path); the #483 breakage was specific to `switch-client`'s dedicated handler and does not affect these verbs. Bare targets route by the caller's `$TMUX`, else most-recent-session — the exact misroute this PR fixes.
2. **CLI probes with deliberately colliding ids.** Two live sessions were brought up so both held a window `@2`, then every verb the adapter replays was driven with `sess:@2`: `send-keys` landed only in the minting session's pane, `capture-pane` read the right pane, `pipe-pane -o` with the positional sidecar sink (#217) captured the marker bytes, `list-panes -F '#{pane_pid}'` returned the correct distinct pids, and `kill-window` killed the minting session's `@2` while the other server's `@2` survived. `=sess:@N` also parses (the `=` is stripped), but plain `session:@N` is the only form probed on every verb, so it is the form the backend emits.
3. **End-to-end smoke through the backend itself.** The same colliding-id scenario driven through `PsmuxMultiplexer`: `new_window` returned the qualified id, `window_alive` stayed true, `send_text` reached the right pane, the pipe log grew with the marker, and `kill_window` took down only the minting session's window.

`native_id` lives only in the in-memory `SessionHandle` (never serialized), so no migration is needed for in-flight runs.

## Verification

- New unit tests: qualified mint + qualified list, colon-session degrade on both methods, falsy-id passthrough, `window_alive(new_window(...))` symmetry round-trip, and a transport-failure test pinning that `list_window_ids` still raises rather than reading as "session crashed".
- Full suite on Windows (`PYTHONUTF8=1`, `-n auto`): 2929 passed; remaining failures are the known local skill-sync baseline plus two that require GNU `sleep`/`true` on PATH (pass with Git `usr/bin`, as on CI runners). Full suite on WSL: 2959 passed; `test_opencode_live` failures reproduce identically on the merge base (environmental).
- `ruff check`, `ruff format --check`, `prettier --check CHANGELOG.md`, `pyright@1.1.411` (basic): all clean.

## Out of scope

The TUI-side surfaces (`new_parked_window` return, `list_windows` field ids, ctl-window prune targets) still hand around bare ids — the same ambiguity class, but a different process context. Per the issue's implementation notes this is deliberately excluded here — now filed as #291, together with the bare-id audit #288 asked for. The audit's live probes found the TUI half is **not** a straight port of this recipe: on stock 3.3.7 `select-window` rejects the `sess:@N` form (rc 1) and the window-option verbs silently ignore the window slot (options land session-scoped), so the parked/select paths need name/index targeting — details and the per-verb acceptance matrix are in the #291 comment.

Part of the #288 umbrella (this PR is its #254 child, taken as the class-level shape #288 recommends — qualify at the minting seam so every downstream consumer inherits it).

Closes #254

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed psmux window targeting by session-qualifying window IDs (e.g., `session:`@N``) so replayed operations route to the correct server.
  * Improved window lifecycle/liveness checks and ensured listing timeouts raise proper errors.
  * Preserved behavior when session names contain `:` by falling back to unqualified `@N`.
* **Documentation**
  * Updated the changelog and adapter authoring guide to clarify the opaque window-id/replay contract.
* **Tests**
  * Added tests covering qualified IDs, `pipe-pane` targeting, fallback behavior, and timeout error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
