### PR TITLE
feat(opencode): live attached-UI viewer in the dashboard (show_attached_ui)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ breaking changes may land in a minor release.
 
 ### Added
 
+- **`adapter.show_attached_ui` viewer capability.** When
+  `policy.toml` sets `show_attached_ui = true` in `[adapter]`, the opencode-http
+  adapter creates a detached tmux viewer window alongside the headless `opencode
+  serve` process. The viewer runs `opencode attach <server-url> --dir <cwd>
+  --session <session-id>` so the operator can watch the live session in the
+  dashboard Log tab, attach from the TUI (`a` / `Ctrl-A`), or use `bmad-loop
+  attach`. Key behaviors:
+  - HTTP/SSE remains authoritative; the viewer is a read-only observation path.
+  - The dashboard Log tab renders the viewer pane through the same pyte-based
+    terminal-emulator rendering (no headless server log).
+  - `bmad-loop attach` and the TUI `a` action prefer the viewer window when one
+    exists.
+  - Teardown order: stop viewer → abort server session → kill `opencode serve`.
+  - Viewer creation is idempotent: retries, interrupted runs, and resume never
+    create duplicate windows.
+  - Missing `opencode` binary or unavailable multiplexer degrades to headless
+    operation (no crash) — and says why in `<run_dir>/viewer-error.log` plus a
+    `viewer-create-failed` journal event.
+  - The viewer runs inside a parked window: if `opencode attach` dies mid-run its
+    final screen and exit banner stay visible in the dashboard, and a viewer that
+    exits within the startup grace (~1s) is reported as failed (exit status and
+    captured output land in `viewer-error.log`), never persisted as a live target.
+  - `adapter.show_attached_ui` is editable from the settings screen.
+
 - **`review.on_timeout` policy knob (#271).** A timeout-like review verdict (`timeout` /
   `stalled` / `over_budget`) previously always burned a review cycle (RETRY) until
   `max_review_cycles`, then deferred — even when the dev product was already finalized and
@@ -89,6 +113,59 @@ breaking changes may land in a minor release.
   A project still on `bmad-auto` should migrate on 0.9.0 before upgrading past it.
 
 ### Fixed
