### PR TITLE
fix(frontmatter): read a YAML-null status as blank, not "none"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -252,6 +252,18 @@ story <id>`, the same annotation a sweep bundle writes. Both sprint and stories 
 
 ### Fixed
 
+- **A blank frontmatter `status:` reads as blank, not as the token `none` (#358).** YAML parses a
+  bare `status:` line as null, and `status_of` stringified it — so every status gate saw `"none"`, a
+  token nothing in the project writes. The allowlist that decides whether a half-finalized generic
+  spec may be reconciled forward (`devcontract.RECONCILABLE_FROM`) therefore treated it as a
+  deliberate custom status and left the spec untouched, contradicting both its own comment and the
+  writer side, which fills exactly that shape. A YAML-null status now reads `""`, the same as a
+  missing key; a literal `status: none` is still the string `"none"`, so a hand-written token keeps
+  its meaning. The engine's local workaround at the reconcile is retired. Two renderings change with
+  it: `confirm`'s drift line says `status: (blank)` instead of trailing off, and the stories-mode
+  board (`status`, `dry-run`) labels a bare-status story `present` — its documented fallback —
+  instead of `none`, which was never a documented value.
+
 - **A trailing inline comment on a spec's `status:` line survives the write (#357, part 2).**
   `set_frontmatter_status` and `set_frontmatter_field` kept everything through the colon and dropped
   the rest, so `status: draft  # set by hand` came back as `status: done` — the last part of

--- a/src/bmad_loop/devcontract.py
+++ b/src/bmad_loop/devcontract.py
@@ -67,8 +67,9 @@ PLAN_HALT_STATUS = "ready-for-dev"
 # its prose terminal `## Auto Run Result` Status is `done`. Deliberately an
 # allowlist: anything else (already-`done`, `blocked`, or an unknown custom token)
 # is left untouched, so reconciliation can never override a status the skill set on
-# purpose. `""` covers a blank or missing frontmatter `status:` — `reset_spec_status`
-# fills/inserts the line in that case. `in-review` is included because step-04 sets
+# purpose. `""` covers a blank or missing frontmatter `status:` — `status_of`
+# normalizes a YAML-null value to `""` alongside the missing key (#358), and
+# `reset_spec_status` fills/inserts the line in either case. `in-review` is included because step-04 sets
 # it transiently at the start of a review pass; the skill self-finalizes to `done`,
 # so a spec left AT `in-review` with a prose `done` result is a mid-review interrupt
 # safe to reconcile forward. The intent-gap patch-restore re-drive (BMAD-METHOD

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -2124,15 +2124,12 @@ class Engine:
             )
             return
         success_status = "in-review" if self._dev_review_enabled() else "done"
-        # A YAML-null status (bare `status:` / `status: null`) reads as the string
-        # "none" through verify.status_of (str(None)), which would dodge the
-        # RECONCILABLE_FROM allowlist; normalize it (and a missing key) to "" so the
-        # blank-status case reconciles. A literal `status: none` stays "none".
         fm = self._observed_frontmatter(spec_path, task.story_key, "reconcile")
         if fm is None:
             return
-        raw_status = fm.get("status")
-        fm_status = "" if raw_status is None else str(raw_status).strip().lower()
+        # A blank `status:` reads "" here (status_of normalizes YAML-null), so the
+        # blank-status template shape reconciles like a missing key does.
+        fm_status = verify.status_of(fm)
         if fm_status == success_status:
             # Already finalized — idempotent for the spec. But a *resumed* result
             # is the pre-reconcile snapshot persisted before the original run's

--- a/src/bmad_loop/frontmatter.py
+++ b/src/bmad_loop/frontmatter.py
@@ -84,8 +84,18 @@ def status_of(fm: dict[str, Any]) -> str:
     lowercase, so a stray ``Done``/``In-Review`` from a hand-edited spec still
     matches. (``devcontract`` keeps its own lowercasing; it parses skill-written
     prose where casing genuinely varies.)
