### PR TITLE
fix(frontmatter): keep a trailing comment on the status line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -248,6 +248,16 @@ story <id>`, the same annotation a sweep bundle writes. Both sprint and stories 
 
 ### Fixed
 
+- **A trailing inline comment on a spec's `status:` line survives the write (#357, part 2).**
+  `set_frontmatter_status` and `set_frontmatter_field` kept everything through the colon and dropped
+  the rest, so `status: draft  # set by hand` came back as `status: done` — the last part of
+  "formatting and comments survive" the writers did not honor. The comment and its separating
+  whitespace now carry through whenever a conservative token pattern can certify where the scalar
+  ends; a value it cannot read as a bare token (a quoted `#`, a `#` abutting the value) falls back to
+  today's full drop rather than guessing. The verified-edit oracle is only a backstop here: it strips
+  comments before it compares, so it cannot see a fabricated one. The value's own quotes are still
+  dropped — deliberately, and pinned.
+
 - **Spec writers no longer relay a spec's line endings (#357, part 1).** `set_frontmatter_status`,
   `set_frontmatter_field`, `reset_spec_status`, and `strip_auto_run_result` read specs through
   `read_text`, whose universal-newline translation handed each writer an all-LF copy of a CRLF spec —

--- a/src/bmad_loop/devcontract.py
+++ b/src/bmad_loop/devcontract.py
@@ -459,10 +459,11 @@ def _render_status_line(line: str, m: re.Match[str], value: str) -> str:
     """`reset_spec_status`'s replacement for a matched ``status:`` line: the
     value moves, its quote style and any trailing inline comment stay.
 
-    Deliberately different from `frontmatter._replace_value`, which drops both —
-    that writer's callers read the result back as a bare ``status: done``, this
-    one's tests pin the preservation. Sharing the VERIFICATION is the point; the
-    formatting each already had right."""
+    Deliberately different from `frontmatter._replace_value`, which carries the
+    comment through but drops the quotes — that writer's callers read the result
+    back as a bare ``status: done``, this one's tests pin the quote style.
+    Sharing the VERIFICATION is the point; the formatting each already had
+    right."""
     # Guarantee `key: value` spacing: a bare `status:` (no trailing space) would
     # otherwise fill to `status:done` — invalid YAML, the key is lost.
     pre = m.group("pre")

--- a/src/bmad_loop/frontmatter.py
+++ b/src/bmad_loop/frontmatter.py
@@ -146,22 +146,55 @@ _STATUS_KEY_RE = _key_line_re("status")
 
 # Builds the replacement for a matched key line, line ending included. A hook
 # rather than one fixed rendering because the two writers on this helper preserve
-# deliberately different things: `set_frontmatter_status` drops the value's quotes
-# and any trailing comment (its callers read the result back as a bare
-# `status: done`), while `devcontract.reset_spec_status` keeps both (its own tests
-# pin them). What they share is the VERIFICATION, which is the part that was
-# wrong in all three writers — not the formatting, which each already had right.
+# deliberately different things: `_replace_value` drops the value's quotes (its
+# callers read the result back as a bare `status: done`), while
+# `devcontract.reset_spec_status` keeps them (its own tests pin them). Both carry
+# a trailing inline comment through. What they share is the VERIFICATION, which
+# is the part that was wrong in all three writers — not the formatting, which
+# each already had right.
 LineRenderer = Callable[[str, "re.Match[str]", str], str]
+
+
+# What follows a key line's colon when the remainder is a bare scalar token and
+# nothing else but a trailing inline comment. Only `sep` and `comment` are data;
+# `q` and `val` are GATES — they certify that the scalar ends exactly where the
+# render assumes it does, which is the one fact a `#` on the line cannot tell you
+# by itself.
+#
+# NEVER WIDEN `val` TO `[^#]*?`. `_verified` cannot backstop this. Against
+# `status: "a # b"` a widened pattern matches with `val` = `"a` and renders
+# `status: done # b"` — which `yaml.safe_load` reads as a clean `status: done`,
+# because it strips comments BEFORE the oracle compares. All three `_verified`
+# gates pass and a fabricated comment lands in the spec. The conservative token
+# class is therefore the gate and `_verified` is only the backstop, the reverse
+# of everywhere else in this module. `[A-Za-z0-9._-]` is every shape a status
+# token and the ordinary scalar frontmatter values have; anything richer than
+# that falls back to the full-drop render, which is merely lossy, never wrong.
+_VALUE_COMMENT_RE = re.compile(
+    r"^[ \t]*(?P<q>['\"]?)(?P<val>[A-Za-z0-9._-]*)(?P=q)(?P<sep>[ \t]+)(?P<comment>#.*)$"
+)
 
 
 def _replace_value(line: str, m: re.Match[str], value: str) -> str:
     """Keep everything through the colon verbatim — indent, a quoted key,
