### PR TITLE
refactor(engine,generic): read spec status through status_of

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,6 +175,14 @@ story <id>`, the same annotation a sweep bundle writes. Both sprint and stories 
 
 ### Changed
 
+- **Every spec-frontmatter status read goes through `status_of` (#358 follow-up).** Five inline
+  `str(fm.get("status", ""))` copies remained in the engine and the generic adapter, each of which
+  read a blank `status:` as the token `none` — the defect #358 fixed at the shared reader. Four were
+  neutral (a blank is non-terminal either way); the pair that was not is the review-launch snapshot
+  and the mid-session status-transition tick, which compare against each other. One behavior change
+  falls out: a session that ERASES a previously-set status no longer records a transition — a blank
+  is not an observed live status.
+
 - **`set_frontmatter_status`'s tests now live in `tests/test_frontmatter.py` (#357, part 3).** They
   had stayed in `tests/test_resolve.py` next to `set_frontmatter_field`'s so parts 1 and 2 read as
   changes rather than as a rename. Tests only — no behavior change.

--- a/src/bmad_loop/adapters/generic.py
+++ b/src/bmad_loop/adapters/generic.py
@@ -42,7 +42,7 @@ from ..policy import Policy
 from ..process_host import ProcessHostError, get_process_host
 from ..signals import SignalWatcher
 from ..tokens import read_usage as tally_usage
-from ..verify import read_frontmatter
+from ..verify import read_frontmatter, status_of
 from .base import CodingCLIAdapter, SessionHandle, SessionResult, SessionSpec, SpecSnapshot
 from .multiplexer import MultiplexerError, TerminalMultiplexer, get_multiplexer
 from .profile import CLIProfile
@@ -1363,13 +1363,25 @@ class _DevSynthesisMixin(_ResultFileMixin):
         terminal frontmatter is the Stop harvest's business, and the launch status
         itself (the ``done`` a review re-opens) is not a transition. A transition
         that flips entirely between two ticks is simply missed, and the fallback
-        keeps its conservative 2-observation path."""
+        keeps its conservative 2-observation path.
+
+        Both sides of the comparison read through ``status_of``, so a blank/
+        YAML-null ``status:`` normalizes to ``""`` here AND in the snapshot
+        ``_reset_spec_for_review`` captures. That pairing is load-bearing and must
+        stay symmetric: normalizing only the snapshot leaves a bare-status spec at
+        ``snap.fm_status == ""`` while this tick reads the stringified ``"none"``,
+        which is neither blank nor terminal nor equal to the snapshot — a fabricated
+        transition, hence a false ``transition_proven`` and a premature
+        single-sighting frontmatter synthesis. A blank is also not an observed live
+        status in its own right: a skill that ERASES a previously-set status
+        mid-session records nothing (the ``s != ""`` guard), where the old
+        ``"none"`` reading slipped past as if it were a value."""
         task_id = handle.task_id
         snap = spec.spec_snapshot
         if snap is None or task_id in self._fm_transition_obs:
             return
         try:
-            s = str(read_frontmatter(Path(snap.path)).get("status", "")).strip().lower()
+            s = status_of(read_frontmatter(Path(snap.path)))
         except OSError:
             return
         if s != "" and s not in (devcontract.DONE, devcontract.BLOCKED) and s != snap.fm_status:
@@ -1534,7 +1546,7 @@ class _DevSynthesisMixin(_ResultFileMixin):
         same_file = snap is not None and self._same_spec(path, snap.path)
         try:
             mtime_ns = path.stat().st_mtime_ns
-            fm_status = str(read_frontmatter(path).get("status", "")).strip().lower()
+            fm_status = status_of(read_frontmatter(path))
             # Content hash only when the candidate IS the snapshotted spec (compared
             # by filesystem identity) — an unrelated marker-less spec under the same
             # artifacts dir shares no launch state, so hashing it is meaningless work.

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -3172,7 +3172,9 @@ class Engine:
         never re-written). "Normalized" means through `status_of`, the same reading
         the adapter's `_observe_tick` compares against: a blank/YAML-null `status:`
         must be `""` on BOTH sides or the tick fabricates a transition off it (see
-        that method's docstring — the two reads are one contract). Snapshot capture is best-effort: a torn/unreadable read
+        that method's docstring — the two reads are one contract).
+
+        Snapshot capture is best-effort: a torn/unreadable read
         degrades to `None` (journaled, `review-launch-snapshot`), and the fallback
         then keeps its conservative 2-observation fingerprint path. Only the capture
         is guarded — the strip keeps its raise-on-unreadable repair doctrine (see

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -1626,7 +1626,7 @@ class Engine:
         fm = self._observed_frontmatter(spec_path, task.story_key, "review-timeout-salvage")
         if fm is None:
             return False
-        fm_status = str(fm.get("status", "")).strip().lower()
+        fm_status = verify.status_of(fm)
         if fm_status not in ("done", "in-review"):
             return False
         reset_from: str | None = None
@@ -2233,7 +2233,7 @@ class Engine:
         fm = self._observed_frontmatter(spec_path, task.story_key, "marker-repair")
         if fm is None:
             return
-        fm_status = str(fm.get("status", "")).strip().lower()
+        fm_status = verify.status_of(fm)
         rj_status = str(rj.get("status", "")).strip().lower()
         # Same terminal set `devcontract.is_frontmatter_candidate` scans for: that
         # scan is what FINDS a marker-less finalized spec, and this repair is what
@@ -3169,7 +3169,10 @@ class Engine:
         content hash, mtime, and normalized frontmatter status — so the generic
         adapter's missing-marker fallback can refuse to synthesize from a candidate
         whose bytes never changed this session (a `done` spec re-opened for review,
-        never re-written). Snapshot capture is best-effort: a torn/unreadable read
+        never re-written). "Normalized" means through `status_of`, the same reading
+        the adapter's `_observe_tick` compares against: a blank/YAML-null `status:`
+        must be `""` on BOTH sides or the tick fabricates a transition off it (see
+        that method's docstring — the two reads are one contract). Snapshot capture is best-effort: a torn/unreadable read
         degrades to `None` (journaled, `review-launch-snapshot`), and the fallback
         then keeps its conservative 2-observation fingerprint path. Only the capture
         is guarded — the strip keeps its raise-on-unreadable repair doctrine (see
@@ -3185,7 +3188,7 @@ class Engine:
         try:
             raw = spec_path.read_bytes()
             mtime_ns = spec_path.stat().st_mtime_ns
-            fm_status = str(verify.read_frontmatter(spec_path).get("status", "")).strip().lower()
+            fm_status = verify.status_of(verify.read_frontmatter(spec_path))
         except OSError as e:
             self._journal_spec_read_failed(spec_path, task.story_key, "review-launch-snapshot", e)
             return None

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -3538,6 +3538,31 @@ def test_review_launch_snapshot_degrades_on_unreadable_spec(project):
     assert events[-1]["story_key"] == "1-1-a"
 
 
+def test_review_launch_snapshot_reads_bare_status_as_blank(project):
+    """The snapshot's `fm_status` goes through `status_of` like every other spec
+    status gate, so a bare `status:` (YAML null) is captured as "" — not the
+    stringified "none".
+
+    The other half of a two-sided contract: the generic adapter's `_observe_tick`
+    compares its own `status_of` read against this field. A snapshot carrying
+    "none" while the tick reads "" (or the reverse) makes every tick on a
+    bare-status spec look like a transition off the launch state — a false
+    `transition_proven`, hence a premature single-sighting frontmatter synthesis.
+    Tick side pinned by `test_observe_tick_ignores_bare_null_status`."""
+    engine, _ = make_engine(project, [])
+    spec = spec_path(project, "1-1-a")
+    spec.parent.mkdir(parents=True, exist_ok=True)
+    spec.write_text(
+        "---\nstatus:\nbaseline_revision: abc123\n---\n\n# Story\n\nbody\n", encoding="utf-8"
+    )
+    task = StoryTask(story_key="1-1-a", epic=1, spec_file=str(spec))
+
+    snap = engine._reset_spec_for_review(task)
+
+    assert snap is not None
+    assert snap.fm_status == ""
+
+
 def test_generic_reconcile_skips_blocked_prose(project):
     """A blocked outcome (prose Status: blocked) is NEVER reconciled: the
     frontmatter stays non-terminal, no `spec-status-reconciled` is emitted, and the

--- a/tests/test_generic_tmux.py
+++ b/tests/test_generic_tmux.py
@@ -3566,6 +3566,30 @@ def test_observe_tick_ignores_terminal_blank_and_launch_status(tmp_path, on_disk
     assert _lifecycle_events(adapter, "spec-status-transition-observed") == []
 
 
+def test_observe_tick_ignores_bare_null_status(tmp_path):
+    """A bare `status:` line parses to YAML null, and BOTH sides of the comparison
+    read it through `status_of` — the tick here, and the launch snapshot
+    `_reset_spec_for_review` captures (pinned by its sibling,
+    `test_review_launch_snapshot_reads_bare_status_as_blank`). It normalizes to ""
+    on both, so the `s != ""` guard drops it and no transition is fabricated.
+
+    Written as its own case rather than a row on the parametrize above: expressing
+    "a bare status line" through that helper's `f"status: {on_disk}"` template needs
+    a sentinel, and a sentinel is exactly how the #358 parametrize silently
+    collapsed its YAML-null row into the missing-key one."""
+    adapter, impl = make_dev_adapter(tmp_path)
+    spec_file = impl / "spec-3-1-foo.md"
+    spec_file.write_text("---\nstatus:\nbaseline_revision: abc123\n---\n\n# Story\n\nbody\n")
+    # fm_status="" is what `_reset_spec_for_review` records for this spec.
+    snap = dataclasses.replace(_snap(spec_file), fm_status="")
+    spec = dataclasses.replace(_dev_spec(tmp_path), role="review", spec_snapshot=snap)
+
+    adapter._observe_tick(_dev_handle(), spec)
+
+    assert adapter._fm_transition_obs == {}
+    assert _lifecycle_events(adapter, "spec-status-transition-observed") == []
+
+
 def test_observe_tick_without_snapshot_or_unreadable_is_noop(tmp_path, monkeypatch):
     """No snapshot (every non-review session) is a pure no-op, and a torn/
     unreadable snapshot read (OSError) is a skipped sample — never a verdict —


### PR DESCRIPTION
Consolidation follow-up to #358. That PR fixed the shared reader — `frontmatter.status_of` now
normalizes a YAML-null `status:` to `""` — and moved `devcontract` onto it. Five inline
`str(fm.get("status", "")).strip().lower()` copies were left behind, each of which still reads a
blank `status:` as the token `"none"`. This moves all five onto `status_of`.

## The sites

| # | Site | Blank-status effect before |
| - | ---- | -------------------------- |
| 1 | `engine._salvage_review_timeout` | neutral — `""` and `"none"` are both outside `("done", "in-review")` |
| 2 | `engine._repair_spec_marker` | neutral — neither is terminal |
| 3 | `engine._reset_spec_for_review` (the `SpecSnapshot.fm_status` it stores) | **coupled — see below** |
| 4 | `adapters/generic._observe_tick` (the per-tick read compared against `snap.fm_status`) | **coupled — see below** |
| 5 | `adapters/generic._frontmatter_fallback` | unreachable |

**5 is pure consolidation, not a fix — no delta to hunt for.** Both paths that reach it pre-filter
their candidates through `devcontract.is_frontmatter_candidate`, whose last line is
`status_of(fm) in (DONE, BLOCKED, AWAITING_OPERATOR)`. A candidate is terminal by construction, so
the null case cannot arrive there.

The `rj`/`result_json` status reads next to sites 2 and 5 are deliberately untouched — those parse
skill-written JSON, not spec frontmatter, and do not go through this reader.

## Why 3 and 4 had to land together

They are the two sides of one comparison, and the coupling is one-directional:

- Normalizing **4 alone** is safe: the tick's existing `s != ""` guard excludes the normalized
  blank, so it records nothing.
- Normalizing **3 alone** breaks: a bare-status spec would read `snap.fm_status == ""` while the
  tick still read `"none"` — neither blank, nor terminal, nor equal to the snapshot. That is a
  fabricated `spec-status-transition-observed`, which is exactly the evidence
  `_frontmatter_fallback` treats as proof this session wrote the terminal frontmatter
  (`transition_proven`) — so it would synthesize a result on ONE terminal sighting instead of the
  conservative 2-observation fingerprint.

The contract is now written into both docstrings, each pointing at the other, so a future
half-migration has to argue with the comment.

## Behavior change

One falls out of site 4, and it is the more correct reading: **a session that ERASES a
previously-set status mid-session no longer records a transition.** The `s != ""` guard now
excludes it, where the old `"none"` reading slipped past as if it were a live value. A blank is not
an observed live status. Nothing else moves — sites 1, 2 and 5 are behavior-neutral as tabled above.

## Tests

Two pins, one per side of the coupling, each cross-referenced to the other by name (not line):

- `test_observe_tick_ignores_bare_null_status` (generic adapter) — a spec whose status line is a
  bare `status:`, a snapshot at `fm_status=""`, one tick, and no `spec-status-transition-observed`
  recorded.
- `test_review_launch_snapshot_reads_bare_status_as_blank` (engine) — `_reset_spec_for_review` on
  that same spec shape captures `fm_status == ""`, not `"none"`.

The first is deliberately its own test rather than a row on the existing
`test_observe_tick_ignores_terminal_blank_and_launch_status` parametrize: expressing "a bare status
line" through that helper's `f"status: {on_disk}"` template needs a sentinel, and a sentinel is
precisely how #358's own parametrize silently collapsed its YAML-null row into the missing-key case.

**Ablations** (AGENTS.md — a negative assertion passes for every reason a value could be absent):

- Reverted **only** the `_observe_tick` read, leaving the snapshot side normalized → the generic
  test FAILS with `assert {'3-1-dev-1': 'none'} == {}`: the fabricated transition, reproduced
  exactly as predicted above.
- Reverted **only** the `_reset_spec_for_review` read → the engine test FAILS with
  `assert 'none' == ''`.

Both restored by re-editing, never `git checkout <file>`.

## Verification

Full suite green (3684 passed, 24 skipped), `trunk fmt` + `trunk check --no-fix` clean (no filter),
pyright 1.1.411 clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized handling of blank specification statuses across review, recovery, and verification workflows.
  * Prevented blank `status:` values from being misinterpreted as a real status, avoiding false status-transition records.
  * Improved consistency when validating and recovering specification markers after review interruptions.

* **Tests**
  * Added coverage for blank-status review snapshots and transition observations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->