### PR TITLE
fix(cli): stop a prose mention of a noqa code from parsing as a directive

### DIFF
--- a/src/bmad_loop/cli.py
+++ b/src/bmad_loop/cli.py
@@ -75,7 +75,9 @@ from .process_host import ProcessHostError
 # used within this module (validate/mux/sweep/resume) and monkeypatched as
 # `cli.<name>` by the test suite — so the seams stay importable here. Each is
 # genuinely referenced below, so no noqa is needed (an unused-import pin would
-# itself trip RUF100); a future caller-less re-export would need `# noqa: F401`.
+# itself trip RUF100); a future caller-less re-export would need a `noqa: F401`
+# pin. Written without the leading hash on purpose: ruff scans comment TEXT for
+# directives, so spelling one out in prose is read as a real (and malformed) one.
 from .runsetup import ROLES
 from .runsetup import make_adapters as _make_adapters
 from .runsetup import mux_reason_label as _mux_reason_label


### PR DESCRIPTION
## What

`ruff check` emits this on every run that covers the package:

```
warning: Invalid `# noqa` directive on src/bmad_loop/cli.py:78:
expected code to consist of uppercase letters followed by digits only (e.g. `F401`)
```

Line 78 is prose, not a directive. The import-block comment explains that a future caller-less re-export "would need `` `# noqa: F401` ``". Ruff scans comment *text* for directives, finds the spelled-out `# noqa:`, and tries to parse what follows — the closing backtick makes the code list invalid.

## Why bother

It never fails anything: it is a warning, and `trunk check` is clean with it. But it is permanent, and ruff reports a **genuinely typo'd** directive through the same channel. A false warning standing forever is how the real one gets scrolled past.

## The fix

Drop the leading hash from the in-prose mention, so there is no directive to parse — and record why, so it is not helpfully restored later. The surrounding guidance is unchanged and still accurate.

Verified by probe: only the `` `# noqa: F401` `` form trips it; `` `noqa: F401` `` and plain-prose forms do not.

## Verification

- Before: `ruff@0.15.17 check src/bmad_loop/cli.py` → the warning above.
- After: same command over `src/bmad_loop/` → **zero** invalid-directive warnings.
- `trunk check --no-fix` clean; `tests/test_cli.py` 253 passed.

Comment-only — no behavior change.