-    whitespace before the colon — then ``<space><value>``, then THIS LINE'S OWN
-    terminator.
+    whitespace before the colon — then ``<space><value>``, then any trailing
+    inline comment the old value carried, then THIS LINE'S OWN terminator.
 
     The gap after the colon is normalized rather than preserved because a bare
     ``status:`` has none to preserve, and filling it would write ``status:done``,
     which is not the key at all.
+
+    The comment is carried only when `_VALUE_COMMENT_RE` can certify where the
+    scalar ends, and its separating whitespace comes through as authored. When it
+    cannot — a quoted value containing a ``#``, a ``#`` abutting the scalar
+    (``done#x``, where it is part of the value, not a comment), a value richer
+    than a bare token — the whole remainder is dropped, which is what this
+    renderer did for every input before. Lossy, never wrong.
+
+    The value's own quotes are still dropped, and that non-preservation is
+    load-bearing rather than pending: `conftest.write_spec` writes
+    ``status: '<v>'`` and three tests read the result back as an unquoted
+    ``status: done`` (tests/test_runs.py, tests/test_stories_e2e.py).
 
     The terminator is carried rather than re-emitted as ``"\\n"``: a CRLF spec
     would otherwise come back with exactly one bare-LF line — the status line the
@@ -171,6 +204,9 @@ def _replace_value(line: str, m: re.Match[str], value: str) -> str:
     final line with no terminator at all each round-trip as authored."""
     stripped = line.rstrip("\r\n")
     nl = line[len(stripped) :]
+    cm = _VALUE_COMMENT_RE.match(stripped[m.end() :])
+    if cm is not None:
+        return f"{line[: m.end()]} {value}{cm['sep']}{cm['comment']}{nl}"
     return f"{line[: m.end()]} {value}{nl}"
 
 
@@ -317,12 +353,14 @@ def set_frontmatter_status(path: Path, status: str) -> bool:
     `FrontmatterWriteError` when the reader CAN see a status the edit cannot
     safely move — `False` never means "I failed".
 
-    Two deliberate non-preservations, both pinned in tests/test_frontmatter.py:
+    A trailing inline comment on the status line survives too, when the render
+    can certify where the scalar ends (`_VALUE_COMMENT_RE`); a value it cannot
+    read as a bare token drops the comment rather than guessing at one.
+
+    ONE deliberate non-preservation remains, pinned in tests/test_frontmatter.py:
     the value's own quotes are dropped (`status: 'x'` -> `status: done`), because
     the standard fixture shape is quoted and callers read the result back
-    unquoted; and a trailing inline comment on the status line is dropped,
-    because knowing where the scalar ends is exactly the guesswork this rewrite
-    exists to stop making.
+    unquoted.
     """
     if not path.is_file():
         return False

--- a/src/bmad_loop/frontmatter.py
+++ b/src/bmad_loop/frontmatter.py
@@ -170,6 +170,13 @@ LineRenderer = Callable[[str, "re.Match[str]", str], str]
 # of everywhere else in this module. `[A-Za-z0-9._-]` is every shape a status
 # token and the ordinary scalar frontmatter values have; anything richer than
 # that falls back to the full-drop render, which is merely lossy, never wrong.
+#
+# `sprintstatus._set_mapping_value` solves the same problem with the WIDE `val`
+# this one refuses (`\S(?:.*?\S)?`), and the asymmetry is deliberate rather than
+# an oversight: it writes the orchestrator-owned board, whose values are status
+# tokens and timestamps, while this writes a hand-authored spec. It has the
+# fabricated-comment defect described above and is tracked separately (#366) —
+# do not "unify" the two by widening this one.
 _VALUE_COMMENT_RE = re.compile(
     r"^[ \t]*(?P<q>['\"]?)(?P<val>[A-Za-z0-9._-]*)(?P=q)(?P<sep>[ \t]+)(?P<comment>#.*)$"
 )

--- a/src/bmad_loop/verify.py
+++ b/src/bmad_loop/verify.py
@@ -974,7 +974,10 @@ def set_frontmatter_field(path: Path, key: str, value: str) -> bool:
     the same three-way return: True on a landed rewrite, False for **nothing to
     change** (no file, no frontmatter block, already at the value), and
     `FrontmatterWriteError` when the reader can see the key in a shape no line
-    edit can safely move.
+    edit can safely move. "Comments survive" includes a trailing inline comment
+    on the edited line itself: this shares `frontmatter._replace_value` with the
+    status helper, so it inherits that renderer's certified-boundary carry (and
+    its quote drop) rather than restating either.
 
     Unlike the status helper, a missing key is INSERTED as the block's last
     line: callers assert a field's value whether or not the skill wrote one

