### PR TITLE
fix(adapters): gate the psmux session project tag on transportability (#320)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -600,6 +600,18 @@ whose seams had diverged enough that several ports needed a different fix, and t
   rather than a vacuous `True` when that is unobservable. Out-of-tree backends still returning
   `None` read as "nothing detached" — degraded, not broken.
 
+- **Gate the psmux session project tag on transportability (#320).** `_ensure_session` wrote the
+  resolved project path straight through `set_session_option`, and psmux's CLI→server control line
+  stores some shapes corrupted at rc 0 — a spaced value loses `\\`, a trailing `\` eats the closing
+  quote, and a standalone `;` token truncates the value and runs the remainder as a command. A
+  corrupted tag never equals the caller's again, so the prune skipped that session forever.
+  `@`-prefixed session values now run through the same transport gate as the window channel: a
+  refusal warns, frees the key (the server loads the user's psmux config, so it can arrive
+  pre-seeded) and leaves the option unset, where the prune's run-dir fallback takes over — bounded
+  by #419. Accepted writes keep the base's raise-on-failure contract. The session tag does **not**
+  bleed across servers the way the window tag did: one server per session makes that map the
+  session's.
+
 - **Give psmux a working per-window option channel (#310).** psmux keeps one user-option scope per
   server and answers `''` to any `-w` read of an `@`-prefixed name, so the ctl-window project tag
   bled across rows — letting a prune in one project `kill-window` another's — and the parked-return

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -600,16 +600,13 @@ whose seams had diverged enough that several ports needed a different fix, and t
   rather than a vacuous `True` when that is unobservable. Out-of-tree backends still returning
   `None` read as "nothing detached" — degraded, not broken.
 
-- **Gate the psmux session project tag on transportability (#320).** `_ensure_session` wrote the
-  resolved project path straight through `set_session_option`, and psmux's CLI→server control line
-  stores some shapes corrupted at rc 0 — a spaced value loses `\\`, a trailing `\` eats the closing
-  quote, and a standalone `;` token truncates the value and runs the remainder as a command. A
+- **Gate the psmux session project tag on transportability (#320).** The session tag rode psmux's
+  CLI→server control line ungated, which stores some project paths corrupted at rc 0 — and a
   corrupted tag never equals the caller's again, so the prune skipped that session forever.
-  `@`-prefixed session values now run through the same transport gate as the window channel: a
-  refusal warns, frees the key (the server loads the user's psmux config, so it can arrive
-  pre-seeded) and leaves the option unset, where the prune's run-dir fallback takes over — bounded
-  by #419. Accepted writes keep the base's raise-on-failure contract. The session tag does **not**
-  bleed across servers the way the window tag did: one server per session makes that map the
+  `@`-prefixed session values now take the same transport gate as the window channel: a refusal
+  warns, frees the key and leaves the option unset, where the prune's run-dir fallback takes over
+  (bounded by #419); accepted writes keep the base's raise-on-failure contract. Unlike the window
+  tag the session tag never bled across servers — one server per session makes that map the
   session's.
 
 - **Give psmux a working per-window option channel (#310).** psmux keeps one user-option scope per

--- a/docs/multiplexer-backends.md
+++ b/docs/multiplexer-backends.md
@@ -66,14 +66,19 @@ server — so the window-option verbs and the `@`-prefixed columns of `list_wind
 by a session-scoped option whose key carries the window id (`@bmad_project_@3` for window `@3`).
 Both are properties of psmux's model, not gaps awaiting an upstream release. Practical
 consequence: such a value is **not** readable via `psmux show-options -w` by hand — read it with
-`psmux show-options -qv -t <session> "@bmad_project_@N"` instead. One visible limit: a value
-that cannot survive psmux's control-line transport verbatim is refused with a stderr warning at
-every launch, and that project's windows stay untagged — the prune then scopes them through the
-run-dir fallback instead of the tag. Which paths those are is counter-intuitive, because the
-psmux client quotes a value only when it contains an ASCII space and `'` is literal inside those
-quotes: `C:\Users\O'Brien\dev` is **refused** while `C:\Users\O'Brien Files\dev` is accepted, and
-a spaced UNC path (`\\server\share\My Proj`) is refused while the spaceless `\\server\share\proj`
-is accepted.
+`psmux show-options -qv -t <session> "@bmad_project_@N"` instead. Session-scoped options need no
+such substitute — one server per session means that server's single map _is_ the session's — but
+they cross the same control line, so the session project tag is gated the same way. One visible
+limit: a value that cannot survive psmux's control-line transport verbatim is refused with a
+stderr warning at every launch, and that project's windows and agent sessions stay untagged —
+the prune then scopes them through the run-dir fallback instead of the tag. Which paths those
+are is counter-intuitive, because the psmux client quotes a value only when it contains an ASCII
+space and `'` is literal inside those quotes: `C:\Users\O'Brien\dev` is **refused** while
+`C:\Users\O'Brien Files\dev` is accepted, and a spaced UNC path (`\\server\share\My Proj`) is
+refused while the spaceless `\\server\share\proj` is accepted. The fallback that catches those
+refusals has a lifecycle ceiling
+([#419](https://github.com/bmad-code-org/bmad-loop/issues/419)): an untagged session whose run
+directory is later removed by `clean` or `archive` can no longer be pruned by any project.
 
 ## External backends
 

--- a/src/bmad_loop/adapters/multiplexer.py
+++ b/src/bmad_loop/adapters/multiplexer.py
@@ -118,7 +118,15 @@ class TerminalMultiplexer(ABC):
 
     @abstractmethod
     def set_session_option(self, name: str, option: str, value: str) -> None:
-        """Set a user option on the named session."""
+        """Set a user option on the named session. A transport failure raises
+        :class:`MultiplexerError` — unlike :meth:`set_window_option`, this write
+        is not best-effort.
+
+        A backend may still refuse a *value* it cannot carry to its server
+        verbatim (psmux does): it warns, leaves the option unset, and returns
+        without raising, because a value stored corrupted is worse than one
+        never stored. So read an unset option as "no answer" — never as proof
+        that nothing was ever written."""
 
     # ------------------------------------------------------------ windows
 

--- a/src/bmad_loop/adapters/psmux_backend.py
+++ b/src/bmad_loop/adapters/psmux_backend.py
@@ -30,13 +30,13 @@ session means that server's single map is the session's — but they cross
 the same lossy control line, so ``set_session_option`` gates its value on
 the same transportability rule (#320). ``detach-client`` and
 ``switch-client`` report dispatch rather than effect — every arm exits 0
-whether or not a client moved — so both seam
-booleans are measured against the session's attached-client count instead of
-read off the exit code; see the ``client verbs: observed effect (#317)``
-block. ``available()`` additionally gates on
-the reported version: psmux releases up to 3.3.6 kill recycled PIDs during
-pane/session teardown without a process-identity check, which can take down
-an unrelated long-lived process mid-run. The psmux behaviors cited in this
+whether or not a client moved — so both seam booleans are measured against
+the session's attached-client count instead of read off the exit code; see
+the ``client verbs: observed effect (#317)`` block. ``available()``
+additionally gates on the reported version: psmux releases up to 3.3.6 kill
+recycled PIDs during pane/session teardown without a process-identity check,
+which can take down an unrelated long-lived process mid-run. The psmux
+behaviors cited in this
 module were read from the psmux source at tag ``v3.3.7``. See
 :mod:`.multiplexer` for the contract.
 """

--- a/src/bmad_loop/adapters/psmux_backend.py
+++ b/src/bmad_loop/adapters/psmux_backend.py
@@ -25,8 +25,12 @@ back to an index first. Per-window user options do not exist at all, so
 the window-option verbs, the ``@``-prefixed columns of ``list_windows``
 and the parked trailer route through a substitute channel — see the
 ``per-window option channel (#310)`` block below for the model and its
-rules. ``detach-client`` and ``switch-client`` report dispatch rather than
-effect — every arm exits 0 whether or not a client moved — so both seam
+rules. Session-scoped options need no such substitute — one server per
+session means that server's single map is the session's — but they cross
+the same lossy control line, so ``set_session_option`` gates its value on
+the same transportability rule (#320). ``detach-client`` and
+``switch-client`` report dispatch rather than effect — every arm exits 0
+whether or not a client moved — so both seam
 booleans are measured against the session's attached-client count instead of
 read off the exit code; see the ``client verbs: observed effect (#317)``
 block. ``available()`` additionally gates on
@@ -466,6 +470,39 @@ class PsmuxMultiplexer(BaseTmuxBackend):
                 return False
             return all(tok not in (";", "\\;") for tok in value.split())
         return not any(c in value for c in ";'\"")
+
+    def set_session_option(self, name: str, option: str, value: str) -> None:
+        # Session scope itself needs no substitute channel: psmux serves one
+        # session per server, so that server's single option map IS the
+        # session's map — the same model that makes per-window options unusable
+        # makes session options correct by construction (probed on 3.3.7: two
+        # sessions on two servers read back their own values). What it does
+        # share with the window channel is the lossy CLI->server control line,
+        # and this write was ungated (#320): a spaced value silently loses
+        # `\\`, a trailing `\`, and standalone `;` tokens at rc 0. A corrupted
+        # tag is non-empty and never equals the caller's tag again, so the
+        # prune skips that session forever.
+        #
+        # Refusing leaves the option UNSET, which is the correct degradation
+        # and not the lesser evil: the prune's untagged path falls back to the
+        # run dir, claiming our own dead runs and skipping foreign ones.
+        #
+        # The refusal frees the key rather than just returning. A session this
+        # backend just created is NOT a blank map — the server loads the user's
+        # psmux config (same shared-map basis as the option-channel block
+        # below), so this name can arrive pre-seeded. Leaving a foreign value
+        # in place would read back as a real non-matching tag and strand the
+        # session forever, which is exactly the failure the gate exists to stop.
+        if option.startswith("@") and not self._transportable(value):
+            print(
+                f"warning: set-option {option} skipped on session {name} — value does "
+                "not survive psmux's control-line transport verbatim; the key is freed "
+                "and ownership falls back to the run dir",
+                file=sys.stderr,
+            )
+            self._write_scoped(["set-option", "-u", "-t", name, option], option)
+            return
+        super().set_session_option(name, option, value)
 
     def _write_scoped(self, verb: list[str], key: str) -> None:
         # Both mutating verbs, one body. A write that silently failed re-opens

--- a/src/bmad_loop/adapters/psmux_backend.py
+++ b/src/bmad_loop/adapters/psmux_backend.py
@@ -284,7 +284,10 @@ class PsmuxMultiplexer(BaseTmuxBackend):
         # qualified — the prune replays those values as kill-window targets, and
         # a bare one can hit another server's identically-numbered window. An
         # `@` field never reaches psmux: `#{@name}` expands from the one
-        # per-server map, so every row would carry the same value. Probe the
+        # per-server map, so every row would carry the same value. That is a
+        # WINDOW-row problem only — one server holds many windows but exactly
+        # one session, so the same expansion in session_options' list-sessions
+        # is correct by construction (see set_session_option). Probe the
         # window id in its place and fill from the id-keyed options, fetched as
         # ONE full listing — a flat extra call per list_windows, regardless of
         # row or column count (#310).
@@ -485,7 +488,13 @@ class PsmuxMultiplexer(BaseTmuxBackend):
         #
         # Refusing leaves the option UNSET, which is the correct degradation
         # and not the lesser evil: the prune's untagged path falls back to the
-        # run dir, claiming our own dead runs and skipping foreign ones.
+        # run dir, claiming our own dead runs and skipping foreign ones. State
+        # the bound rather than the slogan — that fallback proves ownership by
+        # run-id collision on disk, not by identity, so it skips a foreign
+        # session only while no run dir HERE shares its run id. Ids are
+        # timestamped plus two random bytes, but `--run-id` is caller-supplied,
+        # so untagged is weaker proof than a tag even though it beats a
+        # corrupted one. Both edges of that fallback are bounded in #419.
         #
         # The refusal frees the key rather than just returning. A session this
         # backend just created is NOT a blank map — the server loads the user's
@@ -505,11 +514,14 @@ class PsmuxMultiplexer(BaseTmuxBackend):
         super().set_session_option(name, option, value)
 
     def _write_scoped(self, verb: list[str], key: str) -> None:
-        # Both mutating verbs, one body. A write that silently failed re-opens
-        # the mis-scoped prune this channel exists to close, and a silently
-        # failed `-u` leaves a live return key that replays the return move when
-        # the window's command exits — so failures are said out loud either way
-        # (the verbs stay best-effort: warn, never raise).
+        # Both window-channel mutating verbs, one body — plus the session-tag
+        # refusal's free above, which wants the same never-raise contract for
+        # the same reason. A write that silently failed re-opens the mis-scoped
+        # prune this channel exists to close, and a silently failed `-u` leaves
+        # a live return key that replays the return move when the window's
+        # command exits (or, at session scope, a pre-seeded foreign tag that
+        # strands the session) — so failures are said out loud either way (the
+        # verbs stay best-effort: warn, never raise).
         label = " ".join(verb[: verb.index("-t")])  # `set-option` / `set-option -u`
         try:
             proc = self._run(verb, check=False)

--- a/tests/test_psmux_backend.py
+++ b/tests/test_psmux_backend.py
@@ -15,6 +15,7 @@ from bmad_loop.adapters import psmux_backend, tmux_base
 from bmad_loop.adapters.multiplexer import MultiplexerError, get_multiplexer
 from bmad_loop.adapters.psmux_backend import PsmuxMultiplexer
 from bmad_loop.adapters.tmux_backend import TmuxMultiplexer
+from bmad_loop.adapters.tmux_base import TmuxError
 
 
 class _RecordRun:
@@ -1071,6 +1072,80 @@ def test_set_window_option_write_failure_warns(monkeypatch, capsys):
     PsmuxMultiplexer().set_window_option("ctl:@3", "@bmad_project", "C:/p")
     assert rec_.calls  # the write was attempted
     assert "failed" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "C:\\a ; b\\proj",  # live-probed: stores as `C:\a`, remainder EXECUTES
+        "C:\\projects\\my proj\\",  # live-probed: trailing `\` eats the closing quote
+        "\\\\srv\\share name\\proj",  # live-probed: spaced → `\\` collapses to `\`
+        "C:\\Users\\O'Brien\\proj",  # live-probed UNSPACED `'`: read back as `OBrien`
+        'C:\\a"b\\proj',  # live-probed unspaced `"`: read back as `ab`
+        "-flag",  # dropped as a flag server-side
+        "bad\nline",  # the control line is `\n`-terminated
+        "",  # an empty write is a silent server-side no-op
+    ],
+)
+def test_set_session_option_refuses_untransportable_values(monkeypatch, capsys, value):
+    # Same lossy CLI→server hop as the window channel, previously ungated on the
+    # session tag. The first three round-trips were measured on a live psmux
+    # 3.3.7 (sent → read back: `C:\a ; b\proj` → `C:\a`, `C:\projects\my proj\`
+    # → `C:\projects\my proj"`, `\\srv\share name\proj` → `\srv\share name\proj`).
+    # Refusing leaves the option unset, which the prune's run-dir fallback
+    # handles correctly — a corrupted tag would strand the session forever.
+    # The refusal FREES the key instead of just returning: the server loads the
+    # user's psmux config, so the name can arrive pre-seeded, and a surviving
+    # foreign value would read back as a real non-matching tag.
+    rec_ = _option_fake(monkeypatch)
+    PsmuxMultiplexer().set_session_option("bmad-loop-x", "@bmad_project", value)
+    assert [c[0][1:5] for c in rec_.calls] == [["set-option", "-u", "-t", "bmad-loop-x"]]
+    assert rec_.argv[-1] == "@bmad_project"  # the key, never the rejected value
+    assert "transport" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "C:\\my proj\\app",  # spaced but quote-safe
+        "C:\\app",  # unspaced
+        "\\\\srv\\share\\app",  # unspaced UNC rides verbatim (no client quoting)
+        "C:\\Users\\O'Brien Files\\proj",  # spaced `'` is literal inside the quotes
+    ],
+)
+def test_set_session_option_accepts_transportable_values(monkeypatch, value):
+    # All four were confirmed to round-trip unchanged on live psmux 3.3.7; a
+    # gate that refused them would untag ordinary Windows project paths.
+    rec_ = _option_fake(monkeypatch)
+    PsmuxMultiplexer().set_session_option("bmad-loop-x", "@bmad_project", value)
+    assert rec_.argv[1:] == ["set-option", "-t", "bmad-loop-x", "@bmad_project", value]
+
+
+def test_set_session_option_passes_builtin_options_through(monkeypatch):
+    # The gate is for `@` user options only. A builtin keeps the base path even
+    # with a value the `@` branch would refuse — narrowing it here would change
+    # a verb this backend has no evidence about.
+    rec_ = _option_fake(monkeypatch)
+    PsmuxMultiplexer().set_session_option("bmad-loop-x", "status-left", "-flag")
+    assert rec_.argv[1:] == ["set-option", "-t", "bmad-loop-x", "status-left", "-flag"]
+
+
+def test_set_session_option_refusal_free_failure_warns_not_raises(monkeypatch, capsys):
+    # The free is best-effort like every other write in this channel: a dead
+    # multiplexer must not abort session creation over a tag that is only an
+    # optimization — but it must not pass silently either.
+    _option_fake(monkeypatch, rc=1)
+    PsmuxMultiplexer().set_session_option("bmad-loop-x", "@bmad_project", "C:\\a ; b")
+    err = capsys.readouterr().err
+    assert "transport" in err and "failed" in err
+
+
+def test_set_session_option_write_failure_still_raises(monkeypatch):
+    # An accepted value keeps the base's strict contract: session tagging runs
+    # at session creation, where a dead multiplexer must not pass silently.
+    _option_fake(monkeypatch, rc=1)
+    with pytest.raises(TmuxError):
+        PsmuxMultiplexer().set_session_option("bmad-loop-x", "@bmad_project", "C:\\app")
 
 
 def test_list_windows_option_read_failure_degrades_to_unset_with_a_warning(monkeypatch, capsys):


### PR DESCRIPTION
## What

`GenericAdapter._ensure_session` writes `runs.project_tag(project)` — an absolute resolved path — straight through `set_session_option`. On psmux that value crosses a lossy CLI→server control line with no gate, so it can be stored corrupted at `rc=0`. A corrupted tag is non-empty and never equals `project_tag(project)` again, so `prunable_sessions` takes its `tag != mine → continue` branch and the agent session is skipped forever.

This gives `PsmuxMultiplexer` a `set_session_option` override: `@`-prefixed values go through the existing `_transportable()` predicate, a refusal warns and frees the key, and the accepted path delegates to the base unchanged so real transport failures keep raising.

## The issue's own premise was wrong, and the probe says so

#320 opened as a **bleed** hypothesis — that `#{@bmad_project}` might resolve against whichever server answers `list-sessions`, making the cross-project prune unable to discriminate and risking a **kill of another project's live agent session**.

That is **refuted**. Live-probed on Windows 11 / psmux 3.3.7 (`05cc5d4`), two sessions on two servers confirmed distinct by PID:

```
probeA=[C:\projects\alpha]
probeB=[C:\projects\beta]
```

Each row carries its own value. The reason is structural: psmux runs **one server per session**, so that server's single `App.user_options` map *is* that session's map. The very model that makes window-scoped options unusable (#310) makes session-scoped options correct by construction. **There is no wrong-project kill risk**, and the read path (`session_options`) needs no override. Full measurements are in [this issue comment](https://github.com/bmad-code-org/bmad-loop/issues/320#issuecomment-5150640494). The probe ran through `list-sessions -F '#{session_name}=[#{@bmad_project}]'` — the production reader (`tmux_base.py:163-181`), not a proxy for it.

What *is* real is the ungated write. Measured round-trips:

| sent | read back | |
|---|---|---|
| `C:\a ; b\proj` | `C:\a` | chain splitter cuts it; remainder goes to the server as a command |
| `C:\projects\my proj\` | `C:\projects\my proj"` | trailing `\` escapes the closing quote |
| `\\srv\share name\proj` | `\srv\share name\proj` | `\\` collapses inside the quotes |
| `C:\Users\O'Brien\dev` | `C:\Users\OBrien\dev` | unspaced `'` swallowed |
| `C:\a"b\proj` | `C:\ab\proj` | unspaced `"` swallowed |
| `C:\O'Brien Files\p`, `C:\a "b" c`, `C:\`, `\\srv\share\proj` | unchanged | pass |

So the consequence is a **leak, not a wrong kill**: the session becomes permanently unprunable.

## Why refusing is the correct degradation

Not a lesser evil — the better outcome. From `prunable_sessions`:

```python
tag = tags.get(name, "")
if tag:
    if tag != mine:
        continue            # corrupted tag lands here — skipped forever
elif not is_run(run_dir):
    continue                # unset + foreign dir — correctly skipped
# unset + our own dead run dir — correctly prunable
```

One qualification, added in review and now stated in the code: that fallback proves ownership by **run-id collision on disk**, not by identity, so it skips a foreign session only while no run dir *here* shares that session's run id. Run ids are timestamped plus two random bytes, but `--run-id` is caller-supplied. Untagged is therefore weaker proof than a tag even though it comfortably beats a corrupted one — the trade is still right, but "skips foreign ones" is not unconditional. Both edges of the fallback are bounded in #419.

The refusal also **frees the key** rather than just returning. A session this backend just created is not a blank map: the server loads the user's psmux config, so `@bmad_project` can arrive pre-seeded, and a surviving foreign value would read back as a real non-matching tag — reintroducing the exact failure through the fix. (Caught in review; the original patch got this wrong.)

## Notes for the reviewer

- `_transportable()` is reused verbatim, not forked. It models the **wire** — client quoting, server tokenizer, chain splitter — not the option scope, so it carries to session scope unchanged. Its refusal set was **re-measured at session scope** rather than assumed: correct on the shapes that corrupt, conservative on one that does not (`C:\a;b\proj` round-trips but is refused). Over-refusal costs only precision, since the untagged path is handled correctly.
- The free rides `_write_scoped` (warn, never raise); the accepted path keeps the base's strict contract. Deliberate asymmetry: an unwritable tag is a lost optimization, an unexecutable accepted write is a broken environment. `_ensure_session` → `start_session` → `AgentAdapter.run` has no exception handling anywhere on that chain, so a raising refusal would abort the run over a tag.
- `tests/test_multiplexer.py:224` lists `set_session_option` among the seam's raisers. It is not violated: that case runs `TmuxMultiplexer` with a non-`@` option name, so the gate never fires. The new `test_set_session_option_write_failure_still_raises` pins the same contract for the accepted path on psmux.
- Both ablations were run, not assumed. Deleting the whole override reddens all 8 refusal params plus the free-failure test (9 red, 455 green — the accept/builtin/raises trio stays green by design, they guard the base path). Deleting only the `-u` free reddens the same 9 — that is the half review caught.

## Review findings folded in

Three independent reviews ran, plus a validation pass. What landed on top of the behavior commit:

- **The seam contract now licenses the refusal.** `set_session_option`'s ABC docstring was one line while its sibling `set_window_option` spells out both its best-effort contract and its keying-vs-storage licence. This PR makes psmux the first backend whose `set_session_option` neither writes nor raises; the ABC now says a transport failure still raises *and* a backend may refuse a value it cannot carry verbatim, so an unset read means "no answer", not "never written".
- **`list_windows`' "an `@` field never reaches psmux" is scoped to window rows.** As written it reads as a blanket condemnation of `#{@name}` that would condemn `session_options` too. It now names why session scope is exempt and points at `set_session_option`.
- **`_write_scoped`'s comment.** It opened "Both mutating verbs, one body" and framed the stakes entirely in window terms; it now serves the session refusal too.
- **`docs/multiplexer-backends.md`** described the transport refusal as untagging a project's *windows*. It untags its agent sessions too, and the fallback's lifecycle ceiling is worth naming where an operator reads it.
- **CHANGELOG entry**, next to its window-channel sibling (#310) under Unreleased/Fixed.

## Deliberately not folded

1. **The reachable-shape ceiling → filed as #419.** After `Path.resolve()` on Windows, most refusal shapes are unreachable (`"` is illegal in filenames, mid-path `\\` and trailing `\` normalize away). The one genuinely reachable shape is a **spaced UNC path** — where every session for that project goes untagged, and if the run dir is later removed by `clean`/`archive` the sessions leak. Not a regression (a corrupted tag ended identically), but the real fix is a transportable **surrogate** tag, which touches the tmux-shared `runs.project_tag` and is its own intent decision. #419 now also carries the run-id-collision edge described above; direction (1) there closes both.
2. **Builtin (non-`@`) session options bypass the gate** and ride the same tokenizer. Latent — no caller passes a builtin today. Widening `_transportable` to a verb this backend has no evidence about would be worse than the gap.
3. **Mirroring the window channel's full 15-shape refusal list onto the session tests.** `_transportable` is one shared `@staticmethod`, so the 7 extra shapes (leading/trailing ASCII space, NBSP, `it's`, `a \; b`, …) would re-test identical code through a second door — redundancy loss, not a coverage gap.
4. **"Tests don't pin the property the design rests on."** Checked and rejected: `test_prunable_sessions_partitions` (`tests/test_runs.py:626`) already pins untagged + own run dir → prunable via its `untag-fin` case, so a tightening there goes red at the correct layer.

## CodeRabbit's one finding — raised, rebutted, withdrawn

CodeRabbit asked for the refused-key cleanup to raise rather than warn, citing the repo's "repair writes must raise" doctrine. Declined on the record, and the bot withdrew it: the `-u` here is containment rather than repair; `set_window_option`'s refusal path frees through the same warn-never-raise `_write_scoped`; and raising would abort session creation over a lost optimization while the supported fallback stays safe. Whether that channel-wide contract should change is scoped as one unit in #313. Greptile scored 5/5 with no findings.

## Housekeeping

Rebased onto current `main` — the branch was 138 commits behind. No conflicts (the merge was clean before and after), and `psmux_backend.py` had not moved on `main` since the merge base, so nothing drifted under the change. Full suite 4434 passed / 24 skipped, `pyright` clean (the two `platform_util.py` POSIX-only errors noted earlier are gone from `main`), `trunk check` clean.

Closes #320
Refs #419, #313


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session project-tag handling by rejecting values that cannot be safely transported.
  * Invalid values are removed with a warning, allowing fallback to the run directory.
  * Valid options retain existing behavior, while write failures continue to be reported appropriately.
  * Session tags remain isolated between servers.

* **Documentation**
  * Clarified session-option restrictions, fallback behavior, and pruning implications.

* **Tests**
  * Added coverage for valid, invalid, built-in, cleanup, and write-failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->