### PR TITLE
test(win32): use a portable no-op verify command (#292)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,7 +64,9 @@ def write_script_launcher(directory: Path, name: str, body: str) -> Path:
     sidecar.write_text(body, encoding="utf-8")
     if sys.platform == "win32":
         launcher = directory / f"{name}.cmd"
-        launcher.write_text(f'@"{sys.executable}" "{sidecar}" %*\r\n', encoding="utf-8")
+        # `\n`, not `\r\n`: write_text translates it to the CRLF cmd wants, so an
+        # explicit `\r` would land on disk doubled (`\r\r\n`).
+        launcher.write_text(f'@"{sys.executable}" "{sidecar}" %*\n', encoding="utf-8")
     else:
         launcher = directory / name
         launcher.write_text(

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import pytest
 from conftest import (
+    _OK,
     _file_exists_cmd,
     _spec_baseline,
     committing_crash_state,
@@ -4739,9 +4740,6 @@ def test_fix_phase_session_env_fault_escalates(project):
     burning the remaining dev budget on repair sessions that never ran."""
     write_sprint(project, {"1-1-a": "ready-for-dev"})
     marker = project.project / "fixed.marker"
-    script = project.project / "check.sh"
-    script.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
-    script.chmod(0o755)
 
     def dev_with_marker(spec):
         marker.write_text("ok\n")
@@ -4757,7 +4755,10 @@ def test_fix_phase_session_env_fault_escalates(project):
     policy = Policy(
         gates=GatesPolicy(mode="none"),
         notify=QUIET,
-        verify=VerifyPolicy(commands=(_file_exists_cmd(marker), f'"{script}"')),
+        # `_OK`, not a script file (#292): verify commands run through the host shell,
+        # and cmd hands a `.sh` path to ShellExecute instead of running it. Only the
+        # marker command carries signal here — the escalation is the session's.
+        verify=VerifyPolicy(commands=(_file_exists_cmd(marker), _OK)),
         limits=LimitsPolicy(max_dev_attempts=3),  # budget left -> must not be spent
     )
     engine, adapter = make_engine(


### PR DESCRIPTION
Closes #292

> **Note:** the approach changed during review (see [the review comment](https://github.com/bmad-code-org/bmad-loop/pull/301#issuecomment-5081837870)); this description was updated by a maintainer to match what ships. The original diagnosis, the Windows reproduction, and the `write_script_launcher` fix are @dracic's.

## Problem

`test_fix_phase_session_env_fault_escalates` put a POSIX `check.sh` into a `VerifyPolicy` command tuple. Verify commands run through the host shell (`run_verify_commands` is `shell=True`, `verify.py:1379`), so on Windows `cmd` hands that path to ShellExecute — two failure modes, neither of which the test can see:

- **no `.sh` association** (stock Windows): the interactive "How do you want to open this file?" picker pops mid-run and steals focus.
- **`.sh` associated** (e.g. Git for Windows): the associated app launches and the command returns success without the script ever running — a silent false pass.

Either way the test passes, because the fault it asserts comes from an injected `SessionResult(env_fault=True)`, so CI stayed green and only local full-suite runs saw the dialog.

## Fix

Two commits, both test-only.

**1. `tests/test_engine.py`** — drop the script entirely and use conftest's `_OK` as the second verify command.

The script was inert: written once as `exit 0`, never mutated, referenced by no assertion. `run_verify_commands` does not short-circuit, so its whole contribution was rc 0, twice. It is copy-paste residue from the sibling `test_fix_phase_env_fault_escalates_instead_of_looping` (`tests/test_engine.py:5314`), which `chmod(0o644)`s it mid-run to produce rc=126 — there it is the point. Here the only verify signal is the marker command, and the escalation is the session's.

`tests/conftest.py:79-82` is the sanctioned spot for this — the block headed *"host-shell verify/lifecycle stub commands (single platform-detection spot)"*, whose comment reads *"These build them per-OS in one place instead of each test file re-deriving the win32 branch."* It exports `_OK = "exit 0"`, already imported by `tests/test_engine_worktree.py:14`.

```python
-    script = project.project / "check.sh"
-    script.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
-    script.chmod(0o755)
...
-        verify=VerifyPolicy(commands=(_file_exists_cmd(marker), f'"{script}"')),
+        verify=VerifyPolicy(commands=(_file_exists_cmd(marker), _OK)),
```

Net +5/−5, no `sys.platform` branch in the test. A win32 skip was also rejected: the subject (#194 — a fix session that lost its API connection escalates instead of burning dev budget) is not POSIX-specific, unlike the three sibling tests, which skip on win32 because they depend on `sh` rc 126/127.

**2. `tests/conftest.py`** — `write_script_launcher`'s win32 launcher wrote an explicit `\r\n`. `Path.write_text` uses `newline=None` and already translates to CRLF on Windows, so the explicit `\r` landed on disk as `\r\r\n` (reproduced). Harmless for a one-line launcher, and unrelated to #292 once the test stops hand-rolling a launcher — kept as an acknowledged drive-by because the defect is real and the fix is correct.

## Verification

- Windows 11 (original per-OS revision): `pytest tests/test_engine.py` → 194 passed, 3 skipped, no dialog; `pytest tests/test_engine_plugin.py tests/test_opencode_http.py` (the `write_script_launcher` callers) → 112 passed, 4 skipped
- Linux: `pytest tests/test_engine.py` → 198 passed; `-k env_fault` → 6 passed, 0 skipped (unchanged from baseline)
- Linux: full suite → 2960 passed, 1 skipped; `trunk check` clean
- CI: all 11 checks green, including both Windows jobs

Two ablations, since nothing in the suite catches this class on its own — the test's assertions never depended on the script:

- `env_fault=True` → `False` fails the test (the escalation path is still load-bearing)
- `_OK` → `exit 3` fails the test (the second command is genuinely executed, so `_OK` occupies the same slot the script did)

What `_OK` buys over a per-OS branch is that the failure mode becomes structurally impossible rather than handled: no script file exists for any shell to mis-handle.

## Scope

The three other inline `.sh` verify sites (`_self_disarming_script` and `test_fix_phase_env_fault_escalates_instead_of_looping`) are already `@pytest.mark.skipif(sys.platform == "win32")`, so this was the only unguarded one. `test_install.py`'s POSIX-script sites are likewise win32-skipped, and the git-hook sites run under git's own `sh`.

No CHANGELOG entry: test-only.

## Follow-up: #302

One finding from this review is deliberately out of scope and filed as its own issue: `ENV_FAULT_RCS = frozenset({126, 127})` never matches on Windows — `cmd` reports a missing or non-executable verify tool as 9009/1, so the charged-attempt behavior #126 exists to prevent still happens on win32, and the three skips above hide it. Reclassifying rc 1 carries a real false-positive risk (under `cmd` it is also the ordinary "tests failed" code), so it needs its own decision rather than riding a test-only fix.