--- a/tests/test_frontmatter.py
+++ b/tests/test_frontmatter.py
@@ -1,15 +1,17 @@
 """`frontmatter.set_frontmatter_status` — the verified in-place status writer.
 
-Three sections. The CHARACTERIZATION half was written
+Four sections. The CHARACTERIZATION half was written
 against the pre-rewrite line scanner and is green on both sides of it: it pins
-the formatting-preserving minimal edit, and the two deliberate non-preservations
-(a quoted value and a trailing inline comment are both dropped) that a "make it a
-YAML round-trip" refactor would silently change out from under callers three
-files away. The LINE ENDINGS half pins #357 part 1: the same contract, over the
-bytes the old `read_text`/`write_text` pair relaid across the whole file. The
-BEHAVIOR half pins the rewrite: a writer that verifies its own edit by
-re-parsing, and RAISES rather than returning a `False` nobody reads when the
-reader can see a status it cannot safely move.
+the formatting-preserving minimal edit, and the one surviving deliberate
+non-preservation (a quoted value is written back unquoted) that a "make it a YAML
+round-trip" refactor would silently change out from under callers three files
+away. LINE ENDINGS pins #357 part 1: the same contract, over the bytes the old
+`read_text`/`write_text` pair relaid across the whole file. INLINE COMMENTS pins
+#357 part 2, where the gating is inverted — `_verified` cannot see a fabricated
+comment, so a regex is the gate and the oracle is only the backstop. The BEHAVIOR
+half pins the rewrite: a writer that verifies its own edit by re-parsing, and
+RAISES rather than returning a `False` nobody reads when the reader can see a
+status it cannot safely move.
 
 `set_frontmatter_status`'s original tests live in `tests/test_resolve.py:63-138`,
 next to `set_frontmatter_field`'s. They were deliberately left there —
@@ -64,15 +66,6 @@ def test_a_quoted_value_is_written_back_unquoted(tmp_path):
     tests/test_stories_e2e.py:594,793). A refactor that "also preserves the
     value's quotes" breaks those three from here."""
     spec = _spec(tmp_path, "---\nstatus: 'in-review'\n---\nbody\n")