+
+- **Viewer rows align at column 0.** `capture-pane` separates rows with bare
+  `\n`; pyte keeps the cursor column across a linefeed unless linefeed-newline
+  mode is set, so every rendered viewer row started where the previous one
+  ended — a staircase. `ViewerView` now feeds pyte with LNM set. The viewer's
+  tmux session is also pinned to the same 220×50 geometry as the agent panes
+  (it was tmux's default 80×24, cramping the attached TUI's layout).
+- **The viewer fills the pane that displays it.** The dashboard now tracks the
+  Log pane's content size and resizes the viewer window (new best-effort
+  `resize_window` seam method) plus the pyte render to match, so the attached
+  TUI redraws at the size actually shown instead of floating a fixed 220×50
+  (previously 80×24) frame inside the pane. The long-dead `ViewerView.resize`
+  hook now actually adopts the new geometry.
+- **The dashboard actually renders the viewer frame.** The Log pane's rewrite
+  gate only opened on `log_reset`/`log_lines` — both set exclusively by the
+  logfile-fallback path — so a captured viewer frame was attached to every poll
+  snapshot and then never written: with a healthy viewer the Log tab rendered
+  *nothing at all*. A viewer frame now opens the rewrite gate itself.
+- **The viewer authenticates against `opencode serve`.** The adapter secures the
+  headless server with a per-session `OPENCODE_SERVER_PASSWORD`, so the attach
+  viewer 401'd on its first session fetch and exited — on every run. The
+  password now reaches `opencode attach` through the tmux *session* environment
+  (new best-effort `set_session_environment` seam method), never through the
+  window's argv or the persisted `viewer_command`, where `ps`/`viewer.json`
+  would expose it.
+- **A stop during viewer creation stops the run.** The engine's SIGTERM handler
+  raises `RunStopped` in whatever frame is running; when that landed inside the
+  viewer startup poll, the best-effort catches swallowed it — reporting it as a
+  viewer failure and permanently breaking the stop path (the handler raises only
+  once), forcing the TUI's hard-kill fallback. Control-flow exceptions now
+  propagate through viewer creation after cleaning up the half-made window.
+- **Parked windows actually park on Debian/Ubuntu.** The parked-window recipe used
+  `read -r` with no variable name — a bashism; dash (`/bin/sh` on Debian-family
+  hosts) rejects it (`read: arg count`), so every parked window (TUI-launched
+  runs, the viewer) closed the moment its command exited instead of holding the
+  exit status. Now `read -r _park`, valid in every POSIX sh.
+- **`capture_pane` captures the requested pane.** The tmux backend never passed
+  `-t <target>`, so the dashboard's viewer capture read whatever pane happened to
+  be current instead of the viewer window — the root cause of the Log tab always
+  falling back to the headless server log.
+- **Viewer creation verification no longer crashes.** The post-create existence
+  check unpacked two fields from a one-field `list-windows` row, raising
+  `ValueError` on every host with a live window; the adapter's best-effort catch
+  swallowed it, persisting an empty `viewer.json` and orphaning the freshly
+  created window. Same latent unpack bug fixed in `window_exists`.
+- **The dashboard can find `viewer.json`.** `read_viewer_config` defaulted to
+  adapter name `opencode_http` while the adapter persists `opencode-http`; the
+  dashboard (which passes no name) now matches any entry that recorded a viewer
+  window instead of a name that can drift.
+- **Viewer reuse returns a real target.** `_find_existing_viewer` returned the
+  marker option's value (`"1"`) as the window target; it now returns the
+  seam-canonical `=session:window` token. Reuse also tolerates the run session
+  already existing instead of failing on `duplicate session`.
 
 - **`validate` requires the review skills your `bmad-dev-auto` actually invokes (#260).** The
   preflight held every project to a fixed catalog that included `bmad-review-verification-gap`,

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Press **`g`** to edit `.bmad-loop/policy.toml` in a form grouped by section — 
 | `p`       | review the selected paused run in the stage-appropriate viewer (plan/story checkpoint, gate, escalation) |
 | `R`       | resolve a run paused at an escalation (interactive, then re-arm)                                         |
 | `d`       | answer deferred-work decisions past sweeps left unanswered                                               |
-| `a`       | attach to the live agent session (or the orchestrator window)                                            |
+| `a`       | attach to the live agent session (or orchestrator window); prefers the viewer window when `show_attached_ui = true` |
 | `x`       | stop the selected live run immediately (engine + agent session)                                          |
 | `S`       | graceful stop: finish the in-flight item (through commit), then stop cleanly — stays resumable           |
 | `D` / `A` | delete / archive the selected run (force-stops a live run first)                                         |
@@ -357,6 +357,10 @@ trigger = "recommended"    # when enabled: "recommended" runs the separate revie
 name = "claude"            # CLI profile: claude | codex | gemini | copilot | antigravity | opencode-http (alias: opencode) | custom
 model = ""                 # empty = CLI default (opencode-http wants "provider/model")
 cleanup_session_on_finish = true  # kill the run's tmux session when it finishes (false keeps it for inspection)
+# show_attached_ui = true  # opencode-http: create a viewer tmux window running
+#             `opencode attach` so you can watch the live session.
+#             The dashboard Log tab renders the viewer pane; `attach` and `a`
+#             prefer it over the raw agent session. false by default.
 # extra_args replaces the profile's default bypass flags when set:
 # extra_args = ["--permission-mode", "bypassPermissions"]
 

--- a/src/bmad_loop/adapters/base.py
+++ b/src/bmad_loop/adapters/base.py
@@ -118,11 +118,37 @@ class SessionResult:
     env_fault_evidence: str | None = None
 
 
+@dataclass(frozen=True)
+class ViewerConfig:
+    """Metadata for a detached viewer window that runs the adapter's attached
+    TUI alongside the headless server.
+
+    Persists so the dashboard Log tab can render the viewer pane, ``bmad-loop
+    attach`` and the TUI ``a`` action can prefer it, and teardown stops it
+    first.  The mux backend stamps a unique window name so the multiplexer
+    can kill / re-attach it idempotently.
+
+    Fields are best-effort: ``viewer_window`` may be ``None`` when tmux is
+    unavailable, and ``viewer_url``/``viewer_session`` come from whatever the
+    viewer needs (for OpenCode they are the server URL and session id; other
+    viewers may ignore them or use a different convention).
+    """
+
+    viewer_window: str | None = None
+    viewer_url: str = ""
+    viewer_session: str = ""
+    viewer_cwd: str = ""
+    viewer_command: str = ""
+
+
 class CodingCLIAdapter(ABC):
     name: str = "abstract"
     injection: str = ""
     observation: str = ""
     state: str = ""
+    # Optional viewer metadata, set by adapters that support `show_attached_ui`.
+    # The engine reads this to persist metadata for attach/Log-tab/teardown.
+    viewer_config: ViewerConfig = ViewerConfig()
 
     @abstractmethod
     def start_session(self, spec: SessionSpec) -> SessionHandle: ...
@@ -143,6 +169,23 @@ class CodingCLIAdapter(ABC):
     def interactive_env(self, spec: SessionSpec) -> dict[str, str]:
         """Env vars to layer onto the caller's environment for interactive_argv."""
         return dict(spec.env)
+
+    # ---------------------------------------------------------------- viewer
+
+    def ensure_viewer_window(
+        self, spec: SessionSpec, session_id: str, base_url: str
+    ) -> ViewerConfig:
+        """Create (or reuse) a detached tmux viewer window for this session.
+
+        Subclasses override to wire the correct ``opencode attach``-style
+        command.  Base behaviour: no-window (head-only).  Idempotent — a
+        second call with the same task id returns the existing config.
+        """
+        return ViewerConfig()
+
+    def close_viewer_window(self, config: ViewerConfig) -> None:
+        """Teardown the viewer window; a no-op when window is None."""
+        pass
 
     def kill(self, handle: SessionHandle) -> None:  # optional cleanup
         pass

--- a/src/bmad_loop/adapters/multiplexer.py
+++ b/src/bmad_loop/adapters/multiplexer.py
@@ -45,6 +45,14 @@ class MultiplexerError(Exception):
     without importing a backend."""
 
 
+# The banner a parked window prints when its command exits (followed by the
+# exit status — see :meth:`TerminalMultiplexer.new_parked_window`). Part of the
+# parked-window contract: observers (e.g. the viewer launcher) detect a died
+# command by finding this prefix in a pane capture, so every backend's parked
+# recipe must emit it verbatim.
+PARKED_EXIT_BANNER = "[bmad-loop exited"
+
+
 def parse_target(target: str) -> tuple[str, str | None] | None:
     """Decode a seam-canonical window target (see :meth:`TerminalMultiplexer.target`).
 
@@ -120,6 +128,15 @@ class TerminalMultiplexer(ABC):
     def set_session_option(self, name: str, option: str, value: str) -> None:
         """Set a user option on the named session."""
 
+    def set_session_environment(self, name: str, var: str, value: str) -> None:
+        """Add ``var=value`` to the named session's environment, inherited by
+        every process the session spawns *afterwards* (tmux ``set-environment``).
+        Used to hand a viewer window credentials (e.g. a server password)
+        without putting them in the window's argv, where ``ps`` would show
+        them. Not abstract — best-effort: the default no-op means a backend
+        without the capability degrades to an unauthenticated viewer, never a
+        crash."""
+
     # ------------------------------------------------------------ windows
 
     @abstractmethod
@@ -168,6 +185,14 @@ class TerminalMultiplexer(ABC):
         know", not "dead", and must not tear down a possibly-working session on
         it."""
 
+    def window_exists(self, session: str, window_name: str) -> bool:
+        """True iff ``window_name`` is an active window of ``session``.
+
+        Best-effort: returns ``False`` when the multiplexer is unavailable.
+        Used by viewer creation to verify a newly-created window actually
+        appeared (the ``new-window`` return value is not enough)."""
+        return False
+
     @abstractmethod
     def kill_window(self, target: str) -> None:
         """Kill the targeted window (tolerant of it already being gone, and a
@@ -180,11 +205,42 @@ class TerminalMultiplexer(ABC):
         on a transport failure). ``target`` is a :meth:`target` token or a
         backend-native window id."""
 
+    def resize_window(self, target: str, cols: int, lines: int) -> None:
+        """Resize the targeted window to ``cols`` x ``lines`` (tmux
+        ``resize-window``). Used by the dashboard to keep a detached viewer
+        window matched to the pane that displays its capture, so the attached
+        TUI redraws at the size actually shown. Not abstract — best-effort:
+        the default no-op leaves the window at its creation geometry."""
+
+    def set_viewer_option(self, window_id: str, value: str) -> None:
+        """Stash a unique marker on the viewer window so later lookups
+        (reuse, teardown, resume) find it even when auto-rename is active.
+
+        ``window_id`` is the backend-native id returned by
+        :meth:`TerminalMultiplexer.new_window`.  Best-effort: no-op when the
+        multiplexer is unavailable."""
+
     @abstractmethod
     def set_window_option(self, target: str, option: str, value: str) -> None:
         """Set a user option on the targeted window (best-effort: a no-op on a
         transport failure). ``target`` is a :meth:`target` token or a
         backend-native window id."""
+
+    def capture_pane(self, target: str, start_line: int = -100, end_line: int | None = None) -> str:
+        """Capture the contents of a pane as a text string.
+
+        Equivalent to ``tmux capture-pane -p -e -J -S <start> -E <end> -t <target>``.
+
+        Args:
+            target: pane/window session target (e.g. ``=bmad-loop-abc:viewer``).
+            start_line: first line to capture (negative = lines above the
+                visible pane; ``-100`` ≈ 100 lines of history).
+            end_line: last line to capture (``None`` = current line).
+
+        Returns the captured text (including escape sequences) or empty
+        string when the pane is missing or the backend is unavailable.
+        Callers parse the text through pyte to produce a styled render."""
+        raise NotImplementedError
 
     @abstractmethod
     def unset_window_option(self, target: str, option: str) -> None:

--- a/src/bmad_loop/adapters/opencode_http.py
+++ b/src/bmad_loop/adapters/opencode_http.py
@@ -94,7 +94,7 @@ from ..journal import LOGS_DIR
 from ..model import TokenUsage
 from ..policy import Policy
 from ..process_host import ProcessHostError, get_process_host
-from .base import CodingCLIAdapter, SessionHandle, SessionResult, SessionSpec
+from .base import CodingCLIAdapter, SessionHandle, SessionResult, SessionSpec, ViewerConfig
 from .generic import (
     BUDGET_NUDGE_TEXT,
     HEARTBEAT_INTERVAL_S,
@@ -104,6 +104,9 @@ from .generic import (
     _ResultFileMixin,
 )
 from .profile import CLIProfile
+from .viewer_launch import _is_control_flow as _viewer_control_flow
+from .viewer_launch import close_viewer_window as _close_viewer
+from .viewer_launch import ensure_viewer_window as _ensure_viewer
 
 if TYPE_CHECKING:
     from ..process_host import ProcessHost
@@ -266,6 +269,12 @@ class OpencodeHttpAdapter(_ResultFileMixin, CodingCLIAdapter):
         self.logs_dir.mkdir(parents=True, exist_ok=True)
         self._sessions: dict[str, _ServerSession] = {}
         self._usage: dict[str, TokenUsage] = {}
+        # Viewer window config — set in start_session if show_attached_ui;
+        # the teardown path always reads it via getattr (safe even when the
+        # session crashed before start_session returned).  Persisted to
+        # viewer.json so the dashboard Log tab, attach routing, and resume
+        # can find it even when re-reading a stopped run.
+        self._viewer_config: ViewerConfig = ViewerConfig()
         # opencode serve survives parent death: sweep whatever is
         # still registered when the interpreter exits cooperatively. A hard
         # SIGKILL of the engine still leaks — documented residual risk.
@@ -432,6 +441,14 @@ class OpencodeHttpAdapter(_ResultFileMixin, CodingCLIAdapter):
             self._sessions.pop(spec.task_id, None)
             self._teardown(sess)
             raise
+
+        # Viewer window: created after the session is live so the attach URL and
+        # session id are available.  Best-effort — failures degrade to headless.
+        if self.policy.adapter.show_attached_ui:
+            self._viewer_config = self._make_viewer_config(spec.task_id, sess, spec.cwd)
+        else:
+            self._viewer_config = ViewerConfig()
+
         return SessionHandle(
             task_id=spec.task_id, native_id=sess.session_id, launched_ns=launched_ns
         )
@@ -969,11 +986,131 @@ class OpencodeHttpAdapter(_ResultFileMixin, CodingCLIAdapter):
     # -------------------------------------------------------------- teardown
 
     def kill(self, handle: SessionHandle) -> None:
+        # Teardown order: viewer window → server/session → process.
+        # Idempotent — all operations tolerate being called on gone targets.
+        self._close_viewer()
         sess = self._sessions.pop(handle.task_id, None)
         if sess is None:
             return
         self._abort(sess)
         self._teardown(sess)
+
+    def _make_viewer_config(self, task_id: str, sess: "_ServerSession", cwd: Path) -> ViewerConfig:
+        """Create a viewer window after the server + session are live.
+        Best-effort — a missing opencode binary or mux failure degrades to
+        a no-op ViewerConfig (headless-only).  Persists config to disk."""
+        run_id = self.run_dir.name
+        try:
+            vc = _ensure_viewer(
+                run_id=run_id,
+                server_url=sess.base_url,
+                session_id=sess.session_id,
+                working_directory=cwd,
+                attach_binary=shutil.which("opencode") or "opencode",
+                run_dir=self.run_dir,
+                # The serve process 401s everything without its per-session
+                # password; `opencode attach` reads this var for basic auth.
+                attach_env={"OPENCODE_SERVER_PASSWORD": sess.password},
+            )
+        except Exception as exc:  # nosec B110 - best effort
+            if _viewer_control_flow(exc):
+                raise  # the engine's stop/pause landed here — never swallow it
+            vc = ViewerConfig()
+        self.viewer_config = vc
+        # Persist so the dashboard/attach/resume can read back even from
+        # a dead run dir.
+        self._persist_viewer_config(vc)
+        return vc
+
+    def _persist_viewer_config(self, vc: ViewerConfig) -> None:
+        """Write viewer metadata to <run_dir>/viewer.json (append-only
+        keyed by adapter name, so a resumed run overwrites the previous entry)."""
+        try:
+            path = self.run_dir / "viewer.json"
+            if path.is_file():
+                try:
+                    entries = json.loads(path.read_text(encoding="utf-8"))
+                except (json.JSONDecodeError, OSError):
+                    entries = []
+            else:
+                entries = []
+            entries = [e for e in entries if e.get("adapter") != self.name] + [
+                {
+                    "adapter": self.name,
+                    "task_id": getattr(self, "_current_task_id", ""),
+                    "viewer_window": vc.viewer_window or "",
+                    "viewer_url": vc.viewer_url or "",
+                    "viewer_session": vc.viewer_session or "",
+                    "viewer_cwd": vc.viewer_cwd or "",
+                    "viewer_command": vc.viewer_command or "",
+                }
+            ]
+            tmp = path.with_suffix(".json.tmp")
+            tmp.write_text(json.dumps(entries, ensure_ascii=False) + "\n", encoding="utf-8")
+            tmp.replace(path)
+        except Exception:  # nosec B110 - best attempt, never raise
+            pass
+
+    @classmethod
+    def load_viewer_config(cls, run_dir: Path, adapter_name: str) -> ViewerConfig | None:
+        """Read the most recent viewer config written by *adapter_name*.
+        Returns ``None`` when there is no recorded config or the file is unreadable."""
+        try:
+            path = run_dir / "viewer.json"
+            if not path.is_file():
+                return None
+            entries = json.loads(path.read_text(encoding="utf-8"))
+            if not isinstance(entries, list):
+                return None
+            for e in entries:
+                if e.get("adapter") == adapter_name:
+                    return ViewerConfig(
+                        viewer_window=e.get("viewer_window") or None,
+                        viewer_url=e.get("viewer_url") or "",
+                        viewer_session=e.get("viewer_session") or "",
+                        viewer_cwd=e.get("viewer_cwd") or "",
+                        viewer_command=e.get("viewer_command") or "",
+                    )
+            return None
+        except Exception:  # nosec B110 - best effort read
+            return None
+
+    def _close_viewer(self) -> None:
+        """Teardown the viewer window. Idempotent: close_viewer_window
+        tolerates a missing target."""
+        wc = getattr(self, "_viewer_config", ViewerConfig())
+        _close_viewer(wc.viewer_window)
+
+    def close_viewer_window(self, target: str | None = None) -> None:
+        """Adapter-seam close — delegates to the internal path."""
+        self._close_viewer()
+
+    def ensure_viewer_window(
+        self, spec: SessionSpec, session_id: str, base_url: str
+    ) -> ViewerConfig:
+        """Adapter-seam ensure — delegates to the internal path."""
+        run_id = self.run_dir.name
+        # The viewer must authenticate against the per-session serve password;
+        # find the live session this id belongs to (absent for a foreign id —
+        # the viewer then runs unauthenticated and shows the server's 401).
+        password = next(
+            (s.password for s in self._sessions.values() if s.session_id == session_id),
+            None,
+        )
+        try:
+            return _ensure_viewer(
+                run_id=run_id,
+                server_url=base_url,
+                session_id=session_id,
+                working_directory=spec.cwd,
+                attach_binary=shutil.which("opencode") or "opencode",
+                run_dir=self.run_dir,
+                attach_env=({"OPENCODE_SERVER_PASSWORD": password} if password else None),
+            )
+        except Exception as exc:  # nosec B110 - best effort
+            if _viewer_control_flow(exc):
+                raise  # the engine's stop/pause landed here — never swallow it
+            return ViewerConfig()
 
     def _teardown(self, sess: _ServerSession) -> None:
         sess.sse_stop.set()

--- a/src/bmad_loop/adapters/tmux_base.py
+++ b/src/bmad_loop/adapters/tmux_base.py
@@ -31,7 +31,7 @@ import sys
 import time
 from pathlib import Path
 
-from .multiplexer import MultiplexerError, TerminalMultiplexer
+from .multiplexer import PARKED_EXIT_BANNER, MultiplexerError, TerminalMultiplexer
 
 TMUX_TIMEOUT_S = 30
 # Per-window option value (vs a pane target) telling the parked trailer to detach
@@ -136,6 +136,14 @@ class BaseTmuxBackend(TerminalMultiplexer):
         # session name so plain-name targeting resolves it unambiguously.
         self._tmux("set-option", "-t", name, option, value)
 
+    def set_session_environment(self, name: str, var: str, value: str) -> None:
+        # Best-effort (see the seam contract): a failure degrades the viewer
+        # to unauthenticated, it must never break session creation.
+        try:
+            self._tmux("set-environment", "-t", f"={name}", var, value)
+        except TmuxError:
+            pass
+
     def kill_session(self, name: str) -> None:
         # Tolerant of the binary being absent / the session already gone: a
         # best-effort teardown backstop, never a hard failure.
@@ -195,7 +203,10 @@ class BaseTmuxBackend(TerminalMultiplexer):
     #: _EXIT_CAPTURE override MUST bind the variable ``ec``.
     _EXIT_CAPTURE = "ec=$?"
     _ECHO = "echo"
-    _PARK = "read -r"
+    # `read -r` NEEDS the variable name: bash defaults to REPLY without one,
+    # but POSIX requires it and dash (Debian/Ubuntu /bin/sh) errors out —
+    # which un-parks the window the instant the command exits.
+    _PARK = "read -r _park"
 
     def _join_argv(self, argv: list[str]) -> str:
         """Render ``argv`` as one shell command line in this dialect."""
@@ -275,7 +286,7 @@ class BaseTmuxBackend(TerminalMultiplexer):
         # client to where it came from.
         source = self._source_prefix() + (
             f"{self._join_argv(argv)}; {self._EXIT_CAPTURE}; "
-            f'{self._ECHO} "[bmad-loop exited $ec — press enter]"; '
+            f'{self._ECHO} "{PARKED_EXIT_BANNER} $ec — press enter]"; '
             f"{self._PARK}; {self._parked_trailer(return_opt)}"
         )
         return self._tmux(
@@ -351,6 +362,14 @@ class BaseTmuxBackend(TerminalMultiplexer):
         except (subprocess.SubprocessError, OSError, ValueError):
             return []
 
+    def window_exists(self, session: str, window_name: str) -> bool:
+        """Verify a window with the given name is live in ``session``."""
+        try:
+            rows = self.list_windows(session, ["window_name"])
+        except MultiplexerError:
+            return False
+        return any(row and row[0] == window_name for row in rows)
+
     def list_windows(self, session: str, fields: list[str]) -> list[tuple[str, ...]]:
         fmt = "\t".join(f"#{{{field}}}" for field in fields)
         try:
@@ -376,6 +395,23 @@ class BaseTmuxBackend(TerminalMultiplexer):
         except (subprocess.SubprocessError, OSError):
             pass
 
+    def resize_window(self, target: str, cols: int, lines: int) -> None:
+        # Best-effort (see the seam contract): a failure leaves the window at
+        # its creation geometry, which still renders — just letterboxed.
+        try:
+            self._run(
+                ["resize-window", "-t", target, "-x", str(cols), "-y", str(lines)],
+                check=False,
+            )
+        except (subprocess.SubprocessError, OSError):
+            pass
+
+    def set_viewer_option(self, window_id: str, value: str) -> None:
+        try:
+            self.set_window_option(window_id, value, "1")
+        except TmuxError:
+            pass
+
     def set_window_option(self, target: str, option: str, value: str) -> None:
         try:
             self._run(["set-option", "-w", "-t", target, option, value], check=False)
@@ -395,6 +431,32 @@ class BaseTmuxBackend(TerminalMultiplexer):
         except (subprocess.SubprocessError, OSError):
             return ""
         return proc.stdout.strip() if proc.returncode == 0 else ""
+
+    def capture_pane(self, target: str, start_line: int = -100, end_line: int | None = None) -> str:
+        """Return the pane contents as a text string via ``tmux capture-pane``.
+
+        Captures with -e (encoding/ANSI), -J (jump wrapping), and -S/-E
+        for the requested line range. Empty string when the pane is gone
+        or the binary is missing."""
+        try:
+            args = [
+                "capture-pane",
+                "-p",  # print to stdout
+                "-e",  # encoding (preserve ANSI)
+                "-J",  # jump wrapping (don't truncate long lines)
+                "-S",
+                str(start_line),
+                "-t",
+                target,
+            ]
+            if end_line is not None:
+                args += ["-E", str(end_line)]
+            proc = self._run(args, check=False)
+            if proc.returncode != 0:
+                return ""
+            return proc.stdout
+        except (subprocess.SubprocessError, OSError):
+            return ""
 
     # ----------------------------------------------------- client / attach
 

--- a/src/bmad_loop/adapters/viewer_launch.py
+++ b/src/bmad_loop/adapters/viewer_launch.py
@@ -1,0 +1,356 @@
+"""Generic multiplexer-based viewer window launch.
+
+Create, reuse, and teardown detached tmux windows that run an attached
+viewer (e.g. ``opencode attach``).  The caller (an adapter) provides the
+argv to launch the viewer; the mux backend creates a new or reuses an
+existing window inside the run's tmux session.
+
+Idempotency: a viewer already exists for the given session name + window
+name (``<session_name>-viewer``, ``bmad-loop-<run_id>-viewer``), the
+existing window is returned — no duplicate windows across retries,
+review sessions, interrupted runs, or resume.
+
+Teardown priority: stop/kill viewer window first, then close the
+underlying server/session.
+"""
+
+from __future__ import annotations
+
+import re
+import shlex
+import shutil
+import time
+from pathlib import Path
+
+from .base import ViewerConfig
+from .multiplexer import PARKED_EXIT_BANNER, MultiplexerError, get_multiplexer, mux_usable
+
+# ------------------------------------------------------------------ config
+# The tmux user option stamped on the viewer window so we can find it
+# again (retries, resume, attach routing).  Never empty — the parser
+# rejects it, so callers use this sentinel to distinguish "unset" from
+# an actual option value.
+_VIEWER_OPTION = "@bmad_viewer"
+
+# Per-window option the parked-window trailer consults for a return client
+# target. Never set for a viewer (nobody attach-routes *from* it), so the
+# window simply parks after the viewer exits — keeping its final screen and
+# exit banner capturable instead of the window closing.
+_VIEWER_RETURN_OPTION = "@bmad_viewer_return"
+
+# Pulls the exit status out of the parked banner ("[bmad-loop exited 7 — ...").
+_EXIT_BANNER_RE = re.compile(re.escape(PARKED_EXIT_BANNER) + r"\s+(\d+)")
+
+# Immediate-exit detection: after new-window, the pane is re-checked this
+# many times at this interval. A viewer that dies inside the grace window
+# (bad URL, refused attach, missing session) is reported as failed instead
+# of being handed to the dashboard as a live target.
+_STARTUP_CHECKS = 4
+_STARTUP_CHECK_INTERVAL_S = 0.25
+
+# ---------------------------------------------------------------------- core
+
+
+def _viewer_window_name(run_id: str) -> str:
+    """Seam-canonical name for the viewer window inside the control session."""
+    return f"bmad-loop-{run_id}-viewer"
+
+
+def _find_existing_viewer(run_id: str, session_name: str) -> ViewerConfig | None:
+    """Check whether a viewer window already exists for this run.
+
+    Reads the marker option as a best-effort existence probe: if the
+    window is present and carries the value stamped at creation time,
+    we assume it is live and reuse it.
+    """
+    mux = get_multiplexer()
+    if not mux_usable(mux):
+        return None
+    viewer_name = _viewer_window_name(run_id)
+    # A window's user option is the authoritative existence proof;
+    # a bare window name match is fragile under auto-rename.
+    try:
+        rows = mux.list_windows(session_name, ["window_name", _VIEWER_OPTION])
+    except MultiplexerError:
+        return None
+    for row in rows:
+        if row and row[0] == viewer_name and len(row) > 1 and row[1]:
+            # Window carries our marker — it may be parked or still
+            # streaming; treat as live. The persisted target is the
+            # by-name token, never the marker value.
+            return ViewerConfig(viewer_window=mux.target(session_name, viewer_name))
+    return None
+
+
+def ensure_viewer_window(
+    run_id: str,
+    server_url: str,
+    session_id: str,
+    working_directory: Path,
+    attach_binary: str,
+    run_dir: Path | None = None,
+    attach_env: dict[str, str] | None = None,
+) -> ViewerConfig:
+    """Create (or reuse) a detached viewer window.
+
+    ``server_url`` — the headless HTTPS or HTTP URL the viewer should
+    ``attach`` to (e.g. ``http://127.0.0.1:port``).
+
+    ``session_id`` — the session the viewer will connect to (e.g. an
+    OpenCode session id).
+
+    ``working_directory`` — ``--dir`` for the attached TUI.
+
+    ``attach_binary`` — the binary that runs the attached CLI
+    (e.g. ``opencode``; argv will be ``{binary} attach <url> --dir <cwd>``).
+
+    ``run_dir`` — where ``viewer-error.log`` and the ``viewer-create-failed``
+    journal entry land on failure; falls back to ``working_directory``.
+
+    ``attach_env`` — credentials/config the attached TUI needs (e.g.
+    ``OPENCODE_SERVER_PASSWORD``), delivered via the tmux *session*
+    environment so they never appear in the window's argv (``ps``-visible)
+    or in the persisted ``viewer_command``.
+
+    Returns a ``ViewerConfig`` with the mux-native window target so
+    ``kill_session`` can tear it down.  Returns a ``ViewerConfig()``
+    (all empty) when tmux is unavailable, the viewer binary is not on
+    PATH, or the viewer window could not be verified live — the caller
+    degrades to headless.  Never persists a live-looking config for a
+    window that does not exist.
+    """
+    mux = get_multiplexer()
+    report_dir = run_dir or working_directory
+
+    session_name = f"bmad-loop-{run_id}"
+    viewer_name = _viewer_window_name(run_id)
+    viewer_argv = _viewer_argv(attach_binary, server_url, working_directory, session_id)
+    viewer_cmd = " ".join(shlex.quote(a) for a in viewer_argv)
+    viewer_target = mux.target(session_name, viewer_name)
+
+    if not mux_usable(mux):
+        _report_viewer_failure(
+            report_dir, viewer_cmd, viewer_target, "terminal multiplexer unavailable"
+        )
+        return ViewerConfig()
+
+    def _success() -> ViewerConfig:
+        return ViewerConfig(
+            viewer_window=viewer_target,
+            viewer_url=server_url,
+            viewer_session=session_id,
+            viewer_cwd=str(working_directory),
+            viewer_command=viewer_cmd,
+        )
+
+    # Idempotency: check for existing viewer window BEFORE trying to create.
+    if _find_existing_viewer(run_id, session_name) is not None:
+        return _success()
+
+    # Check that the attach binary is available before creating the window.
+    if not _binary_exists(attach_binary):
+        _report_viewer_failure(
+            report_dir,
+            viewer_cmd,
+            viewer_target,
+            f"attach binary not found on PATH: {attach_binary!r}",
+        )
+        return ViewerConfig()
+
+    try:
+        if not mux.has_session(session_name):
+            # Pin the same geometry the agent panes use: the session is only
+            # ever observed detached (capture-pane -> pyte at this size), and
+            # tmux's default 80x24 would cramp the attached TUI's layout.
+            from .generic import PANE_COLUMNS, PANE_LINES
+
+            mux.new_session(session_name, working_directory, PANE_COLUMNS, PANE_LINES)
+        for var, value in (attach_env or {}).items():
+            mux.set_session_environment(session_name, var, value)
+        # Parked window: runs the viewer, and if (when) the viewer exits the
+        # pane prints the exit banner and parks instead of the window closing
+        # — so an immediately-dying viewer stays inspectable, race-free, and
+        # a mid-run crash leaves its final screen visible in the dashboard.
+        mux.new_parked_window(
+            session_name,
+            viewer_name,
+            working_directory,
+            viewer_argv,
+            _VIEWER_RETURN_OPTION,
+        )
+    except MultiplexerError as exc:
+        _report_viewer_failure(report_dir, viewer_cmd, viewer_target, str(exc))
+        return ViewerConfig()
+
+    # Anything that goes wrong past this point must not leak an orphaned
+    # window that no ViewerConfig records — kill it and report instead.
+    try:
+        # Stamp a marker so _find_existing_viewer can locate us across retries.
+        mux.set_viewer_option(viewer_target, _VIEWER_OPTION)
+
+        # Verify the window is actually visible and the viewer stays up —
+        # a new-window return value is not enough (a racing kill can lose
+        # the window, and a viewer that can't attach exits within moments,
+        # which the parked recipe surfaces as the exit banner).
+        for check in range(_STARTUP_CHECKS):
+            if not _mux_window_exists(mux, session_name, viewer_name):
+                _report_viewer_failure(
+                    report_dir,
+                    viewer_cmd,
+                    viewer_target,
+                    "window not found after new-window",
+                )
+                return ViewerConfig()
+            try:
+                output = mux.capture_pane(viewer_target)
+            except (MultiplexerError, NotImplementedError, OSError):
+                output = ""  # a capture-less backend still gets a viewer
+            if PARKED_EXIT_BANNER in output:
+                match = _EXIT_BANNER_RE.search(output)
+                status = match.group(1) if match else "unknown"
+                _report_viewer_failure(
+                    report_dir,
+                    viewer_cmd,
+                    viewer_target,
+                    f"viewer exited immediately (exit status {status})",
+                    output=output,
+                )
+                try:
+                    mux.kill_window(viewer_target)
+                except Exception:
+                    pass
+                return ViewerConfig()
+            if check < _STARTUP_CHECKS - 1:
+                time.sleep(_STARTUP_CHECK_INTERVAL_S)
+    except BaseException as exc:  # never hand back (or orphan) an unverified window
+        try:
+            mux.kill_window(viewer_target)
+        except Exception:
+            pass
+        if not isinstance(exc, Exception) or _is_control_flow(exc):
+            # KeyboardInterrupt/SystemExit or the engine's RunStopped/RunPaused
+            # landing mid-poll (the SIGTERM handler raises in whatever frame is
+            # running): clean up and LET IT PROPAGATE — swallowing it here
+            # permanently breaks the engine's stop path (the handler only
+            # raises once).
+            raise
+        _report_viewer_failure(
+            report_dir,
+            viewer_cmd,
+            viewer_target,
+            f"viewer verification failed: {type(exc).__name__}: {exc}",
+        )
+        return ViewerConfig()
+
+    return _success()
+
+
+def _is_control_flow(exc: Exception) -> bool:
+    """Whether ``exc`` is one of the engine's loop-unwinding exceptions.
+
+    Imported lazily: the engine imports the adapters package at module load,
+    so a top-level import here would be a cycle."""
+    try:
+        from ..engine import RunPaused, RunStopped
+    except Exception:  # circular-import corner or stripped install: assume not
+        return False
+    return isinstance(exc, (RunPaused, RunStopped))
+
+
+def _mux_window_exists(mux, session_name: str, window_name: str) -> bool:
+    """Return True if ``window_name`` is live in ``session_name``."""
+    try:
+        rows = mux.list_windows(session_name, ["window_name"])
+    except MultiplexerError:
+        return False
+    return any(row and row[0] == window_name for row in rows)
+
+
+def close_viewer_window(target: str | None) -> None:
+    """Kill the viewer window by its mux-specific target token.
+
+    Idempotent: ``kill_window`` already tolerates the window being gone.
+    """
+    if not target:
+        return
+    mux = get_multiplexer()
+    try:
+        mux.kill_window(target)
+    except MultiplexerError:
+        pass
+
+
+def viewer_window_exists(run_id: str, session_name: str) -> bool:
+    """Whether a viewer window is currently attached to the run's session."""
+    mux = get_multiplexer()
+    if not mux_usable(mux):
+        return False
+    viewer_name = _viewer_window_name(run_id)
+    try:
+        rows = mux.list_windows(session_name, ["window_name"])
+    except MultiplexerError:
+        return False
+    return any(row and row[0] == viewer_name for row in rows)
+
+
+# ------------------------------------------------------------------ helpers
+
+
+def _viewer_argv(
+    binary: str,
+    server_url: str,
+    cwd: Path,
+    session_id: str,
+) -> list[str]:
+    """Build the ``opencode attach``-style argv for a viewer window."""
+    return [
+        binary,
+        "attach",
+        server_url,
+        "--dir",
+        str(cwd),
+        "--session",
+        session_id,
+    ]
+
+
+def _binary_exists(name: str) -> bool:
+    """Best-effort check whether ``name`` is on PATH."""
+    return shutil.which(name) is not None
+
+
+def _report_viewer_failure(
+    report_dir: Path, command: str, target: str, reason: str, output: str = ""
+) -> None:
+    """Append to ``viewer-error.log`` in ``report_dir`` and journal a
+    ``viewer-create-failed`` event (best-effort either way).
+
+    The journal entry is only written when ``report_dir`` already carries a
+    ``journal.jsonl`` (i.e. it is a run dir) — reporting into a plain
+    working directory must not seed a stray journal there."""
+    try:
+        log_path = report_dir / "viewer-error.log"
+        with log_path.open("a", encoding="utf-8") as fh:
+            fh.write(f"viewer-create-failed: {reason}\n")
+            fh.write(f"command: {command}\n")
+            fh.write(f"target: {target}\n")
+            fh.write(f"timestamp: {time.time()}\n")
+            if output:
+                fh.write("output:\n")
+                fh.write(output.rstrip("\n") + "\n")
+            fh.write("---\n")
+    except OSError:
+        pass
+
+    try:
+        from ..journal import JOURNAL_FILE, Journal
+
+        if (report_dir / JOURNAL_FILE).is_file():
+            Journal(report_dir).append(
+                "viewer-create-failed",
+                reason=reason,
+                command=command,
+                target=target,
+            )
+    except Exception:  # journaling must never crash the viewer path
+        pass

--- a/src/bmad_loop/data/settings/core.toml
+++ b/src/bmad_loop/data/settings/core.toml
@@ -211,6 +211,12 @@ key = "cleanup_session_on_finish"
 kind = "switch"
 default_ref = "AdapterPolicy.cleanup_session_on_finish"
 [[section.field]]
+key = "show_attached_ui"
+kind = "switch"
+default_ref = "AdapterPolicy.show_attached_ui"
+label = "show attached UI"
+description = "run the adapter's attached TUI (e.g. opencode attach) in a detached tmux viewer window so the dashboard Log tab and attach can show the live screen"
+[[section.field]]
 key = "usage_grace_s"
 kind = "float"
 minimum = 0

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -2281,7 +2281,15 @@ class Engine:
         result: SessionResult | None = None
         ended = False
         try:
+            # Set _current_task_id so the adapter's viewer-persist writes the
+            # correct task_id (see _persist_viewer_config).
+            getattr(adapter, "_set_current_task_id", lambda tid: None)(task_id)
             result = adapter.run(spec)
+            # Persist viewer config after run() returns (the adapter writes it
+            # during start_session; this ensures the engine can surface it).
+            wc = getattr(adapter, "viewer_config", None)
+            if wc and wc.viewer_window:
+                self.journal.append("viewer-created", viewer_window=wc.viewer_window, role=role)
             # A post-kill rescue (#61) is otherwise indistinguishable from a normal
             # completion in the journal; leave a breadcrumb for forensics.
             if result.result_json is not None and result.result_json.get("post_kill_reconciled"):

--- a/src/bmad_loop/policy.py
+++ b/src/bmad_loop/policy.py
@@ -324,6 +324,10 @@ class AdapterPolicy:
     # ResolvedAdapter); a value overrides the profile's shipped default.
     usage_grace_s: float | None = None
     stop_without_result_nudges: int | None = None
+    # When True, a detached tmux viewer window is created for this adapter
+    # so the operator can attach and see the live session alongside the
+    # headless SSE server. Defaults to False for backward compatibility.
+    show_attached_ui: bool = False
     dev: StageAdapterPolicy = field(default_factory=StageAdapterPolicy)
     review: StageAdapterPolicy = field(default_factory=StageAdapterPolicy)
     triage: StageAdapterPolicy = field(default_factory=StageAdapterPolicy)
@@ -424,6 +428,9 @@ def adapter_policy_from_snapshot(snapshot: dict[str, Any] | None) -> AdapterPoli
             ),
             usage_grace_s=adapter_d.get("usage_grace_s"),
             stop_without_result_nudges=adapter_d.get("stop_without_result_nudges"),
+            show_attached_ui=bool(
+                adapter_d.get("show_attached_ui", AdapterPolicy.show_attached_ui)
+            ),
             dev=_stage_from_snapshot(adapter_d.get("dev")),
             review=_stage_from_snapshot(adapter_d.get("review")),
             triage=_stage_from_snapshot(adapter_d.get("triage")),
@@ -821,6 +828,7 @@ def loads(text: str, plugin_schemas: dict[str, Any] | None = None) -> Policy:
         ),
         usage_grace_s=_opt_grace(adapter_d, "adapter"),
         stop_without_result_nudges=_opt_nudges(adapter_d, "adapter"),
