### PR TITLE
chore: pin pyright in the dev group and run it via uv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,8 +132,11 @@ jobs:
       - name: Install the project
         # Populates .venv (venvPath/venv in the pyright config) so third-party and
         # optional-extra imports (textual, pyte, httpx, …) resolve instead of being
-        # flagged as missing.
+        # flagged as missing. Also installs pyright itself, which is pinned in the
+        # `dev` dependency group rather than named here — one pin, in the lock.
         run: uv sync --locked --all-extras
 
       - name: Pyright (basic mode)
-        run: uvx pyright@1.1.411
+        # `uv run`, not `uvx pyright@<version>`: the same command a contributor
+        # runs locally, resolving the same pinned version from uv.lock.
+        run: uv run pyright

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,12 +8,13 @@ bmad-loop is a deterministic Python orchestrator that drives unattended BMAD-met
 uv sync --all-extras          # setup (extras: tui, non-linux, opencode)
 uv run pytest -q              # test suite (-n auto to parallelize)
 uv run pytest tests/test_engine.py -q   # single file
+uv run pyright                # typecheck — same pinned version CI runs
 trunk fmt                     # format changed files
 trunk check                   # full lint, no path filter — run before every push (pre-push hook enforces it)
 ```
 
 - Never `pip install`; uv owns the environment. Dependency changes: edit pyproject.toml, run `uv lock` (CI uses `uv sync --locked` and fails on a stale lock).
-- Typecheck: pyright at the CI-pinned version — see the typecheck job in [.github/workflows/ci.yml](.github/workflows/ci.yml).
+- Typecheck: `uv run pyright`. The version is pinned exactly in the `dev` group (pyproject.toml) and CI runs that same command, so there is one pin and no drift — bump it deliberately, never with `uv lock --upgrade`.
 - Windows local runs require `PYTHONUTF8=1` (tests/conftest.py raises UsageError otherwise). Python floor: 3.11.
 
 ## Hard invariants

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,11 @@ dev = [
   "pytest-xdist>=3.6",
   # the opencode-http adapter tests exercise the real httpx client
   "httpx>=0.28",
+  # Exact, not a floor like the rest: pyright is a GATE, and a newer one adds
+  # checks that fail the build on untouched code. This is the single pin — the
+  # typecheck job runs `uv run pyright`, so CI and `uv run pyright` locally are
+  # the same resolved version and cannot drift apart (#245).
+  "pyright==1.1.411",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/uv.lock
+++ b/uv.lock
@@ -41,6 +41,7 @@ tui = [
 [package.dev-dependencies]
 dev = [
     { name = "httpx" },
+    { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-rerunfailures" },
@@ -64,6 +65,7 @@ provides-extras = ["tui", "non-linux", "opencode"]
 [package.metadata.requires-dev]
 dev = [
     { name = "httpx", specifier = ">=0.28" },
+    { name = "pyright", specifier = "==1.1.411" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-asyncio", specifier = ">=1.0" },
     { name = "pytest-rerunfailures", specifier = ">=16.0" },
@@ -204,6 +206,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -265,6 +276,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.411"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/ab/265f7dc69d28113ebba19092e57b075f41543b2ed048429c5f56e2b88eac/pyright-1.1.411.tar.gz", hash = "sha256:d885a0551f2e763b089a02702174e7f4ba77548cddabc972ab86d1f7f1b0f998", size = 4112861, upload-time = "2026-06-25T02:14:06.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/49/385be530a6a5b78d1cbcd5c2e38debc8959a2fc6bdb716f4e581002979fc/pyright-1.1.411-py3-none-any.whl", hash = "sha256:dc7c72a8e2700c55baa127554040e067041ea53ccfd50bf96308cc4291c7d5d9", size = 6181526, upload-time = "2026-06-25T02:14:04.691Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Pins `pyright==1.1.411` in the `dev` dependency group and switches the typecheck job from `uvx
pyright@1.1.411` to `uv run pyright`.

## Why

`uv run pyright` — the obvious local command, and the one AGENTS.md's "pyright at the CI-pinned
version" implies — **did not work**: pyright was never a dependency, so it failed with `Failed to
spawn: pyright`. The only way to typecheck locally was to read the workflow file and retype its
literal. Found while working #377, where that failure looked like a broken environment rather than a
missing dep.

Worse, the version lived in exactly one place — a string in `ci.yml` — with nothing tying it to the
project. Any contributor invoking a bare `pyright` got whatever was on their machine, silently
checking against a different version than the gate.

## How

- `pyright==1.1.411` in the `dev` group. **Exact, not a floor** like the other dev deps: pyright is
  a gate, and a newer one adds checks that fail the build on untouched code. 1.1.411 is both what
  the job already pinned and the current PyPI release, so this pins the status quo, not a bump.
- The job runs `uv run pyright`, resolving that pin from `uv.lock`. One pin, in the lock, used by
  both — no sync test needed, because there is no second copy to drift from.
- AGENTS.md spells the command out in the dev-environment block instead of pointing at the workflow.

Runtime path is unchanged: `uvx pyright@1.1.411` was already fetching this same PyPI package, whose
wheel bundles the pyright dist (`PYRIGHT_PYTHON_USE_BUNDLED_PYRIGHT` defaults on), so no npm or node
download is introduced.

## Testing

- `uv sync --locked --all-extras` clean (what CI runs — fails on a stale lock).
- `uv run pyright` → `0 errors`, and `uv run pyright --version` → `pyright 1.1.411`, matching the
  version the job pinned before.
- **Proved the gate still bites, rather than trusting a green run:** injected
  `def _gate_probe(x: int) -> str: return x` into `model.py` (a strict-list module) and `uv run
  pyright` reported `2 errors` (`reportReturnType`, `reportUnusedFunction`); back to 0 once
  reverted.
- Full suite `3698 passed, 24 skipped`; `scripts/sync_version.py --check` ok; `trunk fmt` + full
  `trunk check` clean.

No CHANGELOG entry: dependency-groups are not installed by consumers, so nothing about the shipped
package changes.