-    assert frontmatter.set_frontmatter_status(spec, "done") is True
-    assert spec.read_bytes().decode() == "---\nstatus: done\n---\nbody\n"
-
-
-def test_a_trailing_inline_comment_on_the_status_line_is_dropped(tmp_path):
-    """The other deliberate non-preservation. Keeping it needs to know where the
-    scalar ends — a `#` inside a quoted value is not a comment — and a wrong
-    guess turns a working spec into a refused write. Filed as #357."""
-    spec = _spec(tmp_path, "---\nstatus: in-review  # set by step-03\n---\nbody\n")
     assert frontmatter.set_frontmatter_status(spec, "done") is True
     assert spec.read_bytes().decode() == "---\nstatus: done\n---\nbody\n"
 
@@ -177,6 +170,109 @@ def test_a_mixed_ending_spec_keeps_each_line_its_own_ending(tmp_path):
     spec = _spec(tmp_path, mixed)
     assert frontmatter.set_frontmatter_status(spec, "done") is True
     assert spec.read_bytes().decode() == mixed.replace("status: in-review", "status: done")
+    assert frontmatter.status_of(frontmatter.read_frontmatter(spec)) == "done"
+
+
+# ============================================================= inline comments
+#
+# #357 part 2. The other half of "comments survive": a trailing comment on the
+# STATUS line itself, which this writer used to drop on every call.
+#
+# WHAT GATES WHAT, because it is the reverse of the rest of this module. Every
+# other edit here is gated by `_verified` re-parsing the candidate. That oracle
+# is BLIND to this one: `yaml.safe_load` strips comments before it compares, so a
+# render that invents a comment out of the tail of a quoted value produces a
+# block whose `status` is exactly right and whose other keys are untouched, and
+# all three gates pass it. `_VALUE_COMMENT_RE`'s conservative token class is the
+# real gate; `_verified` is only the backstop. The quoted-`#` case below is the
+# test that holds that line — ablate it by widening `val` to `[^#]*?` and it
+# writes `status: done # b"`.
+
+
+def test_a_trailing_inline_comment_on_the_status_line_is_preserved(tmp_path):
+    """This used to be the file's other deliberate non-preservation. The
+    separating whitespace comes through as authored (two spaces here), so a
+    hand-aligned comment column is not silently reflowed by a status flip."""
+    spec = _spec(tmp_path, "---\nstatus: in-review  # set by step-03\n---\nbody\n")
+    assert frontmatter.set_frontmatter_status(spec, "done") is True
+    assert spec.read_bytes().decode() == "---\nstatus: done  # set by step-03\n---\nbody\n"
+    assert frontmatter.status_of(frontmatter.read_frontmatter(spec)) == "done"
+
+
+def test_a_hash_inside_a_quoted_value_never_becomes_a_comment(tmp_path):
+    """The case the whole design is shaped around. `status: "a # b"` carries no
+    comment at all — the `#` is scalar text — so the only correct answers are the
+    full drop or a refusal, and the full drop is the one that keeps working specs
+    working. A renderer that split at the `#` would write `status: done # b"`,
+    which reads back as a clean `status: done` and therefore SURVIVES `_verified`
+    with a fabricated comment attached."""
+    spec = _spec(tmp_path, '---\nstatus: "a # b"\ntitle: t\n---\nbody\n')
+    assert frontmatter.set_frontmatter_status(spec, "done") is True
+    assert spec.read_bytes().decode() == "---\nstatus: done\ntitle: t\n---\nbody\n"
+    assert "#" not in spec.read_bytes().decode().split("---")[1]
+
+
+def test_a_hash_abutting_the_scalar_is_part_of_the_value_not_a_comment(tmp_path):
+    """`status: done#x` is the single value `done#x` — YAML needs whitespace
+    before a `#` for it to open a comment. `_VALUE_COMMENT_RE`'s `sep` requires
+    that whitespace, so this falls to the full drop rather than carrying `#x`
+    forward as a comment the spec never had."""
+    spec = _spec(tmp_path, "---\nstatus: in-review#x\ntitle: t\n---\nbody\n")
+    assert frontmatter.read_frontmatter(spec)["status"] == "in-review#x"  # one scalar
+    assert frontmatter.set_frontmatter_status(spec, "done") is True
+    assert spec.read_bytes().decode() == "---\nstatus: done\ntitle: t\n---\nbody\n"
+
+
+def test_a_quoted_value_keeps_its_comment_while_losing_its_quotes(tmp_path):
+    """The two preservations pull in opposite directions on the same line, and
+    both answers are deliberate: the comment is carried, the quotes are not (see
+    test_a_quoted_value_is_written_back_unquoted for what depends on that)."""
+    spec = _spec(tmp_path, "---\nstatus: 'in-review' # c\n---\nbody\n")
+    assert frontmatter.set_frontmatter_status(spec, "done") is True
+    assert spec.read_bytes().decode() == "---\nstatus: done # c\n---\nbody\n"
+
+
+def test_a_present_but_empty_status_keeps_its_comment(tmp_path):
+    """`val` matching empty is not an oversight — a template's blank
+    `status:` line is a shape the writer must fill (see
+    test_a_present_but_empty_status_is_filled), and its comment is as real as any
+    other. The value slots in ahead of the comment instead of replacing it."""
+    spec = _spec(tmp_path, "---\nstatus:  # set by step-03\ntitle: t\n---\nbody\n")
+    assert frontmatter.set_frontmatter_status(spec, "done") is True
+    assert spec.read_bytes().decode() == "---\nstatus: done # set by step-03\ntitle: t\n---\nbody\n"
+
+
+def test_a_comment_glued_to_the_colon_falls_back_to_the_full_drop(tmp_path):
+    """Pinned against the renderer, not through a spec, because no spec can reach
+    it: PyYAML needs whitespace after a `:` for it to separate a key, so
+    `status:# c` is the plain scalar `"status:# c"` and `read_frontmatter` sees
+    no mapping at all — asserted here so the reason is checked, not just claimed.
+    That leaves `_replace_value` the only layer where the shape is observable,
+    and it is worth observing: it is the boundary of `sep`'s `[ \\t]+`, the one
+    character that decides whether a `#` is a comment or scalar text."""
+    spec = _spec(tmp_path, "---\nstatus:# c\n---\nbody\n")
+    assert frontmatter.read_frontmatter(spec) == {}  # not a mapping — unreachable
+    assert frontmatter.set_frontmatter_status(spec, "done") is False
+    line = "status:# c\n"
+    m = frontmatter._STATUS_KEY_RE.match(line)
+    assert m is not None  # the KEY pattern matches; only the value render declines
+    assert frontmatter._replace_value(line, m, "done") == "status: done\n"
+
+
+def test_a_comment_and_a_crlf_ending_both_survive_the_same_write(tmp_path):
+    """Part 1 and part 2 of #357 stack: the comment is carried from the value
+    side of the line and the terminator from the end of it, so a CRLF spec with a
+    commented status line comes back with both. Written as one test because the
+    render builds them in a single f-string — a fix for either that dropped the
+    other would pass both of their own tests."""
+    crlf = (
+        "---\r\ntitle: t\r\nstatus: in-review  # set by step-03\r\nowner: amelia\r\n---\r\nbody\r\n"
+    )
+    spec = _spec(tmp_path, crlf)
+    assert frontmatter.set_frontmatter_status(spec, "done") is True
+    text = spec.read_bytes().decode()
+    assert text == crlf.replace("status: in-review", "status: done")
+    assert "\n" not in text.replace("\r\n", "")  # not one bare LF, anywhere
     assert frontmatter.status_of(frontmatter.read_frontmatter(spec)) == "done"
 
 

