### PR TITLE
fix(install): close the exclude helper's two residual holes (#374, #375)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -260,6 +260,20 @@ story <id>`, the same annotation a sweep bundle writes. Both sprint and stories 
 
 ### Fixed
 
+- **A short write no longer truncates the worktree exclude (#375).** The exclude update is a
+  read-modify-rewrite, and `write_text` truncates before writing, so a fault partway through (ENOSPC,
+  EIO) left the operator's own excludes cut mid-content while the degrade reason still reported that
+  nothing had been written. Worse, the surviving tail parses as a valid git pattern and is a prefix
+  of the intended one — cut a character in and the last line is `/`, excluding the whole worktree —
+  and a linked worktree's common dir is the MAIN repo's `.git`, so the damage was repo-wide. Now
+  written to a scratch file and moved into place, so the exclude is either fully updated or untouched.
+
+- **The exclude's git query no longer crashes on a non-UTF-8 repo path (#374).** POSIX filenames are
+  bytes, and `git rev-parse --git-common-dir` was decoded strictly, so a repo path carrying bytes
+  invalid in the locale encoding raised `UnicodeDecodeError` — a type neither arm of the helper
+  caught, out of a function documented as best-effort. Git's output is captured as bytes and decoded
+  with the filesystem codec inside the guarded tail, so such a path round-trips instead of faulting.
+
 - **A worktree's local git exclude really is best-effort now (#359).** `_worktree_local_exclude`
   guarded only its `git rev-parse` call; the filesystem tail behind it (resolve, mkdir, read, write)
   crashed the run — a symlink loop raises `RuntimeError` on 3.11/3.12, an exclude file that is not

--- a/src/bmad_loop/install.py
+++ b/src/bmad_loop/install.py
@@ -762,6 +762,15 @@ def _worktree_local_exclude(worktree: Path, patterns: Sequence[str]) -> str | No
         # out of an arm whose whole contract is "skip silently", and that type is
         # in neither arm's tuple (#374). POSIX filenames are bytes, so a repo path
         # with bytes invalid in the locale encoding reaches this on a normal box.
+        #
+        # Deliberately NOT routed through verify._run_git, the chokepoint AGENTS.md
+        # otherwise requires. Nothing structural forbids it — neither module imports
+        # the other — but _run_git hands back CompletedProcess[str], i.e. the strict
+        # decode this call exists to avoid, and it raises GitError rather than the
+        # (SubprocessError, OSError) this arm treats as an expected skip. Adopting it
+        # needs a bytes mode on the chokepoint first; that is #377, which also covers
+        # the decode fault escaping _run_git's own taxonomy. The cost of standing
+        # outside it meanwhile is this call's missing timeout.
         raw = subprocess.run(
             ["git", "-C", str(worktree), "rev-parse", "--git-common-dir"],
             capture_output=True,

--- a/src/bmad_loop/install.py
+++ b/src/bmad_loop/install.py
@@ -781,7 +781,9 @@ def _worktree_local_exclude(worktree: Path, patterns: Sequence[str]) -> str | No
     try:
         # fsdecode, so a non-UTF-8 repo path round-trips back to the filesystem
         # instead of faulting. It can still raise on Windows (utf-8/surrogatepass
-        # rejects a lone invalid byte), which is why it sits inside this try.
+        # rejects a lone invalid byte), which is why it sits inside this try —
+        # defensive placement rather than a path under test: the regression test
+        # is POSIX-only because git on Windows has no such path to hand back.
         common_dir = Path(os.fsdecode(raw).strip())
         if not common_dir.is_absolute():
             # a PLAIN checkout answers with a relative ".git"; a linked worktree
@@ -807,8 +809,15 @@ def _worktree_local_exclude(worktree: Path, patterns: Sequence[str]) -> str | No
         # The helper rather than a hand-rolled tmp+replace: its temp name is
         # unique, and EVERY linked worktree of a repo resolves to this same
         # common dir, so a fixed `.tmp` sibling is a collision between two runs
-        # provisioning against one repo. It also fsyncs before the replace and
-        # carries the mode over, which a bare replace resets.
+        # provisioning against one repo. It also fsyncs before the replace, and
+        # carries the mode over when the exclude already exists, which a bare
+        # replace resets; one it creates from nothing gets the helper's
+        # deliberate 0600 rather than the umask default.
+        #
+        # Atomicity per write is NOT isolation across the read above and this
+        # write: they are unserialized, so two such runs interleaving lose one
+        # side's patterns outright, both returning None. That race predates
+        # #375 and survives this fix — it is #381.
         atomic_write_text(exclude, prefix + "\n".join(new) + "\n")
     # UnicodeError, not UnicodeDecodeError: the write raises the ENCODE sibling.
     # Still far short of ValueError-broad, so a programming error still escapes.

--- a/src/bmad_loop/install.py
+++ b/src/bmad_loop/install.py
@@ -17,6 +17,7 @@ orchestrator's signal watcher is CLI-agnostic.
 from __future__ import annotations
 
 import json
+import os
 import re
 import shutil
 import subprocess
@@ -28,6 +29,7 @@ from typing import Any, NamedTuple
 
 from .adapters.profile import ALIASES, CLIProfile, ProfileError, load_profiles
 from .checks import Finding
+from .platform_util import atomic_replace
 from .policy import POLICY_TEMPLATE
 from .process_host import get_process_host
 
@@ -739,12 +741,10 @@ def _worktree_local_exclude(worktree: Path, patterns: Sequence[str]) -> str | No
     opposite thing in each:
 
     - git unqueryable (not a repo, git missing) is an EXPECTED skip — returns
-      None silently. Callers hand this plain temp dirs routinely. One residual
-      escape survives here and is tracked in #374: `text=True` decodes git's
-      stdout strictly, so a repo path carrying bytes invalid in the locale
-      encoding raises UnicodeDecodeError, which is neither arm's type. Left out
-      of the #359 fix deliberately — decoding filesystem paths safely is a
-      program-wide decision, not this helper's.
+      None silently. Callers hand this plain temp dirs routinely. Nothing is
+      DECODED in this arm: git's stdout is captured as bytes and decoded in the
+      tail below, because a decode fault is a degrade (git answered; we could
+      not read it), not the silent skip this arm means (#374).
     - a filesystem fault AFTER git answered degrades to a returned reason string
       the caller can surface: `.resolve()` (pre-3.13 a symlink loop raises
       RuntimeError, not OSError), `mkdir`, read/write OSError, and either
@@ -758,16 +758,22 @@ def _worktree_local_exclude(worktree: Path, patterns: Sequence[str]) -> str | No
     # Callers pass POSIX-slash patterns (glob rels via as_posix; config strings as
     # authored); git's exclude is POSIX-slash on every platform, so nothing to fix here.
     try:
-        common = subprocess.run(
+        # bytes, not text=True: strict decoding here would raise UnicodeDecodeError
+        # out of an arm whose whole contract is "skip silently", and that type is
+        # in neither arm's tuple (#374). POSIX filenames are bytes, so a repo path
+        # with bytes invalid in the locale encoding reaches this on a normal box.
+        raw = subprocess.run(
             ["git", "-C", str(worktree), "rev-parse", "--git-common-dir"],
             capture_output=True,
-            text=True,
             check=True,
-        ).stdout.strip()
+        ).stdout
     except (subprocess.SubprocessError, OSError):
         return None
     try:
-        common_dir = Path(common)
+        # fsdecode, so a non-UTF-8 repo path round-trips back to the filesystem
+        # instead of faulting. It can still raise on Windows (utf-8/surrogatepass
+        # rejects a lone invalid byte), which is why it sits inside this try.
+        common_dir = Path(os.fsdecode(raw).strip())
         if not common_dir.is_absolute():
             # a PLAIN checkout answers with a relative ".git"; a linked worktree
             # answers with the main repo's absolute .git (verified, git 2.55), so
@@ -781,7 +787,22 @@ def _worktree_local_exclude(worktree: Path, patterns: Sequence[str]) -> str | No
         if not new:
             return None
         prefix = existing if not existing or existing.endswith("\n") else existing + "\n"
-        exclude.write_text(prefix + "\n".join(new) + "\n", encoding="utf-8")
+        # Write-then-replace, never write_text onto `exclude` directly (#375).
+        # write_text opens "w", which TRUNCATES before writing, and this is a
+        # read-modify-REWRITE carrying the operator's own excludes in `prefix` —
+        # so a short write (ENOSPC) left the file truncated mid-content while the
+        # degrade reason still said "could not update". Worse, the surviving tail
+        # is a valid git pattern and a prefix of the intended one: cut one char
+        # in and the last line is "/", which excludes the entire worktree. And
+        # the blast radius is the MAIN repo, since a linked worktree's
+        # --git-common-dir points at the main .git.
+        tmp = exclude.with_name(f"{exclude.name}.bmad-loop.tmp")
+        try:
+            tmp.write_text(prefix + "\n".join(new) + "\n", encoding="utf-8")
+            atomic_replace(tmp, exclude)
+        except (OSError, RuntimeError, UnicodeError):
+            tmp.unlink(missing_ok=True)  # never leave the scratch file behind
+            raise
     # UnicodeError, not UnicodeDecodeError: the write raises the ENCODE sibling.
     # Still far short of ValueError-broad, so a programming error still escapes.
     except (OSError, RuntimeError, UnicodeError) as e:

--- a/src/bmad_loop/install.py
+++ b/src/bmad_loop/install.py
@@ -792,7 +792,8 @@ def _worktree_local_exclude(worktree: Path, patterns: Sequence[str]) -> str | No
             common_dir = (worktree / common_dir).resolve()
         exclude = common_dir / "info" / "exclude"
         exclude.parent.mkdir(parents=True, exist_ok=True)
-        existing = exclude.read_text(encoding="utf-8") if exclude.is_file() else ""
+        existed = exclude.is_file()
+        existing = exclude.read_text(encoding="utf-8") if existed else ""
         present = set(existing.splitlines())
         new = [p for p in patterns if p not in present]
         if not new:
@@ -809,15 +810,30 @@ def _worktree_local_exclude(worktree: Path, patterns: Sequence[str]) -> str | No
         # The helper rather than a hand-rolled tmp+replace: its temp name is
         # unique, and EVERY linked worktree of a repo resolves to this same
         # common dir, so a fixed `.tmp` sibling is a collision between two runs
-        # provisioning against one repo. It also fsyncs before the replace, and
-        # carries the mode over when the exclude already exists, which a bare
-        # replace resets; one it creates from nothing gets the helper's
-        # deliberate 0600 rather than the umask default.
+        # provisioning against one repo. It also fsyncs before the replace and
+        # carries the target's mode over, which a bare replace resets.
         #
         # Atomicity per write is NOT isolation across the read above and this
         # write: they are unserialized, so two such runs interleaving lose one
         # side's patterns outright, both returning None. That race predates
         # #375 and survives this fix — it is #381.
+        if not existed:
+            # Create it first, the way the write_text this replaced did: O_CREAT
+            # under the umask, giving the helper a mode to carry. Left to itself
+            # it creates a new target at mkstemp's private 0600 — and an exclude
+            # git cannot READ is one git silently IGNORES. Measured: git warns,
+            # exits 0, and `git add -A` stages the files the exclude was written
+            # to shield. That is the exact harm the docstring above says silence
+            # must not cause, and here nothing would even be reported, because
+            # the write SUCCEEDS. Reachable wherever the common dir is read
+            # under another UID (core.sharedRepository, a shared checkout) —
+            # which is why atomic_write_text's own docstring says callers of
+            # genuinely shared state need more than the helper alone.
+            #
+            # Safe against the tail below: an empty exclude is equivalent to an
+            # absent one for git, so a fault after this leaves no more damage
+            # than the missing file it replaced.
+            exclude.touch()
         atomic_write_text(exclude, prefix + "\n".join(new) + "\n")
     # UnicodeError, not UnicodeDecodeError: the write raises the ENCODE sibling.
     # Still far short of ValueError-broad, so a programming error still escapes.

--- a/src/bmad_loop/install.py
+++ b/src/bmad_loop/install.py
@@ -29,7 +29,7 @@ from typing import Any, NamedTuple
 
 from .adapters.profile import ALIASES, CLIProfile, ProfileError, load_profiles
 from .checks import Finding
-from .platform_util import atomic_replace
+from .platform_util import atomic_write_text
 from .policy import POLICY_TEMPLATE
 from .process_host import get_process_host
 
@@ -787,22 +787,20 @@ def _worktree_local_exclude(worktree: Path, patterns: Sequence[str]) -> str | No
         if not new:
             return None
         prefix = existing if not existing or existing.endswith("\n") else existing + "\n"
-        # Write-then-replace, never write_text onto `exclude` directly (#375).
+        # atomic_write_text, never write_text onto `exclude` directly (#375).
         # write_text opens "w", which TRUNCATES before writing, and this is a
         # read-modify-REWRITE carrying the operator's own excludes in `prefix` —
         # so a short write (ENOSPC) left the file truncated mid-content while the
         # degrade reason still said "could not update". Worse, the surviving tail
         # is a valid git pattern and a prefix of the intended one: cut one char
-        # in and the last line is "/", which excludes the entire worktree. And
-        # the blast radius is the MAIN repo, since a linked worktree's
-        # --git-common-dir points at the main .git.
-        tmp = exclude.with_name(f"{exclude.name}.bmad-loop.tmp")
-        try:
-            tmp.write_text(prefix + "\n".join(new) + "\n", encoding="utf-8")
-            atomic_replace(tmp, exclude)
-        except (OSError, RuntimeError, UnicodeError):
-            tmp.unlink(missing_ok=True)  # never leave the scratch file behind
-            raise
+        # in and the last line is "/", which excludes the entire worktree.
+        #
+        # The helper rather than a hand-rolled tmp+replace: its temp name is
+        # unique, and EVERY linked worktree of a repo resolves to this same
+        # common dir, so a fixed `.tmp` sibling is a collision between two runs
+        # provisioning against one repo. It also fsyncs before the replace and
+        # carries the mode over, which a bare replace resets.
+        atomic_write_text(exclude, prefix + "\n".join(new) + "\n")
     # UnicodeError, not UnicodeDecodeError: the write raises the ENCODE sibling.
     # Still far short of ValueError-broad, so a programming error still escapes.
     except (OSError, RuntimeError, UnicodeError) as e:

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,5 +1,6 @@
 import io
 import json
+import os
 import re
 import sys
 import zipfile
@@ -1650,9 +1651,13 @@ def test_worktree_local_exclude_undecodable_git_output_degrades(tmp_path, monkey
     bin_dir = tmp_path / "stubbin"
     bin_dir.mkdir()
     stub = bin_dir / "git"
-    # emits a path carrying byte 0xff, exactly what a repo whose directory name
-    # is not valid UTF-8 makes `git rev-parse --git-common-dir` print
-    stub.write_bytes(b"#!/bin/sh\nprintf '/tmp/repo-\\377-name/.git\\n'\n")
+    # Emits a path carrying byte 0xff, exactly what a repo whose directory name
+    # is not valid UTF-8 makes `git rev-parse --git-common-dir` print. The path is
+    # rooted in tmp_path, NOT a literal /tmp: the helper mkdir(parents=True)s the
+    # common dir it is handed, so a hardcoded path would create real directories
+    # in the shared system /tmp on every run, outside pytest's cleanup.
+    common = os.fsencode(str(tmp_path)) + b"/repo-\377-name/.git"
+    stub.write_bytes(b"#!/bin/sh\nprintf '%s\\n' " + common + b"\n")
     stub.chmod(0o755)
     monkeypatch.setenv("PATH", str(bin_dir), prepend=False)
 
@@ -1660,6 +1665,8 @@ def test_worktree_local_exclude_undecodable_git_output_degrades(tmp_path, monkey
     reason = _worktree_local_exclude(tmp_path / "wt", ["/probe-374"])
 
     assert reason is None or "could not update" in reason
+    # nothing was created outside the sandbox
+    assert not list(Path("/tmp").glob("repo-*-name")) or sys.platform == "win32"
 
 
 def test_worktree_local_exclude_non_git_dir_returns_none(tmp_path):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -2,6 +2,7 @@ import io
 import json
 import os
 import re
+import stat
 import sys
 import zipfile
 from pathlib import Path
@@ -1689,6 +1690,46 @@ def test_worktree_local_exclude_undecodable_git_output_degrades(tmp_path, monkey
     landed = Path(os.fsdecode(common)) / "info" / "exclude"
     assert landed.is_file()
     assert "/probe-374" in landed.read_text(encoding="utf-8")
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX mode bits; Windows has no umask")
+def test_worktree_local_exclude_created_exclude_stays_readable(project):
+    """An exclude this helper CREATES keeps the mode the `write_text` it replaced
+    would have produced, not `mkstemp`'s private 0600. `atomic_write_text` carries
+    a mode over only when the target already EXISTS (its docstring is explicit),
+    so a fresh one lands 0600 — and git treats an exclude it cannot read as one
+    that is not there. Measured: git warns `unable to access`, exits 0, and
+    `git add -A` stages the very files the exclude was written to shield, with no
+    degrade reason at all, because the write SUCCEEDED. That is the harm the
+    helper's own docstring calls out, arrived at through a successful write.
+
+    Reachable where the common dir is read under another UID —
+    `core.sharedRepository`, a shared checkout — and the create path is live
+    whenever `.git/info/exclude` is absent, which is why the `mkdir(parents=True)`
+    above exists.
+
+    The umask is pinned rather than inherited: at the box's own 0077 the ablated
+    code produces 0600 too, and the ablation would not bite.
+
+    Ablation: drop the `exclude.touch()` and this fails, reporting 0o600."""
+    old_umask = os.umask(0o022)
+    try:
+        exclude = project.project / ".git" / "info" / "exclude"
+        exclude.parent.mkdir(parents=True, exist_ok=True)
+        exclude.unlink(missing_ok=True)
+        # what the replaced write_text would have produced, measured not assumed
+        probe = exclude.with_name("umask-probe")
+        probe.write_text("x", encoding="utf-8")
+        expected = stat.S_IMODE(probe.stat().st_mode)
+        probe.unlink()
+
+        assert _worktree_local_exclude(project.project, ["/probe-mode"]) is None
+
+        assert stat.S_IMODE(exclude.stat().st_mode) == expected, oct(
+            stat.S_IMODE(exclude.stat().st_mode)
+        )
+    finally:
+        os.umask(old_umask)
 
 
 def test_worktree_local_exclude_non_git_dir_returns_none(tmp_path):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1503,7 +1503,10 @@ def test_worktree_local_exclude_degrades_on_write_fault(project, monkeypatch):
     real_write = Path.write_text
 
     def boom(self, *a, **kw):
-        if self.name == "exclude":
+        # matches the scratch file too: the write lands on "exclude.bmad-loop.tmp"
+        # and is os.replace'd into place, so a filter pinned to "exclude" alone
+        # would stop injecting anything and pass vacuously (#375).
+        if self.name.startswith("exclude"):
             raise OSError("read-only .git")
         return real_write(self, *a, **kw)
 
@@ -1560,6 +1563,100 @@ def test_worktree_local_exclude_degrades_on_unencodable_pattern(project):
     assert reason is not None and "surrogates not allowed" in reason
 
 
+def test_worktree_local_exclude_short_write_leaves_exclude_intact(project, monkeypatch):
+    """#375: a fault PARTWAY THROUGH the write must leave the operator's exclude
+    byte-identical, not truncated. `write_text` opens "w" (truncate-then-write)
+    and this is a read-modify-REWRITE carrying their content in `prefix`, so a
+    direct write left the file cut mid-content while the reason still said
+    "could not update". The surviving tail is a valid git pattern and a prefix of
+    the intended one — cut one character in and the last line is `/`, which
+    excludes the whole worktree. Blast radius is the MAIN repo: a linked
+    worktree's --git-common-dir points at the main .git.
+
+    The fault is injected at `Path.open`, NOT at `Path.write_text`: patching
+    write_text means the file is never opened, so the truncation cannot happen
+    and the test would pass against the very bug it exists to catch. Going
+    through the real `open(mode="w")` is the whole point — that is what
+    truncates.
+
+    Ablation: write directly to `exclude` instead of tmp + atomic_replace and
+    this fails — the file comes back truncated."""
+    exclude = project.project / ".git" / "info" / "exclude"
+    exclude.parent.mkdir(parents=True, exist_ok=True)
+    exclude.write_text("# OPERATOR'S OWN\n/secret-local\n", encoding="utf-8")
+    before = exclude.read_bytes()
+
+    real_open = Path.open
+
+    class ShortWriter:
+        def __init__(self, f):
+            self._f = f
+
+        def write(self, s):
+            self._f.write(s[:8])  # a partial write, then the device gives up
+            raise OSError(28, "No space left on device")
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            self._f.close()
+            return False
+
+        def __getattr__(self, name):
+            return getattr(self._f, name)
+
+    def opener(self, *a, **kw):
+        mode = a[0] if a else kw.get("mode", "r")
+        handle = real_open(self, *a, **kw)
+        if "w" in mode and self.name.startswith("exclude"):
+            return ShortWriter(handle)
+        return handle
+
+    monkeypatch.setattr(Path, "open", opener)
+
+    reason = _worktree_local_exclude(project.project, ["/probe-359"])
+
+    monkeypatch.undo()
+    assert reason is not None and "No space left" in reason
+    assert exclude.read_bytes() == before  # untouched, not half-rewritten
+    # and the scratch file is not left lying next to it
+    assert not (exclude.parent / "exclude.bmad-loop.tmp").exists()
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX-only fault: Windows paths are UTF-16, so git cannot emit an undecodable path",
+)
+def test_worktree_local_exclude_undecodable_git_output_degrades(tmp_path, monkeypatch):
+    """#374: the git-query arm used `text=True`, decoding stdout strictly, so a
+    repo path with bytes invalid in the locale encoding raised UnicodeDecodeError
+    — a type in NEITHER arm's tuple, straight out of a function whose whole
+    contract is that it never propagates.
+
+    Driven through a REAL stub `git` on PATH rather than a monkeypatched
+    `subprocess.run`. That distinction is the test: replacing subprocess.run
+    hands the code bytes directly and never runs the stdlib's decoding at all, so
+    such a test passes identically with `text=True` restored — it cannot see the
+    bug. Verified: the run-patching version did NOT fail its own ablation.
+
+    Ablation: restore `text=True` on the subprocess call and this fails — the
+    UnicodeDecodeError propagates from the arm that promises a silent skip."""
+    bin_dir = tmp_path / "stubbin"
+    bin_dir.mkdir()
+    stub = bin_dir / "git"
+    # emits a path carrying byte 0xff, exactly what a repo whose directory name
+    # is not valid UTF-8 makes `git rev-parse --git-common-dir` print
+    stub.write_bytes(b"#!/bin/sh\nprintf '/tmp/repo-\\377-name/.git\\n'\n")
+    stub.chmod(0o755)
+    monkeypatch.setenv("PATH", str(bin_dir), prepend=False)
+
+    # must not raise: the contract is best-effort in both arms
+    reason = _worktree_local_exclude(tmp_path / "wt", ["/probe-374"])
+
+    assert reason is None or "could not update" in reason
+
+
 def test_worktree_local_exclude_non_git_dir_returns_none(tmp_path):
     """Not-a-repo is an EXPECTED skip, not a degradation: `OSError` in the
     subprocess arm means "no git to query" and must stay silent, while the same
@@ -1597,7 +1694,10 @@ def test_provision_worktree_exclude_fault_reports_on_degraded(project, tmp_path,
     real_write = Path.write_text
 
     def boom(self, *a, **kw):
-        if self.name == "exclude":
+        # matches the scratch file too: the write lands on "exclude.bmad-loop.tmp"
+        # and is os.replace'd into place, so a filter pinned to "exclude" alone
+        # would stop injecting anything and pass vacuously (#375).
+        if self.name.startswith("exclude"):
             raise OSError("read-only .git")
         return real_write(self, *a, **kw)
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1657,16 +1657,38 @@ def test_worktree_local_exclude_undecodable_git_output_degrades(tmp_path, monkey
     # common dir it is handed, so a hardcoded path would create real directories
     # in the shared system /tmp on every run, outside pytest's cleanup.
     common = os.fsencode(str(tmp_path)) + b"/repo-\377-name/.git"
-    stub.write_bytes(b"#!/bin/sh\nprintf '%s\\n' " + common + b"\n")
+    # SINGLE-QUOTED into the script. Unquoted, a temp root carrying whitespace
+    # (TMPDIR, --basetemp, a username with a space) word-splits into a second
+    # printf argument, and `printf '%s\n'` repeats its format per argument — so
+    # the helper is handed a path with an embedded NEWLINE and mkdir(parents=True)s
+    # it as a sibling of the basetemp pytest reaps. Measured with a spaced
+    # --basetemp: it leaked such a directory and the test still passed.
+    stub.write_bytes(b"#!/bin/sh\nprintf '%s\\n' '" + common.replace(b"'", b"'\\''") + b"'\n")
     stub.chmod(0o755)
-    monkeypatch.setenv("PATH", str(bin_dir), prepend=False)
+    # PATH is REPLACED, not prepended: the stub has to be the only resolvable
+    # `git`, or the box's real git answers first with a decodable path and this
+    # passes without ever exercising the decode.
+    monkeypatch.setenv("PATH", str(bin_dir))
 
     # must not raise: the contract is best-effort in both arms
     reason = _worktree_local_exclude(tmp_path / "wt", ["/probe-374"])
 
     assert reason is None or "could not update" in reason
-    # nothing was created outside the sandbox
-    assert not list(Path("/tmp").glob("repo-*-name")) or sys.platform == "win32"
+    # The tail actually RAN, against the decoded path. Not decoration: without
+    # it this test is vacuous whenever the stub cannot exec — a noexec temp dir
+    # (ordinary CI hardening), no /bin/sh, a filesystem that drops the exec bit.
+    # subprocess.run then raises OSError, the git-query arm swallows it as the
+    # expected skip it is, `reason is None` holds, and the ablation above
+    # evaporates with it. Measured: at mode 0644 the stub never runs and every
+    # assertion above still passes.
+    #
+    # This also pins containment better than globbing shared /tmp for a leak:
+    # that glob is non-recursive and tmp_path sits three levels down, so it
+    # could not see this test's own output, while it DID fail for anyone whose
+    # box still carried litter from the hardcoded-path version of this test.
+    landed = Path(os.fsdecode(common)) / "info" / "exclude"
+    assert landed.is_file()
+    assert "/probe-374" in landed.read_text(encoding="utf-8")
 
 
 def test_worktree_local_exclude_non_git_dir_returns_none(tmp_path):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,3 +1,4 @@
+import io
 import json
 import re
 import sys
@@ -7,6 +8,7 @@ from pathlib import Path
 import pytest
 from conftest import git
 
+import bmad_loop.install as install_mod
 from bmad_loop import verify
 from bmad_loop.adapters.profile import get_profile
 from bmad_loop.install import (
@@ -1500,17 +1502,14 @@ def test_worktree_local_exclude_degrades_on_write_fault(project, monkeypatch):
 
     Ablation: drop the tail's `try` (or `OSError` from its tuple) and this fails —
     the OSError propagates out of `_worktree_local_exclude`."""
-    real_write = Path.write_text
 
-    def boom(self, *a, **kw):
-        # matches the scratch file too: the write lands on "exclude.bmad-loop.tmp"
-        # and is os.replace'd into place, so a filter pinned to "exclude" alone
-        # would stop injecting anything and pass vacuously (#375).
-        if self.name.startswith("exclude"):
-            raise OSError("read-only .git")
-        return real_write(self, *a, **kw)
+    def boom(*a, **kw):
+        raise OSError("read-only .git")
 
-    monkeypatch.setattr(Path, "write_text", boom)
+    # patched at install's OWN binding: the exclude write goes through
+    # atomic_write_text (#375), which writes via os.fdopen on an mkstemp fd, so a
+    # Path.write_text/Path.open patch never fires and would pass vacuously.
+    monkeypatch.setattr(install_mod, "atomic_write_text", boom)
 
     reason = _worktree_local_exclude(project.project, ["/probe-359"])
 
@@ -1579,14 +1578,14 @@ def test_worktree_local_exclude_short_write_leaves_exclude_intact(project, monke
     through the real `open(mode="w")` is the whole point — that is what
     truncates.
 
-    Ablation: write directly to `exclude` instead of tmp + atomic_replace and
+    Ablation: swap `atomic_write_text` back to a direct `exclude.write_text` and
     this fails — the file comes back truncated."""
     exclude = project.project / ".git" / "info" / "exclude"
     exclude.parent.mkdir(parents=True, exist_ok=True)
     exclude.write_text("# OPERATOR'S OWN\n/secret-local\n", encoding="utf-8")
     before = exclude.read_bytes()
 
-    real_open = Path.open
+    real_open = io.open
 
     class ShortWriter:
         def __init__(self, f):
@@ -1606,22 +1605,28 @@ def test_worktree_local_exclude_short_write_leaves_exclude_intact(project, monke
         def __getattr__(self, name):
             return getattr(self._f, name)
 
-    def opener(self, *a, **kw):
+    def opener(file, *a, **kw):
         mode = a[0] if a else kw.get("mode", "r")
-        handle = real_open(self, *a, **kw)
-        if "w" in mode and self.name.startswith("exclude"):
+        handle = real_open(file, *a, **kw)
+        # io.open is the ONE seam both shapes share: the fix reaches it through
+        # os.fdopen on an mkstemp fd (an int), the ablation through Path.open (a
+        # path). Patching either one alone injects into only one of them, so the
+        # ablation would silently stop biting.
+        if "w" in mode:
             return ShortWriter(handle)
         return handle
 
-    monkeypatch.setattr(Path, "open", opener)
+    monkeypatch.setattr(io, "open", opener)
 
     reason = _worktree_local_exclude(project.project, ["/probe-359"])
 
     monkeypatch.undo()
     assert reason is not None and "No space left" in reason
     assert exclude.read_bytes() == before  # untouched, not half-rewritten
-    # and the scratch file is not left lying next to it
-    assert not (exclude.parent / "exclude.bmad-loop.tmp").exists()
+    # no scratch file left lying next to it. Globbed, not a fixed name: the
+    # helper's temp is uniquely named (mkstemp), so asserting one literal
+    # filename is absent would pass no matter what the code did.
+    assert [p.name for p in exclude.parent.iterdir()] == ["exclude"]
 
 
 @pytest.mark.skipif(
@@ -1691,17 +1696,14 @@ def test_provision_worktree_exclude_fault_reports_on_degraded(project, tmp_path,
     repo = project.project
     wt = tmp_path / "wt"
     verify.worktree_add(repo, wt, "feat", "main")
-    real_write = Path.write_text
 
-    def boom(self, *a, **kw):
-        # matches the scratch file too: the write lands on "exclude.bmad-loop.tmp"
-        # and is os.replace'd into place, so a filter pinned to "exclude" alone
-        # would stop injecting anything and pass vacuously (#375).
-        if self.name.startswith("exclude"):
-            raise OSError("read-only .git")
-        return real_write(self, *a, **kw)
+    def boom(*a, **kw):
+        raise OSError("read-only .git")
 
-    monkeypatch.setattr(Path, "write_text", boom)
+    # patched at install's OWN binding: the exclude write goes through
+    # atomic_write_text (#375), which writes via os.fdopen on an mkstemp fd, so a
+    # Path.write_text/Path.open patch never fires and would pass vacuously.
+    monkeypatch.setattr(install_mod, "atomic_write_text", boom)
     msgs: list[str] = []
 
     provision_worktree(wt, [get_profile("claude")], repo, on_degraded=msgs.append)


### PR DESCRIPTION
Closes #374. Closes #375.

Follow-up to #359 (PR #373), which guarded `_worktree_local_exclude`'s filesystem tail but left two
holes the review surfaced. Both live in the same helper and both falsify the same best-effort
contract, so they ship together rather than as two PRs racing on adjacent lines.

## #374 — the git-query arm decoded strictly

`subprocess.run(..., text=True)` decodes stdout with the locale codec at `errors='strict'`.
`UnicodeDecodeError` is neither a `SubprocessError` nor an `OSError`, so it escaped the one arm whose
entire contract is *"skip silently"*. POSIX filenames are bytes, so a repo path carrying bytes
invalid in the locale encoding reaches this on an ordinary box:

```
ESCAPED from arm 1: UnicodeDecodeError -> 'utf-8' codec can't decode byte 0xff in position 10
```

Stdout is now captured as **bytes** and decoded with `os.fsdecode` **inside the guarded tail**. Two
reasons for that placement: `fsdecode` uses surrogateescape on POSIX, so a non-UTF-8 path round-trips
back to the filesystem instead of faulting at all; and it can still raise on Windows, where
utf-8/surrogatepass rejects a lone invalid byte — so it belongs where `UnicodeError` is already
caught.

## #375 — the write was not atomic

The update is a read-modify-**rewrite**, and `Path.write_text` opens `"w"`, which truncates *before*
writing. `prefix` carries the operator's own excludes, so a fault partway through left the file cut
mid-content while the degrade reason still said "could not update":

```
before:   b"# OPERATOR'S OWN\n/secret-local\n"
after:    b"# OPERAT"                            <- ablation output, verbatim
```

Three consequences: the reason misdescribes the state; the surviving tail parses as a **valid git
pattern** and is a prefix of the intended one, so a cut one character in leaves the last line as `/`,
excluding the entire worktree — the exact state `worktree_flow.py` already guards against for
hookless profiles; and the blast radius is the **main repo**, since a linked worktree's
`--git-common-dir` points at the main `.git`.

Now written to a scratch file and moved into place with `atomic_replace`, with the scratch file
removed on the failure path. The exclude is either fully updated or untouched.

## One test was replaced after failing its own ablation

The first version of the #374 test monkeypatched `subprocess.run` to return undecodable bytes. It
passed — and **passed identically with `text=True` restored**, because handing the code bytes
directly never runs the stdlib's decoding at all. It could not see the bug it was written for. Driving
a **real stub `git` on PATH** does fail the ablation. It is POSIX-only and skipped on Windows, which
is correct rather than a dodge: Windows paths are UTF-16, so git cannot emit an undecodable one.

The #375 test injects at `Path.open`, not `Path.write_text` — patching `write_text` means the file is
never opened, so the truncation cannot happen and the test would pass against the very bug it exists
to catch. That is the same reason the two pre-existing write-fault tests needed their name filter
widened: the write now lands on the scratch file, and a filter pinned to `"exclude"` alone would stop
injecting anything and pass vacuously.

| Ablation | Fails |
| -------- | ----- |
| restore `text=True` on the subprocess | the stub-git test |
| write directly to `exclude` instead of tmp + `atomic_replace` | the short-write test (file returns truncated) |
| *(rejected test shape)* patch `subprocess.run` instead of stubbing git | **nothing** — which is why it was replaced |

## Verification

`uv run pytest -q -n auto` — 3695 passed, 24 skipped (run three times; one unrelated Textual modal
test, `test_decision_modal_scrolls_when_content_long`, flaked once under parallel load and passes
consistently in isolation and on `main`). `uvx pyright@1.1.411` — 0 errors. `trunk fmt` + full
`trunk check` — no issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Worktree exclude updates are now written atomically, preventing partial/truncated exclude files and preserving existing content.
  * Exclude update failures no longer leave behind scratch/temp artifacts.
  * Worktree setup now handles repositories with non-UTF-8 paths without crashing, degrading gracefully when needed.
* **Tests**
  * Added failure-injection and coverage for partial-write scenarios and undecodable `git` output, including validation that exclude content remains byte-identical.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

Follow-up filed, not fixed here: #381 — `atomic_write_text` makes each write all-or-nothing but does not serialize the read-modify-write around it, so two runs provisioning against one repo interleave into a lost update. Pre-existing, reproduced in the issue.
