### PR TITLE
fix(adapters): session-qualify psmux TUI-side window ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,16 @@ story <id>`, the same annotation a sweep bundle writes. Both sprint and stories 
 
 ### Fixed
 
+- **Session-qualify the psmux TUI-side window ids (#291).** #254 covered the engine seam but left
+  the launcher's surfaces bare, and that process usually runs _outside_ any pane — where a bare
+  `@N` resolves through psmux's most-recent-session fallback, not the session that minted it. The
+  ctl-window prune replayed such ids as `kill-window` targets and could close another server's
+  identically-numbered window with rc 0. `new_parked_window`, the `window_id` columns of
+  `list_windows`, and `current_window_id` now emit `session:@N`; the prune compares the last two,
+  so they qualify together or a prune kills the window it runs in. `select_window` resolves the id
+  to an index first — psmux validates a scoped target's window part CLI-side against window
+  index/name only. tmux is untouched (its ids are server-global).
+
 - **Verify environment faults are classified per shell, so Windows stops burning dev attempts on a
   broken tree (#302).** `ENV_FAULT_RCS = {126, 127}` is `sh`'s launcher convention, but verify
   commands run through the host shell — and `cmd` has no equivalent: a missing tool exits `1`,

--- a/docs/adapter-authoring-guide.md
+++ b/docs/adapter-authoring-guide.md
@@ -108,11 +108,14 @@ module-level `parse_target()` — or the backend's own **native id** (whatever y
 `target()`. (Two values are composed by the backend itself rather than by
 `target()`, precisely so the seam grammar never has to carry a pane or window
 id: the parked-window return target — `current_return_target`, above — and the
-native window id, which psmux qualifies to `session:@N` across the
-`new_window`/`list_window_ids` pair because its ids are per-server (falling back
-to the bare id where that grammar would not survive — the backend owns those
-conditions, and applies them to both halves of the pair so the symmetry rule
-still holds). Both are replayed opaquely; neither is parsed by core.) tmux consumes the token natively (it coincides with tmux exact-match
+native window id, which psmux qualifies to `session:@N` because its ids are
+per-server (falling back to the bare id where that grammar would not survive —
+the backend owns those conditions, and applies them uniformly, so the
+`new_window`/`list_window_ids` symmetry rule holds under the fallback too).
+Both are replayed opaquely; neither is parsed by core. psmux applies the same
+qualification to `new_parked_window`, the `window_id` columns of `list_windows`
+and `current_window_id`; the latter two must agree, since the ctl-window prune
+compares them to skip its own window.) tmux consumes the token natively (it coincides with tmux exact-match
 syntax), so `BaseTmuxBackend` passes it straight through. A native-id backend
 calls `parse_target()` first — `None` means "already a native id, use as-is",
 otherwise resolve `(session, window)` yourself; the herdr adapter's

--- a/src/bmad_loop/adapters/multiplexer.py
+++ b/src/bmad_loop/adapters/multiplexer.py
@@ -164,11 +164,10 @@ class TerminalMultiplexer(ABC):
         server per session), so a bare ``@N`` replayed as a ``-t`` target
         routes by the *caller's* server instead of the owning one.
 
-        :meth:`new_parked_window` is deliberately *outside* the rule: nothing
-        membership-tests a parked id — it is only replayed as a ``-t`` target,
-        by the TUI — so a backend MAY mint it in a form this list never
-        carries. psmux keeps it bare, because the qualified grammar is not
-        accepted by the verbs the parked path uses (#291).
+        :meth:`new_parked_window` is *outside* the rule — nothing
+        membership-tests a parked id, it is only replayed as a ``-t`` target by
+        the TUI — so a backend MAY mint it in a form this list never carries
+        (psmux happens to qualify it too, #291).
 
         Raises :class:`MultiplexerError` if the transport itself fails (timeout /
         missing binary): an empty list means "no windows" and must not be
@@ -180,7 +179,10 @@ class TerminalMultiplexer(ABC):
         """One tuple per window in ``session``, each holding the requested
         backend fields in order. Best-effort: returns ``[]`` on a transport
         failure (unlike :meth:`list_window_ids`, this is metadata, not a liveness
-        probe, so a sentinel is safe)."""
+        probe, so a sentinel is safe).
+
+        A ``window_id`` column carries the same id form :meth:`current_window_id`
+        returns; core compares the two directly."""
 
     @abstractmethod
     def window_alive(self, session: str, window_id: str) -> bool:
@@ -247,7 +249,9 @@ class TerminalMultiplexer(ABC):
     @abstractmethod
     def current_window_id(self) -> str | None:
         """Native id of the window this process runs in, or None when not inside
-        the multiplexer."""
+        the multiplexer. Must match the form :meth:`list_windows` puts in a
+        ``window_id`` column — the ctl-window prune skips its own window by
+        comparing them."""
 
     @abstractmethod
     def current_session(self) -> str | None:

--- a/src/bmad_loop/adapters/psmux_backend.py
+++ b/src/bmad_loop/adapters/psmux_backend.py
@@ -12,16 +12,23 @@ command string does not survive psmux's outer re-parse (so shell source
 travels as ``pwsh -EncodedCommand``), and ``pipe-pane`` strips every
 dash-flag token from the piped command (so the log sink travels as a
 positional sidecar ``.ps1``). Window ids are minted per server (one
-server per session), so ``new_window``/``list_window_ids`` hand back
-session-qualified ``session:@N`` ids that route to the owning server from
-any caller (psmux/psmux#483) — the TUI-side mint/list surfaces
-(``new_parked_window``, ``list_windows`` field ids) deliberately still hand
-back bare ids, a different process context tracked in #291.
+server per session), so every id this backend hands back —
+``new_window``, ``list_window_ids``, ``new_parked_window``, the
+``window_id`` columns of ``list_windows``, and ``current_window_id`` — is
+session-qualified to ``session:@N`` (degrading to the bare id only where
+the grammar cannot carry the session name — see ``_qualified_window_id``)
+and routes to the owning server from any caller (psmux/psmux#483).
+``select_window`` is the one verb that
+cannot take that form: psmux validates a scoped target's window part
+CLI-side against window index/name only, so the override resolves the id
+back to an index first. The window-option verbs need no override: psmux
+drops the window slot of a ``-w`` target either way (#310).
 ``available()`` additionally gates on
 the reported version: psmux releases up to 3.3.6 kill recycled PIDs during
 pane/session teardown without a process-identity check, which can take down
-an unrelated long-lived process mid-run. See :mod:`.multiplexer` for the
-contract.
+an unrelated long-lived process mid-run. The psmux behaviors cited in this
+module were read from the psmux source at tag ``v3.3.7``. See
+:mod:`.multiplexer` for the contract.
 """
 
 from __future__ import annotations
@@ -184,16 +191,17 @@ class PsmuxMultiplexer(BaseTmuxBackend):
         # ctl pane that is the wrong server entirely (#254). A `session:@N`
         # target routes by the session's port file instead (psmux/psmux#483:
         # qualified targets are at full parity; bare ids are a permanent model
-        # boundary). Degrade to the bare id when the session name contains `:`
-        # (it would split at the wrong colon) — the #221 rule — or when the id
-        # is falsy (a failure sentinel must pass through unchanged).
+        # boundary). Degrade to the bare id when the session name is empty or
+        # contains `:` (the grammar cannot carry it: `":@N"` parses sessionless
+        # and `a:b:@N` splits at the wrong colon) — the #221 rule — or when the
+        # id is falsy (a failure sentinel must pass through unchanged).
         #
         # Composed here rather than via self.target() — which would emit
         # `=session:@N`, and does parse (psmux strips the `=`) — because the
         # seam requires target() to stay a stable *by-name* token and `@N` is
         # an id. Do not "unify" the two grammars: current_return_target's
         # `=session:%N` is a target(), this is not.
-        if not window_id or ":" in session:
+        if not window_id or not session or ":" in session:
             return window_id
         return f"{session}:{window_id}"
 
@@ -215,6 +223,102 @@ class PsmuxMultiplexer(BaseTmuxBackend):
             self._qualified_window_id(session, window_id)
             for window_id in super().list_window_ids(session)
         ]
+
+    def new_parked_window(
+        self, session: str, name: str, cwd: Path, argv: list[str], return_opt: str
+    ) -> str:
+        # Same per-server ambiguity as new_window, worse context: the launcher
+        # usually runs OUTSIDE any pane, so a bare `@N` replayed as a `-t` target
+        # falls through to the most-recent-session fallback rather than the
+        # session that just minted it.
+        window_id = super().new_parked_window(session, name, cwd, argv, return_opt)
+        return self._qualified_window_id(session, window_id)
+
+    def list_windows(self, session: str, fields: list[str]) -> list[tuple[str, ...]]:
+        # Qualify only the `window_id` columns — the prune replays exactly those
+        # values as kill-window targets, and a bare one can take down another
+        # server's identically-numbered window.
+        rows = super().list_windows(session, fields)
+        id_columns = [i for i, field in enumerate(fields) if field == "window_id"]
+        if not id_columns:
+            return rows
+        return [
+            tuple(
+                self._qualified_window_id(session, value) if i in id_columns else value
+                for i, value in enumerate(row)
+            )
+            for row in rows
+        ]
+
+    # What _qualified_window_id composes: `<session>:@<n>`. The session part
+    # excludes `:` because that is exactly when qualification degrades to a bare
+    # id; requiring `@<digits>` keeps a `=session:window-name` token out.
+    _QUALIFIED_ID = re.compile(r"^(?P<session>[^:]+):(?P<window_id>@\d+)$")
+    _BARE_ID = re.compile(r"^@\d+$")
+
+    def current_window_id(self) -> str | None:
+        # Must match list_windows' window_id form: the ctl prune skips its own
+        # window by comparing them, so a mismatch makes a prune run from inside a
+        # ctl window kill that window. Hence ONE probe rather than a window id
+        # plus a separate session name — a split probe can resolve the id and
+        # fail the session, and rows are qualified from the session list_windows
+        # was *passed*, so neither a bare id nor None could ever equal one.
+        probed = self._display_message("#{session_name}:#{window_id}")
+        if not probed:
+            return None
+        if self._QUALIFIED_ID.fullmatch(probed):
+            return probed
+        # A `:`-bearing (or empty) session name can't carry the grammar — the
+        # #221 degrade, which list_windows applies to its rows identically. A
+        # malformed id is no target at all; half-parsing one would aim a kill.
+        _, _, window_id = probed.rpartition(":")
+        return window_id if self._BARE_ID.fullmatch(window_id) else None
+
+    def select_window(self, target: str) -> None:
+        # psmux checks a scoped target's window part CLI-side before sending, and
+        # only ever matches `#{window_index}`/`#{window_name}` — never
+        # `#{window_id}` — so a qualified id exits 1 with "can't find window"
+        # while the server itself resolves ids fine (FocusWindowById). Translate
+        # to the index that check accepts and the same window is focused.
+        # The `=` strip matters: target(session, window) composes `=session:@N`,
+        # which would capture the session as `=session` and look up `==session`
+        # (psmux's parse_target removes only one `=`), silently focusing nothing.
+        match = self._QUALIFIED_ID.fullmatch(target.removeprefix("="))
+        if match is not None:
+            session = match["session"]
+            index = self._window_index(session, match["window_id"])
+            if index is None:
+                # The unresolved id sent below is exactly the form that CLI-side
+                # check rejects, and its exit 1 lands in a pipe the base
+                # discards — so the send is known-futile and the caller's later
+                # attach shows whichever window happens to be current. Warn
+                # (the pipe-pane sidecar precedent), or that is untraceable;
+                # guessing an index instead could focus an unrelated window.
+                print(
+                    f"warning: select-window could not resolve {target} to a "
+                    "window index; the window will not be focused",
+                    file=sys.stderr,
+                )
+            else:
+                target = f"{session}:{index}"
+        # A name token or a bare id goes through untouched.
+        super().select_window(target)
+
+    def _window_index(self, session: str, window_id: str) -> str | None:
+        """Display index of ``window_id`` within ``session``, or None when it
+        cannot be resolved.
+
+        Known ceiling: psmux can renumber windows between this lookup and the
+        verb using the answer. The race is one round-trip wide and the caller is
+        a best-effort focus change, so no lock; targeting by name instead would
+        reopen the ctl-window name collisions stable ids exist to avoid.
+        """
+        # `window_index` is the display index — the field psmux's own existence
+        # check compares against, so matching it exactly is the point.
+        for row in super().list_windows(session, ["window_id", "window_index"]):
+            if row[0] == window_id:
+                return row[1] or None
+        return None
 
     def current_return_target(self) -> str | None:
         # psmux runs one server per session, so a bare pane id recorded on a