--- a/tests/test_frontmatter.py
+++ b/tests/test_frontmatter.py
@@ -209,14 +209,13 @@ def test_a_hash_inside_a_quoted_value_never_becomes_a_comment(tmp_path):
     spec = _spec(tmp_path, '---\nstatus: "a # b"\ntitle: t\n---\nbody\n')
     assert frontmatter.set_frontmatter_status(spec, "done") is True
     assert spec.read_bytes().decode() == "---\nstatus: done\ntitle: t\n---\nbody\n"
-    assert "#" not in spec.read_bytes().decode().split("---")[1]
 
 
 def test_a_hash_abutting_the_scalar_is_part_of_the_value_not_a_comment(tmp_path):
-    """`status: done#x` is the single value `done#x` — YAML needs whitespace
-    before a `#` for it to open a comment. `_VALUE_COMMENT_RE`'s `sep` requires
-    that whitespace, so this falls to the full drop rather than carrying `#x`
-    forward as a comment the spec never had."""
+    """`status: in-review#x` is the single value `in-review#x` — YAML needs
+    whitespace before a `#` for it to open a comment. `_VALUE_COMMENT_RE`'s `sep`
+    requires that whitespace, so this falls to the full drop rather than carrying
+    `#x` forward as a comment the spec never had."""
     spec = _spec(tmp_path, "---\nstatus: in-review#x\ntitle: t\n---\nbody\n")
     assert frontmatter.read_frontmatter(spec)["status"] == "in-review#x"  # one scalar
     assert frontmatter.set_frontmatter_status(spec, "done") is True

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -122,6 +122,19 @@ def test_set_frontmatter_status_preserves_triple_dash_in_value(tmp_path):
     assert "body text" in spec.read_text(encoding="utf-8")
 
 