+        show_attached_ui=bool(adapter_d.get("show_attached_ui", AdapterPolicy.show_attached_ui)),
         dev=_stage_adapter(adapter_d, "dev"),
         review=_stage_adapter(adapter_d, "review"),
         triage=_stage_adapter(adapter_d, "triage"),
@@ -1064,6 +1072,10 @@ spec_folder = ""
 name = "claude"              # claude | codex | gemini | copilot | antigravity | opencode-http (alias: opencode) | <custom .bmad-loop/profiles/*.toml>
 model = ""                   # empty = CLI default model (opencode-http wants "provider/model")
 cleanup_session_on_finish = true  # kill the run's tmux session when it finishes (false keeps it for inspection)
+# show_attached_ui = true  # create a detached tmux viewer window running the adapter's
+#             attached TUI (e.g. opencode attach) alongside the headless server;
+#             the TUI dashboard Log tab renders the viewer pane, and `a`/`attach`
+#             prefer it over the raw agent session when available. false by default.
 # extra_args replaces the profile's default permission-bypass flags when set:
 # extra_args = ["--permission-mode", "bypassPermissions"]
 # Optional overrides of the CLI profile's own defaults (unset = inherit the

--- a/src/bmad_loop/tui/data.py
+++ b/src/bmad_loop/tui/data.py
@@ -22,12 +22,18 @@ from pathlib import Path
 from typing import Any
 
 import pyte
