### PR TITLE
fix(frontmatter,verify,devcontract): preserve spec line endings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -248,6 +248,16 @@ story <id>`, the same annotation a sweep bundle writes. Both sprint and stories 
 
 ### Fixed
 
+- **Spec writers no longer relay a spec's line endings (#357, part 1).** `set_frontmatter_status`,
+  `set_frontmatter_field`, `reset_spec_status`, and `strip_auto_run_result` read specs through
+  `read_text`, whose universal-newline translation handed each writer an all-LF copy of a CRLF spec —
+  so a write contracted to move one value rewrote every line ending in the file (to LF everywhere, and
+  to CRLF for an all-LF spec on Windows). All four now read bytes and decode; the two `frontmatter`
+  writers write bytes too, and a replaced line carries its own terminator instead of a flat `\n`.
+  A CRLF spec stays CRLF, a mixed-ending spec keeps each line's ending, and only the value moves.
+  One pinned delta: a CR-only spec — never authored by a BMAD tool — is now a clean no-op through
+  `reset_spec_status` / `strip_auto_run_result`, whose patterns are line-oriented on `\r?\n`.
+
 - **A spec status the writer cannot rewrite is no longer a silent no-op.** `set_frontmatter_status`
   found the line with `lstrip().startswith("status:")` while every reader parses the block as YAML,
   so the two disagreed in both directions: a quoted key (`"status": x`), a space before the colon,

--- a/src/bmad_loop/devcontract.py
+++ b/src/bmad_loop/devcontract.py
@@ -505,7 +505,21 @@ def reset_spec_status(spec_path: Path, new_status: str) -> bool:
     reaches the other three call sites, which treat it as a repair write."""
     if not spec_path.is_file():
         return False
-    text = spec_path.read_text(encoding="utf-8")
+    # Raw read (not read_text), like the append/strip siblings: universal-newline
+    # translation would hand this writer an all-LF copy of a CRLF spec and
+    # `_atomic_write_spec` would then persist it, relaying every line ending in
+    # the file from a repair contracted to move one value.
+    #
+    # Reading the bytes as authored makes one asymmetry with
+    # `frontmatter.set_frontmatter_status` observable, and it is pinned rather
+    # than fixed: that writer splits with `splitlines`, which treats a bare `\r`
+    # as a line break, so a CR-only spec rewrites fine there. `_FRONTMATTER_RE`
+    # and `_FM_STATUS_RE` are line-oriented on `\r?\n`, so a CR-only spec finds
+    # no frontmatter block here and returns False. Widening them to `\r` would
+    # change what counts as a line for every reader keyed on these patterns
+    # (`^` in MULTILINE still would not follow), which is a larger contract than
+    # this fix owns — no BMAD tool authors CR-only files.
+    text = spec_path.read_bytes().decode("utf-8")
     fm = _FRONTMATTER_RE.match(text)
     if not fm:
         return False
@@ -544,7 +558,14 @@ def strip_auto_run_result(spec_path: Path) -> bool:
     first save read as a result — so that failure must surface, not be swallowed."""
     if not spec_path.is_file():
         return False
-    text = spec_path.read_text(encoding="utf-8")
+    # Raw read (not read_text) for the append's reason, in reverse: the append
+    # preserves the spec's endings, so a strip that read through universal
+    # newlines would not round-trip its own sibling's output — it would return a
+    # CRLF spec relaid to LF. An undecodable spec still raises UnicodeDecodeError
+    # (repair-write doctrine). A CR-only spec is invisible to
+    # `AUTO_RUN_HEADING_RE`'s MULTILINE `^` and no-ops — the same pinned
+    # asymmetry `reset_spec_status` documents above.
+    text = spec_path.read_bytes().decode("utf-8")
     matches = _section_headings(text)
     if not matches:
         return False

--- a/src/bmad_loop/frontmatter.py
+++ b/src/bmad_loop/frontmatter.py
@@ -6,8 +6,11 @@ Zero git/subprocess dependencies (only stdlib + PyYAML) so pure domain modules
 and dragging in its whole git surface (assessment finding F-1). ``verify``
 re-exports these names, so every existing ``verify.<name>`` / ``from .verify
 import <name>`` call site stays valid. (The same docstring rule bars importing
-``platform_util`` here — it pulls in ``subprocess`` — so this module's writes use
-``write_text``, not ``atomic_replace``.)
+``platform_util`` here — it pulls in ``subprocess`` — so this module's writes are
+a plain ``write_bytes``, not ``atomic_replace``: byte-preserving, but not atomic.
+``read_bytes().decode`` on the way in for the same reason — ``read_text``'s
+universal-newline translation would hand the writer an all-LF copy of a CRLF
+spec, and every line ending in the file would be relaid on the way back out.)
 
 READER AND WRITER DEGRADE IN OPPOSITE DIRECTIONS, deliberately. `read_frontmatter`
 turns an unparseable or undecodable block into ``{}``: it runs on the observation
@@ -153,12 +156,22 @@ LineRenderer = Callable[[str, "re.Match[str]", str], str]
 
 def _replace_value(line: str, m: re.Match[str], value: str) -> str:
     """Keep everything through the colon verbatim — indent, a quoted key,
-    whitespace before the colon — then ``<space><value>``.
+    whitespace before the colon — then ``<space><value>``, then THIS LINE'S OWN
+    terminator.
 
     The gap after the colon is normalized rather than preserved because a bare
     ``status:`` has none to preserve, and filling it would write ``status:done``,
-    which is not the key at all."""
-    return f"{line[: m.end()]} {value}" + ("\n" if line.endswith("\n") else "")
+    which is not the key at all.
+
+    The terminator is carried rather than re-emitted as ``"\\n"``: a CRLF spec
+    would otherwise come back with exactly one bare-LF line — the status line the
+    writer was asked to touch — leaving the file mixed. ``rstrip`` is safe here
+    because the caller splits with ``splitlines(keepends=True)``, so a line
+    carries at most one terminator; ``\\r\\n``, ``\\n``, a bare ``\\r`` and a
+    final line with no terminator at all each round-trip as authored."""
+    stripped = line.rstrip("\r\n")
+    nl = line[len(stripped) :]
+    return f"{line[: m.end()]} {value}{nl}"
 
 
 def _edit_frontmatter_block(
@@ -268,6 +281,15 @@ def set_frontmatter_status(path: Path, status: str) -> bool:
     changes, and the edit is verified by re-parsing before it lands (see
     `_edit_frontmatter_block`).
 
+    That includes the file's LINE ENDINGS, every one of them: the read is
+    ``read_bytes().decode`` and the write is ``write_bytes``, so a CRLF spec
+    stays CRLF and a mixed-ending spec keeps each line's own terminator. Going
+    through ``read_text``/``write_text`` instead relaid the whole file — CRLF in,
+    LF out on POSIX, and every LF out as CRLF on Windows — which is the largest
+    violation a writer contracted to "only the status value changes" can commit.
+    Not atomic (see the module docstring); a torn write is a separate concern
+    from a byte-preserving one.
+
     Returns True when the file was rewritten. Returns False for **nothing to
     change** only: no file, no frontmatter block, no top-level `status` for
     `read_frontmatter` to see, or already at the target. Raises
@@ -283,7 +305,7 @@ def set_frontmatter_status(path: Path, status: str) -> bool:
     """
     if not path.is_file():
         return False
-    text = path.read_text(encoding="utf-8")
+    text = path.read_bytes().decode("utf-8")
     split = _split_frontmatter(text)
     if split is None:
         return False
@@ -291,5 +313,5 @@ def set_frontmatter_status(path: Path, status: str) -> bool:
     edited = _edit_frontmatter_block(block, "status", status, pattern=_STATUS_KEY_RE)
     if edited is None:
         return False
-    path.write_text(before + edited + after, encoding="utf-8")
+    path.write_bytes((before + edited + after).encode("utf-8"))
     return True

--- a/src/bmad_loop/frontmatter.py
+++ b/src/bmad_loop/frontmatter.py
@@ -174,6 +174,26 @@ def _replace_value(line: str, m: re.Match[str], value: str) -> str:
     return f"{line[: m.end()]} {value}{nl}"
 
 
+def _last_line_ending(block: str) -> str:
+    """The terminator of ``block``'s last line — what an INSERTED line must carry
+    so an append does not introduce a foreign ending into the file.
+
+    The same per-line reading `_replace_value` does, for the branch that has no
+    line to copy from: an inserted key goes directly after the block's last line,
+    so that line's ending is the one it should share. Falls back to ``"\\n"`` for
+    an empty block (``---``/``---`` with nothing between) and for a last line
+    carrying no terminator at all — neither can happen through
+    `_split_frontmatter`, whose block is always followed by the closing delimiter
+    line, but an appended key that started on the previous line would be a
+    corruption rather than a formatting nit, so it is guarded rather than
+    reasoned about."""
+    lines = block.splitlines(keepends=True)
+    if not lines:
+        return "\n"
+    last = lines[-1]
+    return last[len(last.rstrip("\r\n")) :] or "\n"
+
+
 def _edit_frontmatter_block(
     block: str,
     key: str,
@@ -218,7 +238,9 @@ def _edit_frontmatter_block(
     `devcontract.reset_spec_status` need and `set_frontmatter_status` must never
     do. It is gated on the READER's view rather than on a scan miss, which is the
     other half of the same defect: a scan that missed a quoted key then appended
-    a SECOND one, and the file ended up with two."""
+    a SECOND one, and the file ended up with two. The inserted line takes the
+    ending of the line it follows (`_last_line_ending`), so an insert cannot
+    introduce a foreign line ending any more than a replacement can."""
     pattern = _key_line_re(key) if pattern is None else pattern
     try:
         original = yaml.safe_load(block)
@@ -231,8 +253,7 @@ def _edit_frontmatter_block(
     if not isinstance(original, dict) or key not in original:
         if not insert:
             return None  # the reader sees no such top-level key — nothing to change
-        nl = "\r\n" if block.endswith("\r\n") else "\n"
-        return _verified(block + f"{key}: {value}{nl}", key, value, rest)
+        return _verified(block + f"{key}: {value}{_last_line_ending(block)}", key, value, rest)
     if original[key] == value:
         return None  # already at the target — idempotent no-op, no write
     lines = block.splitlines(keepends=True)

--- a/src/bmad_loop/verify.py
+++ b/src/bmad_loop/verify.py
@@ -984,10 +984,15 @@ def set_frontmatter_field(path: Path, key: str, value: str) -> bool:
     quoted ``"baseline_revision":`` was missed by the scan and a second one
     appended, so the spec carried the key twice and the reader resolved the
     wrong one.
+
+    Byte-preserving on the same terms as its sibling: ``read_bytes().decode`` in,
+    ``write_bytes`` out, so a CRLF spec is not relaid to LF (nor an LF one to
+    CRLF on Windows) by a write contracted to move one field. The INSERTED line
+    takes the block's own ending, not a bare ``\\n``.
     """
     if not path.is_file():
         return False
-    text = path.read_text(encoding="utf-8")
+    text = path.read_bytes().decode("utf-8")
     split = _split_frontmatter(text)
     if split is None:
         return False
@@ -995,7 +1000,7 @@ def set_frontmatter_field(path: Path, key: str, value: str) -> bool:
     edited = _edit_frontmatter_block(block, key, value, insert=True)
     if edited is None:
         return False
-    path.write_text(before + edited + after, encoding="utf-8")
+    path.write_bytes((before + edited + after).encode("utf-8"))
     return True
 
 

--- a/tests/test_devcontract.py
+++ b/tests/test_devcontract.py
@@ -529,6 +529,54 @@ def test_reset_status_no_frontmatter(tmp_path):
     assert "status: done\n" in sp.read_text()  # body status not touched
 
 
+def test_reset_status_preserves_crlf_across_the_whole_spec(tmp_path):
+    """#357 part 1. The re-open path reads the spec the skill wrote; through
+    `read_text` a CRLF spec was decoded to LF and `_atomic_write_spec` then
+    persisted that — every ending in the file relaid by a repair contracted to
+    move one value. `_render_status_line` already carried the `\\r` (it lands in
+    the pattern's `rest` group), so only the read was wrong."""
+    sp = tmp_path / "spec.md"
+    original = (
+        "---\r\ntitle: 'x'\r\nstatus: 'done' # keep me\r\n---\r\n\r\n## Intent\r\n\r\nbody\r\n"
+    )
+    sp.write_bytes(original.encode("utf-8"))
+    assert devcontract.reset_spec_status(sp, "in-progress") is True
+    text = sp.read_bytes().decode("utf-8")
+    assert text == original.replace("status: 'done'", "status: 'in-progress'")
+    assert "\n" not in text.replace("\r\n", "")  # no bare LF introduced
+
+
+def test_reset_status_inserts_a_missing_status_with_the_blocks_crlf(tmp_path):
+    """The insert half of the same path: a template can omit `status:` entirely,
+    and the appended line takes the block's own ending rather than a flat `\\n`."""
+    sp = tmp_path / "spec.md"
+    sp.write_bytes(b"---\r\ntitle: 'x'\r\n---\r\n\r\nbody\r\n")
+    assert devcontract.reset_spec_status(sp, "in-progress") is True
+    text = sp.read_bytes().decode("utf-8")
+    assert text == "---\r\ntitle: 'x'\r\nstatus: in-progress\r\n---\r\n\r\nbody\r\n"
+    assert "\n" not in text.replace("\r\n", "")
+
+
+def test_reset_status_no_ops_on_a_cr_only_spec(tmp_path):
+    """Characterization of a behavior delta the byte-level read introduces, pinned
+    rather than fixed. `_FRONTMATTER_RE` is line-oriented on `\\r?\\n`, so a
+    CR-only spec now finds no frontmatter block and returns False; through
+    `read_text` the CRs were translated to LFs first and the edit landed (writing
+    the file back as LF, which was the defect). Its
+    `frontmatter.set_frontmatter_status` sibling is `splitlines`-based and DOES
+    rewrite this shape — the asymmetry is documented at both writers. Widening
+    the pattern to `\\r` is a larger contract than this fix owns, and no BMAD tool
+    authors CR-only files."""
+    sp = tmp_path / "spec.md"
+    original = "---\rstatus: 'done'\r---\r\rbody\r"
+    sp.write_bytes(original.encode("utf-8"))
+    assert devcontract.reset_spec_status(sp, "in-progress") is False
+    assert sp.read_bytes() == original.encode("utf-8")  # untouched, not half-written
+    # ...and the splitlines-based sibling rewrites the very same bytes
+    assert verify.set_frontmatter_status(sp, "in-progress") is True
+    assert sp.read_bytes() == b"---\rstatus: in-progress\r---\r\rbody\r"
+
+
 def test_reset_spec_status_noop_when_spec_absent(tmp_path):
     """A re-drive against a spec that no longer exists on disk no-ops cleanly
     rather than raising (mirrors verify.set_frontmatter_status)."""
@@ -743,6 +791,45 @@ def test_strip_auto_run_result_raises_on_undecodable_spec(tmp_path):
     sp.write_bytes(b"---\nstatus: done\n---\n\n\xff\xfe## Auto Run Result\n\nStatus: done\n")
     with pytest.raises(UnicodeDecodeError):
         devcontract.strip_auto_run_result(sp)
+
+
+def test_strip_auto_run_result_preserves_crlf_in_what_it_keeps(tmp_path):
+    """#357 part 1. `append_auto_run_result` already wrote its section in the
+    spec's own endings; a strip that read through `read_text` did not round-trip
+    its own sibling's output — it removed the section and returned the surviving
+    CRLF spec relaid to LF."""
+    sp = tmp_path / "spec.md"
+    kept = "---\r\nstatus: done\r\n---\r\n\r\n## Intent\r\n\r\nbody\r\n"
+    sp.write_bytes((kept + "## Auto Run Result\r\n\r\nStatus: done\r\n").encode("utf-8"))
+    assert devcontract.strip_auto_run_result(sp) is True
+    text = sp.read_bytes().decode("utf-8")
+    assert text == kept
+    assert "\n" not in text.replace("\r\n", "")  # no bare LF introduced
+
+
+def test_append_then_strip_round_trips_a_crlf_spec_byte_for_byte(tmp_path):
+    """The pair, end to end: the LF round-trip is already pinned at
+    `test_append_then_strip_roundtrip`, and before the byte-level read the CRLF
+    one could not hold — the strip's own read decided the file's endings."""
+    sp = tmp_path / "spec.md"
+    original = "---\r\nstatus: done\r\n---\r\n\r\n## Intent\r\n\r\nbody\r\n"
+    sp.write_bytes(original.encode("utf-8"))
+    assert devcontract.append_auto_run_result(sp, "done", detail="extra context") is True
+    assert devcontract.strip_auto_run_result(sp) is True
+    assert sp.read_bytes() == original.encode("utf-8")
+
+
+def test_strip_auto_run_result_no_ops_on_a_cr_only_spec(tmp_path):
+    """Sibling of `test_reset_status_no_ops_on_a_cr_only_spec`, same root cause:
+    `AUTO_RUN_HEADING_RE`'s MULTILINE `^` only matches after a `\\n`, so a CR-only
+    spec's heading is invisible to the scan and the strip no-ops. Through
+    `read_text` the CRs were translated first and the section was removed. Pinned,
+    not fixed — `^` would not follow a widened pattern anyway."""
+    sp = tmp_path / "spec.md"
+    original = "---\rstatus: done\r---\r\r## Auto Run Result\r\rStatus: done\r"
+    sp.write_bytes(original.encode("utf-8"))
+    assert devcontract.strip_auto_run_result(sp) is False
+    assert sp.read_bytes() == original.encode("utf-8")
 
 
 def test_strip_auto_run_result_ignores_heading_quoted_in_code_fence(tmp_path):

--- a/tests/test_frontmatter.py
+++ b/tests/test_frontmatter.py
@@ -1,10 +1,12 @@
 """`frontmatter.set_frontmatter_status` — the verified in-place status writer.
 
-Two halves. The CHARACTERIZATION half was written against the pre-rewrite line
-scanner and is green on both sides of it: it pins the formatting-preserving
-minimal edit, and the two deliberate non-preservations (a quoted value and a
-trailing inline comment are both dropped) that a "make it a YAML round-trip"
-refactor would silently change out from under callers three files away. The
+Three sections. The CHARACTERIZATION half was written
+against the pre-rewrite line scanner and is green on both sides of it: it pins
+the formatting-preserving minimal edit, and the two deliberate non-preservations
+(a quoted value and a trailing inline comment are both dropped) that a "make it a
+YAML round-trip" refactor would silently change out from under callers three
+files away. The LINE ENDINGS half pins #357 part 1: the same contract, over the
+bytes the old `read_text`/`write_text` pair relaid across the whole file. The
 BEHAVIOR half pins the rewrite: a writer that verifies its own edit by
 re-parsing, and RAISES rather than returning a `False` nobody reads when the
 reader can see a status it cannot safely move.
@@ -14,8 +16,6 @@ next to `set_frontmatter_field`'s. They were deliberately left there —
 characterize before restructuring, and moving them would hide this diff behind a
 rename. Consolidating them here is filed as #357.
 """
-
-import os
 
 import pytest
 import yaml
@@ -33,25 +33,6 @@ def _spec(tmp_path, text: str, name: str = "spec.md"):
     return path
 
 
-def _as_written(text: str) -> str:
-    """What `Path.write_text` actually puts on disk for `text`.
-
-    `set_frontmatter_status` writes with `write_text`, whose default newline
-    handling relays EVERY line ending in the file to `os.linesep` — so on Windows
-    an all-LF spec comes back all-CRLF, from a writer whose contract is "only the
-    status value changes". That is the largest possible violation of it, it has
-    always been there, and it is filed as #357 rather than fixed here: fixing it
-    needs `_replace_value` to carry each line's own ending (today it appends a
-    bare `\n`, which would leave a CRLF file with one LF line) plus its own CRLF
-    characterization, and it is shared with `devcontract.reset_spec_status`.
-
-    Modelling the relay keeps the byte-exact "every OTHER byte unchanged" gate —
-    the half that catches a wrong-target write, which no substring assertion has —
-    while letting Windows say what the writer really does. A no-op on POSIX.
-    """
-    return text.replace("\n", os.linesep)
-
-
 # ============================================================ characterization
 #
 # Green before AND after the rewrite. Anything that fails here is a change to the
@@ -63,9 +44,7 @@ def test_a_plain_flip_changes_the_status_line_and_nothing_else(tmp_path):
     comments, quoting and body survive byte-for-byte."""
     spec = _spec(tmp_path, _PLAIN)
     assert frontmatter.set_frontmatter_status(spec, "done") is True
-    assert spec.read_bytes().decode() == _as_written(
-        _PLAIN.replace("status: in-review", "status: done")
-    )
+    assert spec.read_bytes().decode() == _PLAIN.replace("status: in-review", "status: done")
 
 
 def test_flipping_to_the_status_already_there_returns_false_and_does_not_write(tmp_path):
@@ -86,7 +65,7 @@ def test_a_quoted_value_is_written_back_unquoted(tmp_path):
     value's quotes" breaks those three from here."""
     spec = _spec(tmp_path, "---\nstatus: 'in-review'\n---\nbody\n")
     assert frontmatter.set_frontmatter_status(spec, "done") is True
-    assert spec.read_bytes().decode() == _as_written("---\nstatus: done\n---\nbody\n")
+    assert spec.read_bytes().decode() == "---\nstatus: done\n---\nbody\n"
 
 
 def test_a_trailing_inline_comment_on_the_status_line_is_dropped(tmp_path):
@@ -95,23 +74,19 @@ def test_a_trailing_inline_comment_on_the_status_line_is_dropped(tmp_path):
     guess turns a working spec into a refused write. Filed as #357."""
     spec = _spec(tmp_path, "---\nstatus: in-review  # set by step-03\n---\nbody\n")
     assert frontmatter.set_frontmatter_status(spec, "done") is True
-    assert spec.read_bytes().decode() == _as_written("---\nstatus: done\n---\nbody\n")
+    assert spec.read_bytes().decode() == "---\nstatus: done\n---\nbody\n"
 
 
 def test_a_status_prefixed_key_is_never_targeted(tmp_path):
     spec = _spec(tmp_path, "---\nstatus_note: keep me\nstatus: in-review\n---\nbody\n")
     assert frontmatter.set_frontmatter_status(spec, "done") is True
-    assert spec.read_bytes().decode() == _as_written(
-        "---\nstatus_note: keep me\nstatus: done\n---\nbody\n"
-    )
+    assert spec.read_bytes().decode() == "---\nstatus_note: keep me\nstatus: done\n---\nbody\n"
 
 
 def test_a_commented_out_status_line_is_never_targeted(tmp_path):
     spec = _spec(tmp_path, "---\n# status: draft\nstatus: in-review\n---\nbody\n")
     assert frontmatter.set_frontmatter_status(spec, "done") is True
-    assert spec.read_bytes().decode() == _as_written(
-        "---\n# status: draft\nstatus: done\n---\nbody\n"
-    )
+    assert spec.read_bytes().decode() == "---\n# status: draft\nstatus: done\n---\nbody\n"
 
 
 def test_no_frontmatter_block_returns_false_with_the_bytes_unchanged(tmp_path):
@@ -137,13 +112,72 @@ def test_a_present_but_empty_status_is_filled(tmp_path):
     the writer must be able to move, not as a missing key."""
     spec = _spec(tmp_path, "---\nstatus:\ntitle: t\n---\nbody\n")
     assert frontmatter.set_frontmatter_status(spec, "done") is True
-    assert spec.read_bytes().decode() == _as_written("---\nstatus: done\ntitle: t\n---\nbody\n")
+    assert spec.read_bytes().decode() == "---\nstatus: done\ntitle: t\n---\nbody\n"
 
 
 def test_indentation_on_the_status_line_survives(tmp_path):
     spec = _spec(tmp_path, "---\n  status: in-review\n---\nbody\n")
     assert frontmatter.set_frontmatter_status(spec, "done") is True
-    assert spec.read_bytes().decode() == _as_written("---\n  status: done\n---\nbody\n")
+    assert spec.read_bytes().decode() == "---\n  status: done\n---\nbody\n"
+
+
+# =============================================================== line endings
+#
+# The half of "only the status value changes" the writer used to break on every
+# call (#357). `read_text`/`write_text` relaid EVERY ending in the file — a CRLF
+# spec came back all-LF on POSIX and an all-LF spec came back all-CRLF on
+# Windows — so these were unwritable before the byte-level read/write. Two gates
+# per case, because either alone passes for the wrong reason: byte-exact equality
+# (which a substring assertion cannot give) AND "no bare LF was introduced", the
+# one that catches `_replace_value` re-emitting a flat `"\n"` for the single line
+# it touched and leaving the file mixed.
+#
+# WHICH PLATFORM PROVES WHAT. These three cover the READ half; reverting it to
+# `read_text` fails all three anywhere. The WRITE half is POSIX-invisible —
+# `write_text`'s `newline=None` translates `"\n"` to `os.linesep`, which on POSIX
+# is `"\n"` — so reverting `write_bytes` keeps this whole file green on Linux and
+# only the Windows CI leg catches it. What catches it there is the byte-exact
+# equality in the CHARACTERIZATION half above: those fixtures are all-LF, and
+# `write_text` on Windows returns them all-CRLF. That is why those assertions are
+# bare comparisons rather than routed through an os.linesep-modelling helper —
+# the helper that used to sit here described the defect instead of failing on it.
+
+
+def test_a_crlf_spec_keeps_every_crlf_and_only_the_status_line_changes(tmp_path):
+    crlf = _PLAIN.replace("\n", "\r\n")
+    spec = _spec(tmp_path, crlf)
+    assert frontmatter.set_frontmatter_status(spec, "done") is True
+    text = spec.read_bytes().decode()
+    assert text == crlf.replace("status: in-review", "status: done")
+    assert "\n" not in text.replace("\r\n", "")  # not one bare LF, anywhere
+    assert frontmatter.status_of(frontmatter.read_frontmatter(spec)) == "done"
+
+
+def test_a_cr_only_spec_keeps_its_bare_carriage_returns(tmp_path):
+    """`_split_frontmatter` and `_replace_value` are both `splitlines`-based, which
+    treats a bare `\\r` as a line break — so this writer rewrites a CR-only spec as
+    authored. Its `devcontract.reset_spec_status` sibling is regex-based on
+    `\\r?\\n` and no-ops on the same input; that asymmetry is pinned deliberately
+    in tests/test_devcontract.py."""
+    cr = _PLAIN.replace("\n", "\r")
+    spec = _spec(tmp_path, cr)
+    assert frontmatter.set_frontmatter_status(spec, "done") is True
+    text = spec.read_bytes().decode()
+    assert text == cr.replace("status: in-review", "status: done")
+    assert "\n" not in text
+    assert frontmatter.status_of(frontmatter.read_frontmatter(spec)) == "done"
+
+
+def test_a_mixed_ending_spec_keeps_each_line_its_own_ending(tmp_path):
+    """The ending is carried from the line being edited, not detected once for the
+    file. The status line is the odd one out on purpose — a whole-file `nl =
+    "\\r\\n" if "\\r\\n" in text else "\\n"` reading is green on the pure-CRLF case
+    above and rewrites this LF status line to CRLF."""
+    mixed = "---\r\ntitle: List command\r\nstatus: in-review\nowner: amelia\r\n---\r\nbody\r\n"
+    spec = _spec(tmp_path, mixed)
+    assert frontmatter.set_frontmatter_status(spec, "done") is True
+    assert spec.read_bytes().decode() == mixed.replace("status: in-review", "status: done")
+    assert frontmatter.status_of(frontmatter.read_frontmatter(spec)) == "done"
 
 
 # ================================================================== behavior
@@ -232,7 +266,7 @@ def test_a_decoy_before_the_real_status_does_not_capture_the_write(tmp_path, dec
     text = f"---\n{decoy}status: in-review\n---\nbody\n"
     spec = _spec(tmp_path, text)
     assert frontmatter.set_frontmatter_status(spec, "done") is True
-    assert spec.read_bytes().decode() == _as_written(f"---\n{decoy}status: done\n---\nbody\n")
+    assert spec.read_bytes().decode() == f"---\n{decoy}status: done\n---\nbody\n"
     assert frontmatter.status_of(frontmatter.read_frontmatter(spec)) == "done"
 
 
@@ -249,7 +283,7 @@ def test_a_key_spelling_yaml_accepts_is_rewritten_with_its_formatting_kept(tmp_p
     reader ever accepts — it lands on the unparseable-block raise above.)"""
     spec = _spec(tmp_path, f"---\n{key}: {value}\n---\nbody\n")
     assert frontmatter.set_frontmatter_status(spec, "done") is True
-    assert spec.read_bytes().decode() == _as_written(f"---\n{key}: done\n---\nbody\n")
+    assert spec.read_bytes().decode() == f"---\n{key}: done\n---\nbody\n"
     assert frontmatter.status_of(frontmatter.read_frontmatter(spec)) == "done"
 
 
@@ -289,9 +323,7 @@ def test_the_verified_edit_is_never_a_yaml_round_trip(tmp_path):
     )
     spec = _spec(tmp_path, text)
     assert frontmatter.set_frontmatter_status(spec, "done") is True
-    assert spec.read_bytes().decode() == _as_written(
-        text.replace("status: in-review", "status: done")
-    )
+    assert spec.read_bytes().decode() == text.replace("status: in-review", "status: done")
     fm = frontmatter.read_frontmatter(spec)
     assert fm["status"] == "done" and fm["tags"] == ["a", "b"]
     assert list(fm) == ["title", "tags", "status", "owner"]  # order survives

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -195,6 +195,20 @@ def test_set_frontmatter_field_inserts_with_the_blocks_own_line_ending(tmp_path)
     assert fm == {"title": "t", "status": "done", "baseline_revision": "abc123"}
 
 
+def test_set_frontmatter_field_inserts_without_introducing_a_foreign_line_ending(tmp_path):
+    """The insert copies the ending of the line it follows, so it cannot be the
+    one line in the file with a different one. A CR-only spec is the shape that
+    tells the two readings apart: `block.endswith("\\r\\n")` is False here and a
+    flat `\\n` fallback would append the sole LF line to an all-CR file."""
+    spec = tmp_path / "spec.md"
+    spec.write_bytes(b"---\rtitle: t\rstatus: done\r---\r\rbody\r")
+    assert verify.set_frontmatter_field(spec, "baseline_revision", "abc123") is True
+    text = spec.read_bytes().decode("utf-8")
+    assert text == "---\rtitle: t\rstatus: done\rbaseline_revision: abc123\r---\r\rbody\r"
+    assert "\n" not in text
+    assert verify.read_frontmatter(spec)["baseline_revision"] == "abc123"
+
+
 # ----------------------------------------------------------- build_context
 
 

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -163,6 +163,38 @@ def test_set_frontmatter_field_preserves_triple_dash_in_value(tmp_path):
     assert "body text" in spec.read_text(encoding="utf-8")
 
 
+def test_set_frontmatter_field_replaces_without_relaying_crlf(tmp_path):
+    """#357 part 1. The re-arm re-stamps `baseline_revision` on whatever the skill
+    wrote; if the spec is CRLF, `read_text`/`write_text` rewrote every ending in
+    the file (to LF here, to CRLF for an all-LF spec on Windows) from a write
+    contracted to move one field."""
+    spec = tmp_path / "spec.md"
+    original = "---\r\ntitle: t\r\nbaseline_revision: old\r\nstatus: done\r\n---\r\n\r\nbody\r\n"
+    spec.write_bytes(original.encode("utf-8"))
+    assert verify.set_frontmatter_field(spec, "baseline_revision", "abc123") is True
+    text = spec.read_bytes().decode("utf-8")
+    assert text == original.replace("baseline_revision: old", "baseline_revision: abc123")
+    assert "\n" not in text.replace("\r\n", "")  # no bare LF introduced
+
+
+def test_set_frontmatter_field_inserts_with_the_blocks_own_line_ending(tmp_path):
+    """The insert path, which only this helper has. The appended line takes the
+    block's ending rather than a flat `\\n` — before the byte-level read the block
+    was always LF by the time it got here, so the CRLF branch of the insert was
+    unreachable and untested."""
+    spec = tmp_path / "spec.md"
+    original = "---\r\ntitle: t\r\nstatus: done\r\n---\r\n\r\nbody\r\n"
+    spec.write_bytes(original.encode("utf-8"))
+    assert verify.set_frontmatter_field(spec, "baseline_revision", "abc123") is True
+    text = spec.read_bytes().decode("utf-8")
+    assert text == (
+        "---\r\ntitle: t\r\nstatus: done\r\nbaseline_revision: abc123\r\n---\r\n\r\nbody\r\n"
+    )
+    assert "\n" not in text.replace("\r\n", "")  # the inserted line is CRLF too
+    fm = verify.read_frontmatter(spec)
+    assert fm == {"title": "t", "status": "done", "baseline_revision": "abc123"}
+
+
 # ----------------------------------------------------------- build_context
 
 


### PR DESCRIPTION
Part 1 of #357.

## The defect

All four spec frontmatter writers read with `Path.read_text`. Universal-newline
handling means a CRLF spec arrives in memory as LF — **in its entirety**, not
just the line being edited. Writing that back relays every line ending in the
file, from functions whose contract is "a minimal in-place line replacement so
the spec's formatting, comments, and field order survive — only the value
changes". Two of the four compounded it with `Path.write_text`, whose
`newline=None` default translates `\n` to `os.linesep`, so on Windows an all-LF
spec came back all-CRLF.

| Writer | Read | Write |
| --- | --- | --- |
| `frontmatter.set_frontmatter_status` | `read_text` ❌ | `write_text` ❌ |
| `verify.set_frontmatter_field` | `read_text` ❌ | `write_text` ❌ |
| `devcontract.reset_spec_status` | `read_text` ❌ | `_atomic_write_spec` ✅ |
| `devcontract.strip_auto_run_result` | `read_text` ❌ | `_atomic_write_spec` ✅ |

`devcontract`'s write side was already byte-preserving, and the comment above
`_atomic_write_spec` had already reasoned this out for `append_auto_run_result`
— which reads bytes. Its two siblings never got the same read.

## The fix

`read_bytes().decode("utf-8")` on all four; `write_bytes(....encode("utf-8"))`
on the two `frontmatter` writers. `frontmatter.py`'s module docstring bars
importing `platform_util` (it drags in `subprocess`), so this cannot borrow
`atomic_replace` — the write stays non-atomic, which is a separate concern from
a byte-preserving one and out of scope here.

`_replace_value` now carries the edited line's **own** terminator rather than
re-emitting a flat `"\n"`, which would have left a CRLF spec with exactly one
bare-LF line — the very line the writer was asked to touch. `splitlines(keepends=True)`
guarantees at most one terminator per line, so `\r\n`, `\n`, a bare `\r`, and a
final line with no terminator each round-trip as authored.

`devcontract._render_status_line` needed no change: `_FM_STATUS_RE`'s
`(?P<rest>.*)$` already captures the `\r` of a raw CRLF line (verified before
touching it, not assumed).

Side effect: this makes `_edit_frontmatter_block`'s insert branch reachable for
the first time — before the byte-level read, the block was always LF by the time
it got there. It is now covered on both writers that can insert.

**Second commit, flagged for the maintainer as a scope call.** Making that branch
live exposed that it hardcoded `"\r\n" if block.endswith("\r\n") else "\n"`,
which agrees with the line it follows for CRLF and LF but not for a bare `\r` —
so an insert into a CR-only spec appended the file's *only* LF line. That is the
same hardcoded-`\n` defect as `_replace_value`'s, in the sibling branch of the
same function, and leaving it would have shipped a writer where one branch
carries endings and the other invents them. `_last_line_ending` reads the
terminator off the block's last line instead. Happy to split this out if you'd
rather part 1 stay strictly to the four read/write swaps.

## Behavior delta, pinned rather than fixed

`_FRONTMATTER_RE` and `AUTO_RUN_HEADING_RE` are line-oriented on `\r?\n`. A
CR-only spec used to be normalized by `read_text` on the way in, so the edit
landed (and the file was rewritten as LF, which was the defect). Reading the
bytes as authored, it finds no frontmatter block / no heading and returns a
silent `False`.

`frontmatter.set_frontmatter_status` is `splitlines`-based and still rewrites
that same shape, so the two siblings now disagree on CR-only input. That
asymmetry is documented at both writers and pinned by
`test_reset_status_no_ops_on_a_cr_only_spec` / `test_strip_auto_run_result_no_ops_on_a_cr_only_spec`,
which assert the no-op *and* that the sibling rewrites the identical bytes.
Widening the patterns to `\r` would change what counts as a line for every
reader keyed on them (and `^` in `MULTILINE` would not follow anyway) — a larger
contract than this fix owns, and no BMAD tool authors CR-only files.

## Tests

New coverage, all byte-exact:

- `tests/test_frontmatter.py` — a `line endings` section: CRLF whole-file
  (only the status line changes, plus `"\n" not in text.replace("\r\n", "")`),
  bare-CR round-trip, and a mixed-ending file where the status line is the odd
  one out on purpose, so a whole-file `nl` detection fails it.
- `tests/test_resolve.py` — `set_frontmatter_field` CRLF replace, CRLF insert, and
  a CR-only insert that pins "the inserted line is never the file's odd one out".
- `tests/test_devcontract.py` — `reset_spec_status` CRLF replace + CRLF insert,
  `strip_auto_run_result` CRLF preservation, an append→strip CRLF byte-for-byte
  round-trip, and the two CR-only characterizations.

`_as_written` (the `os.linesep`-modelling helper) is **deleted** and its ten call
sites reverted to bare byte-exact comparisons. It existed to keep the byte-exact
gate green on Windows by *describing* the relay; with the relay gone, those bare
comparisons are what fails on Windows if the write half regresses.

## Ablations

Every gate was reverted individually by a scripted patch → run → restore, with
the restore sha256-verified against the original (no `git checkout <file>`).

| Ablation | Result |
| --- | --- |
| `frontmatter` read_bytes → read_text | CRLF + bare-CR + mixed all **fail** ✅ |
| `_replace_value` per-line ending → bare `"\n"` | CRLF + bare-CR **fail**; plain-LF flip still passes ✅ |
| `_replace_value` → CRLF/LF only (bare CR dropped) | bare-CR **fails**; CRLF still passes ✅ |
| `_replace_value` → hardcoded `"\r\n"` | mixed **fails**; CRLF still passes ✅ |
| `verify` read_bytes → read_text | both new resolve tests **fail** ✅ |
| `devcontract.reset_spec_status` read revert | all three of its tests **fail** ✅ |
| `devcontract.strip_auto_run_result` read revert | all three of its tests **fail** ✅ |
| `_last_line_ending` → the old `block.endswith("\r\n")` branch | CR-only insert **fails**; CRLF insert still passes ✅ |

The "still passes" rows matter as much as the failures: they show each test
discriminates a specific wrong implementation rather than firing on any change.

**One honest limit.** Reverting `write_bytes` → `write_text` keeps the whole
suite green on Linux — `os.linesep` is `\n` there, so the write half is
POSIX-invisible. The **Windows CI leg is its only oracle**, via the reverted
byte-exact assertions in the characterization half. That is recorded in a
comment in `tests/test_frontmatter.py` so the next reader does not conclude the
write change is untested.

## Verification

- `uv run pytest -q -n auto` — 3671 passed, 24 skipped
- `trunk check --no-fix` — no issues
- `uvx pyright@1.1.411` — 0 errors

Out of scope, staying in #357: the trailing-inline-comment drop (part 2), moving
`set_frontmatter_status`'s tests out of `tests/test_resolve.py`, and making these
writes atomic.