--- a/src/bmad_loop/adapters/psmux_backend.py
+++ b/src/bmad_loop/adapters/psmux_backend.py
@@ -291,9 +291,18 @@ class PsmuxMultiplexer(BaseTmuxBackend):
                 # The unresolved id sent below is exactly the form that CLI-side
                 # check rejects, and its exit 1 lands in a pipe the base
                 # discards — so the send is known-futile and the caller's later
-                # attach shows whichever window happens to be current. Warn
-                # (the pipe-pane sidecar precedent), or that is untraceable;
-                # guessing an index instead could focus an unrelated window.
+                # attach shows whichever window happens to be current. Guessing
+                # an index instead could focus an unrelated window, so warn and
+                # send: the pipe-pane sidecar precedent, but a weaker one, and
+                # deliberately not load-bearing. Today's only caller of the
+                # qualified-id path (select_ctl_window_id, from the TUI's resolve
+                # launch) runs inside the Textual app, which captures stderr for
+                # the app's whole run — see the run_tui note in tui/app.py, which
+                # pre-trips the forced-backend warning for exactly this reason —
+                # so this emission is invisible there. It is kept for the CLI-side
+                # callers tui/launch.py is textual-free to allow; a TUI-visible
+                # miss would need a return value, which is more seam than a
+                # best-effort focus change is worth.
                 print(
                     f"warning: select-window could not resolve {target} to a "
                     "window index; the window will not be focused",

--- a/src/bmad_loop/tui/launch.py
+++ b/src/bmad_loop/tui/launch.py
@@ -67,8 +67,9 @@ def select_ctl_window(window: str) -> None:
 
 
 def select_ctl_window_id(window_id: str) -> None:
-    """Like select_ctl_window but by stable tmux window id (@N). Immune to the
-    by-name first-match ambiguity in ctl_window and to tmux auto-rename."""
+    """Like select_ctl_window but by the backend's stable window id (bare `@N` on
+    tmux, session-qualified on psmux), as returned by start_detached. Immune to
+    the by-name first-match ambiguity in ctl_window and to tmux auto-rename."""
     get_multiplexer().select_window(window_id)
 
 
@@ -101,7 +102,8 @@ def set_return_pane(window_target: str, target: str) -> None:
     """Record `target` (a current_return_target value or RETURN_DETACH) as the
     return move on a control-session window, so its trailing shell sends the
     client back there when the window's command exits. `window_target` is any
-    tmux window spec (e.g. `=bmad-loop-ctl:run-…` or a stable `@N` id)."""
+    window spec the backend accepts (e.g. `=bmad-loop-ctl:run-…`, or a stable id
+    from start_detached — bare `@N` on tmux, session-qualified on psmux)."""
     get_multiplexer().set_window_option(window_target, RETURN_OPTION, target)
 
 
@@ -281,8 +283,9 @@ def start_detached(project: Path, argv_tail: list[str], run_id: str, kind: str) 
     handled by the multiplexer's parked-window primitive, keyed by the
     RETURN_OPTION recorded on the window by set_return_pane.
 
-    Returns the new window's stable tmux id (@N) so callers can target it
-    unambiguously (window names collide when several kinds share a run_id).
+    Returns the new window's stable backend id (bare `@N` on tmux,
+    session-qualified on psmux) so callers can target it unambiguously (window
+    names collide when several kinds share a run_id).
     """
     mux = get_multiplexer()
     if not mux_usable(mux):

--- a/tests/test_psmux_backend.py
+++ b/tests/test_psmux_backend.py
@@ -14,6 +14,7 @@ import pytest
 from bmad_loop.adapters import psmux_backend, tmux_base
 from bmad_loop.adapters.multiplexer import MultiplexerError, get_multiplexer
 from bmad_loop.adapters.psmux_backend import PsmuxMultiplexer
+from bmad_loop.adapters.tmux_backend import TmuxMultiplexer
 
 
 class _RecordRun:
@@ -545,3 +546,213 @@ def test_registry_selects_psmux_when_forced(monkeypatch):
         assert isinstance(get_multiplexer(), PsmuxMultiplexer)
     finally:
         get_multiplexer.cache_clear()  # don't leak the forced pick to other tests
+
+
+# ------------------------------------------ TUI-side qualified window ids (#291)
+# The launcher/prune surfaces hand ids around from a process that is usually
+# OUTSIDE any pane, where a bare `@N` resolves through the most-recent-session
+# fallback instead of the session that minted it. kill-window on such an id is
+# destructive against the wrong server, so new_parked_window, the `window_id`
+# columns of list_windows, and current_window_id all carry `session:@N` — and
+# select_window, whose CLI-side check matches only window index/name, resolves
+# that form back to an index before sending.
+
+
+def _rows_fake(monkeypatch, rows: str, *, new_window_id: str = "@2\n"):
+    """Script list-windows to emit tab-separated -F rows (and new-window an id)."""
+
+    def fake(argv, **kwargs):
+        out = new_window_id if argv[1] == "new-window" else rows
+        return subprocess.CompletedProcess(argv, 0, stdout=out, stderr="")
+
+    monkeypatch.setattr(tmux_base.subprocess, "run", fake)
+
+
+def test_new_parked_window_returns_session_qualified_id(monkeypatch, tmp_path):
+    _window_fake(monkeypatch)
+    win = PsmuxMultiplexer().new_parked_window("ctl", "run-x", tmp_path, ["prog"], "@ret")
+    assert win == "ctl:@2"
+
+
+def test_new_parked_window_degrades_on_colon_session(monkeypatch, tmp_path):
+    # Same #221 rule the engine-side mint follows: `a:b:@2` would split at the
+    # wrong colon, so the id stays bare rather than becoming a wrong target.
+    _window_fake(monkeypatch)
+    win = PsmuxMultiplexer().new_parked_window("a:b", "run-x", tmp_path, ["prog"], "@ret")
+    assert win == "@2"
+
+
+def test_qualified_window_id_degrades_on_empty_session():
+    # An empty session name would compose ":@2", which current_window_id parses
+    # back to the bare "@2" — the two sides of the prune comparison must degrade
+    # together, so the compose side degrades too.
+    assert PsmuxMultiplexer()._qualified_window_id("", "@2") == "@2"
+
+
+def test_new_parked_window_falsy_id_passes_through(monkeypatch, tmp_path):
+    # An empty id is start_detached's "window id not captured" sentinel; forging
+    # "ctl:" out of it would turn a detected failure into a plausible target.
+    _window_fake(monkeypatch, new_window_id="")
+    assert PsmuxMultiplexer().new_parked_window("ctl", "r", tmp_path, ["p"], "@ret") == ""
+
+
+def test_list_windows_qualifies_only_the_window_id_column(monkeypatch):
+    _rows_fake(monkeypatch, "@1\tshell\t\n@2\trun-x\tproj-tag\n")
+    rows = PsmuxMultiplexer().list_windows("ctl", ["window_id", "window_name", "@bmad_project"])
+    assert rows == [("ctl:@1", "shell", ""), ("ctl:@2", "run-x", "proj-tag")]
+
+
+def test_list_windows_without_id_column_is_untouched(monkeypatch):
+    # ctl_window() asks for names only; nothing there may be rewritten.
+    _rows_fake(monkeypatch, "shell\nrun-x\n")
+    assert PsmuxMultiplexer().list_windows("ctl", ["window_name"]) == [("shell",), ("run-x",)]
+
+
+def test_list_windows_degrades_on_colon_session(monkeypatch):
+    _rows_fake(monkeypatch, "@1\tshell\n")
+    assert PsmuxMultiplexer().list_windows("a:b", ["window_id", "window_name"]) == [("@1", "shell")]
+
+
+_CURRENT_FMT = "#{session_name}:#{window_id}"
+
+
+def test_current_window_id_is_session_qualified(monkeypatch):
+    _probe_fake(monkeypatch, {_CURRENT_FMT: (0, "ctl:@2\n")})
+    assert PsmuxMultiplexer().current_window_id() == "ctl:@2"
+
+
+def test_current_window_id_matches_list_windows_form(monkeypatch):
+    # The load-bearing symmetry: the prune candidate scan skips its own window by
+    # comparing these two values. Qualify one side only and the scan stops
+    # recognizing itself — a prune from inside a ctl window kills that window.
+    _probe_fake(monkeypatch, {_CURRENT_FMT: (0, "ctl:@2\n")})
+    mux = PsmuxMultiplexer()
+    current = mux.current_window_id()
+    _rows_fake(monkeypatch, "@1\tshell\n@2\trun-x\n")
+    assert current in [row[0] for row in mux.list_windows("ctl", ["window_id", "window_name"])]
+
+
+def test_current_window_id_resolves_session_and_id_in_one_probe(monkeypatch):
+    # Two probes would open a gap where the id resolves and the session does not.
+    # There is no safe answer in that gap — list_windows qualifies its rows from
+    # the session it was PASSED, so they stay qualified whatever a probe here
+    # says, and a bare id can never equal one: the prune would stop excluding its
+    # own window and kill it. One expansion yields both parts or neither.
+    recorder = _RecordRun(stdout="ctl:@2\n")
+    monkeypatch.setenv("TMUX", "/tmp/psmux-1000/default,123,0")
+    monkeypatch.setattr(tmux_base.subprocess, "run", recorder)
+    assert PsmuxMultiplexer().current_window_id() == "ctl:@2"
+    assert len(recorder.calls) == 1
+    assert recorder.argv[1:] == ["display-message", "-p", _CURRENT_FMT]
+
+
+def test_current_window_id_none_outside_mux(monkeypatch):
+    # Not inside psmux: the probe is skipped entirely rather than answering for
+    # some other client's session.
+    monkeypatch.delenv("TMUX", raising=False)
+    rec = _RecordRun()
+    monkeypatch.setattr(tmux_base.subprocess, "run", rec)
+    assert PsmuxMultiplexer().current_window_id() is None
+    assert rec.calls == []
+
+
+def test_current_window_id_bare_on_colon_session(monkeypatch):
+    # `a:b:@2` cannot be split back at the right colon, so it degrades to the
+    # bare id — and list_windows("a:b", ...) degrades its rows identically, so
+    # the prune comparison still lines up.
+    _probe_fake(monkeypatch, {_CURRENT_FMT: (0, "a:b:@2\n")})
+    mux = PsmuxMultiplexer()
+    assert mux.current_window_id() == "@2"
+    _rows_fake(monkeypatch, "@2\trun-x\n")
+    assert mux.list_windows("a:b", ["window_id", "window_name"]) == [("@2", "run-x")]
+
+
+def test_current_window_id_none_on_unparseable_probe(monkeypatch):
+    # A probe that did not answer a window id is not a target; composing one from
+    # the fragment would aim a later kill somewhere unintended.
+    for answer in ("ctl:\n", "ctl:notanid\n", ":\n", "ctl:@\n"):
+        _probe_fake(monkeypatch, {_CURRENT_FMT: (0, answer)})
+        assert PsmuxMultiplexer().current_window_id() is None, answer
+
+
+def test_select_window_resolves_qualified_id_to_index(monkeypatch):
+    # psmux exits 1 with "can't find window: @3" for the id form, because the
+    # CLI-side existence check compares only against #{window_index}/#{window_name}.
+    recorder = _RecordRun(stdout="@1\t0\n@3\t2\n")
+    monkeypatch.setattr(tmux_base.subprocess, "run", recorder)
+    PsmuxMultiplexer().select_window("ctl:@3")
+    assert recorder.calls[0][0][1:] == [
+        "list-windows",
+        "-t",
+        "=ctl",
+        "-F",
+        "#{window_id}\t#{window_index}",
+    ]
+    assert recorder.argv[1:] == ["select-window", "-t", "ctl:2"]
+
+
+def test_select_window_resolve_scopes_the_lookup_to_the_session(monkeypatch):
+    # The lookup must carry -t =<session>: psmux routes by the explicit session,
+    # and an unscoped list-windows would read whichever server the fallback picks.
+    recorder = _RecordRun(stdout="@3\t2\n")
+    monkeypatch.setattr(tmux_base.subprocess, "run", recorder)
+    PsmuxMultiplexer().select_window("ctl:@3")
+    assert "-t" in recorder.calls[0][0] and "=ctl" in recorder.calls[0][0]
+
+
+def test_select_window_unresolved_id_sends_original_target(monkeypatch, capsys):
+    # No matching row: send the id anyway (guessing an index would focus an
+    # unrelated window) — but warn, because psmux's "can't find window" exit 1
+    # lands in a discarded pipe and the miss would otherwise be untraceable.
+    recorder = _RecordRun(stdout="@1\t0\n")
+    monkeypatch.setattr(tmux_base.subprocess, "run", recorder)
+    PsmuxMultiplexer().select_window("ctl:@9")
+    assert recorder.argv[1:] == ["select-window", "-t", "ctl:@9"]
+    assert "could not resolve ctl:@9" in capsys.readouterr().err
+
+
+def test_select_window_resolve_failure_sends_original_target(monkeypatch, capsys):
+    # A transport failure during the resolve must not escalate: select_window is
+    # best-effort, so it degrades to the unresolved target (with the same
+    # warning as a resolve miss), never raises — and it must still SEND, not
+    # swallow the verb along with the failure.
+    sent = []
+
+    def fake(argv, **kwargs):
+        if argv[1] == "list-windows":
+            raise subprocess.TimeoutExpired(argv, 1)
+        sent.append(argv)
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(tmux_base.subprocess, "run", fake)
+    PsmuxMultiplexer().select_window("ctl:@3")  # must not raise
+    assert sent and sent[-1][1:] == ["select-window", "-t", "ctl:@3"]
+    assert "could not resolve ctl:@3" in capsys.readouterr().err
+
+
+def test_select_window_resolves_equals_prefixed_qualified_id(monkeypatch):
+    # target(session, "@3") composes `=ctl:@3`, which the seam documents as a
+    # legal argument here. Matching without stripping the `=` would capture the
+    # session as "=ctl" and look up `-t ==ctl`; psmux strips only one `=`, so the
+    # resolve would miss and the select would quietly focus nothing.
+    recorder = _RecordRun(stdout="@3\t2\n")
+    monkeypatch.setattr(tmux_base.subprocess, "run", recorder)
+    PsmuxMultiplexer().select_window("=ctl:@3")
+    assert recorder.calls[0][0][3] == "=ctl"
+    assert recorder.argv[1:] == ["select-window", "-t", "ctl:2"]
+
+
+def test_select_window_name_token_passes_through(rec):
+    # A target() name token already resolves CLI-side; it must not be rewritten.
+    PsmuxMultiplexer().select_window("=ctl:run-abc")
+    assert rec.argv[1:] == ["select-window", "-t", "=ctl:run-abc"]
+    assert len(rec.calls) == 1  # no resolve lookup spawned
+
+
+def test_tmux_backend_keeps_bare_tui_ids(monkeypatch, tmp_path):
+    # The divergence is psmux-only: tmux ids are server-global, so qualifying
+    # them would produce targets its own verbs do not accept.
+    _rows_fake(monkeypatch, "@1\tshell\n")
+    mux = TmuxMultiplexer()
+    assert mux.new_parked_window("ctl", "run-x", tmp_path, ["prog"], "@ret") == "@2"
+    assert mux.list_windows("ctl", ["window_id", "window_name"]) == [("@1", "shell")]


### PR DESCRIPTION
Closes #291

## What

#254/#290 covered the engine seam but left the launcher's surfaces bare — and the TUI usually runs *outside* any psmux pane, where a bare `@N` replayed as a `-t` target resolves through psmux's most-recent-session fallback. The ctl-window prune could `kill-window` another server's identically-numbered window with rc 0, and the detached-resolve select/attach could land on the wrong server.

- `new_parked_window`, the `window_id` columns of `list_windows`, and `current_window_id` now emit `session:@N` (via the existing `_qualified_window_id`, sharing its degrade rules — including a new guard so an empty session name degrades on the compose side exactly like the parse side).
- `current_window_id` resolves session and id from **one** `#{session_name}:#{window_id}` expansion — a split probe can resolve the id while the session fails, which would break the prune's self-exclusion and kill the window it runs in.
- `select_window` resolves a qualified id to `session:<index>` just-in-time: psmux validates a scoped target's window part CLI-side against index/name only (never `window_id`), while the server resolves ids fine (`FocusWindowById`). On a resolve miss/failure it still sends the original target (best-effort contract) but now warns on stderr — psmux's `can't find window` exit 1 lands in a discarded pipe, so the miss was previously untraceable.
- tmux untouched: its ids are server-global (divergence pinned by test).

Every psmux behavior relied on here was read from the psmux source at tag `v3.3.7`, the tag matching the installed build.

## Follow-ups (split out, not fixed here)

- #310 — per-window user options are session-scoped on psmux, so the `PROJECT_OPTION` prune guard cannot discriminate between projects and the `RETURN_OPTION` parked-return mechanism is inert. Split out of #291 by scope review: this PR fixes *id routing* only; that needs a different *state channel*. The window-option verbs are deliberately untouched here — psmux drops the window slot of a `-w` target either way, so the qualified ids this PR introduces neither help nor harm those surfaces.
- A garbled `current_window_id` probe degrades to `None`, which disables the prune's self-exclusion; pre-existing on both backends and out of scope here — will be filed separately.

## Verification

- `pytest tests/test_psmux_backend.py tests/test_tui_launch.py tests/test_multiplexer.py tests/test_portability_guard.py -q` → 134 passed (16 new tests, incl. ablation-checked degrade/passthrough gates)
- `trunk check` clean, `pyright@1.1.411` clean on the touched module

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved psmux window targeting by consistently scoping TUI window IDs to their sessions.
  * Prevented selection/cleanup from targeting identically numbered windows belonging to different sessions.
  * Added safer handling when session-qualified IDs can’t be represented or resolved.
* **Documentation**
  * Clarified adapter and TUI expectations for backend-specific window ID formatting and matching behavior.
* **Tests**
  * Added coverage for session-qualified ID behavior across parked-window creation, listing, probing, and selection, plus tmux compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