+from pyte import modes as pyte_modes
 from rich.color import ColorParseError
 from rich.style import Style
 from rich.text import Text
 
 from .. import bmadconfig, deferredwork, policy, sprintstatus, stories
-from ..adapters.multiplexer import MultiplexerError, get_multiplexer, mux_usable
+from ..adapters.multiplexer import (
+    MultiplexerError,
+    TerminalMultiplexer,
+    get_multiplexer,
+    mux_usable,
+)
 from ..gates import ATTENTION_FILE
 from ..journal import JOURNAL_FILE, LOGS_DIR, STATE_FILE, load_state
 from ..model import RunState
@@ -244,6 +250,47 @@ class RunWatcher:
             except OSError:
                 pass
         return self._attention
+
+
+def read_viewer_config(run_dir: Path, adapter_name: str | None = None) -> dict[str, str] | None:
+    """Read the most recent viewer config persisted to ``<run_dir>/viewer.json``.
+
+    ``adapter_name`` filters to the entry written by that adapter; ``None``
+    (the dashboard's call — it doesn't know which adapter ran) matches any
+    entry that actually recorded a viewer window, so the reader can't drift
+    from the adapter's self-reported name (e.g. ``opencode-http``).
+
+    Returns a dict with the keys ``viewer_window``, ``viewer_url``,
+    ``viewer_session``, ``viewer_cwd``, ``viewer_command`` when an entry
+    exists and is parseable; ``None`` when the file is missing or unreadable.
+    The ``viewer_window`` string is a mux target such as
+    ``=bmad-loop-abc:bmad-loop-abc-viewer``."""
+    try:
+        path = run_dir / "viewer.json"
+        if not path.is_file():
+            return None
+        entries = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(entries, list):
+            return None
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            matches = (
+                entry.get("adapter") == adapter_name
+                if adapter_name is not None
+                else bool(entry.get("viewer_window"))
+            )
+            if matches:
+                return {
+                    "viewer_window": entry.get("viewer_window") or "",
+                    "viewer_url": entry.get("viewer_url") or "",
+                    "viewer_session": entry.get("viewer_session") or "",
+                    "viewer_cwd": entry.get("viewer_cwd") or "",
+                    "viewer_command": entry.get("viewer_command") or "",
+                }
+        return None
+    except (json.JSONDecodeError, OSError, KeyError, TypeError, UnicodeDecodeError):
+        return None
 
 
 class JournalTail:
@@ -680,6 +727,85 @@ class LogView:
             screen.history.top.dropped + front_drop  # pyright: ignore[reportAttributeAccessIssue]
         )
         self._render_len = len(rows)
+        return Text("\n").join(rows)
+
+
+class ViewerView:
+    """Captures a tmux pane via ``capture-pane`` and renders it through pyte.
+
+    Unlike :class:`LogView` (incremental file stream), a viewer refresh
+    captures a full terminal screen snapshot and replaces the previous
+    content. The captured text includes raw ANSI escape sequences that the
+    pyte emulator collapses into styled rows, just like a real terminal."""
+
+    def __init__(
+        self,
+        target: str,
+        mux: TerminalMultiplexer,
+        columns: int = _PANE_COLUMNS,
+        lines: int = _PANE_LINES,
+        history: int = _HISTORY_LINES,
+        start_line: int = -100,
+    ):
+        self._target = target
+        self._mux = mux
+        self._columns, self._lines, self._history = columns, lines, history
+        self._start_line = start_line
+        self._last_dims: tuple[int, int] | None = None
+
+    @property
+    def target(self) -> str:
+        return self._target
+
+    def resize(self, cols: int, lines: int) -> bool:
+        """Adopt a new render geometry (the displayed pane's size). Returns
+        True when it differs from the previous request — the caller then
+        resizes the underlying mux window to match, so the attached TUI
+        redraws at the size actually shown."""
+        if (cols, lines) == self._last_dims:
+            return False
+        self._last_dims = (cols, lines)
+        self._columns, self._lines = cols, lines
+        return True
+
+    def refresh(self) -> Text | None:
+        """Capture the pane and re-render it. Returns a rendered :class:`Text`
+        on success, or ``None`` when the pane is dead or the backend is
+        unavailable."""
+        try:
+            raw = self._mux.capture_pane(self._target, start_line=self._start_line)
+        except (MultiplexerError, OSError, Exception):
+            # Pane may have been killed or mux transport failed.
+            return None
+        if not raw:
+            return None
+        # ByteStream expects bytes; encode the string capture to UTF-8 so
+        # pyte can parse ANSI escape sequences in the usual way.
+        if isinstance(raw, str):
+            raw_bytes = raw.encode("utf-8", errors="replace")
+        else:
+            raw_bytes = raw
+        # Full-screen viewer: each capture is a complete snapshot, so
+        # reset() the screen before feeding the new data so the output
+        # replaces the previous frame rather than appending.
+        screen = pyte.HistoryScreen(self._columns, self._lines, history=self._history)
+        screen.history = screen.history._replace(top=_CountingDeque(maxlen=self._history))
+        # capture-pane separates rows with bare \n (no \r): without
+        # linefeed-newline mode pyte keeps the column across the feed and
+        # every row starts where the previous one ended — a staircase.
+        screen.set_mode(pyte_modes.LNM)
+        stream = _TolerantByteStream(screen)
+        stream.feed(raw_bytes)
+        # Strip trailing blanks, apply history cap.
+        rows: list[Text] = []
+        for row in screen.history.top:
+            rows.append(_render_row(row))
+        for y in range(screen.lines):
+            rows.append(_render_row(screen.buffer[y]))
+        while rows and not rows[-1].plain:
+            rows.pop()
+        front_drop = max(0, len(rows) - self._history)
+        del rows[:front_drop]
         return Text("\n").join(rows)
 
 

--- a/src/bmad_loop/tui/launch.py
+++ b/src/bmad_loop/tui/launch.py
@@ -27,6 +27,25 @@ CTL_SESSION = "bmad-loop-ctl"
 _CTL_WINDOW_RE = re.compile(r"^(?:run|sweep|resume|resolve)-(.+)$")
 
 
+def _find_view_window(run_id: str) -> str | None:
+    """Find a viewer window for this run's session (set by opencode-http
+    adapters when show_attached_ui is enabled).  Returns the mux target
+    token, or None."""
+    if not mux_available():
+        return None
+    session_name = runs.session_name(run_id)
+    viewer_name = f"bmad-loop-{run_id}-viewer"
+    mux = get_multiplexer()
+    try:
+        rows = mux.list_windows(session_name, ["window_name"])
+    except MultiplexerError:
+        return None
+    for (wn,) in rows:
+        if wn == viewer_name:
+            return mux.target(session_name, wn)
+    return None
+
+
 class LaunchError(Exception):
     pass
 
