### PR TITLE
fix(verify): decode verify-command output with errors="replace" (#378)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -260,6 +260,14 @@ story <id>`, the same annotation a sweep bundle writes. Both sprint and stories 
 
 ### Fixed
 
+- **One undecodable byte of verify output no longer crashes the run (#378).** Verify commands are
+  arbitrary operator tools, and their captured output was decoded strictly — a child emitting bytes
+  invalid in the run's encoding raised `UnicodeDecodeError` out of `run_verify_commands`, losing
+  every command's result and crashing the dev phase instead of classifying the failure. Output now
+  decodes with `errors="replace"`: the tail is display-only feedback for a human or repair session,
+  so a replacement character costs nothing, while exit codes and the rest of the tail keep driving
+  classification.
+
 - **A short write no longer truncates the worktree exclude (#375).** The exclude update is a
   read-modify-rewrite, and `write_text` truncates before writing, so a fault partway through (ENOSPC,
   EIO) left the operator's own excludes cut mid-content while the degrade reason still reported that

--- a/src/bmad_loop/verify.py
+++ b/src/bmad_loop/verify.py
@@ -1629,6 +1629,15 @@ def env_fault_reason(result: CommandResult, cwd: Path) -> str | None:
 
 
 def run_verify_commands(policy: Policy, cwd: Path) -> list[CommandResult]:
+    """Run each of the policy's verify commands, one CommandResult apiece.
+
+    Output decodes with ``errors="replace"`` (#378): the children are arbitrary
+    operator tools whose bytes are not ours to constrain, the captured tail is
+    display-only feedback for a human or a repair session (already lossy at
+    ``[-2000:]``), and one undecodable byte must not raise mid-loop and lose
+    *every* command's result. Decoding stays on the locale codec (``text=True``)
+    precisely because these are host tools — contrast tui/launch.py, which pins
+    ``encoding="utf-8"`` because its child is our own UTF-8 CLI."""
     results = []
     for command in policy.verify.commands:
         try:
@@ -1640,6 +1649,7 @@ def run_verify_commands(policy: Policy, cwd: Path) -> list[CommandResult]:
                 cwd=cwd,
                 capture_output=True,
                 text=True,
+                errors="replace",
                 timeout=COMMAND_TIMEOUT_S,
             )
             output = (proc.stdout + proc.stderr)[-2000:]

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1,4 +1,5 @@
 import dataclasses
+import io
 import os
 import subprocess
 import sys
@@ -879,6 +880,37 @@ def test_verify_commands_timeout_stays_charged(tmp_path, monkeypatch):
 # code str objects directly and never runs the stdlib's decoding at all, so such
 # a test passes identically with the bug restored — see the #374 regression
 # test's docstring (tests/test_install.py) for the same distinction.
+#
+# They are also codec-conditional, which is the subtler way they could go quiet.
+# Byte 0xff is undecodable only in UTF-8/ASCII; every ISO-8859-x and cp125x
+# codec maps all 256 byte values, so under such a locale the strict decode never
+# raises and both tests pass *with the bug restored* — a silent vacuity rather
+# than a failure (verified: under LC_ALL=et_EE.iso885915 the ablation passes).
+# No single byte is undecodable everywhere, so the guard below skips instead,
+# leaving the tests either exercising the fault or saying plainly that they did
+# not. CI is always on the exercising side: the Linux legs run UTF-8 and the
+# Windows legs set PYTHONUTF8=1 (.github/workflows/ci.yml).
+
+
+def _codec_rejects_bad_byte() -> bool:
+    """Whether byte 0xff is undecodable in the codec ``text=True`` will use.
+
+    Probes ``TextIOWrapper`` with ``encoding=None`` rather than naming a codec,
+    because that is the very default ``subprocess``'s text mode resolves for the
+    child's streams — asking the machinery beats predicting it from the locale.
+    """
+    try:
+        io.TextIOWrapper(io.BytesIO(b"\xff")).read()
+    except UnicodeDecodeError:
+        return True
+    return False
+
+
+needs_strict_codec = pytest.mark.skipif(
+    not _codec_rejects_bad_byte(),
+    reason="host codec decodes 0xff (e.g. an ISO-8859-x locale), so nothing here "
+    "would exercise the strict decode this fix is about",
+)
 
 
 def _undecodable_cmd(tmp_path: Path, rc: int) -> str:
@@ -897,6 +929,7 @@ def _undecodable_cmd(tmp_path: Path, rc: int) -> str:
     return f'"{sys.executable}" "{script}"'
 
 
+@needs_strict_codec
 def test_verify_commands_undecodable_output_keeps_every_result(tmp_path):
     """A child emitting a byte invalid in the run's encoding is decoded with
     replacement, not strictly: the strict decode raised UnicodeDecodeError
@@ -904,9 +937,10 @@ def test_verify_commands_undecodable_output_keeps_every_result(tmp_path):
     later command's result were lost, and the dev phase crashed instead of
     classifying a failure.
 
-    The surviving text around the bad byte is asserted, not the replacement
-    glyph itself: which glyph (or how many) appears depends on the locale codec,
-    while the contract here is only that the loop neither raises nor drops.
+    U+FFFD is asserted, not merely "did not raise": under `needs_strict_codec`
+    the codec provably cannot decode the byte, so `errors="replace"` must have
+    produced exactly that character. Its *count* stays unasserted — that is what
+    varies by codec — and the text on both sides pins the rest of the tail.
 
     Ablation: remove `errors="replace"` from run_verify_commands and this fails
     with UnicodeDecodeError."""
@@ -916,12 +950,19 @@ def test_verify_commands_undecodable_output_keeps_every_result(tmp_path):
 
     assert [r.returncode for r in results] == [5, 0]
     assert "before" in results[0].output_tail and "after" in results[0].output_tail
+    assert "\ufffd" in results[0].output_tail  # the replacement, not a survivor
 
 
+@needs_strict_codec
 def test_verify_commands_undecodable_failure_stays_fixable_retry(tmp_path):
     """Through the outcome path: an undecodable tail still classifies as an
-    ordinary fixable failure and still reaches the repair session's feedback —
-    env_fault_reason runs over the replaced text without raising."""
+    ordinary fixable failure and still reaches the repair session's feedback.
+
+    What the env-fault probe contributes is platform-split, so this does not
+    claim more than it runs: on POSIX `verify.env_fault_reason` returns at its
+    `sys.platform != "win32"` guard without ever reading the tail, and only the
+    Windows leg takes `_win32_env_fault_reason` over the replaced text. The
+    classification asserted here holds on both."""
     policy = Policy(verify=VerifyPolicy(commands=(_undecodable_cmd(tmp_path, 1),)))
 
     out = verify.verify_commands_outcome(policy, tmp_path)

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -873,6 +873,64 @@ def test_verify_commands_timeout_stays_charged(tmp_path, monkeypatch):
     assert not out.ok and out.fixable and not out.env_fault
 
 
+# ---- undecodable verify output (issue #378)
+#
+# Both tests drive a REAL child process. Monkeypatching subprocess.run hands the
+# code str objects directly and never runs the stdlib's decoding at all, so such
+# a test passes identically with the bug restored — see the #374 regression
+# test's docstring (tests/test_install.py) for the same distinction.
+
+
+def _undecodable_cmd(tmp_path: Path, rc: int) -> str:
+    """A shell string running a child that emits byte 0xff on stdout and exits
+    with `rc`. Interpreter is `sys.executable`, never a bare `python`: the tests
+    run under uv, where no `python` need be on PATH. The double quotes are
+    honored by both sh and cmd."""
+    script = tmp_path / "emit378.py"
+    script.write_text(
+        "import sys\n"
+        "sys.stdout.buffer.write(b'before \\xff after\\n')\n"
+        "sys.stdout.buffer.flush()\n"
+        f"sys.exit({rc})\n",
+        encoding="utf-8",
+    )
+    return f'"{sys.executable}" "{script}"'
+
+
+def test_verify_commands_undecodable_output_keeps_every_result(tmp_path):
+    """A child emitting a byte invalid in the run's encoding is decoded with
+    replacement, not strictly: the strict decode raised UnicodeDecodeError
+    *before* any result was appended, so the offender's exit code AND every
+    later command's result were lost, and the dev phase crashed instead of
+    classifying a failure.
+
+    The surviving text around the bad byte is asserted, not the replacement
+    glyph itself: which glyph (or how many) appears depends on the locale codec,
+    while the contract here is only that the loop neither raises nor drops.
+
+    Ablation: remove `errors="replace"` from run_verify_commands and this fails
+    with UnicodeDecodeError."""
+    policy = Policy(verify=VerifyPolicy(commands=(_undecodable_cmd(tmp_path, 5), _OK)))
+
+    results = verify.run_verify_commands(policy, tmp_path)
+
+    assert [r.returncode for r in results] == [5, 0]
+    assert "before" in results[0].output_tail and "after" in results[0].output_tail
+
+
+def test_verify_commands_undecodable_failure_stays_fixable_retry(tmp_path):
+    """Through the outcome path: an undecodable tail still classifies as an
+    ordinary fixable failure and still reaches the repair session's feedback —
+    env_fault_reason runs over the replaced text without raising."""
+    policy = Policy(verify=VerifyPolicy(commands=(_undecodable_cmd(tmp_path, 1),)))
+
+    out = verify.verify_commands_outcome(policy, tmp_path)
+
+    assert not out.ok and out.fixable and out.retryable and not out.env_fault
+    assert "rc=1" in out.reason
+    assert "after" in out.reason
+
+
 def make_bundle_task(paths, dw_ids=("DW-1", "DW-2")):
     task = StoryTask(story_key="dw-test-bundle", epic=0, dw_ids=list(dw_ids))
     task.baseline_commit = verify.rev_parse_head(paths.project)


### PR DESCRIPTION
## Problem

`verify.run_verify_commands` runs the operator's policy verify commands through the host shell and captures their output with `text=True` — the locale codec at `errors="strict"`. `except subprocess.TimeoutExpired` is the entire net, so a `UnicodeDecodeError` raised while decoding a child's stdout/stderr escapes it.

The decoded bytes are arbitrary test-suite output, not a path: any non-UTF-8 byte does it — a latin-1 fixture filename in a traceback, a `bytes` repr in an assertion diff, a compiler or linter diagnostic in a non-UTF-8 locale.

## Consequence

The exception escapes *before* any `results` entry is appended, so the whole list is lost — not just the offending command. It propagates `run_verify_commands` → `verify_commands_outcome` → `_dev_phase` → engine, and a deterministic verify gate is reported as a run crash with `UnicodeDecodeError`, pointing nowhere near the test suite that actually produced the byte. Re-running reproduces it forever, because the offending output is deterministic.

## Fix

`errors="replace"` on the one call, plus the function's first docstring recording why.

Locale decode (`text=True`) deliberately stays, and `encoding="utf-8"` is deliberately **not** pinned the way `tui/launch.py` does: that child is bmad-loop's own UTF-8 CLI, whereas these children are arbitrary operator tools whose output follows the host locale (which, on every supported config, decodes UTF-8 anyway — POSIX PEP 538/540 coercion, Windows `PYTHONUTF8=1`). Surrogate round-tripping is not needed either: unlike the `_run_git` sites, nothing here is fed back to a filesystem API. The tail is display-only feedback and already lossy at `[-2000:]`, so a replacement character costs nothing while exit codes and the rest of the tail keep driving classification.

Sibling `_run_git` decode work is #377 — a different guard and a different fix, out of scope here.

## Tests

`tests/test_verify.py`, new `# ---- undecodable verify output (issue #378)` section. Both tests drive a **real child process** (`sys.executable` running a generated script that writes `b'before \xff after\n'`), never a monkeypatched `subprocess.run` — patching `run` hands the code `str` and never exercises the stdlib's decode at all, so such a test passes identically with the bug restored (the #374 regression test's docstring records that same finding).

- `test_verify_commands_undecodable_output_keeps_every_result` — drives `run_verify_commands` directly with `(bad-child rc=5, "exit 0")`; asserts the exit codes are `[5, 0]` (the offender's rc preserved **and** the later command's result not lost) and that the text on both sides of the bad byte survives. Deliberately asserts no `U+FFFD` literal — which glyph appears is locale-dependent, while the contract is "neither raises nor drops".
- `test_verify_commands_undecodable_failure_stays_fixable_retry` — through `verify_commands_outcome`; the run stays a fixable/retryable ordinary failure (not an env fault), with `rc=1` and the tail reaching the repair session's feedback, i.e. `env_fault_reason` ran over the replaced text without raising.

**Ablation performed:** removing `errors="replace"` fails both new tests with `UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 7`, raised inside `subprocess._translate_newlines` — the real decode path. Restored by edit.

Full suite green (3698 passed), pyright 1.1.411 clean, full `trunk check` clean.

Closes #378


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Verify-command results are no longer lost when command output contains undecodable bytes.
  * Undecodable output is safely displayed with replacement characters while exit codes and remaining output continue to determine verification status.
  * Failures with undecodable output are correctly classified as fixable and retryable rather than environment faults.
* **Tests**
  * Added regression coverage for undecodable output and result preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->