### PR TITLE
fix(tests): remove hardcoded GNU coreutils dependencies on Windows (#293)

### DIFF
--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -3,6 +3,7 @@ artifact trim, and the `clean` CLI command."""
 
 import argparse
 import subprocess
+import sys
 
 from conftest import install_bmad_config, machine_json
 
@@ -22,7 +23,7 @@ def _state_run(project, run_id, **kw):
 
 
 def _dead_pid() -> int:
-    p = subprocess.Popen(["true"])
+    p = subprocess.Popen([sys.executable, "-c", ""])
     p.wait()
     return p.pid
 

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -2,8 +2,6 @@
 artifact trim, and the `clean` CLI command."""
 
 import argparse
-import subprocess
-import sys
 
 from conftest import install_bmad_config, machine_json
 
@@ -20,12 +18,6 @@ def _state_run(project, run_id, **kw):
         RunState(run_id=run_id, project=str(project), started_at="2026-06-11T10:00:00", **kw),
     )
     return run_dir
-
-
-def _dead_pid() -> int:
-    p = subprocess.Popen([sys.executable, "-c", ""])
-    p.wait()
-    return p.pid
 
 
 # --------------------------------------------------------------- predicates

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -405,12 +405,17 @@ def test_stop_run_dead_pid_falls_back(tmp_path, monkeypatch):
 def test_stop_run_signals_live_process(tmp_path, monkeypatch):
     monkeypatch.setattr(runs, "kill_session", lambda _rid: None)
     run_dir = _make_state_run(tmp_path, "r1")
-    proc = subprocess.Popen(["sleep", "30"])
-    (run_dir / "engine.pid").write_text(str(proc.pid))
-    assert runs.stop_run(run_dir) is True
-    # the process received SIGTERM and is gone
-    assert proc.poll() is not None or proc.wait(timeout=5) is not None
-    assert load_state(run_dir).stopped is True
+    proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    try:
+        (run_dir / "engine.pid").write_text(str(proc.pid))
+        assert runs.stop_run(run_dir) is True
+        # the process received SIGTERM and is gone
+        assert proc.poll() is not None or proc.wait(timeout=5) is not None
+        assert load_state(run_dir).stopped is True
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait()
 
 
 def test_stop_run_respects_engine_written_stopped(tmp_path, monkeypatch):

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -415,7 +415,7 @@ def test_stop_run_signals_live_process(tmp_path, monkeypatch):
     finally:
         if proc.poll() is None:
             proc.kill()
-            proc.wait()
+            proc.wait(timeout=10)
 
 
 def test_stop_run_respects_engine_written_stopped(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Two tests depended on GNU coreutils being resolvable on Windows PATH:
- `tests/test_runs.py::test_stop_run_signals_live_process` spawned `subprocess.Popen(["sleep", "30"])`.
- `tests/test_cleanup.py::_dead_pid()` spawned `subprocess.Popen(["true"])`.

On stock Windows environments without `Git\usr\bin` on PATH, these failed with `FileNotFoundError` or exit code 9009 (`'true' is not recognized as an internal or external command`).

## Changes

- Updated `test_stop_run_signals_live_process` to use `sys.executable` with `import time; time.sleep(30)` and added process cleanup in a `finally` block.
- Updated `_dead_pid` in `tests/test_cleanup.py` to spawn `sys.executable` with `""`.

The `tests/test_verify.py` half of the original diff (`true`/`false` verify commands) landed on main via #308, so this branch was rebased onto it and now carries only the two `Popen` call sites.

Fixes #293

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved process-related test reliability by using the active Python interpreter instead of platform-specific external commands.
  * Added cleanup safeguards to ensure test processes are terminated and reaped properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->