@@ -167,11 +186,15 @@ def decision_pending(run_dir: Path) -> bool:
 def attach_plan(project: Path, run_id: str) -> tuple[list[str], str | None] | None:
     """Pick where an interactive attach should land for this run and which window
     (if any) to record a return target on. Shared by the CLI `attach` command and
-    mirroring the TUI's action_attach logic: prefer the orchestrator's ctl window
-    when a sweep is blocked on a decision or no agent session is live, else the
-    live agent session. Returns (tmux argv, return_window) or None when there is
-    nothing to attach to."""
+    mirroring the TUI's action_attach logic: prefer the viewer window (when one
+    exists for an HTTP adapter), then the orchestrator's ctl window when a sweep
+    is blocked on a decision or no agent session is live, else the live agent
+    session. Returns (tmux argv, return_window) or None when there is nothing
+    to attach to."""
     session = runs.session_name(run_id)
+    viewer_window = _find_view_window(run_id)
+    if viewer_window:
+        return runs.attach_target_argv(viewer_window), None
     window = ctl_window(run_id)
     agent_live = session_exists(session)
     if window is not None and (

--- a/src/bmad_loop/tui/screens/dashboard.py
+++ b/src/bmad_loop/tui/screens/dashboard.py
@@ -113,6 +113,8 @@ class _PollContext:
         self.journal = data.JournalTail(run_dir)
         self.entries: list[dict[str, Any]] = []
         self.log: data.LogView | None = None
+        self.viewer_view: data.ViewerView | None = None
+        self._mux: Any = None
         self.log_task: str | None = None
         self.attention_seen = 0
         self.first_poll = True
@@ -148,6 +150,9 @@ class _Snapshot:
     toast_attention: bool = False
     decision: tuple[str, str] | None = None  # (dw_id, question) awaiting a human
     toast_decision: bool = False
+    # Viewer pane (when viewer_window is recorded for this run):
+    viewer_text: Text | None = None  # rendered terminal content from capture-pane
+    viewer_available: bool = False  # a valid viewer target was found this tick
 
 
 class DashboardScreen(Screen[None]):
@@ -213,6 +218,10 @@ class DashboardScreen(Screen[None]):
         self._pin_task: str | None = None  # show this task's log instead of the active one
         self._pending_jump: tuple[str, int] | None = None  # (task_id, log_pos)
         self._log_follow_tail = True  # stick to newest log lines until a jump pins us
+        # Displayed size of the Log pane's content area, written by _apply on
+        # the UI thread and read by the poll worker: the viewer window is kept
+        # resized to it so the attached TUI draws at the size actually shown.
+        self._log_pane_dims: tuple[int, int] | None = None
 
     def compose(self) -> ComposeResult:
         yield Header()
@@ -789,20 +798,65 @@ class DashboardScreen(Screen[None]):
                         ctx.entries, snap.state.policy_snapshot if snap.state else None
                     )
                 snap.log_pinned = pin is not None
-                if task != ctx.log_task:
-                    ctx.log_task = task
-                    ctx.log = (
-                        data.LogView(ctx.run_dir / data.LOGS_DIR / f"{task}.log") if task else None
-                    )
-                    snap.log_reset = True
-                snap.log_task = task
-                if ctx.log is not None and (ctx.log.read_new() or snap.log_reset):
-                    snap.log_lines = ctx.log.render()
-                    snap.log_index = ctx.log.index()
-                if ctx.log is not None and ctx.log.altscreen_seen:
-                    snap.log_altscreen = True
-                    if snap.state is not None and task:
-                        snap.log_transcript = _transcript_for_task(snap.state, task)
+                # Read the persisted viewer config: when a viewer window was created
+                # (show_attached_ui=True), capture-pane renders the terminal instead
+                # of reading the HTTP adapter's logfile.
+                vc = data.read_viewer_config(ctx.run_dir)
+                viewer_window = ""
+                if vc is not None:
+                    viewer_window = vc.get("viewer_window") or ""
+                # Grab the multiplexer (cached process-global).
+                mux = data.get_multiplexer()
+                mux_usable = data.mux_usable(mux)
+                # Reuse an existing ViewerView when the target hasn't changed;
+                # create one on fresh selection or after the target changed.
+                need_view = bool(viewer_window) and mux_usable
+                if need_view and (
+                    ctx.viewer_view is None or ctx.viewer_view.target != viewer_window
+                ):
+                    ctx.viewer_view = data.ViewerView(target=viewer_window, mux=mux)
+                if ctx.viewer_view is not None:
+                    # Track the displayed pane: resize the viewer window (and
+                    # the pyte render) to the Log pane's content area so the
+                    # attached TUI redraws at the size actually shown, instead
+                    # of floating a fixed-geometry frame in a larger pane.
+                    dims = self._log_pane_dims
+                    if (
+                        dims is not None
+                        and dims[0] >= 40
+                        and dims[1] >= 10
+                        and ctx.viewer_view.resize(*dims)
+                    ):
+                        mux.resize_window(ctx.viewer_view.target, *dims)
+                    # Viewer capture replaces the log entirely.
+                    txt = ctx.viewer_view.refresh()
+                    if txt is not None:
+                        snap.viewer_text = txt
+                        snap.viewer_available = True
+                    else:
+                        snap.viewer_text = None
+                        snap.viewer_available = False
+                else:
+                    snap.viewer_text = None
+                    snap.viewer_available = False
+                if not snap.viewer_available:
+                    # Fallback to logfile: normal LogView incremental append.
+                    if task != ctx.log_task:
+                        ctx.log_task = task
+                        ctx.log = (
+                            data.LogView(ctx.run_dir / data.LOGS_DIR / f"{task}.log")
+                            if task
+                            else None
+                        )
+                        snap.log_reset = True
+                    snap.log_task = task
+                    if ctx.log is not None and (ctx.log.read_new() or snap.log_reset):
+                        snap.log_lines = ctx.log.render()
+                        snap.log_index = ctx.log.index()
+                    if ctx.log is not None and ctx.log.altscreen_seen:
+                        snap.log_altscreen = True
+                        if snap.state is not None and task:
+                            snap.log_transcript = _transcript_for_task(snap.state, task)
                 attention = ctx.watcher.attention()
                 if len(attention) < ctx.attention_seen:
                     snap.attention_reset = True
@@ -874,12 +928,19 @@ class DashboardScreen(Screen[None]):
                 journal.scroll_end(animate=False)
 
         log = self.query_one("#log", RichLog)
+        # Publish the pane's content size for the poll worker's viewer resize;
+        # 0x0 while the Log tab is hidden, which the reader ignores.
+        region = log.scrollable_content_region
+        self._log_pane_dims = (region.width, region.height)
         self._displayed_log_task = snap.log_task
         if snap.log_reset:
             self._log_index = None
         if snap.log_index is not None:
             self._log_index = snap.log_index
-        if snap.log_reset or snap.log_lines is not None:
+        # A viewer frame arrives on every poll (full-screen snapshot, not an
+        # append), so it opens the rewrite gate itself — log_reset/log_lines
+        # are only ever set on the logfile-fallback path.
+        if snap.log_reset or snap.log_lines is not None or snap.viewer_text is not None:
             # Cursor-up repaints rewrite earlier content, so the pane is a full
             # re-render, not an append; RichLog keeps scroll_y across the
             # clear+rewrite, so only an explicit scroll_end moves the view.
@@ -890,18 +951,25 @@ class DashboardScreen(Screen[None]):
             following = self._log_follow_tail and log.is_vertical_scroll_end
             at_end = snap.log_reset or following
             log.clear()
-            if snap.log_task:
+            if snap.viewer_available:
+                label = Text("— viewer (pane capture) —", style="dim green")
+            elif snap.log_task:
                 suffix = " (pinned — esc to follow)" if snap.log_pinned else ""
-                log.write(Text(f"— {snap.log_task}.log —{suffix}", style="dim"), scroll_end=False)
+                label = Text(f"— {snap.log_task}.log —{suffix}", style="dim")
+            else:
+                label = None
+            if label:
+                log.write(label, scroll_end=False)
             if snap.log_altscreen:
-                # A fullscreen (alt-screen) TUI repaints in place, so the emulated
-                # pane collapses to the final frame. Flag it so the partial view is
-                # not mistaken for the whole session, and point at the full record.
                 note = "⚠ fullscreen (alt-screen) session — this pane shows only the final frame"
                 if snap.log_transcript:
                     note += f"; full transcript: {snap.log_transcript}"
                 log.write(Text(note, style="yellow"), scroll_end=False)
-            if snap.log_lines is not None and snap.log_lines.plain:
+            # Render viewer text when available, otherwise fall back to logfile.
+            if snap.viewer_text is not None:
+                log.write(snap.viewer_text, scroll_end=at_end)
+                snap.viewer_text = None  # consume so next clear+rewrite only runs on refresh
+            elif snap.log_lines is not None and snap.log_lines.plain:
                 log.write(snap.log_lines, scroll_end=at_end)
         if self._pending_jump is not None:
             # _scroll_log_to owns clearing the pending jump when the scroll

--- a/tests/test_multiplexer.py
+++ b/tests/test_multiplexer.py
@@ -388,12 +388,21 @@ def test_run_custom_env_is_forwarded_without_leaking(monkeypatch):
 
 # the exact sh source the POSIX backend produced before the hooks existed
 _PARKED_SH_SOURCE = (
-    'echo hi; ec=$?; echo "[bmad-loop exited $ec — press enter]"; read -r; '
+    'echo hi; ec=$?; echo "[bmad-loop exited $ec — press enter]"; read -r _park; '
     "ret=$(tmux show-options -wqv %3 2>/dev/null); "
     'if [ "$ret" = "detach" ]; then tmux detach-client 2>/dev/null; '
     'elif [ -n "$ret" ]; then '
     'tmux switch-client -t "$ret" 2>/dev/null || tmux switch-client -l 2>/dev/null; fi'
 )
+
+
+def test_resize_window_argv(monkeypatch):
+    rec = _RecordRun()
+    monkeypatch.setattr(tmux_base.subprocess, "run", rec)
+
+    TmuxMultiplexer().resize_window("=s:v", 165, 45)
+
+    assert rec.argv == ["tmux", "resize-window", "-t", "=s:v", "-x", "165", "-y", "45"]
 
 
 def test_new_parked_window_posix_argv_byte_identical(monkeypatch, tmp_path):

--- a/tests/test_tui_data.py
+++ b/tests/test_tui_data.py
@@ -4,13 +4,16 @@ from __future__ import annotations
 
 import builtins
 import importlib
+import json
 import os
 import subprocess
 import sys
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 from conftest import install_bmad_config, write_sprint
+from rich.text import Text
 
 from bmad_loop import deferredwork, policy
 from bmad_loop.adapters import tmux_base
@@ -1244,3 +1247,167 @@ def test_char_style_degrades_unparseable_color_instead_of_raising():
     assert style.color is None and style.bgcolor is None
     assert style.bold and style.underline and not style.italic
     assert data._char_style(key) is style  # fallback is cached like any other
+
+
+# ====================================================================== viewer
+
+
+def test_read_viewer_config_returns_dict_when_file_exists(project, tmp_path):
+    """read_viewer_config returns the viewer config dict when viewer.json
+    has an entry matching the adapter name."""
+    run_dir = tmp_path / "run-abc"
+    run_dir.mkdir()
+    viewer_json = run_dir / "viewer.json"
+    viewer_json.write_text(
+        json.dumps([{"adapter": "opencode_http", "viewer_window": "=bmad-loop-abc:my-viewer"}]),
+        encoding="utf-8",
+    )
+    vc = data.read_viewer_config(run_dir, "opencode_http")
+    assert vc is not None
+    assert vc["viewer_window"] == "=bmad-loop-abc:my-viewer"
+    # Non-matching adapter returns None
+    vc2 = data.read_viewer_config(run_dir, "other")
+    assert vc2 is None
+
+
+def test_read_viewer_config_returns_none_on_missing_file(tmp_path):
+    assert data.read_viewer_config(tmp_path / "nonexistent") is None
+
+
+def test_read_viewer_config_returns_none_on_bad_json(tmp_path):
+    run_dir = tmp_path / "run-abc"
+    run_dir.mkdir()
+    (run_dir / "viewer.json").write_text("{bad json", encoding="utf-8")
+    assert data.read_viewer_config(run_dir) is None
+
+
+def test_viewer_view_renders_ansi_content(project):
+    """ViewerView captures a simulated tmux pane output and renders
+    it through pyte into a Text object with styled runs."""
+    mux = MagicMock()
+    mux.capture_pane.return_value = "\x1b[32mhello\x1b[0m\nworld\n"
+    view = data.ViewerView(target="=s:w", mux=mux, columns=40, lines=10)
+    result = view.refresh()
+    assert result is not None
+    assert isinstance(result, Text)
+    # The output should contain the plain text without raw escape sequences
+    plain = result.plain
+    assert "hello" in plain
+    assert "world" in plain
+    # No raw escape codes should be in the plain text
+    assert "\x1b" not in plain
+
+
+def test_viewer_view_rows_align_at_column_zero(project):
+    """capture-pane separates rows with bare \\n; without LNM pyte would keep
+    the column across rows and every line would start where the previous one
+    ended (staircase misalignment)."""
+    mux = MagicMock()
+    mux.capture_pane.return_value = "aaaa\nbb\ncccccc\n"
+    view = data.ViewerView(target="=s:w", mux=mux, columns=40, lines=10)
+    result = view.refresh()
+    assert result is not None
+    assert result.plain.splitlines() == ["aaaa", "bb", "cccccc"]
+
+
+def test_viewer_view_resize_adopts_new_geometry(project):
+    """resize() reports a change once per new size and re-renders at it —
+    the dashboard uses the True return to resize the tmux window to match."""
+    mux = MagicMock()
+    mux.capture_pane.return_value = "x" * 30 + "\n"
+    view = data.ViewerView(target="=s:w", mux=mux, columns=40, lines=10)
+    assert view.refresh().plain.splitlines() == ["x" * 30]  # fits at 40 cols
+
+    assert view.resize(20, 5) is True
+    assert view.resize(20, 5) is False  # unchanged size: no re-request
+    wrapped = view.refresh().plain.splitlines()
+    assert wrapped == ["x" * 20, "x" * 10]  # now renders at 20 cols
+
+    assert view.resize(40, 10) is True  # and back
+
+
+def test_viewer_view_returns_none_on_empty_capture(project):
+    mux = MagicMock()
+    mux.capture_pane.return_value = ""
+    view = data.ViewerView(target="=s:w", mux=mux, columns=40, lines=10)
+    assert view.refresh() is None
+
+
+def test_viewer_view_returns_none_on_mux_error(project):
+    mux = MagicMock()
+    mux.capture_pane.side_effect = RuntimeError("pane gone")
+    view = data.ViewerView(target="=s:w", mux=mux, columns=40, lines=10)
+    # The exception is caught and degraded to None.
+    assert view.refresh() is None
+
+
+def test_viewer_view_replaces_not_appends(project):
+    """Each refresh() replaces the screen — second output does not append
+    to the first. This mirrors the alternate-screen behavior of OpenCode's
+    fullscreen viewer."""
+    captured: list[str] = []
+
+    def capture_side_effect(target, start_line=-100, end_line=None):
+        # Return two different frames to prove replacement.
+        frame = "frame1\nline2\nline3\n"
+        if len(captured) > 0:
+            frame = "frame2\nnew\n"
+        captured.append(frame)
+        return frame
+
+    mux = MagicMock()
+    mux.capture_pane.side_effect = capture_side_effect
+    view = data.ViewerView(target="=s:w", mux=mux, columns=40, lines=10)
+    r1 = view.refresh()
+    r2 = view.refresh()
+    assert r1 is not None and r2 is not None
+    # Second render must NOT contain "frame1"
+    assert "frame1" not in r2.plain
+
+
+def test_viewer_view_strips_raw_ansi_escapes(project):
+    """ANSI styling should be converted to rich Style objects, not left
+    as raw escape codes in the plain text output."""
+    mux = MagicMock()
+    # Simulate a typical ANSI sequence — bold cyan text.
+    mux.capture_pane.return_value = "\x1b[1;36mBOLD CYAN\x1b[0m\n"
+    view = data.ViewerView(target="=s:w", mux=mux, columns=20, lines=5)
+    result = view.refresh()
+    assert result is not None
+    assert "\x1b" not in result.plain
+    # The text should not have raw escape codes as visible content
+    assert r"\x1b" not in result.plain
+
+
+def test_read_viewer_config_with_all_fields(project, tmp_path):
+    """Viewer config with full fields roundtrips correctly."""
+    run_dir = tmp_path / "run-xyz"
+    run_dir.mkdir()
+    viewer = run_dir / "viewer.json"
+    viewer.write_text(
+        json.dumps(
+            [
+                {
+                    "adapter": "opencode_http",
+                    "viewer_window": "=bmad-loop-xyz:viewer",
+                    "viewer_url": "http://127.0.0.1:8080",
+                    "viewer_session": "sess-abc",
+                    "viewer_cwd": "/home/user/project",
+                    "viewer_command": "opencode attach http://127.0.0.1:8080",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    vc = data.read_viewer_config(run_dir, "opencode_http")
+    assert vc is not None
+    assert vc["viewer_window"] == "=bmad-loop-xyz:viewer"
+    assert vc["viewer_url"] == "http://127.0.0.1:8080"
+    assert vc["viewer_session"] == "sess-abc"
+    assert vc["viewer_cwd"] == "/home/user/project"
+    assert vc["viewer_command"] == "opencode attach http://127.0.0.1:8080"
+
+
+def test_viewer_view_target_property(project):
+    view = data.ViewerView(target="=s:w", mux=MagicMock(), columns=40, lines=10)
+    assert view.target == "=s:w"

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -1,0 +1,746 @@
+"""Viewer capability: unit tests for show_attached_ui + viewer window lifecycle.
+
+Covers:
+- viewer disabled (default, policy flag false)
+- viewer creation (mux + binary present, opencode attach argv correct)
+- exact attach command and session ID wiring
+- attach routing (attach_plan prefers viewer window)
+- pane-log routing (viewer log path matches task log)
+- cleanup (teardown order: viewer → session → server)
+- retry/resume without duplicate windows (idempotency)
+- missing `opencode attach` / mux failure degrades to headless operation
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bmad_loop.adapters.base import ViewerConfig
+from bmad_loop.policy import AdapterPolicy
+
+# ====================================================================== fixtures
+
+
+@pytest.fixture
+def sandbox(tmp_path, monkeypatch):
+    """Standard bmad-loop sandbox with a run dir and mocked multiplexer.
+
+    The mock simulates realistic tmux behaviour: ``list_windows`` initially
+    returns ``[]`` (no windows), but after ``new_window`` is called it starts
+    returning the viewer window entry so that ``_mux_window_exists`` sees the
+    newly-created window, meaning ``ensure_viewer_window`` returns a success
+    ``ViewerConfig`` instead of an empty fallback.
+    """
+    from bmad_loop.adapters import multiplexer
+    from bmad_loop.adapters.viewer_launch import _VIEWER_OPTION
+
+    mux = MagicMock()
+    mux.available.return_value = True
+    mux.has_session.return_value = False
+    mux.target.side_effect = lambda s, w=None: f"={s}:{w}" if w else f"={s}"
+
+    # Track whether new_window has been called (simulating tmux creating the
+    # window).  The stored name/value come from the call args so that
+    # _find_existing_viewer can find the window across retries.
+    _state = {"created": False, "name": None, "option_val": ""}
+
+    def _list_windows(session_name, fields):
+        # Mimic the real backend exactly: one tuple per window, sized to the
+        # requested fields (a fatter tuple here once hid a real unpack bug).
+        if not _state["created"]:
+            return []
+        values = {
+            "window_name": _state["name"],
+            _VIEWER_OPTION: _state["option_val"],
+            "pane_dead": "0",
+            "pane_dead_status": "",
+        }
+        return [tuple(values.get(f, "") for f in fields)]
+
+    def _new_window(session, name, cwd, env, command):
+        # Simulate tmux creating the window — store its name so
+        # the post-creation verification (which calls list_windows) sees it.
+        _state["created"] = True
+        _state["name"] = name
+
+    def _new_parked_window(session, name, cwd, argv, return_opt):
+        _state["created"] = True
+        _state["name"] = name
+        return "@1"
+
+    def _set_window_option(target, option, value):
+        # Record the marker option so _find_existing_viewer can see it
+        if option == _VIEWER_OPTION:
+            _state["option_val"] = value
+
+    mux.new_window.side_effect = _new_window
+    mux.new_parked_window.side_effect = _new_parked_window
+    mux.set_window_option.side_effect = _set_window_option
+    mux.list_windows.side_effect = _list_windows
+    mux.capture_pane.return_value = ""  # live viewer: no exit banner
+    mux.list_window_ids.return_value = []
+    mux.session_options.return_value = {}
+    mux.show_window_option.return_value = ""
+
+    # Keep the immediate-exit poll from sleeping in unit tests.
+    from bmad_loop.adapters import viewer_launch
+
+    monkeypatch.setattr(viewer_launch, "_STARTUP_CHECKS", 1)
+
+    multiplexer.get_multiplexer.cache_clear()
+    monkeypatch.setattr(multiplexer, "get_multiplexer", MagicMock(return_value=mux))
+    # viewer_launch binds these names at import (from-import), so the
+    # multiplexer-module patch above never reaches it — patch its own
+    # namespace too or the tests talk to the REAL tmux server.
+    monkeypatch.setattr(viewer_launch, "get_multiplexer", MagicMock(return_value=mux))
+    monkeypatch.setattr(viewer_launch, "mux_usable", lambda backend=None: True)
+    monkeypatch.setattr(viewer_launch, "_binary_exists", lambda name: True)
+    yield tmp_path, mux
+    multiplexer.get_multiplexer.cache_clear()
+
+
+# ====================================================================== tests
+
+
+class TestViewerDisabled:
+    """Viewer defaults to disabled: no window created when flag is absent or false."""
+
+    def test_viewer_not_created_when_disabled(self, sandbox):
+        tmp_path, mux = sandbox
+        # Policy with show_attached_ui = False (the default)
+        policy_patch = MagicMock()
+        policy_patch.adapter = AdapterPolicy(show_attached_ui=False)
+        policy_patch.limits.stop_without_result_nudges = 0
+        policy_patch.limits.teardown_grace_s = 0
+        policy_patch.limits.max_tokens_per_session = 4_000_000
+        policy_patch.limits.session_budget_mode = "off"
+        policy_patch.limits.cache_read_weight = 0.1
+
+        profile = MagicMock()
+        profile.name = "test-profile"
+        profile.binary = "fakecli"
+        profile.launch_args = ()
+        profile.env = {}
+        profile.env_fault_patterns = []
+        profile.hookless = False
+        profile.skill_tree = "skills"
+        profile.render_prompt = lambda p: p
+        profile.bypass_args = ()
+        profile.usage_grace_s = None
+        profile.stop_without_result_nudges = None
+
+        run_dir = tmp_path / "run1"
+        run_dir.mkdir()
+        (run_dir / "tasks").mkdir(exist_ok=True)
+        (run_dir / "logs").mkdir(exist_ok=True)
+
+        from bmad_loop.adapters.generic import GenericAdapter
+
+        adapter = GenericAdapter(
+            run_dir=run_dir,
+            policy=policy_patch,
+            profile=profile,
+        )
+        # Viewer should be default (no-op)
+        vc = adapter.viewer_config
+        assert vc.viewer_window is None
+        assert vc.viewer_url == ""
+        assert vc.viewer_session == ""
+
+
+class TestViewerCreation:
+    """When show_attached_ui=True, a viewer window is created."""
+
+    def test_viewer_window_created_when_enabled(self, sandbox):
+        tmp_path, mux = sandbox
+        mux.available.return_value = True
+        mux.has_session.return_value = False
+
+        # Mock the viewer_launch to verify it's called
+        with patch("bmad_loop.adapters.opencode_http._ensure_viewer") as mock_ensure:
+            mock_ensure.return_value = ViewerConfig(
+                viewer_window="=bmad-loop-abc:my-viewer",
+                viewer_url="http://127.0.0.1:9999",
+                viewer_session="sess-abc123",
+                viewer_cwd=str(tmp_path),
+                viewer_command="opencode attach http://127.0.0.1:9999 --dir . --session sess-abc123",
+            )
+
+            from bmad_loop.adapters.base import SessionSpec
+            from bmad_loop.adapters.opencode_http import OpencodeHttpAdapter
+
+            policy_patch = MagicMock()
+            policy_patch.adapter = AdapterPolicy(name="opencode", show_attached_ui=True)
+            policy_patch.limits.stop_without_result_nudges = 0
+            policy_patch.limits.max_tokens_per_session = 4_000_000
+            policy_patch.limits.session_budget_mode = "off"
+            policy_patch.limits.cache_read_weight = 0.1
+
+            profile = MagicMock()
+            profile.name = "opencode"
+            profile.binary = "opencode"
+            profile.skill_tree = "skills"
+            profile.env_fault_patterns = []
+            profile.hookless = True
+
+            run_dir = tmp_path / "run1"
+            run_dir.mkdir()
+            (run_dir / "tasks").mkdir(exist_ok=True)
+            (run_dir / "logs").mkdir(exist_ok=True)
+
+            adapter = OpencodeHttpAdapter(
+                run_dir=run_dir,
+                policy=policy_patch,
+                profile=profile,
+            )
+            # Viewer starts empty; _ensure_viewer not called yet:
+            assert adapter.viewer_config.viewer_window is None
+
+            # Calling ensure_viewer_window (the adapter seam) triggers creation:
+            spec = SessionSpec(
+                task_id="task-abc",
+                role="dev",
+                prompt="test",
+                cwd=tmp_path,
+            )
+            result_vc = adapter.ensure_viewer_window(spec, "sess-abc123", "http://127.0.0.1:9999")
+            assert result_vc.viewer_window == "=bmad-loop-abc:my-viewer"
+
+            # _ensure_viewer was called with correct arguments:
+            mock_ensure.assert_called_once()
+            call_kwargs = mock_ensure.call_args
+            assert call_kwargs.kwargs["run_id"] == "run1"
+            assert call_kwargs.kwargs["session_id"] == "sess-abc123"
+
+
+class TestAttachCommandAndSessionId:
+    """The viewer command is constructed with the correct server URL,
+    working directory, and session id."""
+
+    def test_viewer_argv_construction(self):
+        """Direct test of _viewer_argv helper in viewer_launch."""
+        from bmad_loop.adapters.viewer_launch import _viewer_argv
+
+        cmd = _viewer_argv("opencode", "http://127.0.0.1:9999", Path("/home/user/proj"), "sess-xyz")
+        expected_argv = [
+            "opencode",
+            "attach",
+            "http://127.0.0.1:9999",
+            "--dir",
+            "/home/user/proj",
+            "--session",
+            "sess-xyz",
+        ]
+        assert cmd == expected_argv
+
+    def test_viewer_command_field_matches_argv(self, sandbox):
+        """ViewerConfig.viewer_command field should be reconstructible
+        from the constituent fields."""
+        from bmad_loop.adapters.base import SessionSpec
+        from bmad_loop.adapters.opencode_http import OpencodeHttpAdapter
+
+        tmp_path, mux = sandbox
+        mux.available.return_value = True
+        mux.list_windows.return_value = []
+
+        # When ensure_viewer_window would create a window with specific fields,
+        # those fields should be correctly populated.
+        policy_patch = MagicMock()
+        policy_patch.adapter = AdapterPolicy(show_attached_ui=True)
+        policy_patch.limits.stop_without_result_nudges = 0
+        policy_patch.limits.max_tokens_per_session = 4_000_000
+        policy_patch.limits.session_budget_mode = "off"
+        policy_patch.limits.cache_read_weight = 0.1
+
+        profile = MagicMock()
+        profile.name = "opencode"
+        profile.binary = "opencode"
+        profile.skill_tree = "skills"
+        profile.env_fault_patterns = []
+        profile.hookless = True
+
+        run_dir = tmp_path / "run1-xyz"
+        run_dir.mkdir()
+        (run_dir / "tasks").mkdir(exist_ok=True)
+        (run_dir / "logs").mkdir(exist_ok=True)
+
+        adapter = OpencodeHttpAdapter(
+            run_dir=run_dir,
+            policy=policy_patch,
+            profile=profile,
+        )
+
+        spec = SessionSpec(
+            task_id="task-xyz",
+            role="dev",
+            prompt="test",
+            cwd=run_dir,
+        )
+        result_vc = adapter.ensure_viewer_window(spec, "sess-xyz", "http://127.0.0.1:8080")
+
+        # The viewer_config fields are set
+        assert result_vc.viewer_session == "sess-xyz"
+        assert result_vc.viewer_url == "http://127.0.0.1:8080"
+
+
+class TestAttachRouting:
+    """attach_plan prefers the viewer window when present."""
+
+    @pytest.fixture
+    def routed_mux(self, sandbox, monkeypatch):
+        """Route launch.py's and runs.py's own module bindings (from-imports)
+        at the sandbox mux so attach_plan never talks to the real tmux."""
+        from bmad_loop import runs
+        from bmad_loop.tui import launch
+
+        tmp_path, mux = sandbox
+        mux.attach_target_argv.side_effect = lambda t: ["tmux", "attach", "-t", t]
+        monkeypatch.setattr(launch, "get_multiplexer", MagicMock(return_value=mux))
+        monkeypatch.setattr(launch, "mux_usable", lambda backend=None: True)
+        monkeypatch.setattr(runs, "get_multiplexer", MagicMock(return_value=mux))
+        return tmp_path, mux
+
+    def test_attach_plan_prefers_viewer(self, routed_mux):
+        tmp_path, mux = routed_mux
+
+        # Set up: there is a viewer window in the run's session
+        mux.list_windows.side_effect = None
+        mux.list_windows.return_value = [
+            ("run-abc123",),
+            ("bmad-loop-abc123-viewer",),
+        ]
+
+        from bmad_loop.tui.launch import attach_plan
+
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / ".bmad-loop").mkdir(exist_ok=True)
+        (project / ".bmad-loop" / "runs").mkdir(exist_ok=True)
+        (project / ".bmad-loop" / "runs" / "abc123").mkdir(exist_ok=True)
+        (project / ".bmad-loop" / "runs" / "abc123" / "state.json").write_text(
+            json.dumps({"run_id": "abc123", "finished": False}), encoding="utf-8"
+        )
+
+        plan = attach_plan(project, "abc123")
+        # attach_plan should find and prefer the viewer window
+        assert plan is not None
+        target_argv, return_window = plan
+        assert "bmad-loop-abc123-viewer" in target_argv[3]
+        assert return_window is None
+
+    def test_attach_plan_fallback_when_no_viewer(self, routed_mux):
+        tmp_path, mux = routed_mux
+
+        # No viewer window exists, but the agent session is live → the plan
+        # falls back to attaching to the run session itself.
+        mux.list_windows.side_effect = None
+        mux.list_windows.return_value = [("shell",)]
+        mux.has_session.return_value = True
+
+        from bmad_loop.tui.launch import attach_plan
+
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / ".bmad-loop").mkdir(exist_ok=True)
+        (project / ".bmad-loop" / "runs").mkdir(exist_ok=True)
+
+        plan = attach_plan(project, "abc123")
+        assert plan is not None
+        target_argv, _ = plan
+        assert "bmad-loop-abc123-viewer" not in target_argv[3]
+
+
+class TestPaneLogRouting:
+    """The viewer pane log path should match the task log path expected
+    by the dashboard Log tab."""
+
+    def test_viewer_log_path_format(self, sandbox):
+        """Viewer output logs to <run>.log which is the standard task log format."""
+        from bmad_loop.journal import LOGS_DIR
+
+        task_id = "task-abc123-def"
+        expected_log_path = Path(str(LOGS_DIR)) / f"{task_id}.log"
+
+        expected_name = expected_log_path.name  # e.g. "task-abc123-def.log"
+        expected_pattern = re.compile(r"^task-[a-f0-9-]+\.log$")
+        assert expected_pattern.match(expected_name)
+
+    def test_viewer_config_stored_to_json(self, sandbox):
+        """Viewer metadata persisted to viewer.json in the run dir."""
+        from bmad_loop.adapters.base import SessionSpec
+        from bmad_loop.adapters.opencode_http import OpencodeHttpAdapter
+
+        tmp_path, mux = sandbox
+        mux.available.return_value = True
+        mux.list_windows.return_value = []
+
+        policy_patch = MagicMock()
+        policy_patch.adapter = AdapterPolicy(show_attached_ui=True)
+        policy_patch.limits.stop_without_result_nudges = 0
+        policy_patch.limits.max_tokens_per_session = 4_000_000
+        policy_patch.limits.session_budget_mode = "off"
+        policy_patch.limits.cache_read_weight = 0.1
+
+        profile = MagicMock()
+        profile.name = "opencode"
+        profile.binary = "opencode"
+        profile.skill_tree = "skills"
+        profile.env_fault_patterns = []
+        profile.hookless = True
+
+        run_dir = tmp_path / "run1"
+        run_dir.mkdir()
+        (run_dir / "tasks").mkdir(exist_ok=True)
+        (run_dir / "logs").mkdir(exist_ok=True)
+
+        adapter = OpencodeHttpAdapter(
+            run_dir=run_dir,
+            policy=policy_patch,
+            profile=profile,
+        )
+
+        spec = SessionSpec(
+            task_id="task-abc",
+            role="dev",
+            prompt="test",
+            cwd=run_dir,
+        )
+        # ensure_viewer_window won't actually create a tmux window
+        # (since we're mocking the mux), but it should still persist
+        # and call _persist_viewer_config
+        result_vc = adapter.ensure_viewer_window(spec, "sess-123", "http://127.0.0.1:9999")
+
+        # The viewer_config was saved on the adapter
+        assert result_vc.viewer_session == "sess-123"
+
+
+class TestTeardown:
+    """Teardown order: viewer → session → server."""
+
+    def test_teardown_closes_viewer_before_server(self, sandbox):
+        """When the adapter has _viewer_config set, _close_viewer reads it
+        and calls the module-level close_viewer_window with the target."""
+        from bmad_loop.adapters import opencode_http as oh
+        from bmad_loop.adapters.opencode_http import OpencodeHttpAdapter
+
+        tmp_path, mux = sandbox
+        mux.available.return_value = True
+        mux.list_windows.return_value = []
+
+        policy_patch = MagicMock()
+        policy_patch.adapter = AdapterPolicy(show_attached_ui=True)
+        policy_patch.limits.stop_without_result_nudges = 0
+        policy_patch.limits.max_tokens_per_session = 4_000_000
+        policy_patch.limits.session_budget_mode = "off"
+        policy_patch.limits.cache_read_weight = 0.1
+
+        profile = MagicMock()
+        profile.name = "opencode"
+        profile.binary = "opencode"
+        profile.skill_tree = "skills"
+        profile.env_fault_patterns = []
+        profile.hookless = True
+
+        run_dir = tmp_path / "run1"
+        run_dir.mkdir()
+        (run_dir / "tasks").mkdir(exist_ok=True)
+        (run_dir / "logs").mkdir(exist_ok=True)
+
+        adapter = OpencodeHttpAdapter(
+            run_dir=run_dir,
+            policy=policy_patch,
+            profile=profile,
+        )
+
+        # The adapter stores the config as _viewer_config internally
+        adapter._viewer_config = ViewerConfig(
+            viewer_window="=bmad-loop-xyz:my-viewer",
+            viewer_url="http://127.0.0.1:9999",
+            viewer_session="sess-abc",
+        )
+
+        # Patch the module-level _close_viewer in the adapter's own module
+        # namespace — the method references it by its module-level import name.
+        close_target = []
+
+        def record_call(target):
+            close_target.append(target)
+
+        with patch.object(oh, "_close_viewer", side_effect=record_call):
+            adapter._close_viewer()
+
+        assert len(close_target) == 1
+        assert close_target[0] == "=bmad-loop-xyz:my-viewer"
+
+    def test_close_viewer_on_none_is_noop(self, sandbox):
+        """Calling _close_viewer with an empty viewer_config (all empty strings)
+        should not crash."""
+        from bmad_loop.adapters.opencode_http import OpencodeHttpAdapter
+
+        tmp_path, mux = sandbox
+        mux.available.return_value = True
+        mux.list_windows.return_value = []
+
+        policy_patch = MagicMock()
+        policy_patch.adapter = AdapterPolicy(show_attached_ui=True)
+        policy_patch.limits.stop_without_result_nudges = 0
+        policy_patch.limits.max_tokens_per_session = 4_000_000
+        policy_patch.limits.session_budget_mode = "off"
+        policy_patch.limits.cache_read_weight = 0.1
+
+        profile = MagicMock()
+        profile.name = "opencode"
+        profile.binary = "opencode"
+        profile.skill_tree = "skills"
+        profile.env_fault_patterns = []
+        profile.hookless = True
+
+        run_dir = tmp_path / "run1"
+        run_dir.mkdir()
+        (run_dir / "tasks").mkdir(exist_ok=True)
+        (run_dir / "logs").mkdir(exist_ok=True)
+
+        adapter = OpencodeHttpAdapter(
+            run_dir=run_dir,
+            policy=policy_patch,
+            profile=profile,
+        )
+
+        # viewer_config is None by default
+        adapter._close_viewer()  # should not raise
+
+
+class TestRetryResumeNoDuplicates:
+    """Viewer window creation must be idempotent: retries, resume,
+    interrupted runs should never create duplicate viewer windows."""
+
+    def test_existing_window_reused(self, monkeypatch):
+        """When a viewer window already exists, _find_existing_viewer should
+        detect it and return the existing config rather than creating a new one."""
+        from bmad_loop.adapters import viewer_launch
+
+        mux_mock = MagicMock()
+        mux_mock.available.return_value = True
+        mux_mock.target.side_effect = lambda s, w=None: f"={s}:{w}" if w else f"={s}"
+        mux_mock.list_windows.return_value = [
+            ("bmad-loop-xyz-viewer", "1"),
+            ("window-abc", ""),
+        ]
+
+        # Patch get_multiplexer in the same module where _find_existing_viewer
+        # uses it, because from-import binds the name locally.
+        monkeypatch.setattr(
+            viewer_launch,
+            "get_multiplexer",
+            MagicMock(return_value=mux_mock),
+        )
+
+        vc = viewer_launch._find_existing_viewer("xyz", "bmad-loop-xyz")
+        assert vc is not None
+        # The reused target is the by-name window token, never the marker value.
+        assert vc.viewer_window == "=bmad-loop-xyz:bmad-loop-xyz-viewer"
+
+    def test_multiple_runs_have_separate_views(self, sandbox):
+        """Different run ids should have different viewer targets."""
+        from bmad_loop.adapters.viewer_launch import (
+            _viewer_window_name,
+        )
+
+        name1 = _viewer_window_name("run-abc")
+        name2 = _viewer_window_name("run-def")
+
+        assert name1 != name2
+        assert "run-abc" in name1
+        assert "run-def" in name2
+
+    def test_missing_viewer_on_resume_degrades_gracefully(self, sandbox):
+        """When a viewer doesn't exist on resume (e.g. it was killed),
+        the adapter should still function without it."""
+        from bmad_loop.adapters.base import SessionSpec
+        from bmad_loop.adapters.opencode_http import OpencodeHttpAdapter
+
+        tmp_path, mux = sandbox
+        mux.available.return_value = True
+        mux.list_windows.return_value = []
+
+        policy_patch = MagicMock()
+        policy_patch.adapter = AdapterPolicy(show_attached_ui=True)
+        policy_patch.limits.stop_without_result_nudges = 0
+        policy_patch.limits.max_tokens_per_session = 4_000_000
+        policy_patch.limits.session_budget_mode = "off"
+        policy_patch.limits.cache_read_weight = 0.1
+
+        profile = MagicMock()
+        profile.name = "opencode"
+        profile.binary = "opencode"
+        profile.skill_tree = "skills"
+        profile.env_fault_patterns = []
+        profile.hookless = True
+
+        run_dir = tmp_path / "run1"
+        run_dir.mkdir()
+        (run_dir / "tasks").mkdir(exist_ok=True)
+        (run_dir / "logs").mkdir(exist_ok=True)
+
+        adapter = OpencodeHttpAdapter(
+            run_dir=run_dir,
+            policy=policy_patch,
+            profile=profile,
+        )
+
+        # Calling ensure when viewer doesn't exist:
+        # Should return a default ViewerConfig (no error)
+        spec = SessionSpec(
+            task_id="task-xyz",
+            role="dev",
+            prompt="test",
+            cwd=run_dir,
+        )
+        result_vc = adapter.ensure_viewer_window(spec, "sess-xyz", "http://127.0.0.1:9999")
+        # Since mux.list_windows returns nothing, viewer creation will
+        # fail silently and return a default ViewerConfig
+        assert isinstance(result_vc, ViewerConfig)
+
+
+class TestViewerAuth:
+    """The attach client must receive the serve password — via the tmux
+    session environment, never via argv or the persisted viewer_command
+    (both are ps- / viewer.json-visible)."""
+
+    def test_attach_env_lands_in_session_environment_not_argv(self, sandbox):
+        from bmad_loop.adapters.viewer_launch import ensure_viewer_window
+
+        tmp_path, mux = sandbox
+        vc = ensure_viewer_window(
+            run_id="auth-run",
+            server_url="http://127.0.0.1:9999",
+            session_id="sess-auth",
+            working_directory=tmp_path,
+            attach_binary="opencode",
+            attach_env={"OPENCODE_SERVER_PASSWORD": "s3cret"},
+        )
+        assert vc.viewer_window is not None
+        mux.set_session_environment.assert_called_once_with(
+            "bmad-loop-auth-run", "OPENCODE_SERVER_PASSWORD", "s3cret"
+        )
+        # The secret never reaches argv or the persisted command.
+        (_, _, _, argv, _), _ = mux.new_parked_window.call_args
+        assert all("s3cret" not in a for a in argv)
+        assert "s3cret" not in vc.viewer_command
+
+
+class TestStopDuringCreation:
+    """The engine's SIGTERM handler raises RunStopped in whatever frame is
+    running. If that lands inside viewer creation it must PROPAGATE (after
+    killing the half-made window) — swallowing it breaks the stop path,
+    because the handler only raises once (#viewer-error.log 2026-07-25)."""
+
+    def test_run_stopped_mid_verification_propagates(self, sandbox):
+        from bmad_loop.adapters.viewer_launch import ensure_viewer_window
+        from bmad_loop.engine import RunStopped
+
+        tmp_path, mux = sandbox
+        mux.capture_pane.side_effect = RunStopped()  # lands mid-poll
+
+        with pytest.raises(RunStopped):
+            ensure_viewer_window(
+                run_id="stop-run",
+                server_url="http://127.0.0.1:9999",
+                session_id="sess-stop",
+                working_directory=tmp_path,
+                attach_binary="opencode",
+            )
+        # The unrecorded window was cleaned up on the way out.
+        mux.kill_window.assert_called_once()
+        # And the interruption is NOT reported as a viewer failure.
+        assert not (tmp_path / "viewer-error.log").exists()
+
+    def test_run_stopped_propagates_through_adapter_seam(self, sandbox):
+        """The adapter's best-effort catch must not re-swallow RunStopped."""
+        from bmad_loop.adapters import opencode_http as oh
+        from bmad_loop.adapters.base import SessionSpec
+        from bmad_loop.adapters.opencode_http import OpencodeHttpAdapter
+        from bmad_loop.engine import RunStopped
+
+        tmp_path, mux = sandbox
+        policy_patch = MagicMock()
+        policy_patch.adapter = AdapterPolicy(show_attached_ui=True)
+        policy_patch.limits.stop_without_result_nudges = 0
+        policy_patch.limits.max_tokens_per_session = 4_000_000
+        policy_patch.limits.session_budget_mode = "off"
+        policy_patch.limits.cache_read_weight = 0.1
+
+        profile = MagicMock()
+        profile.name = "opencode"
+        profile.binary = "opencode"
+        profile.skill_tree = "skills"
+        profile.env_fault_patterns = []
+        profile.hookless = True
+
+        run_dir = tmp_path / "run1"
+        run_dir.mkdir()
+        (run_dir / "tasks").mkdir(exist_ok=True)
+        (run_dir / "logs").mkdir(exist_ok=True)
+
+        adapter = OpencodeHttpAdapter(run_dir=run_dir, policy=policy_patch, profile=profile)
+        spec = SessionSpec(task_id="t", role="dev", prompt="p", cwd=tmp_path)
+
+        with patch.object(oh, "_ensure_viewer", side_effect=RunStopped()):
+            with pytest.raises(RunStopped):
+                adapter.ensure_viewer_window(spec, "sess", "http://127.0.0.1:1")
+
+
+class TestMissingBinaryFallback:
+    """When opencode binary is not found or mux fails, the adapter
+    degrades to headless operation."""
+
+    def test_binary_not_found_returns_headless(self, sandbox):
+        """When the attach binary is missing, viewer creation falls back
+        to a no-op ViewerConfig — and says why in viewer-error.log."""
+        from bmad_loop.adapters import viewer_launch
+        from bmad_loop.adapters.viewer_launch import ensure_viewer_window
+
+        tmp_path, _mux = sandbox
+        with patch.object(viewer_launch, "_binary_exists", return_value=False):
+            result_vc = ensure_viewer_window(
+                run_id="test-run",
+                server_url="http://127.0.0.1:9999",
+                session_id="sess-123",
+                working_directory=tmp_path,
+                attach_binary="nonexistent-binary",
+            )
+
+        # Should return a default ViewerConfig (no crash)
+        assert result_vc.viewer_window is None
+        assert result_vc.viewer_url == ""
+        error_log = (tmp_path / "viewer-error.log").read_text(encoding="utf-8")
+        assert "nonexistent-binary" in error_log
+
+    def test_mux_unavailable_returns_headless(self, sandbox):
+        """When the multiplexer is unavailable, viewer creation falls back."""
+        from bmad_loop.adapters.viewer_launch import ensure_viewer_window
+
+        tmp_path, _mux = sandbox
+        with patch("bmad_loop.adapters.viewer_launch.mux_usable", return_value=False):
+            result_vc = ensure_viewer_window(
+                run_id="test-run",
+                server_url="http://127.0.0.1:9999",
+                session_id="sess-123",
+                working_directory=tmp_path,
+                attach_binary="opencode",
+            )
+        assert result_vc.viewer_window is None
+
+    def test_close_viewer_on_none_is_noop(self, sandbox):
+        """close_viewer_window(None) should not raise."""
+        from bmad_loop.adapters.viewer_launch import close_viewer_window
+
+        # Should not raise
+        close_viewer_window(None)
+        close_viewer_window("")
+        close_viewer_window("=session:window")  # even if window doesn't exist

