### PR TITLE
fix(devcontract): read spec status through status_of, not str()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -252,6 +252,15 @@ story <id>`, the same annotation a sweep bundle writes. Both sprint and stories 
 
 ### Fixed
 
+- **A finished session whose spec left `status:` blank is rescued again (#369).** The second copy of
+  the #358 stringification lived in `devcontract.synthesize_result`, which that fix did not reach: a
+  present-but-blank `status:` read as the truthy token `"none"`, so the prose `## Auto Run Result`
+  fallback never fired and the synthesis was flagged inconsistent. `status_consistent` gates the
+  post-kill rescue (#61), so a session that finished real work but lost its final Stop event was
+  discarded as `stalled`/`timeout` — for exactly the template shape that gate's docstring names as
+  rescuable. Both readers now go through `frontmatter.status_of`. A blank frontmatter with prose
+  `blocked` or `awaiting-operator` also gets a truthful status label; routing for those is unchanged.
+
 - **A blank frontmatter `status:` reads as blank, not as the token `none` (#358).** YAML parses a
   bare `status:` line as null, and `status_of` stringified it — so every status gate saw `"none"`, a
   token nothing in the project writes. The allowlist that decides whether a half-finalized generic

--- a/src/bmad_loop/devcontract.py
+++ b/src/bmad_loop/devcontract.py
@@ -26,7 +26,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from .frontmatter import _edit_frontmatter_block
+from .frontmatter import _edit_frontmatter_block, status_of
 from .platform_util import atomic_replace
 from .verify import DEV_WORKFLOW, operator_actions_of, read_frontmatter
 
@@ -254,7 +254,14 @@ def synthesize_result(
         # rescue. Crashing here would take the whole run down for a spec the CLI
         # merely had open for writing.
         return SynthResult(result_json=None, status_consistent=True)
-    fm_status = str(fm.get("status", "")).strip().lower()
+    # Through `status_of`, never a local `str(...)`: it normalizes a YAML-null
+    # `status:` (the blank line a bmad-dev-auto template legitimately leaves — see
+    # `_FM_STATUS_RE`) to `""` alongside the missing key. A local stringification
+    # made that `"none"`, which is truthy, so the prose fallback below never fired
+    # and a blank-frontmatter/prose-`done` spec synthesized `status="none"` with
+    # `status_consistent=False` — the exact shape `_post_kill_reconcile` documents
+    # as rescuable (#369).
+    fm_status = status_of(fm)
     arr = parse_auto_run_result(_read_text_or_empty(spec_path))
 
     terminal = (
@@ -430,7 +437,7 @@ def is_frontmatter_candidate(path: Path, *, since_ns: int) -> bool:
         fm = read_frontmatter(path)
     except OSError:
         return False
-    return str(fm.get("status", "")).strip().lower() in (DONE, BLOCKED, AWAITING_OPERATOR)
+    return status_of(fm) in (DONE, BLOCKED, AWAITING_OPERATOR)
 
 
 def _atomic_write_spec(spec_path: Path, text: str) -> None:

--- a/src/bmad_loop/frontmatter.py
+++ b/src/bmad_loop/frontmatter.py
@@ -82,8 +82,9 @@ def status_of(fm: dict[str, Any]) -> str:
     The single point all spec-frontmatter status gates read through, so casing
     never decides a gate — the spec template and sprint-status tokens are
     lowercase, so a stray ``Done``/``In-Review`` from a hand-edited spec still
-    matches. (``devcontract`` keeps its own lowercasing; it parses skill-written
-    prose where casing genuinely varies.)
+    matches. (``devcontract`` reads its frontmatter status through here too; the
+    separate lowercasing it keeps is for the skill-written *prose* ``Status:``
+    line, where casing genuinely varies.)
 
     A YAML-null status (a bare ``status:`` line, or ``status: null``) reads as
     ``""`` — the same as a missing key — because a spec template may legitimately

--- a/tests/test_devcontract.py
+++ b/tests/test_devcontract.py
@@ -189,6 +189,47 @@ def test_synth_status_inconsistent_flagged(tmp_path):
     assert out.status_consistent is False
 
 
+def test_synth_blank_frontmatter_status_falls_back_to_prose_done(tmp_path):
+    """A present-but-blank `status:` (YAML null — the shape a bmad-dev-auto template
+    leaves, per `_FM_STATUS_RE`'s own comment) must read as `""`, so the prose
+    `done` fallback fires and the synthesis is self-consistent. A local
+    `str(fm.get("status", ""))` made it the truthy token `"none"`, which pinned
+    `status="none"` and `status_consistent=False` — and `status_consistent` is the
+    gate on `_post_kill_reconcile`, whose docstring names this very shape as
+    rescuable, so a session that finished real work was discarded (#369).
+
+    Written verbatim rather than through `_spec`: that fixture quotes the value
+    (`status: '{status}'`), which yields an empty *string*, not YAML-null, and so
+    cannot express the failing shape at all.
+    """
+    sp = tmp_path / "spec-1-1-a.md"
+    sp.write_text(
+        "---\ntitle: 'x'\nstatus:\n---\n\n## Auto Run Result\n\n- Status: done\n",
+        encoding="utf-8",
+    )
+    out = devcontract.synthesize_result(sp, story_key="1-1-a")
+
+    assert out.result_json["status"] == "done"
+    assert out.status_consistent is True
+
+
+def test_synth_literal_none_status_still_blocks_the_prose_fallback(tmp_path):
+    """The other half of the #369 fix: `status: none` written as a literal token is
+    a deliberate custom status, not a blank. PyYAML resolves only `~`/`null`/
+    `Null`/`NULL`/empty as null, so this stays the string `"none"` — truthy, so it
+    wins over the prose and the disagreement is surfaced. Without this pin the fix
+    could be "widened" into treating the token itself as blank."""
+    sp = tmp_path / "spec-1-1-a.md"
+    sp.write_text(
+        "---\ntitle: 'x'\nstatus: none\n---\n\n## Auto Run Result\n\n- Status: done\n",
+        encoding="utf-8",
+    )
+    out = devcontract.synthesize_result(sp, story_key="1-1-a")
+
+    assert out.result_json["status"] == "none"
+    assert out.status_consistent is False
+
+
 def test_synth_dw_ids_included(tmp_path):
     sp = _spec(tmp_path / "spec-dw-x.md", status="done", auto_run="done")
     out = devcontract.synthesize_result(sp, story_key=None, dw_ids=["DW-1", "DW-2"])

--- a/tests/test_generic_tmux.py
+++ b/tests/test_generic_tmux.py
@@ -2329,6 +2329,25 @@ def test_post_kill_reconcile_blank_frontmatter_prose_done_rescues(tmp_path):
     assert result.result_json["status"] == "done"
 
 
+def test_post_kill_reconcile_present_but_blank_frontmatter_status_rescues(tmp_path):
+    """Sibling of the test above at the shape that actually shipped broken: a
+    frontmatter block IS present, with a blank `status:` line (YAML null) — the
+    bmad-dev-auto template shape. The test above covers only fm={} (no block at
+    all), and the two diverged: the no-block spec rescued while the template shape
+    synthesized `status="none"`/`status_consistent=False` and was discarded as
+    stalled, losing a session's finished work (#369)."""
+    adapter, impl = make_dev_adapter(tmp_path)
+    adapter._window_alive = lambda handle: False
+    (impl / "spec-3-1-foo.md").write_text(
+        "---\nstatus:\nbaseline_revision: blankbase\n---\n\n"
+        "## Auto Run Result\n\nStatus: done\nDone.\n"
+    )
+    result = adapter._post_kill_reconcile(_dev_handle(), _dev_spec(tmp_path), _unvouched())
+    assert result.status == "completed"
+    assert result.result_json["status"] == "done"
+    assert result.result_json["baseline_commit"] == "blankbase"
+
+
 def test_post_kill_reconcile_rescues_stories_spec(tmp_path):
     adapter, _ = make_dev_adapter(tmp_path)
     adapter._window_alive = lambda handle: False


### PR DESCRIPTION
Closes #369.

`devcontract.synthesize_result` held the second copy of the stringification #358
fixed in `frontmatter.status_of`. A present-but-blank `status:` (YAML null — the
shape a bmad-dev-auto template legitimately leaves, per `_FM_STATUS_RE`'s own
comment) became the truthy token `"none"`, so `status = fm_status or arr.status`
never fell back to the prose `## Auto Run Result`, and `consistent` came out
`False`.

`status_consistent`'s only behavioral consumer is the post-kill rescue gate
(`adapters/generic.py::_post_kill_reconcile`, line 1823 — grepped; every other
hit is the dataclass field, its constructors, or prose). That rescue exists for a
session that finished its work but lost its final Stop event, and its docstring
states the intent explicitly: "a blank frontmatter with prose `done` passes,
exactly what a delivered Stop would have synthesized." That was the one shape it
refused, so such a session was discarded as `stalled`/`timeout`.

## Changes

- `synthesize_result` and `is_frontmatter_candidate` both read through
  `frontmatter.status_of`, so the two copies cannot drift again. Imported from
  `.frontmatter` directly, not re-exported via `.verify` — frontmatter is the
  lower layer.
- `is_frontmatter_candidate` is behavior-neutral: `"none"` and `""` are both
  non-terminal, so the terminal-status membership test is unchanged. Pure
  consolidation.
- One stale parenthetical in `status_of`'s docstring corrected: devcontract now
  reads its *frontmatter* status through it; the separate lowercasing it keeps is
  for the skill-written *prose* `Status:` line.

## Behavior changes

**The fix.** A bare `status:` plus prose `Status: done` now yields result status
`"done"` and `status_consistent=True`, so the post-kill rescue rescues the
template shape, matching its own docstring. The engine's reconcile repairs the
lagging frontmatter downstream, as it already does for the no-frontmatter-block
case that always worked.

**Truthful labels, routing unchanged.** A blank frontmatter with prose `blocked`
now reports status `"blocked"` instead of `"none"` — the blocked escalation was
already raised off `arr.status`, so it drove PAUSE either way. Prose
`awaiting-operator` likewise gets its own label and is still refused by the
rescue (not `done`, no plan-halt marker), and verify re-reads `status_of(fm)` off
disk, which is `""`.

**One genuine gate-widening.** With `plan_halt=True`, a blank frontmatter plus
prose `Status: ready-for-dev` now sets the `plan_halt` marker the rescue gate
accepts. Practically unreachable: a plan-halt writes the frontmatter status and
appends no prose marker, and downstream verify re-checks disk. Named here rather
than left implicit.

## Tests

All new coverage — the wrong behavior was uncharacterized.

- `test_synth_blank_frontmatter_status_falls_back_to_prose_done` — the fix at the
  unit layer. Written verbatim rather than through the `_spec` fixture: that
  fixture quotes the value (`status: '{status}'`), yielding an empty *string*,
  not YAML-null, so it cannot express the failing shape at all.
- `test_synth_literal_none_status_still_blocks_the_prose_fallback` — pins that a
  deliberate `status: none` token stays `"none"` and still blocks the fallback,
  so the fix cannot be "widened" into swallowing the token itself.
- `test_post_kill_reconcile_present_but_blank_frontmatter_status_rescues` —
  sibling of `test_post_kill_reconcile_blank_frontmatter_prose_done_rescues`,
  which covers only `fm={}` (no frontmatter block at all). The two shapes had
  diverged; this covers the one that shipped broken, at the rescue layer.

**Ablation.** Reverting the `synthesize_result` line to the inline `str()` form
fails both new positive tests — `assert 'none' == 'done'` at the unit layer and
`assert 'stalled' == 'completed'` at the rescue layer. The `status: none` pin
passes under the ablation, as it should: it characterizes behavior the fix does
not change.

## Verification

Full suite `3682 passed, 24 skipped`; `trunk fmt` and full `trunk check --no-fix`
clean; pyright at the CI-pinned 1.1.411 reports 0 errors.
