### PR TITLE
fix(setup): run merge-config with uv

### DIFF
--- a/src/bmad_loop/data/skills/bmad-loop-setup/SKILL.md
+++ b/src/bmad_loop/data/skills/bmad-loop-setup/SKILL.md
@@ -72,13 +72,14 @@ Write a temp JSON file with the collected answers structured as `{"core": {...},
 In the commands below, replace `{project-root}` in every path argument with the actual project root (e.g. `/home/me/myapp`) before running — these are filesystem paths, not config values.
 
 ```bash
-python3 ./scripts/merge-config.py --config-path "{project-root}/_bmad/config.yaml" --user-config-path "{project-root}/_bmad/config.user.yaml" --module-yaml ./assets/module.yaml --answers {temp-file} --legacy-dir "{project-root}/_bmad"
+uv run ./scripts/merge-config.py --config-path "{project-root}/_bmad/config.yaml" --user-config-path "{project-root}/_bmad/config.user.yaml" --module-yaml ./assets/module.yaml --answers {temp-file} --legacy-dir "{project-root}/_bmad"
 python3 ./scripts/merge-help-csv.py --target "{project-root}/_bmad/module-help.csv" --source ./assets/module-help.csv --legacy-dir "{project-root}/_bmad" --module-code bmad-loop
 ```
 
 Both scripts output JSON to stdout with results. If either exits non-zero, surface the error and stop. The scripts automatically read legacy config values as fallback defaults. Legacy config files are **preserved, never deleted** — on BMAD v6 the per-module and core `config.yaml` / `module-help.csv` are live, manifest-tracked files (so `legacy_configs_deleted` / `legacy_csvs_deleted` are always empty).
 
-Run `./scripts/merge-config.py --help` or `./scripts/merge-help-csv.py --help` for full usage.
+Run `uv run ./scripts/merge-config.py --help` or
+`python3 ./scripts/merge-help-csv.py --help` for full usage.
 
 ## Create Output Directories
 

--- a/tests/test_setup_cleanup_scripts.py
+++ b/tests/test_setup_cleanup_scripts.py
@@ -294,6 +294,7 @@ def test_setup_skill_uses_uv_for_dependency_bearing_merge_config():
 
     assert skill.count("uv run ./scripts/merge-config.py") == 2
     assert "python3 ./scripts/merge-config.py" not in skill
+    assert skill.count("python3 ./scripts/merge-help-csv.py") == 2
 
 
 def test_merge_config_preserves_legacy_configs(tmp_path):

--- a/tests/test_setup_cleanup_scripts.py
+++ b/tests/test_setup_cleanup_scripts.py
@@ -20,6 +20,7 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parent.parent
 SCRIPTS = REPO / "src" / "bmad_loop" / "data" / "skills" / "bmad-loop-setup" / "scripts"
 ASSETS = REPO / "src" / "bmad_loop" / "data" / "skills" / "bmad-loop-setup" / "assets"
+SETUP_SKILL = SCRIPTS.parent / "SKILL.md"
 
 
 def _run(script: str, *args: str) -> subprocess.CompletedProcess:
@@ -286,6 +287,13 @@ def test_cleanup_removes_payload_whose_skill_ships_marker_named_assets(tmp_path)
 
 
 # ---------------------------------------------------------------- merge-config
+
+
+def test_setup_skill_uses_uv_for_dependency_bearing_merge_config():
+    skill = SETUP_SKILL.read_text()
+
+    assert skill.count("uv run ./scripts/merge-config.py") == 2
+    assert "python3 ./scripts/merge-config.py" not in skill
 
 
 def test_merge_config_preserves_legacy_configs(tmp_path):


### PR DESCRIPTION
## What

Run the dependency-bearing `merge-config.py` setup helper through `uv`, including its documented help command. Keep the dependency-free CSV helper on `python3`.

## Why

Bare `python3` does not provision the script's PEP 723 `pyyaml` dependency, so setup can fail on otherwise valid uv-managed installations.

Fixes #259
Related #287

## How

- changed both documented `merge-config.py` invocations to `uv run`
- added a focused guard preventing those commands from drifting back to bare Python

## Testing

- exact `uv run .../merge-config.py --help` command
- `uv run pytest -q tests/test_setup_cleanup_scripts.py` (11 passed)
- `uv run pytest -q` (2938 passed, 29 skipped)
- `trunk check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated setup instructions to run the configuration merge through the project’s managed command environment.
  - Consolidated usage and help guidance for the merge scripts in the setup workflow.
  - Preserved existing behavior for JSON output, error handling, and legacy configuration.

- **Tests**
  - Added regression coverage to verify the documented setup command uses the correct execution method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->