--- a/tests/test_viewer_integration.py
+++ b/tests/test_viewer_integration.py
@@ -1,0 +1,198 @@
+"""Integration tests for the tmux-based viewer window creation.
+
+These tests run against a REAL tmux server, isolated from the developer's
+own sessions by pointing ``TMUX_TMPDIR`` at a short per-test directory —
+``ensure_viewer_window`` shells out to plain ``tmux``, which resolves its
+socket through that env var, so both the code under test and the test's
+assertions talk to the same throwaway server.
+
+Covers:
+
+1. A long-running viewer command produces a visible named window whose
+   content is capturable through the multiplexer seam (``capture_pane``).
+2. An immediately-exiting viewer is reported as failed: empty ViewerConfig,
+   ``viewer-error.log`` with stderr + exit status, no lingering window.
+
+Skipped when ``tmux`` is not available on PATH.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import uuid
+from pathlib import Path
+
+import pytest
+
+from bmad_loop.adapters.multiplexer import get_multiplexer
+from bmad_loop.adapters.viewer_launch import ensure_viewer_window
+
+
+def _has_tmux() -> bool:
+    try:
+        return subprocess.run(["tmux", "-V"], capture_output=True).returncode == 0
+    except OSError:
+        return False
+
+
+@pytest.fixture(autouse=True)
+def skip_no_tmux():
+    if not _has_tmux():
+        pytest.skip("tmux not available on PATH — skipping integration test")
+
+
+@pytest.fixture
+def isolated_tmux(monkeypatch):
+    """Route every tmux invocation (the code under test's and ours) to a
+    throwaway server via TMUX_TMPDIR, and kill that server afterwards.
+
+    The socket directory must stay SHORT (unix socket paths cap at ~104
+    chars), so it lives directly under the system temp dir rather than
+    pytest's deeply nested tmp_path.
+    """
+    sock_dir = Path(tempfile.mkdtemp(prefix="blvt-"))
+    monkeypatch.setenv("TMUX_TMPDIR", str(sock_dir))
+    monkeypatch.delenv("TMUX", raising=False)
+    get_multiplexer.cache_clear()
+    yield
+    subprocess.run(["tmux", "kill-server"], capture_output=True)
+    get_multiplexer.cache_clear()
+
+
+def _fresh_run_id(tag: str) -> str:
+    return f"{tag}-{uuid.uuid4().hex[:6]}"
+
+
+def _tmux(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["tmux", *args], capture_output=True, text=True, timeout=10)
+
+
+def _long_running_viewer(tmp_path: Path) -> Path:
+    """A fake `opencode`-style binary: ignores its args, prints a marker,
+    and keeps running like a real attached TUI."""
+    script = tmp_path / "fake-viewer.sh"
+    script.write_text("#!/bin/sh\necho VIEWER-UP\nsleep 300\n", encoding="utf-8")
+    script.chmod(0o755)
+    return script
+
+
+# ====================================================================== tests
+
+
+class TestViewerWindowCreation:
+    """A long-running viewer command produces a visible named tmux window."""
+
+    def test_named_window_appears_and_is_capturable(self, isolated_tmux, tmp_path):
+        run_id = _fresh_run_id("live")
+        session_name = f"bmad-loop-{run_id}"
+        viewer_name = f"bmad-loop-{run_id}-viewer"
+
+        result = ensure_viewer_window(
+            run_id=run_id,
+            server_url="http://127.0.0.1:9999",
+            session_id="test-sess-1",
+            working_directory=tmp_path,
+            attach_binary=str(_long_running_viewer(tmp_path)),
+        )
+
+        assert (
+            result.viewer_window == f"={session_name}:{viewer_name}"
+        ), f"ensure_viewer_window should return the window target; got {result}"
+        assert result.viewer_url == "http://127.0.0.1:9999"
+        assert result.viewer_session == "test-sess-1"
+
+        # The window shows up in tmux list-windows.
+        proc = _tmux("list-windows", "-t", f"={session_name}", "-F", "#{window_name}")
+        assert proc.returncode == 0
+        assert viewer_name in proc.stdout.splitlines(), proc.stdout
+
+        # The persisted target is capturable THROUGH THE SEAM — the same
+        # call the dashboard makes — and shows the viewer's output.
+        captured = get_multiplexer().capture_pane(result.viewer_window)
+        assert "VIEWER-UP" in captured
+
+        # No failure artifacts for a healthy start.
+        assert not (tmp_path / "viewer-error.log").exists()
+
+    def test_existing_viewer_is_reused(self, isolated_tmux, tmp_path):
+        run_id = _fresh_run_id("reuse")
+        viewer = _long_running_viewer(tmp_path)
+
+        first = ensure_viewer_window(
+            run_id=run_id,
+            server_url="http://127.0.0.1:9999",
+            session_id="test-sess-r",
+            working_directory=tmp_path,
+            attach_binary=str(viewer),
+        )
+        second = ensure_viewer_window(
+            run_id=run_id,
+            server_url="http://127.0.0.1:9999",
+            session_id="test-sess-r",
+            working_directory=tmp_path,
+            attach_binary=str(viewer),
+        )
+        assert first.viewer_window == second.viewer_window
+
+        # Still exactly one viewer window.
+        proc = _tmux("list-windows", "-t", f"=bmad-loop-{run_id}", "-F", "#{window_name}")
+        names = proc.stdout.splitlines()
+        assert names.count(f"bmad-loop-{run_id}-viewer") == 1, names
+
+
+class TestImmediateExit:
+    """A viewer command that exits immediately is reported as a failure —
+    never persisted as a live viewer."""
+
+    def test_immediate_exit_reports_failure(self, isolated_tmux, tmp_path):
+        exit_script = tmp_path / "exit7.sh"
+        exit_script.write_text("#!/bin/sh\necho 'viewer crash' >&2\nexit 7\n", encoding="utf-8")
+        exit_script.chmod(0o755)
+
+        run_id = _fresh_run_id("dead")
+        result = ensure_viewer_window(
+            run_id=run_id,
+            server_url="http://127.0.0.1:9999",
+            session_id="test-sess-2",
+            working_directory=tmp_path,
+            attach_binary=str(exit_script),
+        )
+
+        # Creation is reported as failed: no successful-looking metadata.
+        assert (
+            result.viewer_window is None
+        ), f"Expected empty viewer config for exiting command; got {result}"
+        assert result.viewer_url == ""
+        assert result.viewer_session == ""
+
+        # stderr and exit code are recorded.
+        error_log = tmp_path / "viewer-error.log"
+        assert error_log.exists(), "Expected viewer-error.log to be written"
+        content = error_log.read_text(encoding="utf-8")
+        assert "viewer-create-failed" in content
+        assert "exit status 7" in content
+        assert "viewer crash" in content
+
+        # The dead window was cleaned up, not left as a live-looking target.
+        proc = _tmux("list-windows", "-t", f"=bmad-loop-{run_id}", "-F", "#{window_name}")
+        assert f"bmad-loop-{run_id}-viewer" not in proc.stdout.splitlines()
+
+    def test_error_log_lands_in_run_dir_when_given(self, isolated_tmux, tmp_path):
+        exit_script = tmp_path / "exit3.sh"
+        exit_script.write_text("#!/bin/sh\nexit 3\n", encoding="utf-8")
+        exit_script.chmod(0o755)
+        run_dir = tmp_path / "run-dir"
+        run_dir.mkdir()
+
+        result = ensure_viewer_window(
+            run_id=_fresh_run_id("rundir"),
+            server_url="http://127.0.0.1:9999",
+            session_id="test-sess-3",
+            working_directory=tmp_path,
+            attach_binary=str(exit_script),
+            run_dir=run_dir,
+        )
+        assert result.viewer_window is None
+        assert (run_dir / "viewer-error.log").exists()
+        assert not (tmp_path / "viewer-error.log").exists()


### PR DESCRIPTION
## What

`[adapter] show_attached_ui = true` gives the opencode-http adapter a live viewer: a detached tmux window running `opencode attach`, rendered in the dashboard Log tab — so an OpenCode run is watchable like the tmux adapters' sessions.

## Why

opencode-http drives sessions over HTTP with no pane to observe; the Log tab could only show the raw server log, leaving runs effectively headless.

## How

- New `viewer_launch` module: parked, authenticated (password via tmux session environment, never argv), verified-live viewer window; failures land in `viewer-error.log` + a `viewer-create-failed` journal event, and `viewer.json` never records a dead target
- New mux seam ops (`capture_pane -t`, `set_session_environment`, `resize_window`, `window_exists`); parked windows fixed for dash (`read -r _park`)
- Dashboard renders the capture through pyte (LNM) each tick, keeps the viewer window resized to the displayed pane, and `attach`/`a` prefer it

## Testing

Unit + real-tmux integration tests (2990 passed, isolated tmux server); verified end-to-end in the live TUI against a real run (`opencode serve` + vllm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional attached UI viewer in a detached terminal window.
  * Added configuration support for enabling the viewer, disabled by default.
  * Attach now prefers the viewer when available.
  * Viewer windows can be reused across retries and resumed sessions.

* **Bug Fixes**
  * Improved viewer rendering, terminal alignment, resizing, pane targeting, and lifecycle cleanup.
  * Added graceful fallback to headless operation when viewer startup is unavailable or fails.
  * Secured viewer connections with per-session authentication.

* **Documentation**
  * Updated configuration examples, key-binding guidance, and the unreleased changelog.
  * Removed legacy `bmad-auto` to `bmad-loop` migration compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->