+def test_set_frontmatter_field_preserves_a_trailing_inline_comment(tmp_path):
+    """This helper's docstring has always promised "comments survive"; until #357
+    part 2 that was true of every line except the one it edited. It shares
+    `frontmatter._replace_value` with `set_frontmatter_status`, so the carry is
+    inherited rather than reimplemented — pinned here because a renderer change
+    made for the status writer reaches this caller silently."""
+    spec = tmp_path / "spec.md"
+    spec.write_bytes(b"---\nbaseline_revision: old  # stamped by step-03\n---\nbody\n")
+    assert verify.set_frontmatter_field(spec, "baseline_revision", "abc123") is True
+    assert spec.read_bytes() == b"---\nbaseline_revision: abc123  # stamped by step-03\n---\nbody\n"
+    assert verify.read_frontmatter(spec)["baseline_revision"] == "abc123"
+
+
 def test_set_frontmatter_field_rewrites_a_quoted_key_instead_of_duplicating_it(tmp_path):
     """The insert-on-miss half of this helper had a defect of its own: the line
     scan missed a quoted key, so it APPENDED a second one and the spec carried


### PR DESCRIPTION
Part 2 of #357.

`frontmatter._replace_value` keeps everything through the colon and then writes `<space><value>`, so a trailing inline comment on the line it edits is dropped: `status: draft  # set by hand` comes back as `status: done`. That is the last part of the writers' "a minimal in-place line replacement … so the spec's formatting, comments, and field order survive" contract that was not honored. Part 1 (line endings, #364) fixed the other one.

The comment and its separating whitespace now carry through, whenever a conservative token pattern can certify where the scalar ends. Anything it cannot read as a bare token falls back to today's full-drop render.

## The issue text is wrong about the oracle, and the fix depends on that

> a comment-preserving render can be *attempted* and simply rejected by `_verified` if it did not mean what it claimed

**This is false, and it is the whole reason the change is shaped the way it is.** `_verified` re-parses the candidate block with `yaml.safe_load`, which strips comments *before* the oracle compares. A fabricated comment is therefore invisible to all three of its gates.

Concretely, for `status: "a # b"` — where the `#` is scalar text, not a comment — a naive split-at-`#` render produces:

```yaml
status: done # b"
```

That parses as `{"status": "done"}` with every other key untouched. It passes "still a mapping", "the key is exactly the value", and "every other key unchanged", the write returns `True`, and the junk lands in the user's spec. Silently.

So the gating here is the **reverse** of everywhere else in this module: the regex is the gate and `_verified` is only the backstop.

```python
_VALUE_COMMENT_RE = re.compile(
    r"^[ \t]*(?P<q>['\"]?)(?P<val>[A-Za-z0-9._-]*)(?P=q)(?P<sep>[ \t]+)(?P<comment>#.*)$"
)
```

Matched against the remainder after the colon (line ending stripped). Only `sep` and `comment` are data — `q` and `val` are **gates**, certifying the scalar boundary. `val` must never be widened to `[^#]*?`; the code comment says so and explains why. `sep`'s `[ \t]+` is load-bearing too: YAML needs whitespace before a `#` for it to open a comment at all.

If a reviewer proposes the "simpler" oracle-only version the issue describes, this is the reason it does not work.

## Ablation

The quoted-`#` test is an "X is absent" assertion, so it was ablated rather than trusted. Widening `val` to `[^#]*?` (scripted patch → run → restore, sha256-verified identical after):

```
>       assert spec.read_bytes().decode() == "---\nstatus: done\ntitle: t\n---\nbody\n"
E         - status: done
E         + status: done # b"
```

It fails on exactly the junk comment, and — the part that matters — the write **succeeded**: `set_frontmatter_status` returned `True` and `_verified` passed it. The other seven tests in the section stayed green under the ablation, so that one test is the sole holder of this line.

## Behavior

| status line | result |
| --- | --- |
| `status: in-review  # c` | `status: done  # c` — separator whitespace as authored |
| `status: 'in-review' # c` | `status: done # c` — comment kept, quotes still dropped |
| `status:  # c` (empty value) | `status: done # c` |
| `status: "a # b"` | `status: done` — fallback, no fabricated comment |
| `status: in-review#x` | `status: done` — `#x` was part of the scalar |
| `status:# c` | full drop (renderer-level only; PyYAML reads that line as a plain scalar, so no spec can reach it — the test asserts that rather than claiming it) |
| comment + CRLF | both survive — stacks on part 1 |

**Quotes are still dropped, deliberately.** `conftest.write_spec` writes `status: '<v>'` and three tests read the result back as an unquoted `status: done` (`tests/test_runs.py:772`, `tests/test_stories_e2e.py:594,793`). Preserving them here breaks those three.

## Inherited ripple

`verify.set_frontmatter_field` uses the same default renderer, so it picks up the carry with no change of its own. Its docstring has always claimed "the spec's formatting, comments, and field order survive" — that was true of every line except the one it edited, and is now true as written. Pinned with a test in `tests/test_resolve.py`, next to that helper's other tests.

`devcontract.reset_spec_status` is untouched: it passes its own renderer and already preserved both the comment and the quote style. Its docstring said the sibling "drops both", which is now half wrong; corrected.

## Verification

- `uv run pytest -q -n auto` → 3678 passed, 24 skipped
- `trunk check --no-fix` → no issues (`--no-fix` because F401 autofix deletes `verify.py`'s re-exports)
- `uvx pyright@1.1.411` → 0 errors


## A sibling with the opposite shape, left alone on purpose

`sprintstatus._set_mapping_value` already preserves inline comments on the board, using the wide `val` pattern this PR refuses (`\S(?:.*?\S)?`) — so `status: "a # b"` there splits to `val='"a'`, `rest=' # b"'` and has the same fabricated-comment defect, with no oracle at all behind it.

It is not fixed here. The board is orchestrator-owned and its values are status tokens and timestamps, and its `val` legitimately contains spaces (`last_updated: 01-06-2026 10:00`), so it cannot borrow this token class — it needs its own shape and its own test. Filed as #366.

What this PR does do is make the asymmetry deliberate in the code, so the next reader does not "unify" the two by widening the spec-side one back into the bug.
