### PR TITLE
test(frontmatter): consolidate set_frontmatter_status tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,6 +175,10 @@ story <id>`, the same annotation a sweep bundle writes. Both sprint and stories 
 
 ### Changed
 
+- **`set_frontmatter_status`'s tests now live in `tests/test_frontmatter.py` (#357, part 3).** They
+  had stayed in `tests/test_resolve.py` next to `set_frontmatter_field`'s so parts 1 and 2 read as
+  changes rather than as a rename. Tests only — no behavior change.
+
 - **The story token budget is checked while the story runs (#336).** `max_tokens_per_story` was
   read once, after the story had already been marked done — so an overrun was reported only after
   every token was spent, and a story that deferred or escalated was never checked at all (one field

--- a/tests/test_frontmatter.py
+++ b/tests/test_frontmatter.py
@@ -12,11 +12,6 @@ comment, so a regex is the gate and the oracle is only the backstop. The BEHAVIO
 half pins the rewrite: a writer that verifies its own edit by re-parsing, and
 RAISES rather than returning a `False` nobody reads when the reader can see a
 status it cannot safely move.
-
-`set_frontmatter_status`'s original tests live in `tests/test_resolve.py:63-138`,
-next to `set_frontmatter_field`'s. They were deliberately left there —
-characterize before restructuring, and moving them would hide this diff behind a
-rename. Consolidating them here is filed as #357.
 """
 
 import pytest
@@ -24,7 +19,10 @@ import yaml
 
 from bmad_loop import frontmatter, verify
 
-_PLAIN = "---\ntitle: List command\nstatus: in-review\nowner: amelia\n---\n\n# Spec\n\nbody\n"
+_PLAIN = (
+    "---\ntitle: List command\nstatus: in-review\nowner: amelia\n---\n\n# Spec\n\n"
+    "<frozen-after-approval>\nFilter notes by workspace name.\n</frozen-after-approval>\n"
+)
 
 
 def _spec(tmp_path, text: str, name: str = "spec.md"):
@@ -43,7 +41,12 @@ def _spec(tmp_path, text: str, name: str = "spec.md"):
 
 def test_a_plain_flip_changes_the_status_line_and_nothing_else(tmp_path):
     """The whole point of a line edit over a YAML round-trip: field order,
-    comments, quoting and body survive byte-for-byte."""
+    comments, quoting and body survive byte-for-byte.
+
+    The fixture carries the shape the orchestrator actually flips — the other
+    frontmatter fields plus a `<frozen-after-approval>` body block the writer must
+    never reach. One byte-exact comparison subsumes any list of per-field
+    substring assertions: it also fails on what such a list forgot to name."""
     spec = _spec(tmp_path, _PLAIN)
     assert frontmatter.set_frontmatter_status(spec, "done") is True
     assert spec.read_bytes().decode() == _PLAIN.replace("status: in-review", "status: done")
@@ -112,6 +115,18 @@ def test_indentation_on_the_status_line_survives(tmp_path):
     spec = _spec(tmp_path, "---\n  status: in-review\n---\nbody\n")
     assert frontmatter.set_frontmatter_status(spec, "done") is True
     assert spec.read_bytes().decode() == "---\n  status: done\n---\nbody\n"
+
+
+def test_set_frontmatter_status_preserves_triple_dash_in_value(tmp_path):
+    """A `---` inside a scalar is not the closing delimiter: status flips and the
+    ---bearing title + body survive (a plain split("---", 2) corrupted this)."""
+    text = "---\ntitle: 'restore --- review'\nstatus: in-review\n---\nbody text\n"
+    spec = _spec(tmp_path, text)
+    assert frontmatter.set_frontmatter_status(spec, "done") is True
+    fm = frontmatter.read_frontmatter(spec)
+    assert fm["status"] == "done"
+    assert fm["title"] == "restore --- review"  # scalar with --- intact
+    assert "body text" in spec.read_bytes().decode()
 
 
 # =============================================================== line endings

--- a/tests/test_frontmatter.py
+++ b/tests/test_frontmatter.py
@@ -126,7 +126,7 @@ def test_set_frontmatter_status_preserves_triple_dash_in_value(tmp_path):
     fm = frontmatter.read_frontmatter(spec)
     assert fm["status"] == "done"
     assert fm["title"] == "restore --- review"  # scalar with --- intact
-    assert "body text" in spec.read_bytes().decode()
+    assert spec.read_bytes().decode() == text.replace("status: in-review", "status: done")
 
 
 # =============================================================== line endings

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -1,4 +1,4 @@
-"""Escalation-resolution: context build, re-arm, spec status writer, session."""
+"""Escalation-resolution: context build, re-arm, spec field writer, session."""
 
 import json
 
@@ -60,33 +60,12 @@ def _escalated_run(
     return run.run_dir, run.state, run.task
 
 
-# ----------------------------------------------------------- set_frontmatter_status
-
-
-def test_set_frontmatter_status_replaces(tmp_path):
-    spec = tmp_path / "spec.md"
-    spec.write_text(SPEC, encoding="utf-8")
-    assert verify.set_frontmatter_status(spec, "ready-for-dev") is True
-    assert verify.read_frontmatter(spec)["status"] == "ready-for-dev"
-    # other fields + the frozen block survive untouched
-    text = spec.read_text(encoding="utf-8")
-    assert "owner: amelia" in text
-    assert "<frozen-after-approval>" in text
-    assert "title: List command" in text
-
-
-def test_set_frontmatter_status_idempotent(tmp_path):
-    spec = tmp_path / "spec.md"
-    spec.write_text(SPEC, encoding="utf-8")
-    verify.set_frontmatter_status(spec, "ready-for-dev")
-    # second call is a no-op (already at the target)
-    assert verify.set_frontmatter_status(spec, "ready-for-dev") is False
-
-
-def test_set_frontmatter_status_no_frontmatter(tmp_path):
-    spec = tmp_path / "spec.md"
-    spec.write_text("# just a heading\n", encoding="utf-8")
-    assert verify.set_frontmatter_status(spec, "ready-for-dev") is False
+# ------------------------------------------------------------ set_frontmatter_field
+#
+# `set_frontmatter_status`'s own tests live in tests/test_frontmatter.py, next to
+# the module that defines it (#357). What stays here is `set_frontmatter_field`,
+# which is `verify`'s — it shares the renderer and the verified-edit core, so the
+# tests below are about the half that differs: insert-on-miss.
 
 
 def test_set_frontmatter_field_replaces_inserts_idempotent(tmp_path):
@@ -94,7 +73,8 @@ def test_set_frontmatter_field_replaces_inserts_idempotent(tmp_path):
     spec.write_text(SPEC, encoding="utf-8")
     assert verify.set_frontmatter_field(spec, "owner", "winston") is True
     assert verify.read_frontmatter(spec)["owner"] == "winston"
-    # unlike set_frontmatter_status, a missing key is INSERTED (block's last line)
+    # unlike set_frontmatter_status, a missing key is INSERTED (block's last line);
+    # its refusal to invent one is pinned in tests/test_frontmatter.py
     assert verify.set_frontmatter_field(spec, "baseline_revision", "abc123") is True
     fm = verify.read_frontmatter(spec)
     assert fm["baseline_revision"] == "abc123"
@@ -105,21 +85,6 @@ def test_set_frontmatter_field_replaces_inserts_idempotent(tmp_path):
     bare = tmp_path / "bare.md"
     bare.write_text("# just a heading\n", encoding="utf-8")
     assert verify.set_frontmatter_field(bare, "baseline_revision", "abc123") is False
-
-
-def test_set_frontmatter_status_preserves_triple_dash_in_value(tmp_path):
-    """A `---` inside a scalar is not the closing delimiter: status flips and the
-    ---bearing title + body survive (a plain split("---", 2) corrupted this)."""
-    spec = tmp_path / "spec.md"
-    spec.write_text(
-        "---\ntitle: 'restore --- review'\nstatus: in-review\n---\nbody text\n",
-        encoding="utf-8",
-    )
-    assert verify.set_frontmatter_status(spec, "done") is True
-    fm = verify.read_frontmatter(spec)
-    assert fm["status"] == "done"
-    assert fm["title"] == "restore --- review"  # scalar with --- intact
-    assert "body text" in spec.read_text(encoding="utf-8")
 
 
 def test_set_frontmatter_field_preserves_a_trailing_inline_comment(tmp_path):
@@ -149,9 +114,10 @@ def test_set_frontmatter_field_rewrites_a_quoted_key_instead_of_duplicating_it(t
 
 
 def test_set_frontmatter_field_refuses_a_key_no_line_edit_can_move(tmp_path):
-    """Same three-way contract as `set_frontmatter_status`: False means nothing
-    to change, and a field the reader CAN see in an unrewritable shape raises
-    instead of silently appending a duplicate the reader would never resolve."""
+    """Same three-way contract as `set_frontmatter_status` (pinned in
+    tests/test_frontmatter.py): False means nothing to change, and a field the
+    reader CAN see in an unrewritable shape raises instead of silently appending
+    a duplicate the reader would never resolve."""
     spec = tmp_path / "spec.md"
     original = "---\n{baseline_revision: old, keep: 1}\n---\nbody\n"
     spec.write_text(original, encoding="utf-8")

--- a/tests/test_stories.py
+++ b/tests/test_stories.py
@@ -55,7 +55,8 @@ def test_load_missing_file_raises_pinned_message(tmp_path):
 # A manifest / spec is agent- or human-authored, so it can hold non-UTF-8 bytes.
 # `read_text(encoding="utf-8")` raises UnicodeDecodeError (a ValueError, NOT a
 # yaml.YAMLError), so the stories-mode reads must surface it as a clean error / degrade
-# rather than crash preflight/dry-run/status. Mirrors tests/test_resolve.py:346.
+# rather than crash preflight/dry-run/status. Mirrors the "non-UTF-8 robustness"
+# section of tests/test_resolve.py.
 _BAD_UTF8 = b"\xff\xfe\x00\x01 not utf-8 \x80\x81"
 
 


### PR DESCRIPTION
Part 3 of #357 — the last one. Parts 1 (line endings, #364) and 2 (inline comments, #365) are merged; both were confirmed on `main` before this branch was cut (`frontmatter.py` reads `read_bytes().decode`, `_replace_value` carries a trailing comment).

**Tests only. Zero `src/` changes** — `src/bmad_loop/frontmatter.py` is byte-identical to `main` (verified by `diff` against a pre-edit copy after the ablation below).

`set_frontmatter_status`'s original tests stayed in `tests/test_resolve.py` through parts 1 and 2 on purpose: moving them then would have hidden those diffs behind a rename. AGENTS.md — flat `tests/` mirrors src modules by name — puts them in `tests/test_frontmatter.py`, next to the module that defines them. `set_frontmatter_field`'s tests stay in `test_resolve.py`: that function lives in `verify.py`, so moving it is a different change.

## What happened to each of the four

Judged against the destination file's actual current content, not against the issue's description of it.

| `test_resolve.py` test | Disposition |
| --- | --- |
| `..._idempotent` | **Deleted, not moved.** `test_flipping_to_the_status_already_there_returns_false_and_does_not_write` already covers it, and covers it harder: it asserts `st_mtime_ns` is unchanged, so a no-op *write* fails it. The resolve copy only checked the return value. |
| `..._no_frontmatter` | **Deleted, not moved.** `test_no_frontmatter_block_returns_false_with_the_bytes_unchanged` is the same case plus a byte assertion. |
| `..._replaces` | **Folded**, to leave one test rather than two near-twins. Its three substring asserts (`owner:`, `title:`, `<frozen-after-approval>`) are strictly weaker than the destination's byte-exact whole-file comparison — but its fixture carried one thing `_PLAIN` did not: a `<frozen-after-approval>` body block. That block moved into `_PLAIN`, so the byte-exact assertion now covers it (and the CRLF / CR-only / idempotence tests inherit the richer fixture). |
| `..._preserves_triple_dash_in_value` | **Moved**, then strengthened (see below). Nothing in the destination names this property. `test_the_verified_edit_is_never_a_yaml_round_trip` happens to carry a `---`-bearing title today, but that is incidental to what it pins — simplify its fixture and the coverage vanishes silently. Name kept as-is so it still pairs with `test_set_frontmatter_field_preserves_triple_dash_in_value`, which stays in `test_resolve.py`. |

Adjustments to the moved test, per the destination file's conventions: `tmp_path` + `write_text` → the `_spec` byte-writing helper, `verify.*` → `frontmatter.*` (the re-export identity is already pinned by `test_verify_re_exports_the_same_exception_object`), and `read_text` → `read_bytes().decode()` so universal-newline translation can't mask a line-ending change.

Its final assertion also stopped being `assert "body text" in ...` (d2ca45f, on CodeRabbit's review) — the one substring check in a file whose convention is byte-exact comparison. That is not a style nit: ablating `_verified` to `return yaml.safe_dump(parsed)`, the round-trip the line edit exists to refuse, reorders the keys and strips the scalar's quotes **while leaving `body text` in place**. The substring form passes that corruption — run against the ablated writer to confirm rather than infer it — and the byte-exact form fails it.

## Cross-references repaired

- `test_resolve.py` module docstring: "spec status writer" → "spec field writer".
- The `set_frontmatter_status` section header becomes a `set_frontmatter_field` header that says where the status tests went and why these stayed.
- Two `set_frontmatter_field` docstrings/comments that contrast against `set_frontmatter_status` now name `tests/test_frontmatter.py` instead of pointing at a neighbour that left.
- `test_frontmatter.py`'s module docstring loses the paragraph that said this consolidation "is filed as #357".
- **Not in the original scope, found while checking:** `tests/test_stories.py:58` pointed at `tests/test_resolve.py:346`. That reference was correct when written (#77) and had already rotted to an unrelated assertion through later growth; this PR shifts it again. Replaced with a section name rather than a fresh line number, so it can't rot the same way.

## Verification

- `uv run pytest tests/test_frontmatter.py tests/test_resolve.py -q` → 79 passed.
- Collected-test count moves **exactly** as the moves predict, checked per file rather than in aggregate: `test_frontmatter.py` 36 → 37 (+1 moved in), `test_resolve.py` 46 → 42 (−4), whole suite 3702 → 3699 (−3 = 2 deleted + 1 folded). A silent selector miss would show up here as a mismatch.
- No test-name collision: `test_set_frontmatter_status_preserves_triple_dash_in_value` resolves to exactly one definition suite-wide. (A cross-file name-reuse audit turns up 13 pre-existing pairs in other modules; none involve these files.)
- **Two ablations on the moved test**, so it is neither vacuous in its new home nor weaker than the file around it. (1) Replacing `_split_frontmatter`'s standalone-delimiter scan with the naive `text.split("---", 2)` it exists to refuse makes it FAIL — the property it names is live. (2) The `yaml.safe_dump` round-trip described above, which the pre-d2ca45f assertion form passed. `src/` was restored and confirmed byte-identical after each.
- Full suite `uv run pytest -q -n auto`: 3675 passed, 24 skipped — run 4× green here, and `main` run 3× green for comparison. One earlier run failed `test_stories_e2e.py::test_e2e_sprint_mode_regression`, which did not reproduce in 4 subsequent full runs or in 3 isolated `-n auto` runs of that file; it is a real-tmux E2E flake with no path to a docstring-and-deletion diff in three unrelated test modules.
- `trunk fmt` + full `trunk check --no-fix`: no issues.

Closes #357
