### PR TITLE
docs: add AGENTS.md + CLAUDE.md agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,94 @@
+# AGENTS.md — bmad-loop
+
+bmad-loop is a deterministic Python orchestrator that drives unattended BMAD-method dev loops by spawning coding-CLI sessions (claude, codex, gemini, copilot, antigravity, opencode) inside terminal multiplexers (tmux; psmux on Windows). **The control loop contains no LLM calls — hard rule.** Orchestration is deterministic Python; LLMs run only inside disposable coding-CLI sessions. PRs that move orchestration into an LLM are rejected ([CONTRIBUTING.md](CONTRIBUTING.md)). User-facing overview: [README.md](README.md); behavior reference: [docs/FEATURES.md](docs/FEATURES.md).
+
+## Dev environment
+
+```bash
+uv sync --all-extras          # setup (extras: tui, non-linux, opencode)
+uv run pytest -q              # test suite (-n auto to parallelize)
+uv run pytest tests/test_engine.py -q   # single file
+trunk fmt                     # format changed files
+trunk check                   # full lint, no path filter — run before every push (pre-push hook enforces it)
+```
+
+- Never `pip install`; uv owns the environment. Dependency changes: edit pyproject.toml, run `uv lock` (CI uses `uv sync --locked` and fails on a stale lock).
+- Typecheck: pyright at the CI-pinned version — see the typecheck job in [.github/workflows/ci.yml](.github/workflows/ci.yml).
+- Windows local runs require `PYTHONUTF8=1` (tests/conftest.py raises UsageError otherwise). Python floor: 3.11.
+
+## Hard invariants
+
+Things that break silently. Never violate; when in doubt, read the named module's docstring.
+
+- No LLM calls in the orchestrator control loop.
+- Sessions complete only on hook Stop events or window death — never on LLM prose. Never add another completion path. Post-session state is re-verified deterministically (`verify.py`).
+- `sprintstatus.advance()` is the orchestrator's sole write path to sprint-status.yaml (the dev skill flips only spec frontmatter; the engine mirrors it onto the board pre-verify). Legal phase transitions live only in `statemachine.py`.
+- All git subprocess calls go through the `_run_git` chokepoint in `verify.py` (timeouts, `LC_ALL=C`) — no bare subprocess git.
+- Every new policy field needs an entry in `src/bmad_loop/data/settings/core.toml` (a sync test enforces defaults/options match `policy.py`). New core env vars register in `envvars.py`; plugin-owned env-var families stay with their plugin.
+- Version strings are stamped only by `scripts/sync_version.py` from `src/bmad_loop/__init__.py` — never hand-edit pyproject.toml, module.yaml, marketplace.json, or uv.lock versions.
+- Canonical module skills live in `src/bmad_loop/data/skills/`; their copies in the gitignored `.claude/skills/` and `.agents/skills/` are seeded forks (`scripts/seed_skills.py`) — editing a fork loses work on reseed (drift-tested locally; the test skips in CI). Other skills in those dirs are BMAD-installed, not seeded. (The `.agents/` directory is unrelated to this file.)
+- `bmad-loop <cmd> --json` output is a schema-versioned contract (`machine.py`): one JSON object on stdout, nothing else.
+- `ExitCode` allocation is closed (`cli.py`): OK=0, FAILURE=1, USAGE=2, INTERRUPTED=130; 3–129 and 131+ stay unallocated.
+- tmux/POSIX argv construction is quarantined in `adapters/tmux_base.py` + `tmux_backend.py`; `tests/test_portability_guard.py` enforces it.
+- Live/E2E tests must consume zero LLM tokens.
+
+## Architecture
+
+Two orthogonal seams: **which CLI** (adapter axis: `adapters/base.py` `CodingCLIAdapter`, TOML profiles in `src/bmad_loop/data/profiles/`, user overlay `.bmad-loop/profiles/*.toml` — a new coding CLI is a TOML profile plus `bmad-loop probe-adapter`, not Python) and **which transport** (mux axis: `adapters/multiplexer.py` `TerminalMultiplexer` registry; selection: `BMAD_LOOP_MUX_BACKEND` env > policy `[mux] backend` > platform default > first available match > fallback — full 5-step precedence in [docs/multiplexer-backends.md](docs/multiplexer-backends.md)).
+
+| Module                                     | Role                                                                                        |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------- |
+| `cli.py`                                   | argparse CLI, all `cmd_*` handlers; injectable `engine_cls`/`make_adapters` seams           |
+| `engine.py`                                | `Engine` — the deterministic control loop                                                   |
+| `worktree_flow.py`, `recovery_flow.py`     | engine collaborators: worktree isolation/merge; rollback + recovery-ref preservation        |
+| `sweep.py`, `stories_engine.py`            | deferred-work sweep run type; stories.yaml mode                                             |
+| `statemachine.py`, `model.py`, `policy.py` | pure typed core (pyright-strict): transitions, data model, policy.toml → frozen dataclasses |
+| `verify.py`                                | deterministic post-session verification; `_run_git` chokepoint                              |
+| `machine.py`, `documents.py`               | `--json` contract; read-model projections                                                   |
+| `adapters/`                                | coding-CLI adapters + mux backends (see seams above)                                        |
+| `tui/`                                     | Textual dashboard (`tui` extra); observer/launcher only — never runs engines in-process     |
+| `plugins/`                                 | manifest-driven extension layer (`plugin.toml`, trust tiers, hook bus)                      |
+
+~25 further leaf modules — read the module docstring before assuming. Deeper maps: [docs/FEATURES.md](docs/FEATURES.md), [docs/adapter-authoring-guide.md](docs/adapter-authoring-guide.md), [docs/multiplexer-backends.md](docs/multiplexer-backends.md).
+
+## Testing
+
+- Flat `tests/` mirrors src modules by name; `asyncio_mode=auto`; no custom markers.
+- Use the conftest sandbox fixtures (`project` copies a session-scoped template repo per test — never hand-roll temp repos or touch the template). Mock adapter drives engine tests without tmux or an LLM; caveat: it exercises the generic adapter path only.
+- Pin the backend with the `force_tmux_backend` fixture when asserting tmux argv through the mux seam.
+- E2E gates: `tests/test_stories_e2e.py` (real tmux on Linux + a scripted fake-claude profile, zero LLM tokens) and `tests/test_opencode_live.py` (zero-token invariant — never sends a prompt). Never "fix" these to call real CLIs.
+- Ablation rule: for any test asserting "X is refused/absent", delete the gating code and confirm the test FAILS before trusting it — negative assertions pass for every reason a value could be absent.
+- New behavior lands with a test at the lowest layer that can catch its regression: pure-core unit > seam > sandbox E2E.
+
+## Git & PRs
+
+[CONTRIBUTING.md](CONTRIBUTING.md) is binding: conventional commits (subject < 72 chars), PRs 200–400 LOC ideal / 800 max, one logical change, feature-sized work needs maintainer confirmation first. Additional working agreements:
+
+- Open PRs ready for review, never draft.
+- CHANGELOG entries: terse, scannable, imperative, under the Unreleased heading.
+- Never commit session notes, probe records, or run artifacts. Durable facts belong in docstrings; records in git history.
+- Review non-convergence is evidence about the approach, not just a defect queue — escalate rather than grind.
+
+## Engineering doctrine
+
+These rules apply to code you are already touching — do not initiate refactors of untouched code to satisfy them.
+
+- Preserve behavior first: released CLI syntax, `--json` output, exit codes, config formats, and persisted data are compatibility contracts — characterize before restructuring.
+- Split by responsibility, never by line count: a cohesive state machine stays whole (`statemachine.py`); size thresholds are review heuristics, not lint gates.
+- Strict typing lives in the pure core, not the I/O edges (the staged pyright config in pyproject.toml is deliberate). Do NOT ratchet ruff stricter than CI — the `[tool.ruff.lint]` comment documents why.
+- Fail loud at boundaries: typed escalation over bare except; observation may degrade, repair writes must raise.
+
+## Docs index
+
+| Doc                                                                | Read when                                    |
+| ------------------------------------------------------------------ | -------------------------------------------- |
+| [docs/setup-guide.md](docs/setup-guide.md)                         | installing/initializing a target project     |
+| [docs/FEATURES.md](docs/FEATURES.md)                               | any behavior or policy question              |
+| [docs/tui-guide.md](docs/tui-guide.md)                             | TUI work                                     |
+| [docs/adapter-authoring-guide.md](docs/adapter-authoring-guide.md) | adding/finalizing a coding-CLI profile       |
+| [docs/multiplexer-backends.md](docs/multiplexer-backends.md)       | mux backend selection/porting                |
+| [docs/plugin-authoring-guide.md](docs/plugin-authoring-guide.md)   | plugin work (incl. game-engine + TEA guides) |
+| [docs/porting-to-a-new-os.md](docs/porting-to-a-new-os.md)         | OS seams                                     |
+| [docs/ROADMAP.md](docs/ROADMAP.md)                                 | planned vs deliberately-deferred work        |
+
+Full list: [docs/README.md](docs/README.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# CLAUDE.md
+
+@AGENTS.md
+
+## Claude Code specifics
+
+- Never edit anything under `.claude/` — `.claude/skills/` mixes BMAD-installed skills with seeded forks of the module skills in `src/bmad_loop/data/skills/`. Edit the canonical copy, then run `uv run python scripts/seed_skills.py`.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Inspired by the original [bmad-automator](https://github.com/bmad-code-org/bmad-
 - 🧠 **No LLM in the control loop.** Story selection, retry budgets, gates, and completion checks are code, not prompts — so they're deterministic, debuggable, and free.
 - 📡 **No pane-scraping.** Coding-agent hooks (`Stop` / `SessionStart` / `SessionEnd` / `PreCompact`) write structured event files the orchestrator watches; skills in automation mode write a machine-readable `result.json` at the end of each workflow.
 - 🔍 **Trust nothing, verify everything.** After each session the orchestrator checks artifacts on disk: spec frontmatter status, baseline-commit match (recorded independently — a cheap LLM-lie detector), non-empty diff, sprint-status sync, and _your_ test/lint commands before any commit.
-- 📒 **One source of truth.** `sprint-status.yaml` is owned by the BMAD skills; the orchestrator only ever reads it.
+- 📒 **One source of truth.** `sprint-status.yaml` is the workflow ledger: the loop's dev skill flips only its story spec's status, the orchestrator mirrors that onto the board through a single idempotent, never-regress writer, and verification re-checks the stage after every session.
 - 🪟 **Fresh context per step.** Dev and review are separate sessions — review never inherits the implementer's context, so there's no anchoring bias.
 - ♻️ **Resumable & multi-agent.** Every run is a resumable state machine on disk, and a generic tmux adapter drives `claude`, `codex`, `gemini`, `copilot`, or `antigravity` (mix per stage).
 - 🌿 **Optional worktree isolation.** Opt in (`[scm] isolation = "worktree"`) and each story runs in its own git worktree/branch and merges back locally — your main checkout stays free while a run is in flight.


### PR DESCRIPTION
## What

Adds the two root agent-instruction files this repo has been missing, plus one README wording fix they exposed.

**`AGENTS.md`** (94 lines) — what a coding agent needs before its first edit here:

- **Hard invariants** — the things that break silently: no LLM in the control loop, sessions complete only on hook `Stop`/window death, `sprintstatus.advance()` as the sole write path to the board, the `_run_git` chokepoint, new policy fields needing a `settings/core.toml` entry, canonical-vs-seeded skills, the `--json` schema contract, closed `ExitCode` allocation, tmux argv quarantine.
- **Architecture** — the two orthogonal seams (adapter axis / mux axis) and a module table, so an agent stops guessing which of ~35 modules owns a behavior.
- **Dev environment, testing conventions, git/PR agreements, doctrine, docs index.**

**`CLAUDE.md`** (7 lines) — `@AGENTS.md` plus the one Claude-Code-specific rule: never edit under `.claude/`; edit the canonical skill in `src/bmad_loop/data/skills/` and run `scripts/seed_skills.py`.

Both were fact-checked line by line against the code — every claim traced to the module that enforces it, generic doctrine and CONTRIBUTING duplicates cut. All 12 relative links resolve.

## The README fix (second commit — separable)

Auditing AGENTS.md against the code showed README.md:34 was wrong in both directions:

> ~~`sprint-status.yaml` is owned by the BMAD skills; the orchestrator only ever reads it.~~

The loop's dev skill doesn't touch `sprint-status.yaml` at all — it flips its story spec's frontmatter, and the **engine** mirrors that onto the board (`engine.py` `_post_dev_state_sync` → `sprint_advance`) *before* `verify_dev` gates on the stage. So the orchestrator plainly does write it. Replaced with the accurate invariant — `advance()` is the single idempotent, never-regress writer — which is also what AGENTS.md records.

Happy to drop that commit if you'd rather keep this PR to just the two new files.

## Notes

- Docs only — no code, no tests, no CHANGELOG entry (contributor-facing, not a released behavior change).
- `trunk check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added operational and architectural guidance for the bmad-loop project, including workflow rules, testing expectations, and contribution practices.
  * Added guidance for Claude Code on referencing project instructions and managing configuration changes.
  * Clarified that sprint status is synchronized with the board and re-verified after each session to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->