+
+    A YAML-null status (a bare ``status:`` line, or ``status: null``) reads as
+    ``""`` — the same as a missing key — because a spec template may legitimately
+    leave the value blank (see the comment on ``devcontract._FM_STATUS_RE``, whose
+    writer side fills exactly that shape). Without the guard ``str(None)`` would
+    make it the token ``"none"``, which every allowlist then treats as a
+    deliberate custom status (#358). A *literal* ``status: none`` is the string
+    ``"none"`` — PyYAML resolves only ``~``/``null``/``Null``/``NULL``/empty as
+    null — so a hand-written token still reads back exactly as written.
     """
-    return str(fm.get("status", "")).strip().lower()
+    raw = fm.get("status", "")
+    return ("" if raw is None else str(raw)).strip().lower()
 
 
 def operator_actions_of(fm: dict[str, Any]) -> tuple[str, ...]:

--- a/src/bmad_loop/operatoractions.py
+++ b/src/bmad_loop/operatoractions.py
@@ -329,7 +329,9 @@ class ParkedStory:
         if self.spec_status is None:
             return f"its spec is missing or unreadable ({self.spec_path})"
         if self.spec_status != AWAITING_OPERATOR:
-            return f"its spec now says status: {self.spec_status}"
+            # A blank frontmatter `status:` reads "" (status_of normalizes YAML-null),
+            # which would otherwise render as an empty tail on a human-facing line.
+            return f"its spec now says status: {self.spec_status or '(blank)'}"
         if self.board_status is None:
             return "it is not on the sprint board"
         if self.board_status != AWAITING_OPERATOR:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2387,8 +2387,8 @@ def test_generic_reconcile_in_review_followup_false_skips_review(project):
 
 def test_generic_reconcile_advances_bare_null_frontmatter_status(project):
     """The skill left a bare `status:` (YAML null) but finalized in prose with real
-    code. status_of would read that as "none"; the reconcile normalizes null to ""
-    so it still advances to done — and the filled line is valid YAML."""
+    code. status_of reads that as "" — the same as a missing key — so it is in
+    RECONCILABLE_FROM and still advances to done, and the filled line is valid YAML."""
     from bmad_loop.adapters.base import SessionResult
     from bmad_loop.policy import DevPolicy, ReviewPolicy
     from bmad_loop.sprintstatus import story_status
@@ -2434,6 +2434,40 @@ def test_generic_reconcile_advances_bare_null_frontmatter_status(project):
     assert status_of(read_frontmatter(spec_path(project, "1-1-a"))) == "done"
     recon = [e for e in engine.journal.entries() if e["kind"] == "spec-status-reconciled"]
     assert len(recon) == 1 and recon[0]["frm"] == "" and recon[0]["to"] == "done"
+
+
+def test_generic_reconcile_leaves_unknown_custom_status(project):
+    """The RECONCILABLE_FROM allowlist's design point: a status token nothing in the
+    project writes is a status somebody set on purpose, so a prose `done` never
+    overrides it. `reset_spec_status`'s line regex WOULD happily rewrite it, so the
+    allowlist is the only thing standing between the deliberate token and the
+    repair write — hence the assertion on the untouched bytes."""
+    from bmad_loop.policy import DevPolicy, ReviewPolicy
+
+    sp = spec_path(project, "1-1-a")
+    sp.parent.mkdir(parents=True, exist_ok=True)
+    sp.write_text(
+        "---\ntitle: 'x'\nstatus: needs-triage\n---\n\n## Auto Run Result\n\n- Status: done\n",
+        encoding="utf-8",
+    )
+    before = sp.read_bytes()
+
+    pol = Policy(
+        gates=GatesPolicy(mode="none"),
+        notify=QUIET,
+        review=ReviewPolicy(enabled=False),
+        dev=DevPolicy(skill="bmad-dev-auto"),
+        scm=ScmPolicy(rollback_on_failure=True),
+    )
+    engine, _ = make_engine(project, [generic_dev_effect(project, "1-1-a")], policy=pol)
+    task = StoryTask(story_key="1-1-a", epic=1)
+    rj = {"workflow": "auto-dev", "spec_file": str(sp), "status": "needs-triage"}
+
+    engine._reconcile_generic_terminal_status(task, rj)
+
+    assert sp.read_bytes() == before  # the deliberate token survives
+    assert rj["status"] == "needs-triage"  # result dict untouched
+    assert "spec-status-reconciled" not in [e["kind"] for e in engine.journal.entries()]
 
 
 def test_generic_reconcile_skips_out_of_tree_spec(project, tmp_path):

--- a/tests/test_operatoractions.py
+++ b/tests/test_operatoractions.py
@@ -423,6 +423,20 @@ def test_drift_names_the_side_that_disagrees(project, spec_status, board, expect
     assert story.confirmable is (expect_drift is None)
 
 
+def test_drift_renders_a_blank_spec_status_readably(project):
+    """A YAML-null `status:` reads back as "" (`status_of`, #358), so this line would
+    otherwise trail off after "status: " and tell a human nothing. The remedy is the
+    same as for any moved-on spec — but only if they can see what it actually says."""
+    spec = _park(project)
+    spec.write_text(
+        spec.read_text().replace("status: 'awaiting-operator'", "status:"), encoding="utf-8"
+    )
+    (story,) = operatoractions.resolve(project.project, project)
+    assert story.spec_status == ""
+    assert story.drift() == "its spec now says status: (blank)"
+    assert story.confirmable is False
+
+
 def test_drift_reports_a_missing_spec_before_a_missing_status(project):
     spec = _park(project)
     spec.unlink()

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -211,18 +211,20 @@ def test_run_git_locale_merge_preserves_explicit_env(project, monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "raw,expected",
+    "fm,expected",
     [
-        ("in-review", "in-review"),
-        ("  in-review  ", "in-review"),
-        ("In-Review", "in-review"),
-        ("DONE", "done"),
-        (None, ""),
-        (123, "123"),
+        ({"status": "in-review"}, "in-review"),
+        ({"status": "  in-review  "}, "in-review"),
+        ({"status": "In-Review"}, "in-review"),
+        ({"status": "DONE"}, "done"),
+        ({}, ""),  # missing key
+        ({"status": None}, ""),  # YAML-null (bare `status:`) reads like a missing key
+        ({"status": "none"}, "none"),  # a literal token stays itself
+        ({"status": 123}, "123"),
     ],
 )
-def test_status_of_normalizes(raw, expected):
-    assert verify.status_of({"status": raw} if raw is not None else {}) == expected
+def test_status_of_normalizes(fm, expected):
+    assert verify.status_of(fm) == expected
 
 
 def test_verify_dev_happy(project):


### PR DESCRIPTION
Closes #358.

`devcontract.RECONCILABLE_FROM`'s comment claims `""` covers "a blank or missing frontmatter `status:`". A *missing* one did. A *blank* one did not: YAML parses a bare `status:` as null, `status_of` did `str(fm.get("status", ""))`, and `str(None)` is `"none"` — so the blank-status shape landed in the "unknown custom token" arm and was left untouched, while `devcontract._FM_STATUS_RE`'s own comment says the writer side deliberately fills exactly that shape ("a bmad-dev-auto template can leave it blank").

## The fix

Guard `None` before `str()` in `frontmatter.status_of`, the single point all spec-frontmatter status gates read through. A YAML-null status now reads `""`, the same as a missing key.

The other candidate from the issue — adding `"none"` to `RECONCILABLE_FROM` — is not taken. It would be dead code (the sole consumer already hand-normalized `None` first), it leaves a stringified `None` as a load-bearing token, and it breaks the byte-exact set pin in `tests/test_devcontract.py`.

**The deliberate-token semantic is preserved exactly.** PyYAML resolves only `~` / `null` / `Null` / `NULL` / empty as null, so a literal `status: none` is the *string* `"none"` and still reads back as `"none"`. The guard only touches values that were never written as a token at all.

## Blast radius

`status_of` is deliberately wide by design, so I measured it. Of its 12 call sites, **zero flip a branch on `"none"` → `""`** — no gate, allowlist, or comparison changes verdict. Only message text moves, in two places, both handled here:

- `operatoractions.committed_drift` rendered `f"its spec now says status: {self.spec_status}"`, which would now trail off after `status: ` on a blank spec. It renders `(blank)`. (Not `!r` — six assertions across `test_operatoractions.py` and `test_cli.py` pin the exact string `its spec now says status: done`.)
- `stories.state_label` labels a bare-status story `present` — its documented `KIND_PRESENT` fallback — instead of `none`, which was never a documented value; the fallback was being dodged because `"none"` is truthy. Text `status` board and `dry-run` only; `--json` carries no story labels. Classification is `wedged` either way, so the engine's behavior is unchanged.

`engine._reconcile_generic_terminal_status` already hand-normalized `None` → `""` locally right before its `RECONCILABLE_FROM` check, with a comment naming this exact defect. That workaround is retired — it now reads through `status_of` like everything else.

## Tests

- `test_status_of_normalizes` had a misleading `(None, "")` row: the parametrize ternary turned it into `{}`, so it characterized the *missing key* and `{"status": None}` was never covered. Restructured to pass dicts directly, with rows for `{}`, `{"status": None}` (the fix), and `{"status": "none"}` (the deliberate token).
- New `test_generic_reconcile_leaves_unknown_custom_status`: a spec at `status: needs-triage` with a prose `Status: done` is left byte-identical and journals no reconcile.
- Docstring corrected on `test_generic_reconcile_advances_bare_null_frontmatter_status` — it described the retired engine-local workaround. The test stays green.
- A `committed_drift` row pinning `(blank)`.

**Ablations** (per AGENTS.md — a negative assertion passes for every reason a value could be absent):

- Deleted the `fm_status not in devcontract.RECONCILABLE_FROM` guard → the new unknown-token test FAILS, `needs-triage` rewritten to `done`. `reset_spec_status`'s line regex matches `needs-triage` happily, so the allowlist is the only thing standing between a deliberate token and the repair write.
- Reverted the `status_of` guard (keeping the engine workaround removed) → the `{"status": None}` row, `test_generic_reconcile_advances_bare_null_frontmatter_status`, and the new `(blank)` drift test all FAIL.

Both restored by re-editing, never `git checkout <file>`.

Full suite green (3679 passed, 24 skipped), `trunk check --no-fix` clean, pyright 1.1.411 clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Blank YAML `status:` values are now treated as blank rather than `"none"`.
  * Reconciliation correctly handles missing and blank statuses while preserving unknown custom statuses.
  * Drift messages now clearly display blank statuses as `status: (blank)`.
  * Stories-mode board labels report bare-status stories as `present` instead of `none`.
* **Documentation**
  * Updated the changelog with the revised blank-status behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->