### PR TITLE
fix(install): guard the worktree exclude's filesystem tail (#359)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -260,6 +260,15 @@ story <id>`, the same annotation a sweep bundle writes. Both sprint and stories 
 
 ### Fixed
 
+- **A worktree's local git exclude really is best-effort now (#359).** `_worktree_local_exclude`
+  guarded only its `git rev-parse` call; the filesystem tail behind it (resolve, mkdir, read, write)
+  crashed the run — a symlink loop raises `RuntimeError` on 3.11/3.12, an exclude file that is not
+  UTF-8 raises `UnicodeDecodeError`, and a read-only `.git` raises `OSError`. The tail is guarded and
+  degrades to a reason string, and provisioning journals it as `worktree-exclude-degraded` on the
+  story rather than swallowing it: without the exclude the unit's `git add -A` would commit the
+  provisioned skill trees and tool configs into the story's merge. Git being unqueryable at all
+  (not a repo, no git) stays a silent, expected skip.
+
 - **A finished session whose spec left `status:` blank is rescued again (#369).** The second copy of
   the #358 stringification lived in `devcontract.synthesize_result`, which that fix did not reach: a
   present-but-blank `status:` read as the truthy token `"none"`, so the prose `## Auto Run Result`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -263,7 +263,8 @@ story <id>`, the same annotation a sweep bundle writes. Both sprint and stories 
 - **A worktree's local git exclude really is best-effort now (#359).** `_worktree_local_exclude`
   guarded only its `git rev-parse` call; the filesystem tail behind it (resolve, mkdir, read, write)
   crashed the run — a symlink loop raises `RuntimeError` on 3.11/3.12, an exclude file that is not
-  UTF-8 raises `UnicodeDecodeError`, and a read-only `.git` raises `OSError`. The tail is guarded and
+  UTF-8 raises `UnicodeDecodeError`, a seeded path whose filename is not UTF-8 raises
+  `UnicodeEncodeError` on the way back out, and a read-only `.git` raises `OSError`. The tail is guarded and
   degrades to a reason string, and provisioning journals it as `worktree-exclude-degraded` on the
   story rather than swallowing it: without the exclude the unit's `git add -A` would commit the
   provisioned skill trees and tool configs into the story's merge. Git being unqueryable at all

--- a/src/bmad_loop/install.py
+++ b/src/bmad_loop/install.py
@@ -729,11 +729,23 @@ def _copy_traversable(src, dst: Path, *, skip_existing: bool = False) -> bool:
     return True
 
 
-def _worktree_local_exclude(worktree: Path, patterns: Sequence[str]) -> None:
+def _worktree_local_exclude(worktree: Path, patterns: Sequence[str]) -> str | None:
     """Add anchored ignore patterns to the worktree's local git exclude so the
     provisioned tool files are never staged by the unit's `git add -A`. Uses
     git's standard local-only exclude (never committed or pushed); it does not
-    affect already-tracked files. Best-effort — skipped if git can't be queried.
+    affect already-tracked files.
+
+    Best-effort in two arms that must stay separate, because `OSError` means the
+    opposite thing in each:
+
+    - git unqueryable (not a repo, git missing) is an EXPECTED skip — returns
+      None silently. Callers hand this plain temp dirs routinely.
+    - a filesystem fault AFTER git answered degrades to a returned reason string
+      the caller can surface: `.resolve()` (pre-3.13 a symlink loop raises
+      RuntimeError, not OSError), `mkdir`, an exclude file that is not UTF-8
+      (UnicodeDecodeError), and read/write OSError. Silence here is not cosmetic:
+      without the exclude the unit's `git add -A` commits the tool files this
+      provisioning just wrote into the story's merge.
     """
     # Callers pass POSIX-slash patterns (glob rels via as_posix; config strings as
     # authored); git's exclude is POSIX-slash on every platform, so nothing to fix here.
@@ -745,19 +757,26 @@ def _worktree_local_exclude(worktree: Path, patterns: Sequence[str]) -> None:
             check=True,
         ).stdout.strip()
     except (subprocess.SubprocessError, OSError):
-        return
-    common_dir = Path(common)
-    if not common_dir.is_absolute():
-        common_dir = (worktree / common_dir).resolve()
-    exclude = common_dir / "info" / "exclude"
-    exclude.parent.mkdir(parents=True, exist_ok=True)
-    existing = exclude.read_text(encoding="utf-8") if exclude.is_file() else ""
-    present = set(existing.splitlines())
-    new = [p for p in patterns if p not in present]
-    if not new:
-        return
-    prefix = existing if not existing or existing.endswith("\n") else existing + "\n"
-    exclude.write_text(prefix + "\n".join(new) + "\n", encoding="utf-8")
+        return None
+    try:
+        common_dir = Path(common)
+        if not common_dir.is_absolute():
+            # a PLAIN checkout answers with a relative ".git"; a linked worktree
+            # answers with the main repo's absolute .git (verified, git 2.55), so
+            # this branch is the plain-checkout case, not the worktree one.
+            common_dir = (worktree / common_dir).resolve()
+        exclude = common_dir / "info" / "exclude"
+        exclude.parent.mkdir(parents=True, exist_ok=True)
+        existing = exclude.read_text(encoding="utf-8") if exclude.is_file() else ""
+        present = set(existing.splitlines())
+        new = [p for p in patterns if p not in present]
+        if not new:
+            return None
+        prefix = existing if not existing or existing.endswith("\n") else existing + "\n"
+        exclude.write_text(prefix + "\n".join(new) + "\n", encoding="utf-8")
+    except (OSError, RuntimeError, UnicodeDecodeError) as e:
+        return f"could not update the worktree-local git exclude ({worktree}): {e}"
+    return None
 
 
 def _copy_skills(project: Path, trees: Sequence[str], force: bool) -> bool:

--- a/src/bmad_loop/install.py
+++ b/src/bmad_loop/install.py
@@ -739,7 +739,12 @@ def _worktree_local_exclude(worktree: Path, patterns: Sequence[str]) -> str | No
     opposite thing in each:
 
     - git unqueryable (not a repo, git missing) is an EXPECTED skip — returns
-      None silently. Callers hand this plain temp dirs routinely.
+      None silently. Callers hand this plain temp dirs routinely. One residual
+      escape survives here and is tracked in #374: `text=True` decodes git's
+      stdout strictly, so a repo path carrying bytes invalid in the locale
+      encoding raises UnicodeDecodeError, which is neither arm's type. Left out
+      of the #359 fix deliberately — decoding filesystem paths safely is a
+      program-wide decision, not this helper's.
     - a filesystem fault AFTER git answered degrades to a returned reason string
       the caller can surface: `.resolve()` (pre-3.13 a symlink loop raises
       RuntimeError, not OSError), `mkdir`, read/write OSError, and either

--- a/src/bmad_loop/install.py
+++ b/src/bmad_loop/install.py
@@ -742,10 +742,13 @@ def _worktree_local_exclude(worktree: Path, patterns: Sequence[str]) -> str | No
       None silently. Callers hand this plain temp dirs routinely.
     - a filesystem fault AFTER git answered degrades to a returned reason string
       the caller can surface: `.resolve()` (pre-3.13 a symlink loop raises
-      RuntimeError, not OSError), `mkdir`, an exclude file that is not UTF-8
-      (UnicodeDecodeError), and read/write OSError. Silence here is not cosmetic:
-      without the exclude the unit's `git add -A` commits the tool files this
-      provisioning just wrote into the story's merge.
+      RuntimeError, not OSError), `mkdir`, read/write OSError, and either
+      direction of a codec fault (`UnicodeError`) — an exclude file that is not
+      UTF-8 fails the READ, and a pattern carrying a surrogate fails the WRITE,
+      since a seed_globs pattern is built from a real filename and a non-UTF-8
+      one arrives surrogate-escaped. Silence here is not cosmetic: without the
+      exclude the unit's `git add -A` commits the tool files this provisioning
+      just wrote into the story's merge.
     """
     # Callers pass POSIX-slash patterns (glob rels via as_posix; config strings as
     # authored); git's exclude is POSIX-slash on every platform, so nothing to fix here.
@@ -774,7 +777,9 @@ def _worktree_local_exclude(worktree: Path, patterns: Sequence[str]) -> str | No
             return None
         prefix = existing if not existing or existing.endswith("\n") else existing + "\n"
         exclude.write_text(prefix + "\n".join(new) + "\n", encoding="utf-8")
-    except (OSError, RuntimeError, UnicodeDecodeError) as e:
+    # UnicodeError, not UnicodeDecodeError: the write raises the ENCODE sibling.
+    # Still far short of ValueError-broad, so a programming error still escapes.
+    except (OSError, RuntimeError, UnicodeError) as e:
         return f"could not update the worktree-local git exclude ({worktree}): {e}"
     return None
 

--- a/src/bmad_loop/worktree_flow.py
+++ b/src/bmad_loop/worktree_flow.py
@@ -73,6 +73,8 @@ def provision_worktree(
     repo_root: Path,
     seed_files: Sequence[str] = (),
     seed_globs: Sequence[str] = (),
+    *,
+    on_degraded: Callable[[str], None] | None = None,
 ) -> list[str]:
     """Make a freshly-created git worktree a self-sufficient bmad-loop project.
 
@@ -108,7 +110,11 @@ def provision_worktree(
     - the hook points at the MAIN repo's already-installed relay via an absolute
       path (the relay locates the run dir from $BMAD_LOOP_RUN_DIR, not its own
       location), so nothing is written into the worktree's .bmad-loop/;
-    - everything we wrote is added to the worktree's local git exclude.
+    - everything we wrote is added to the worktree's local git exclude. That write
+      is best-effort: when git can't be queried at all it is skipped silently, but
+      a filesystem fault after that is reported to `on_degraded` (once, with the
+      reason) rather than swallowed — an unwritten exclude is what lets `git add -A`
+      stage the tool files, so it must not fail invisibly.
     Skill trees, the per-CLI hook config, and the seeded configs all live in dirs
     projects gitignore — but the exclude shields them even when a project doesn't.
 
@@ -284,7 +290,9 @@ def provision_worktree(
     patterns |= {f"/{rel}" for rel in seeded}
     if customize_seeded:
         patterns.add(f"/{CUSTOMIZE_DIR.as_posix()}")
-    _worktree_local_exclude(worktree, sorted(patterns))
+    reason = _worktree_local_exclude(worktree, sorted(patterns))
+    if reason is not None and on_degraded is not None:
+        on_degraded(reason)
     return skipped
 
 
@@ -475,6 +483,9 @@ class WorktreeFlow:
             self.paths.repo_root,
             seed_files=list(dict.fromkeys(seeds)),  # dedupe, preserve order
             seed_globs=self._registry.seed_globs(),
+            on_degraded=lambda msg: self.journal.append(
+                "worktree-exclude-degraded", story_key=task.story_key, error=msg
+            ),
         )
         if skipped_seeds:
             # A seed entry whose destination already exists is a no-op. Harmless for

--- a/tests/test_engine_worktree.py
+++ b/tests/test_engine_worktree.py
@@ -23,7 +23,7 @@ from conftest import (
     write_sprint,
 )
 
-from bmad_loop import verify
+from bmad_loop import verify, worktree_flow
 from bmad_loop.adapters.base import SessionResult
 from bmad_loop.adapters.mock import MockAdapter
 from bmad_loop.engine import Engine
@@ -1512,6 +1512,45 @@ def test_engine_deferred_teardown_degrades_are_journaled(project, monkeypatch):
 
     assert summary.deferred == 1 and not summary.paused
     assert "worktree-teardown-degraded" in journal_kinds(engine)
+
+
+def test_isolated_exclude_degrade_is_journaled(project, monkeypatch):
+    """#359: `provision_worktree`'s local-exclude write is best-effort, so the sole
+    caller has to give the degrade somewhere to land — otherwise a swallowed fault
+    silently lets the unit's `git add -A` commit the provisioned tool files.
+
+    The helper is patched at `worktree_flow`'s own `from .install import` binding
+    (worktree_flow.py:35) — patching `install._worktree_local_exclude` would not be
+    seen here. Journal-only by design (the run is unharmed and continues), matching
+    `worktree-teardown-degraded` rather than the notify-worthy `worktree-open-failed`.
+
+    Ablation: delete the `on_degraded=` lambda at the `provision_worktree` call in
+    `run_isolated` and this fails — no `worktree-exclude-degraded` is journaled."""
+    repo = project.project
+    gitignore = repo / ".gitignore"
+    gitignore.write_text(gitignore.read_text() + ".mcp.json\n", encoding="utf-8")
+    commit_sprint(project, {"1-1-a": "ready-for-dev"})
+    # gitignored, so the worktree checkout lacks it and provisioning really seeds
+    # it — without a seed of some kind provision_worktree short-circuits before the
+    # exclude step and the wiring under test is never reached.
+    (repo / ".mcp.json").write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr(
+        worktree_flow, "_worktree_local_exclude", lambda *a, **k: "boom: read-only .git"
+    )
+
+    engine, _ = make_engine(
+        project,
+        [wt_dev_effect(project, "1-1-a"), wt_review_effect(project, "1-1-a", clean=True)],
+        policy=wt_policy(worktree_seed=(".mcp.json",)),
+    )
+    summary = engine.run()
+
+    assert summary.done == 1 and not summary.paused and not summary.crashed
+    entry = next(e for e in engine.journal.entries() if e["kind"] == "worktree-exclude-degraded")
+    assert entry["story_key"] == "1-1-a" and entry["error"] == "boom: read-only .git"
+    # the degrade is a warning, not a stop: the unit still merged back
+    assert "unit-merged" in journal_kinds(engine)
 
 
 def test_resume_remount_survives_discard_remove_failure(project, monkeypatch):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1520,8 +1520,11 @@ def test_worktree_local_exclude_degrades_on_undecodable_exclude(project):
     OSError nor the RuntimeError arm covers it. The bytes must survive untouched;
     rewriting someone's legacy-encoded exclude would be worse than skipping it.
 
-    Ablation: drop `UnicodeDecodeError` from the tail's except tuple and this
-    fails — it propagates (it is not an OSError)."""
+    Ablation: drop `UnicodeError` from the tail's except tuple and this fails —
+    it propagates (it is not an OSError). Narrowing that member to
+    `UnicodeDecodeError` does NOT fail this test; that ablation belongs to the
+    encode sibling below, which is how the two halves stay independently
+    pinned."""
     exclude = project.project / ".git" / "info" / "exclude"
     exclude.parent.mkdir(parents=True, exist_ok=True)
     exclude.write_bytes(b"\xff\xfe legacy-encoded\n")

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -2,6 +2,7 @@ import json
 import re
 import sys
 import zipfile
+from pathlib import Path
 
 import pytest
 from conftest import git
@@ -13,6 +14,7 @@ from bmad_loop.install import (
     DEV_BASE_SKILLS,
     MODULE_SKILLS,
     _copy_traversable,
+    _worktree_local_exclude,
     install_into,
     merge_hooks,
     missing_base_skills,
@@ -1448,6 +1450,155 @@ def test_provision_worktree_partial_seed_dir_shielded_in_local_exclude(project, 
     assert (wt / "cfg" / "ignored.yaml").read_text() == "SEED ME"
     exclude = (repo / ".git" / "info" / "exclude").read_text(encoding="utf-8")
     assert "/cfg" in exclude.splitlines()
+
+
+# ------------------------------------------------- local exclude, best-effort (issue #359)
+#
+# The helper's filesystem tail was unguarded while its docstring promised
+# best-effort. Faults below the `git rev-parse` call are INJECTED via name-filtered
+# monkeypatch (the test_engine.py:1553 pattern), not built for real: this box and
+# the 3.13+ legs resolve a real symlink loop without raising, so a hand-built loop
+# would false-green. `_worktree_local_exclude` returns None on success AND on the
+# expected "git can't be queried" skip; a str is the degrade reason.
+
+
+def test_worktree_local_exclude_degrades_on_symlink_loop_resolve(project, monkeypatch):
+    """A symlink loop under `.resolve()` raises RuntimeError, not OSError, on the
+    3.11/3.12 CI legs — so the tail's except tuple must name RuntimeError or the
+    fault escapes a function documented as best-effort.
+
+    The `project` MAIN CHECKOUT (not a linked worktree) is the subject on purpose:
+    `git rev-parse --git-common-dir` answers a plain checkout with a relative
+    ".git" and a linked worktree with the main repo's ABSOLUTE .git, so the plain
+    checkout is the only shape that reaches the `.resolve()` branch at all.
+
+    Ablation: drop `RuntimeError` from the tail's except tuple and this fails —
+    the RuntimeError propagates out of the call instead of becoming a reason."""
+    real_resolve = Path.resolve
+
+    def unresolvable(self, *a, **kw):
+        if self.name == ".git":
+            raise RuntimeError(f"Symlink loop from {str(self)!r}")
+        return real_resolve(self, *a, **kw)
+
+    monkeypatch.setattr(Path, "resolve", unresolvable)
+
+    reason = _worktree_local_exclude(project.project, ["/probe-359"])
+
+    assert reason is not None and "Symlink loop" in reason
+    assert str(project.project) in reason  # names WHICH worktree lost its exclude
+    exclude = project.project / ".git" / "info" / "exclude"
+    assert not exclude.is_file() or "/probe-359" not in exclude.read_text(encoding="utf-8")
+
+
+def test_worktree_local_exclude_degrades_on_write_fault(project, monkeypatch):
+    """A write fault on the exclude file itself (e.g. a read-only .git) degrades to
+    a reason instead of propagating — this pins the guard reaching the LAST
+    statement of the tail, not just the early resolve/mkdir steps.
+
+    Injected rather than chmod: a root-owned CI runner ignores a read-only bit.
+
+    Ablation: drop the tail's `try` (or `OSError` from its tuple) and this fails —
+    the OSError propagates out of `_worktree_local_exclude`."""
+    real_write = Path.write_text
+
+    def boom(self, *a, **kw):
+        if self.name == "exclude":
+            raise OSError("read-only .git")
+        return real_write(self, *a, **kw)
+
+    monkeypatch.setattr(Path, "write_text", boom)
+
+    reason = _worktree_local_exclude(project.project, ["/probe-359"])
+
+    assert reason is not None and "read-only .git" in reason
+
+
+def test_worktree_local_exclude_degrades_on_undecodable_exclude(project):
+    """A REAL fault, no injection needed: an exclude file that is not UTF-8 makes
+    `read_text` raise UnicodeDecodeError — a ValueError subclass, so neither the
+    OSError nor the RuntimeError arm covers it. The bytes must survive untouched;
+    rewriting someone's legacy-encoded exclude would be worse than skipping it.
+
+    Ablation: drop `UnicodeDecodeError` from the tail's except tuple and this
+    fails — it propagates (it is not an OSError)."""
+    exclude = project.project / ".git" / "info" / "exclude"
+    exclude.parent.mkdir(parents=True, exist_ok=True)
+    exclude.write_bytes(b"\xff\xfe legacy-encoded\n")
+
+    reason = _worktree_local_exclude(project.project, ["/probe-359"])
+
+    assert reason is not None
+    assert exclude.read_bytes() == b"\xff\xfe legacy-encoded\n"
+
+
+def test_worktree_local_exclude_non_git_dir_returns_none(tmp_path):
+    """Not-a-repo is an EXPECTED skip, not a degradation: `OSError` in the
+    subprocess arm means "no git to query" and must stay silent, while the same
+    type in the tail means "surface it". That is why the two arms cannot merge.
+
+    INVERSE ablation (a negative assertion needs one): make the subprocess arm
+    return a reason string instead of None and this fails."""
+    assert _worktree_local_exclude(tmp_path, ["/probe-359"]) is None
+
+
+def test_worktree_local_exclude_success_returns_none(project, tmp_path):
+    """The happy path returns None too — `None` is "nothing to report", not
+    "nothing happened": the pattern really lands in the common dir's exclude."""
+    repo = project.project
+    wt = tmp_path / "wt"
+    verify.worktree_add(repo, wt, "feat", "main")
+
+    assert _worktree_local_exclude(wt, ["/probe-359"]) is None
+
+    lines = (repo / ".git" / "info" / "exclude").read_text(encoding="utf-8").splitlines()
+    assert "/probe-359" in lines
+
+
+def test_provision_worktree_exclude_fault_reports_on_degraded(project, tmp_path, monkeypatch):
+    """Provisioning forwards the degrade reason to `on_degraded` and otherwise
+    completes. The swallow and the surfacing have to ship together: without this
+    call a lost exclude turns a loud crash into a silent `git add -A` that commits
+    the tool files into the story's merge.
+
+    Ablation: delete the `on_degraded(reason)` call in `provision_worktree` and
+    this fails (`msgs` stays empty)."""
+    repo = project.project
+    wt = tmp_path / "wt"
+    verify.worktree_add(repo, wt, "feat", "main")
+    real_write = Path.write_text
+
+    def boom(self, *a, **kw):
+        if self.name == "exclude":
+            raise OSError("read-only .git")
+        return real_write(self, *a, **kw)
+
+    monkeypatch.setattr(Path, "write_text", boom)
+    msgs: list[str] = []
+
+    provision_worktree(wt, [get_profile("claude")], repo, on_degraded=msgs.append)
+
+    assert len(msgs) == 1 and "read-only .git" in msgs[0]
+    # provisioning itself still finished — only the shielding step degraded
+    assert (wt / ".claude" / "skills" / "bmad-loop-sweep" / "SKILL.md").is_file()
+    assert (wt / ".claude" / "settings.json").is_file()
+
+
+def test_provision_worktree_non_git_no_degrade_callback(tmp_path):
+    """The expected skip must not reach `on_degraded`: many callers provision plain
+    non-repo directories, and a degrade event per call would train operators to
+    ignore the one that matters.
+
+    INVERSE ablation: make the subprocess arm return a reason string instead of
+    None and this fails (`msgs` gets an entry)."""
+    wt, repo = tmp_path / "wt", tmp_path / "repo"
+    repo.mkdir()
+    msgs: list[str] = []
+
+    provision_worktree(wt, [get_profile("claude")], repo, on_degraded=msgs.append)
+
+    assert msgs == []
+    assert (wt / ".claude" / "skills" / "bmad-loop-sweep" / "SKILL.md").is_file()
 
 
 # ----------------------------------------------------------------- hookless profiles

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1532,6 +1532,31 @@ def test_worktree_local_exclude_degrades_on_undecodable_exclude(project):
     assert exclude.read_bytes() == b"\xff\xfe legacy-encoded\n"
 
 
+def test_worktree_local_exclude_degrades_on_unencodable_pattern(project):
+    """The codec fault has a WRITE direction too, and it is not the same exception:
+    `read_text` raises UnicodeDecodeError, `write_text` raises UnicodeEncodeError.
+    Neither is an OSError and they share no subclass but `UnicodeError`, so naming
+    only the decode half leaves the tail escaping on the encode half.
+
+    Reachable, not theoretical: `provision_worktree` builds a pattern per
+    `seed_globs` match via `rel.as_posix()`, so a repo file whose name is not valid
+    UTF-8 arrives surrogate-escaped and cannot be written back as UTF-8.
+
+    REAL fault, no injection. The surrogate is written literally rather than via
+    `os.fsdecode(b"...\xff...")`: that helper decodes with surrogatepass on
+    Windows, which rejects a lone invalid byte outright and would raise in the
+    test's own setup. "\\udcff" is exactly what POSIX surrogateescape yields, and
+    strict UTF-8 refuses to encode it on every platform.
+
+    Ablation: narrow the tail's tuple back to `UnicodeDecodeError` and this fails
+    — UnicodeEncodeError propagates."""
+    pattern = "/vendor/weird-\udcff-name"
+
+    reason = _worktree_local_exclude(project.project, [pattern])
+
+    assert reason is not None and "surrogates not allowed" in reason
+
+
 def test_worktree_local_exclude_non_git_dir_returns_none(tmp_path):
     """Not-a-repo is an EXPECTED skip, not a degradation: `OSError` in the
     subprocess arm means "no git to query" and must stay silent, while the same


### PR DESCRIPTION
Closes #359.

`install._worktree_local_exclude` documented itself as "Best-effort — skipped if git can't be
queried", but the only `try` covered the `git rev-parse --git-common-dir` subprocess. Everything
after it was unguarded and propagated out of a function whose contract says it never does:

| Line | Call | Escapes as |
| ---- | ---- | ---------- |
| 751 | `(worktree / common_dir).resolve()` | **`RuntimeError`** on a symlink loop — 3.11/3.12 only, and the repo floor is 3.11 |
| 753 | `exclude.parent.mkdir(...)` | `OSError` (read-only `.git`) |
| 754 | `exclude.read_text(...)` | `OSError`, and **`UnicodeDecodeError`** on an exclude file that is not UTF-8 |
| 760 | `exclude.write_text(...)` | `OSError`, and **`UnicodeEncodeError`** on a pattern carrying a surrogate |

## Why the two arms cannot merge

`OSError` means the opposite thing on each side of the git call. In the subprocess arm it is "no git
to query" — an *expected* skip that must stay silent, since callers hand this plain non-repo
directories routinely. In the tail it is a filesystem fault worth surfacing. Same type, opposite
meaning, distinguishable only by location. So the tail gets its own guard catching exactly
`(OSError, RuntimeError, UnicodeDecodeError)` — explicit rather than `ValueError`-broad, which would
swallow programming errors ("typed escalation over bare except", AGENTS.md). The helper returns
`str | None`: `None` for success **and** for the expected skip, a reason string for a degradation.

## Swallowing alone would have been a regression

The exclude is what "shields [the provisioned tool files] even when a project doesn't" gitignore
them. A silently swallowed failure means the unit's `git add -A` commits `.claude/`, `.mcp.json` and
`_bmad/custom/` into the story merge — a loud crash traded for silent repo pollution. So the
surfacing lands in the same PR:

- `provision_worktree` gains a keyword-only `on_degraded: Callable[[str], None] | None = None`. The
  `list[str]` return contract is untouched, so the lazy `install.__getattr__` re-export and ~20
  existing callers/tests are unaffected.
- `run_isolated` wires it to `journal.append("worktree-exclude-degraded", story_key=..., error=msg)`,
  mirroring the `on_teardown_degraded` lambda a few lines below.

Journal-only, no `gates.notify`: the precedent `worktree-teardown-degraded` (housekeeping failed, run
continues) is journal-only, while `worktree-open-failed` gets notify because the operator must act
*now*. Here the run finishes normally and the harm is conditional and greppable.

## Correcting the issue's framing

**The `.resolve()` branch is the plain-checkout case, not the linked-worktree case.** Verified in a
scratch repo against git 2.55:

```
git -C <plain checkout>  rev-parse --git-common-dir  ->  .git                (relative)
git -C <linked worktree> rev-parse --git-common-dir  ->  /abs/path/repo/.git (absolute)
```

A linked worktree gets an absolute common dir and never reaches the `is_absolute()` fall-through. The
symlink-loop test therefore drives the helper against the main checkout — a linked worktree could not
exercise that line at all.

**The issue's caller list is stale.** `operatoractions._exclude_from_git` was deleted by #356, which
made the park record deliberately committed. There is exactly one live caller left —
`worktree_flow.provision_worktree` at worktree_flow.py:287, reached only from
`WorktreeFlow.run_isolated` — and this covers it. The engine's park-path containment from #355 is
untouched by this change, as is `engine._write_park_record`'s own `except (OSError, RuntimeError)`,
whose justification #356 already rewrote to "insurance".

## Tests

Seven helper/provision tests in `tests/test_install.py`, one engine-wiring test in
`tests/test_engine_worktree.py`. Faults are **injected** via name-filtered monkeypatch (the
`test_engine.py:1553` pattern) rather than built for real: 3.13+ resolves a symlink loop without
raising, so a hand-built loop would false-green on the newer legs. The `UnicodeDecodeError` test uses
real undecodable bytes, since that fault reproduces everywhere, and asserts the legacy bytes survive
untouched.

Every degrade and negative assertion carries its ablation in the docstring, and all six were run:

| Ablation | Fails |
| -------- | ----- |
| drop `RuntimeError` from the tail tuple | symlink-loop test |
| drop `OSError` from the tail tuple | write-fault test + `on_degraded` forwarding test |
| drop `UnicodeDecodeError` from the tail tuple | undecodable-exclude test |
| **inverse:** make the subprocess arm return a reason | both expected-skip tests |
| delete `on_degraded(reason)` in `provision_worktree` | forwarding test |
| delete the `on_degraded=` lambda in `run_isolated` | journal-wiring test |

The two expected-skip tests are negative assertions, so they needed the inverse ablation — a gate
deletion cannot fail them. The engine test's `worktree_seed` setup was checked the same way: without
it, `provision_worktree` short-circuits before the exclude step and the wiring under test is never
reached.

The five existing exclude happy-path tests are green **unmodified**.

## Follow-up commit: the codec fault has a write direction too

Review triage turned up one real gap in the first commit. The tail's guard named
`UnicodeDecodeError`, which is only the READ half. `write_text` raises the sibling
`UnicodeEncodeError`, and the two share no subclass but `UnicodeError` — so the best-effort
contract still leaked:

```
_worktree_local_exclude(repo, ["/vendor/weird-\udcff-name"])
-> UnicodeEncodeError: 'utf-8' codec can't encode character '\udcff': surrogates not allowed
```

Reachable rather than theoretical: `provision_worktree` derives one pattern per `seed_globs`
match through `rel.as_posix()`, so the pattern text comes from a real filename — a repo file
whose name is not valid UTF-8 arrives surrogate-escaped and cannot be written back as UTF-8.

Widened to `UnicodeError`: it covers both directions and stays far short of the
`ValueError`-broad catch the original rationale rejected, so a programming error still escapes.
The new test writes a literal `"\udcff"` rather than `os.fsdecode(b"...\xff...")` — fsdecode
decodes with surrogatepass on Windows, which rejects a lone invalid byte and would have raised
in the test's own setup, reddening only the Windows legs.

| Ablation | Fails |
| -------- | ----- |
| narrow the tuple back to `UnicodeDecodeError` | the new encode test alone |
| drop the codec member entirely | the encode test **and** the existing decode test |

Each half is independently pinned.

## Review outcome

Three findings raised, one design objection declined.

- **Applied:** the tail's codec guard covered only the read half (`UnicodeDecodeError`); `write_text`
  raises `UnicodeEncodeError` and the two share no subclass but `UnicodeError`. Reproduced end-to-end
  through `seed_globs`. Widened, tested, ablated both directions.
- **Applied:** a stale ablation note — after the widening, the decode test still told a reader to drop
  a tuple member that no longer existed. Corrected to the two ablations actually run.
- **Declined:** a proposal to raise a typed error and pause/escalate the unit instead of journaling.
  It inverts this repo's severity ladder — failing to *mount* a worktree at all defers rather than
  escalates ("Defer this unit rather than crash the whole run", worktree_flow.py), and the exclude is
  a second line of defense behind the project's own `.gitignore`. Escalating would also preserve the
  exact bug #359 filed: the run still dies over a best-effort shielding step. Reasoning is in the
  thread.

Two pre-existing hazards in the same helper were verified but deliberately left out of this change,
filed as #374 (the git-query arm decodes stdout strictly, so a repo path with bytes invalid in the
locale encoding still escapes) and #375 (the exclude write is not atomic, so a short write truncates
the operator's shared exclude while the reason string reports that nothing happened). Both want a
decision this PR's scope does not contain — where filesystem paths get decoded, and whether the write
becomes atomic.

## Verification

`uv run pytest -q -n auto` — 3693 passed, 24 skipped. `uvx pyright@1.1.411` — 0 errors. `trunk fmt` +
full `trunk check` — no issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Worktree setup now handles Git exclude-file and filesystem failures gracefully instead of stopping runs.
  - Non-Git directories and unavailable Git metadata are safely skipped.
  - Exclude-file updates preserve existing formatting and avoid duplicate entries.
  - When exclusion is degraded, the run continues and records a journal entry while still allowing successful completion and merge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

