### PR TITLE
fix(adapters): guarantee a single-line multiplexer version() (#321)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -569,6 +569,21 @@ whose seams had diverged enough that several ports needed a different fix, and t
   report apart: `ATTENDED` (a human is still there) versus `UNREACHABLE` (no client at all), which
   journals `sweep-return-no-client`.
 
+- **`bmad-loop mux` renders a readable table whatever a backend reports as its version (#321).**
+  `psmux -V` prints two lines — a `tmux X.Y.Z` compat line plus its own — and the embedded newline
+  split every row, stranding SELECTED on a line of its own; a very long single line broke the same
+  table just as thoroughly, since the column widths are sized off the widest cell.
+  `TerminalMultiplexer.version()` now promises one bounded line. The tmux-family base folds the
+  probe with `"; "` rather than truncating (the tail is what names psmux as the answering binary),
+  keeps the compat segment first because psmux's own version gate parses it with an anchored match,
+  and reports `None` — not `""` — for an all-blank probe. Every inline consumer applies the same
+  fold defensively, so an out-of-tree backend that breaks the promise cannot split a row or a
+  message: the `mux` table, `validate`'s preflight finding and its `version` detail, the
+  forced-backend warning, the unusable-backend refusal, and `diagnose`'s `tmux_version` — where the
+  old line cap's "(N more lines redacted)" marker had been re-introducing the newline it removed.
+  `mux` also now explains the row where a backend is AVAILABLE because its binary answers here
+  while the platform check still excludes it from automatic selection.
+
 - **Both mux client verbs now owe effect, not dispatch (#317).** `TerminalMultiplexer.detach_client`
   widens from `None` to `bool`. tmux reads the effect off the exit code; psmux cannot — every arm of
   its `detach-client`/`switch-client` exits 0 whether or not a client moved — so it measures the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -576,13 +576,22 @@ whose seams had diverged enough that several ports needed a different fix, and t
   `TerminalMultiplexer.version()` now promises one bounded line. The tmux-family base folds the
   probe with `"; "` rather than truncating (the tail is what names psmux as the answering binary),
   keeps the compat segment first because psmux's own version gate parses it with an anchored match,
-  and reports `None` — not `""` — for an all-blank probe. Every inline consumer applies the same
-  fold defensively, so an out-of-tree backend that breaks the promise cannot split a row or a
-  message: the `mux` table, `validate`'s preflight finding and its `version` detail, the
-  forced-backend warning, the unusable-backend refusal, and `diagnose`'s `tmux_version` — where the
-  old line cap's "(N more lines redacted)" marker had been re-introducing the newline it removed.
-  `mux` also now explains the row where a backend is AVAILABLE because its binary answers here
-  while the platform check still excludes it from automatic selection.
+  caps the result at 80 characters, and reports `None` — not `""` — for an all-blank probe. Every
+  inline consumer applies the same fold defensively, so an out-of-tree backend that breaks the
+  promise cannot split a row or a message: the `mux` table, the forced-backend warning, the
+  unusable-backend refusal, `validate`'s preflight finding, and `diagnose`'s `tmux_version` — where
+  the old line cap's "(N more lines redacted)" marker had been re-introducing the newline it
+  removed, in the markdown dump as well as the JSON one. On a psmux host the folded value
+  **replaces** the previously truncated `env.tmux_version` in `diagnose --json` and the `version`
+  details of `validate --json`'s `mux.backend` and `mux.backends-detected` findings; the field
+  shapes are unchanged.
+
+- **`bmad-loop mux` explains a row that is available but unselectable.** A backend reads AVAILABLE
+  because its binary answers here, which is not the same question as whether automatic selection
+  can pick it — on Windows `tmux` is psmux's compatibility shim, so the tmux row looks like a real
+  tmux install. Gating the column would be wrong (a forced choice does reach those backends), so
+  the listing now carries a `note:` naming them instead. A forced backend is exempt: it is selected,
+  and calling it unselectable would contradict the `*` marker one line above.
 
 - **Both mux client verbs now owe effect, not dispatch (#317).** `TerminalMultiplexer.detach_client`
   widens from `None` to `bool`. tmux reads the effect off the exit code; psmux cannot — every arm of

--- a/docs/adapter-authoring-guide.md
+++ b/docs/adapter-authoring-guide.md
@@ -97,7 +97,9 @@ seams of a full OS port are in
   override only when your ids do not resolve from another session's context,
   as psmux does to emit `=session:%N`), `detach_client` / `switch_client` (with
   an optional last-client fallback — see the rule below),
-  `available` (is this backend usable on the current host).
+  `available` (is this backend usable on the current host), `version` (the
+  binary's version string or `None` — **one bounded line**, folded with
+  `fold_version()`; see [the porting guide](porting-to-a-new-os.md)).
 
   **Both client verbs report effect, not dispatch.** They answer a bool the
   parked-window return path trusts, so a backend with no real detach (herdr —

--- a/docs/multiplexer-backends.md
+++ b/docs/multiplexer-backends.md
@@ -29,6 +29,13 @@ The choice applies to the next invocation — switch between runs, not while one
 After switching, `bmad-loop validate` reports the selected backend's availability and
 version as part of the preflight.
 
+The `AVAILABLE` column answers "does this backend's binary answer on this host", not
+"can it be selected here". The two diverge when a foreign-platform binary shares a name
+with a local one — on Windows, `tmux` is psmux's compatibility shim, so the tmux row
+reads as a real tmux install. Only steps 3–5 above consult the platform, so `bmad-loop
+mux` prints a `note:` naming any row where the two disagree; a forced choice (step 1
+or 2) reaches those backends anyway, which is why the column is not simply gated.
+
 ## tmux (the default)
 
 tmux is the reference backend: everything else in these docs — the `bmad-loop-<run-id>`

--- a/docs/multiplexer-backends.md
+++ b/docs/multiplexer-backends.md
@@ -33,8 +33,11 @@ The `AVAILABLE` column answers "does this backend's binary answer on this host",
 "can it be selected here". The two diverge when a foreign-platform binary shares a name
 with a local one — on Windows, `tmux` is psmux's compatibility shim, so the tmux row
 reads as a real tmux install. Only steps 3–5 above consult the platform, so `bmad-loop
-mux` prints a `note:` naming any row where the two disagree; a forced choice (step 1
-or 2) reaches those backends anyway, which is why the column is not simply gated.
+mux` prints a `note:` naming exactly the rows that are **available, foreign to this
+platform, and not the selected one** — the combination that looks like a contradiction.
+A forced choice (step 1 or 2) reaches those backends anyway, which is why the column is
+not gated instead; and a backend forced _into_ selection is left out of the note, since
+calling it unselectable would contradict its own `*` marker.
 
 ## tmux (the default)
 

--- a/docs/porting-to-a-new-os.md
+++ b/docs/porting-to-a-new-os.md
@@ -135,8 +135,21 @@ out-of-tree adapter is
   [the adapter's operator guide](https://github.com/pbean/bmad-loop-adapter-herdr/blob/main/docs/adapter-multiplexer-herdr.md).)
 
 `available()` gates whether the backend is usable on the current host (e.g. its
-binary is on PATH); the optional `version()` feeds the diagnostic dump and the
-validate preflight (seam 4).
+binary is on PATH); the optional `version()` feeds `bmad-loop mux`, the diagnostic
+dump, and the validate preflight (seam 4).
+
+**`version()` returns one bounded line.** Every one of those consumers renders it
+inline — a table row whose width sets every other row's, a finding message, a
+scalar `--json` field — so a binary whose `--version` prints several lines (psmux
+prints a `tmux X.Y.Z` compatibility line plus its own) folds them in the backend,
+and a very long single line breaks the same surfaces a newline does. Use
+`fold_version()` from `adapters/multiplexer.py`: it joins the non-blank lines with
+`"; "` **in order**, caps the result at `VERSION_MAX_CHARS`, and returns `None` —
+the "no version" sentinel, never `""` — for an all-blank probe. Order is
+load-bearing wherever something parses the string: psmux's version gate anchors at
+the first segment, and the cap only ever cuts the tail. Core applies the same fold
+defensively at each consumer, so breaking the promise cannot split a `mux` row —
+but fold at the source, since only the backend knows which line identifies it.
 
 ### Availability discriminators (same-platform backends)
 

--- a/src/bmad_loop/adapters/multiplexer.py
+++ b/src/bmad_loop/adapters/multiplexer.py
@@ -309,11 +309,12 @@ class TerminalMultiplexer(ABC):
         abstract: backends that can't report one inherit this default. The
         implementation owns the binary invocation so it stays behind the seam.
 
-        **Single line.** Consumers render this inline — the `bmad-loop mux`
+        **One bounded line.** Consumers render this inline — the `bmad-loop mux`
         table, `validate`'s preflight finding, the diagnostic dump, the
         forced-backend warning — so a binary whose `--version` prints several
         lines (psmux prints a `tmux X.Y.Z` compatibility line plus its own)
-        must fold them into one here rather than leave each caller to cope.
+        must fold them into one here rather than leave each caller to cope, and
+        a very long one line breaks the same surfaces a newline does.
         :func:`fold_version` is the canonical fold, and the inline consumers
         also apply it defensively: an out-of-tree backend can only be asked to
         keep this promise, not made to. The one caller that also *parses* this
@@ -330,15 +331,35 @@ class TerminalMultiplexer(ABC):
         return []
 
 
+# A version is rendered inline, and `bmad-loop mux` sizes every column off its
+# widest cell — so one 300-char version pads the VERSION column to 306 and the
+# row past 350, unreadable for the same reason an embedded newline was (#321).
+# Length is half the seam's promise, not a separate concern. 80 keeps the widest
+# cell inside a standard terminal with room to spare over the real probes, which
+# fold to ~44 (`tmux 3.3.7; psmux 3.3.7 (05cc5d4 2026-07-20)`).
+VERSION_MAX_CHARS = 80
+
+
 def fold_version(raw: str | None) -> str | None:
-    """Collapse a version string onto the single line the
+    """Collapse a version string onto the one bounded line the
     :meth:`TerminalMultiplexer.version` seam promises. Segments keep their
     order (the psmux version gate anchors a parse at the first) and are
-    stripped; an all-blank value folds to None — the seam's "no version"
-    sentinel — never to ``""``."""
+    stripped; a fold over :data:`VERSION_MAX_CHARS` is cut at the tail, which
+    that anchored parse never reads; an all-blank value folds to None — the
+    seam's "no version" sentinel — never to ``""``. Idempotent, so the seam's
+    own fold and each consumer's defensive one compose.
+
+    Line breaks only: a tab or an ANSI escape *inside* a segment survives and
+    can still misalign a table. Widening this to collapse all whitespace would
+    rewrite well-behaved single-line versions, which the seam promises not to
+    touch. And the fold is one-way — ``"; "`` is a plausible substring of a real
+    version banner, so a boundary is not recoverable by splitting on it."""
     if not raw:
         return None
-    return "; ".join(line.strip() for line in raw.splitlines() if line.strip()) or None
+    folded = "; ".join(line.strip() for line in raw.splitlines() if line.strip())
+    if len(folded) > VERSION_MAX_CHARS:
+        folded = folded[: VERSION_MAX_CHARS - 1] + "…"
+    return folded or None
 
 
 # (name, matches(platform) -> bool, factory() -> TerminalMultiplexer)

--- a/src/bmad_loop/adapters/multiplexer.py
+++ b/src/bmad_loop/adapters/multiplexer.py
@@ -306,9 +306,19 @@ class TerminalMultiplexer(ABC):
 
     def version(self) -> str | None:
         """The backend binary's version string, or None when unavailable. Not
-        abstract: backends that can't report one inherit this default. Used by
-        the diagnostic dump; the implementation owns the binary invocation so it
-        stays behind the seam."""
+        abstract: backends that can't report one inherit this default. The
+        implementation owns the binary invocation so it stays behind the seam.
+
+        **Single line.** Consumers render this inline — the `bmad-loop mux`
+        table, `validate`'s preflight finding, the diagnostic dump, the
+        forced-backend warning — so a binary whose `--version` prints several
+        lines (psmux prints a `tmux X.Y.Z` compatibility line plus its own)
+        must fold them into one here rather than leave each caller to cope.
+        :func:`fold_version` is the canonical fold, and the inline consumers
+        also apply it defensively: an out-of-tree backend can only be asked to
+        keep this promise, not made to. The one caller that also *parses* this
+        string (the psmux backend's version gate) anchors at its start, so a
+        folding backend keeps the identifying version in the first segment."""
         return None
 
     def window_pane_pids(self, target: str) -> list[int]:
@@ -318,6 +328,17 @@ class TerminalMultiplexer(ABC):
         callers must degrade (skip the pid-level escalation) and never read
         ``[]`` as "no processes". Must not raise."""
         return []
+
+
+def fold_version(raw: str | None) -> str | None:
+    """Collapse a version string onto the single line the
+    :meth:`TerminalMultiplexer.version` seam promises. Segments keep their
+    order (the psmux version gate anchors a parse at the first) and are
+    stripped; an all-blank value folds to None — the seam's "no version"
+    sentinel — never to ``""``."""
+    if not raw:
+        return None
+    return "; ".join(line.strip() for line in raw.splitlines() if line.strip()) or None
 
 
 # (name, matches(platform) -> bool, factory() -> TerminalMultiplexer)
@@ -486,7 +507,7 @@ def mux_usable(backend: TerminalMultiplexer | None = None) -> bool:
     if not _FORCED_UNUSABLE_WARNED:
         _FORCED_UNUSABLE_WARNED = True
         try:
-            version = backend.version()
+            version = fold_version(backend.version())
         except Exception:  # a broken probe must not break the warning
             version = None
         print(
@@ -626,7 +647,7 @@ def detect_multiplexers() -> list[MuxBackendInfo]:
             # already-computed availability (a selected backend would
             # otherwise show a contradictory available=False row).
             try:
-                version = backend.version()
+                version = fold_version(backend.version())
             except Exception:
                 version = None
         selected = name == selected_name

--- a/src/bmad_loop/adapters/tmux_base.py
+++ b/src/bmad_loop/adapters/tmux_base.py
@@ -31,7 +31,7 @@ import sys
 import time
 from pathlib import Path
 
-from .multiplexer import MultiplexerError, TerminalMultiplexer
+from .multiplexer import MultiplexerError, TerminalMultiplexer, fold_version
 
 TMUX_TIMEOUT_S = 30
 # Per-window option value (vs a pane target) telling the parked trailer to detach
@@ -459,6 +459,13 @@ class BaseTmuxBackend(TerminalMultiplexer):
         if not shutil.which(self._BINARY):
             return None
         try:
-            return self._tmux("-V")
+            raw = self._tmux("-V")
         except (MultiplexerError, subprocess.SubprocessError, OSError):
             return None
+        # The seam promises one line (TerminalMultiplexer.version). `-V` is one
+        # line on tmux, two on psmux (a `tmux X.Y.Z` compat line then its own),
+        # so fold rather than truncate — the tail is what names psmux as the
+        # answering binary. Order is load-bearing: PsmuxMultiplexer.available()
+        # parses the compat segment with an anchored match, so the first
+        # segment must stay first.
+        return fold_version(raw)

--- a/src/bmad_loop/cli.py
+++ b/src/bmad_loop/cli.py
@@ -338,7 +338,8 @@ def cmd_validate(args: argparse.Namespace) -> int:
         channel = (
             "the ATTENTION file in the run directory is the only alert channel left"
             if pol.notify.file
-            else "notify.file is also off, so no alert channel is configured — enable notify.file"
+            else "notify.file is also off, so no alert channel is configured — "
+            "enable notify.file"
         )
         report.warn(
             "notify.desktop-unavailable",
@@ -505,10 +506,8 @@ def cmd_mux(args: argparse.Namespace) -> int:
     stranded = [r.name for r in rows if r.available and not r.matches_platform and not r.selected]
     if stranded:
         print(
-            f"note: AVAILABLE yes but not selectable on {sys.platform}: {', '.join(stranded)} "
-            "— automatic selection only picks backends that match the platform, and AVAILABLE "
-            f"means the binary answers here, not that the backend supports {sys.platform}. "
-            "A forced choice bypasses the platform check"
+            "note: AVAILABLE means the binary answers here, not that the backend supports "
+            f"{sys.platform} — {', '.join(stranded)} can only be reached by forcing the choice"
         )
     # A failed external package is invisible in the table (it never registered),
     # so name it here — the one place an operator looks when a backend is missing.

--- a/src/bmad_loop/cli.py
+++ b/src/bmad_loop/cli.py
@@ -338,8 +338,7 @@ def cmd_validate(args: argparse.Namespace) -> int:
         channel = (
             "the ATTENTION file in the run directory is the only alert channel left"
             if pol.notify.file
-            else "notify.file is also off, so no alert channel is configured — "
-            "enable notify.file"
+            else "notify.file is also off, so no alert channel is configured — enable notify.file"
         )
         report.warn(
             "notify.desktop-unavailable",
@@ -485,6 +484,8 @@ def cmd_mux(args: argparse.Namespace) -> int:
             r.name,
             "yes" if r.matches_platform else "no",
             "yes" if r.available else "no",
+            # detect_multiplexers folds multi-line versions (fold_version), so
+            # an out-of-tree backend can't split the row and strand SELECTED.
             r.version or "-",
             f"* {_mux_reason_label(r.reason)}" if r.selected else "",
         )
@@ -493,6 +494,22 @@ def cmd_mux(args: argparse.Namespace) -> int:
     widths = [max(len(h), *(len(row[i]) for row in table), 0) for i, h in enumerate(header)]
     for row in (header, *table):
         print("  ".join(cell.ljust(w) for cell, w in zip(row, widths)).rstrip())
+    # AVAILABLE answers "could this backend run here", not "could it be picked",
+    # and the two diverge whenever a foreign-platform binary shares a name with
+    # a local one — on Windows `tmux` is psmux's compatibility shim, so the tmux
+    # row reads as a real tmux install. Explaining the row beats gating the
+    # column: a forced choice genuinely does reach these backends.
+    # A forced backend is exempt: it IS selected, and telling an operator the
+    # row they just pinned cannot be selected reads as a contradiction of the
+    # `*` marker one line above.
+    stranded = [r.name for r in rows if r.available and not r.matches_platform and not r.selected]
+    if stranded:
+        print(
+            f"note: AVAILABLE yes but not selectable on {sys.platform}: {', '.join(stranded)} "
+            "— automatic selection only picks backends that match the platform, and AVAILABLE "
+            f"means the binary answers here, not that the backend supports {sys.platform}. "
+            "A forced choice bypasses the platform check"
+        )
     # A failed external package is invisible in the table (it never registered),
     # so name it here — the one place an operator looks when a backend is missing.
     for ep_name, reason in sorted(external_backend_errors().items()):

--- a/src/bmad_loop/diagnostics.py
+++ b/src/bmad_loop/diagnostics.py
@@ -248,10 +248,14 @@ def collect_env() -> EnvInfo:
     try:
         backend = get_multiplexer()
         mux = type(backend).__name__
-        # Fold before the line cap: on a multi-line version scrub_text's
-        # "(N more lines redacted)" marker would re-introduce the newline.
-        raw = fold_version(backend.version())
-        tmux_v = sanitize.scrub_text(raw, max_lines=1) if raw else None
+        # fold_version both flattens and bounds (the seam's inline-render
+        # contract), so the max_lines=1 this used to carry is redundant — and it
+        # never held anyway: scrub_text's "(N more lines redacted)" marker is
+        # itself a new line, re-introducing exactly what the cap removed.
+        # Scrub first so the home/email redaction reads the whole probe rather
+        # than a tail the fold already cut.
+        raw = backend.version()
+        tmux_v = fold_version(sanitize.scrub_text(raw)) if raw else None
     except Exception:  # nosec B110 - env probe is best-effort; absent mux is fine
         pass
     return EnvInfo(

--- a/src/bmad_loop/diagnostics.py
+++ b/src/bmad_loop/diagnostics.py
@@ -241,14 +241,16 @@ class Diagnostics:
 
 
 def collect_env() -> EnvInfo:
-    from .adapters.multiplexer import get_multiplexer
+    from .adapters.multiplexer import fold_version, get_multiplexer
 
     mux = "none"
     tmux_v = None
     try:
         backend = get_multiplexer()
         mux = type(backend).__name__
-        raw = backend.version()
+        # Fold before the line cap: on a multi-line version scrub_text's
+        # "(N more lines redacted)" marker would re-introduce the newline.
+        raw = fold_version(backend.version())
         tmux_v = sanitize.scrub_text(raw, max_lines=1) if raw else None
     except Exception:  # nosec B110 - env probe is best-effort; absent mux is fine
         pass

--- a/src/bmad_loop/runsetup.py
+++ b/src/bmad_loop/runsetup.py
@@ -62,7 +62,7 @@ ROLES = ("dev", "review", "triage")
 
 def make_adapters(project: Path, run_dir: Path, policy) -> dict[str, CodingCLIAdapter]:
     from .adapters.generic import GenericAdapter, GenericDevAdapter
-    from .adapters.multiplexer import get_multiplexer, mux_usable
+    from .adapters.multiplexer import fold_version, get_multiplexer, mux_usable
     from .adapters.profile import ProfileError, get_profile
 
     # The dev skill (bmad-dev-auto) writes no result.json: its adapter
@@ -120,7 +120,7 @@ def make_adapters(project: Path, run_dir: Path, policy) -> dict[str, CodingCLIAd
                     mux = get_multiplexer()
                     if not mux_usable(mux):
                         try:
-                            version = mux.version()
+                            version = fold_version(mux.version())
                         except Exception:  # diagnosing must not mask the refusal
                             version = None
                         raise SystemExit(
@@ -171,6 +171,7 @@ def platform_preflight() -> list[Finding]:
     from .adapters.multiplexer import (
         detect_multiplexers,
         external_backend_errors,
+        fold_version,
         get_multiplexer,
     )
     from .process_host import get_process_host
@@ -180,7 +181,9 @@ def platform_preflight() -> list[Finding]:
     try:
         backend = get_multiplexer()
         label = type(backend).__name__
-        version = backend.version()
+        # Defensive fold: an out-of-tree backend can break the seam's
+        # single-line promise, and this string lands in an inline message.
+        version = fold_version(backend.version())
         if backend.available():
             found.append(
                 Finding(

--- a/tests/test_backend_registry.py
+++ b/tests/test_backend_registry.py
@@ -356,6 +356,58 @@ def test_detect_multiplexers_version_crash_keeps_availability(fresh_registry):
     assert rows["verless"].selected is True and rows["verless"].reason == "first-match"
 
 
+# ------------------------------------------------ fold_version, directly (#321)
+#
+# The seam folds and then every inline consumer folds again defensively, so the
+# helper's own edges have to hold on their own — and most of them are invisible
+# through any single consumer's rendering (`r.version or "-"` collapses "" and
+# None to the same cell, and the tmux-family probe strips its capture, so the
+# whitespace-only input is only reachable from a duck-typed backend at all).
+
+
+def test_fold_version_edges():
+    assert m.fold_version(None) is None  # the seam's own default version()
+    assert m.fold_version("") is None
+    # Truthy, but no segment survives: the sentinel this seam documents is None,
+    # not a version that happens to be empty.
+    assert m.fold_version("  \n \t \n") is None
+    assert m.fold_version("tmux 3.4") == "tmux 3.4"  # single line: byte-identical
+
+
+def test_fold_version_is_idempotent():
+    """Load-bearing, and nothing else asserts it: `version()` folds at the
+    tmux-family seam and detect_multiplexers / platform_preflight / collect_env /
+    mux_usable / make_adapters each fold that already-folded result again."""
+    for raw in ("tmux 3.4", "tmux 3.3.7\npsmux 3.3.7", "tmux 3.4 " + "x" * 300):
+        once = m.fold_version(raw)
+        assert m.fold_version(once) == once
+
+
+def test_fold_version_bounds_the_line_it_produces():
+    """`mux` sizes every column off the widest cell, so an unbounded single line
+    breaks the table exactly as an embedded newline did. The cut is at the tail,
+    which the one parser of this string (the psmux gate) never reads."""
+    folded = m.fold_version("tmux 3.4 " + "x" * 300)
+
+    assert folded is not None
+    assert len(folded) == m.VERSION_MAX_CHARS
+    assert folded.startswith("tmux 3.4 ") and folded.endswith("…")
+
+
+def test_forced_unusable_warning_folds_the_reported_version(fresh_registry, monkeypatch, capsys):
+    """The warning renders with `{version!r}`, which already escapes a newline —
+    so this fold buys readability, not safety. Assert the readable form, or the
+    site is indistinguishable from dead code."""
+    monkeypatch.setattr(fresh_registry, "_FORCED_UNUSABLE_WARNED", False)
+    monkeypatch.setenv("BMAD_LOOP_MUX_BACKEND", "alpha")
+    fresh_registry._BUILTINS_LOADED = True
+    fresh_registry.register_multiplexer("alpha", lambda p: True, lambda: _Stub(avail=False))
+
+    assert fresh_registry.mux_usable(_Stub(avail=False, version="alpha 1.2\nbuild 7")) is True
+
+    assert "version: 'alpha 1.2; build 7'" in capsys.readouterr().err
+
+
 # ---------------------------------------------------------------------------
 # Bundled-registry platform behavior. These exercise the REAL builtin load (they
 # leave `_BUILTINS_LOADED` False) and control the outcome by monkeypatching

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4413,6 +4413,31 @@ def test_mux_table_survives_a_multi_line_version(mux_registry, tmp_path, capsys)
     assert not any(line.startswith("psmux 3.3.7") for line in out.splitlines())
 
 
+def test_mux_table_survives_an_over_long_version(mux_registry, tmp_path, capsys):
+    # The other half of the same breakage (#321): widths come from len() of the
+    # widest cell and every row is ljust-ed to them, so one unbounded version
+    # pushes SELECTED hundreds of columns out — unreadable for the same reason
+    # the split row was. The fold bounds as well as flattens.
+    import sys as _sys
+
+    from bmad_loop.adapters.multiplexer import VERSION_MAX_CHARS
+
+    mux_registry.register_multiplexer(
+        "alpha",
+        lambda p: p == _sys.platform,
+        lambda: _MuxStub(avail=True, version="alpha 1.2 " + "x" * 300),
+    )
+    assert cli.main(["mux", "--project", str(tmp_path)]) == 0
+    out = capsys.readouterr().out
+
+    row = next(line for line in out.splitlines() if line.startswith("alpha"))
+    assert "* first available platform match" in row
+    assert "…" in row  # cut, rather than silently dropping the tail
+    # Tied to the bound, not to a magic width: the version cell no longer
+    # dominates the row, which unbounded ran past 350 columns.
+    assert len(row) < 2 * VERSION_MAX_CHARS
+
+
 def test_mux_notes_an_available_backend_that_cannot_be_selected(mux_registry, tmp_path, capsys):
     # On Windows `tmux` is psmux's compatibility shim, so the tmux row reports
     # AVAILABLE yes and reads as a real tmux install. The column stays honest —
@@ -4422,16 +4447,20 @@ def test_mux_notes_an_available_backend_that_cannot_be_selected(mux_registry, tm
     mux_registry.register_multiplexer(
         "alpha", lambda p: p == _sys.platform, lambda: _MuxStub(avail=True, version="alpha 1.2")
     )
-    mux_registry.register_multiplexer("foreign", lambda p: False, lambda: _MuxStub(avail=True))
+    # Registered counter-alphabetically on purpose: with `foreign` first, a
+    # sorted() list and a registration-ordered one are indistinguishable, and
+    # the note claims the same order the table above it prints.
     mux_registry.register_multiplexer("zeta", lambda p: False, lambda: _MuxStub(avail=True))
+    mux_registry.register_multiplexer("foreign", lambda p: False, lambda: _MuxStub(avail=True))
     assert cli.main(["mux", "--project", str(tmp_path)]) == 0
     out = capsys.readouterr().out
 
     note = next(line for line in out.splitlines() if line.startswith("note: "))
-    assert "foreign, zeta" in note  # every stranded backend, registration order
-    assert "not selectable" in note and "bypasses the platform check" in note
-    # What AVAILABLE actually measures — the fact that makes the row make sense.
+    assert "zeta, foreign" in note  # every stranded backend, in registration order
+    # What AVAILABLE actually measures — the fact that makes the row make sense —
+    # and the one way an operator reaches a backend it excludes.
     assert "the binary answers here" in note
+    assert "forcing the choice" in note
     assert "alpha" not in note  # the local platform match is not named
 
 
@@ -4458,8 +4487,10 @@ def test_mux_does_not_call_a_forced_backend_unselectable(
 
 
 def test_mux_keeps_the_placeholder_for_a_blank_version(mux_registry, tmp_path, capsys):
-    # Blank but truthy: the fold must collapse it to the None sentinel, not to
-    # "" — an empty cell plus the trailing rstrip eats SELECTED with it.
+    # Blank but truthy: unfolded, the whitespace lands in the cell and the row's
+    # trailing rstrip eats SELECTED with it. This pins falsiness only — the cell
+    # is `r.version or "-"`, so it cannot tell None from "" (that distinction is
+    # the seam's, and test_backend_registry.test_fold_version_edges owns it).
     import sys as _sys
 
     mux_registry.register_multiplexer(
@@ -4504,6 +4535,46 @@ def test_platform_preflight_folds_a_multi_line_version(mux_registry):
     finding = next(f for f in cli._platform_preflight() if f.check == "mux.backend")
     assert finding.detail["version"] == "alpha 1.2; extra build line"
     assert "\n" not in finding.message
+
+
+def test_platform_preflight_bounds_an_over_long_version(mux_registry):
+    # The same string is a released `validate --json` detail, and nothing
+    # downstream of documents.py bounds it — so the fold has to.
+    import sys as _sys
+
+    from bmad_loop.adapters.multiplexer import VERSION_MAX_CHARS
+
+    mux_registry.register_multiplexer(
+        "alpha",
+        lambda p: p == _sys.platform,
+        lambda: _MuxStub(avail=True, version="alpha 1.2 " + "x" * 300),
+    )
+
+    finding = next(f for f in cli._platform_preflight() if f.check == "mux.backend")
+    assert len(finding.detail["version"]) == VERSION_MAX_CHARS
+    assert finding.detail["version"].endswith("…")
+
+
+def test_make_adapters_refusal_names_a_folded_version(project, monkeypatch):
+    # The refusal interpolates the version bare (no !r to escape a newline for
+    # it, unlike the forced-backend warning), so an out-of-tree backend that
+    # breaks the seam's promise would split the one message explaining why the
+    # run will not start.
+    install_bmad_config(project)
+    monkeypatch.delenv("BMAD_LOOP_MUX_BACKEND", raising=False)
+    monkeypatch.setattr(mux_mod, "_CONFIGURED", None)
+    monkeypatch.setattr(mux_mod, "_usable", lambda mux: False)
+    monkeypatch.setattr(
+        mux_mod, "get_multiplexer", lambda: _MuxStub(avail=False, version="alpha 1.2\nextra line")
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        cli._make_adapters(
+            project.project, project.project / ".bmad-loop" / "runs" / "r", policy_mod.load(None)
+        )
+
+    assert "alpha 1.2; extra line" in str(exc.value)
+    assert "\n" not in str(exc.value)
 
 
 def test_mux_exits_1_on_forced_unknown_name(mux_registry, tmp_path, capsys, monkeypatch):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4392,6 +4392,120 @@ def test_mux_lists_backends_and_selection(mux_registry, tmp_path, capsys):
     assert "bmad-loop mux set <name>" in out  # the no-prompt override hint
 
 
+def test_mux_table_survives_a_multi_line_version(mux_registry, tmp_path, capsys):
+    # _MuxStub is duck-typed, exactly like an out-of-tree backend: the seam's
+    # single-line promise (#321) is a docstring it never inherits, so
+    # detect_multiplexers folds defensively. An unfolded newline used to split
+    # the row and strand SELECTED on a line of its own.
+    import sys as _sys
+
+    mux_registry.register_multiplexer(
+        "alpha",
+        lambda p: p == _sys.platform,
+        lambda: _MuxStub(avail=True, version="tmux 3.3.7\npsmux 3.3.7 (05cc5d4)"),
+    )
+    assert cli.main(["mux", "--project", str(tmp_path)]) == 0
+    out = capsys.readouterr().out
+
+    row = next(line for line in out.splitlines() if line.startswith("alpha"))
+    assert "tmux 3.3.7; psmux 3.3.7 (05cc5d4)" in row
+    assert "* first available platform match" in row  # SELECTED stayed on the row
+    assert not any(line.startswith("psmux 3.3.7") for line in out.splitlines())
+
+
+def test_mux_notes_an_available_backend_that_cannot_be_selected(mux_registry, tmp_path, capsys):
+    # On Windows `tmux` is psmux's compatibility shim, so the tmux row reports
+    # AVAILABLE yes and reads as a real tmux install. The column stays honest —
+    # a forced choice does reach it — and a note explains the row instead.
+    import sys as _sys
+
+    mux_registry.register_multiplexer(
+        "alpha", lambda p: p == _sys.platform, lambda: _MuxStub(avail=True, version="alpha 1.2")
+    )
+    mux_registry.register_multiplexer("foreign", lambda p: False, lambda: _MuxStub(avail=True))
+    mux_registry.register_multiplexer("zeta", lambda p: False, lambda: _MuxStub(avail=True))
+    assert cli.main(["mux", "--project", str(tmp_path)]) == 0
+    out = capsys.readouterr().out
+
+    note = next(line for line in out.splitlines() if line.startswith("note: "))
+    assert "foreign, zeta" in note  # every stranded backend, registration order
+    assert "not selectable" in note and "bypasses the platform check" in note
+    # What AVAILABLE actually measures — the fact that makes the row make sense.
+    assert "the binary answers here" in note
+    assert "alpha" not in note  # the local platform match is not named
+
+
+def test_mux_does_not_call_a_forced_backend_unselectable(
+    mux_registry, tmp_path, capsys, monkeypatch
+):
+    # The forced row carries the `*` marker, so naming it in the note would
+    # contradict the line right above it.
+    import sys as _sys
+
+    monkeypatch.setenv("BMAD_LOOP_MUX_BACKEND", "foreign")
+    mux_registry.register_multiplexer(
+        "alpha", lambda p: p == _sys.platform, lambda: _MuxStub(avail=True, version="alpha 1.2")
+    )
+    mux_registry.register_multiplexer(
+        "foreign", lambda p: False, lambda: _MuxStub(avail=True, version="foreign 9.9")
+    )
+    mux_registry.get_multiplexer.cache_clear()
+    assert cli.main(["mux", "--project", str(tmp_path)]) == 0
+    out = capsys.readouterr().out
+
+    assert "* forced by BMAD_LOOP_MUX_BACKEND" in out
+    assert "note:" not in out
+
+
+def test_mux_keeps_the_placeholder_for_a_blank_version(mux_registry, tmp_path, capsys):
+    # Blank but truthy: the fold must collapse it to the None sentinel, not to
+    # "" — an empty cell plus the trailing rstrip eats SELECTED with it.
+    import sys as _sys
+
+    mux_registry.register_multiplexer(
+        "alpha", lambda p: p == _sys.platform, lambda: _MuxStub(avail=True, version="  \n \n")
+    )
+    assert cli.main(["mux", "--project", str(tmp_path)]) == 0
+
+    row = next(line for line in capsys.readouterr().out.splitlines() if line.startswith("alpha"))
+    assert "-" in row and "* first available platform match" in row
+
+
+def test_mux_omits_the_note_when_every_available_backend_matches(mux_registry, tmp_path, capsys):
+    import sys as _sys
+
+    mux_registry.register_multiplexer(
+        "alpha", lambda p: p == _sys.platform, lambda: _MuxStub(avail=True, version="alpha 1.2")
+    )
+    # Registered but unavailable, and foreign — the note is about the overlap.
+    mux_registry.register_multiplexer("beta", lambda p: False, lambda: _MuxStub(avail=False))
+    # Available + matching but unselected (alpha won first-match): still local,
+    # so the note must not name it either.
+    mux_registry.register_multiplexer(
+        "gamma", lambda p: p == _sys.platform, lambda: _MuxStub(avail=True)
+    )
+    assert cli.main(["mux", "--project", str(tmp_path)]) == 0
+
+    assert "note:" not in capsys.readouterr().out
+
+
+def test_platform_preflight_folds_a_multi_line_version(mux_registry):
+    # validate renders the version inline in its finding message and keeps it
+    # as a scalar --json detail; an out-of-tree backend that breaks the seam's
+    # single-line promise must not put a newline in either.
+    import sys as _sys
+
+    mux_registry.register_multiplexer(
+        "alpha",
+        lambda p: p == _sys.platform,
+        lambda: _MuxStub(avail=True, version="alpha 1.2\nextra build line"),
+    )
+
+    finding = next(f for f in cli._platform_preflight() if f.check == "mux.backend")
+    assert finding.detail["version"] == "alpha 1.2; extra build line"
+    assert "\n" not in finding.message
+
+
 def test_mux_exits_1_on_forced_unknown_name(mux_registry, tmp_path, capsys, monkeypatch):
     monkeypatch.setenv("BMAD_LOOP_MUX_BACKEND", "ghost")
     mux_registry.get_multiplexer.cache_clear()

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -482,6 +482,23 @@ def test_non_ascii_sensitive_value_reaches_the_guard(monkeypatch):
     assert json.loads(rendered)["backstop_repairs"] == {f"story:{alias}": 1}
 
 
+def test_env_tmux_version_folds_a_multi_line_probe(monkeypatch):
+    """tmux_version is a scalar JSON field. Pre-fold (#321), a two-line probe
+    hit scrub_text's line cap, whose "(N more lines redacted)" marker line
+    re-introduced the very newline the cap was meant to remove."""
+    from bmad_loop.adapters import multiplexer as mux_mod
+
+    class _TwoLineMux:
+        def version(self):
+            return "tmux 3.3.7\npsmux 3.3.7"
+
+    monkeypatch.setattr(mux_mod, "get_multiplexer", lambda: _TwoLineMux())
+
+    env = diagnostics.collect_env()
+    assert env.tmux_version == "tmux 3.3.7; psmux 3.3.7"
+    assert env.multiplexer == "_TwoLineMux"
+
+
 def test_non_ascii_survives_the_utf8_round_trip(tmp_path, monkeypatch):
     """ensure_ascii=False emits real non-ASCII, so confirm the document still
     round-trips through the encoding the CLI writes it with."""

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -499,6 +499,45 @@ def test_env_tmux_version_folds_a_multi_line_probe(monkeypatch):
     assert env.multiplexer == "_TwoLineMux"
 
 
+def test_env_tmux_version_stays_bounded(monkeypatch):
+    """Nothing between here and the rendered dump bounds this field — asdict,
+    json.dumps and sanitize.guard all pass it through — and scrub_text's cap
+    only ever counted lines, so the fold owns the bound (#321)."""
+    from bmad_loop.adapters import multiplexer as mux_mod
+
+    class _ChattyMux:
+        def version(self):
+            return "tmux 3.3.7\n" + "\n".join("build detail " + "y" * 40 for _ in range(20))
+
+    monkeypatch.setattr(mux_mod, "get_multiplexer", lambda: _ChattyMux())
+
+    env = diagnostics.collect_env()
+    assert env.tmux_version is not None
+    assert len(env.tmux_version) == mux_mod.VERSION_MAX_CHARS
+    assert "\n" not in env.tmux_version
+    assert env.tmux_version.startswith("tmux 3.3.7")
+
+
+def test_env_tmux_version_is_redacted_before_it_is_cut(monkeypatch):
+    """The scrub runs on the whole probe, not on what survives the fold: a home
+    path past the bound must still be redacted rather than half-copied into the
+    dump by a truncation that lands mid-path."""
+    from bmad_loop.adapters import multiplexer as mux_mod
+
+    home = sanitize._home()  # the same source redact_home reads, so it can't drift
+
+    class _HomeyMux:
+        def version(self):
+            return f"tmux 3.3.7 built from {home}/src/tmux"
+
+    monkeypatch.setattr(mux_mod, "get_multiplexer", lambda: _HomeyMux())
+
+    env = diagnostics.collect_env()
+    assert env.tmux_version is not None
+    assert home not in env.tmux_version
+    assert "~" in env.tmux_version
+
+
 def test_non_ascii_survives_the_utf8_round_trip(tmp_path, monkeypatch):
     """ensure_ascii=False emits real non-ASCII, so confirm the document still
     round-trips through the encoding the CLI writes it with."""

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -519,23 +519,37 @@ def test_env_tmux_version_stays_bounded(monkeypatch):
 
 
 def test_env_tmux_version_is_redacted_before_it_is_cut(monkeypatch):
-    """The scrub runs on the whole probe, not on what survives the fold: a home
-    path past the bound must still be redacted rather than half-copied into the
-    dump by a truncation that lands mid-path."""
+    """The scrub runs on the whole probe, not on what survives the fold.
+
+    The home path has to *straddle* the cut for this to mean anything: a probe
+    that fits under the bound passes whichever way round the two run. Padded so
+    the cut lands inside the path, folding first leaves a fragment `redact_home`
+    can no longer match — and its `~` never appears, which is what discriminates
+    the orders. `home not in ...` alone does not: the fragment isn't the whole
+    path either.
+    """
     from bmad_loop.adapters import multiplexer as mux_mod
 
-    home = sanitize._home()  # the same source redact_home reads, so it can't drift
+    # A fixed home, not the host's: the padding below is arithmetic against its
+    # length, and CI's home differs per runner. expanduser reads HOME on POSIX
+    # and USERPROFILE on Windows, so set both (tests/test_sanitize.py does too).
+    home = "/private/bmad-loop-home"
+    monkeypatch.setenv("HOME", home)
+    monkeypatch.setenv("USERPROFILE", home)
+    lead = "tmux 3.3.7 "
+    pad = lead + "x" * (mux_mod.VERSION_MAX_CHARS - len(lead) - 3)
 
     class _HomeyMux:
         def version(self):
-            return f"tmux 3.3.7 built from {home}/src/tmux"
+            return f"{pad}{home}/src/tmux"
 
     monkeypatch.setattr(mux_mod, "get_multiplexer", lambda: _HomeyMux())
 
     env = diagnostics.collect_env()
     assert env.tmux_version is not None
+    assert env.tmux_version.endswith("…")  # the cut really fired
     assert home not in env.tmux_version
-    assert "~" in env.tmux_version
+    assert "~" in env.tmux_version  # redaction saw the whole path, then the cut
 
 
 def test_non_ascii_survives_the_utf8_round_trip(tmp_path, monkeypatch):

--- a/tests/test_multiplexer.py
+++ b/tests/test_multiplexer.py
@@ -14,7 +14,7 @@ import subprocess
 
 import pytest
 
-from bmad_loop.adapters import tmux_base
+from bmad_loop.adapters import multiplexer, tmux_base
 from bmad_loop.adapters.base import SessionSpec
 from bmad_loop.adapters.generic import GenericAdapter
 from bmad_loop.adapters.multiplexer import MultiplexerError, TerminalMultiplexer, parse_target
@@ -315,12 +315,13 @@ def test_tmux_window_pane_pids_degrades_to_empty(monkeypatch, outcome):
     assert mux.window_pane_pids("@7") == []
 
 
-# ------------------------------------- version() is one line, always (#321)
+# -------------------------------- version() is one bounded line, always (#321)
 #
 # Consumers render version() inline (the `mux` table, validate's preflight
-# finding, the diagnostic dump), so the seam owes them a single line. psmux's
-# `-V` prints two — a `tmux X.Y.Z` compat line plus its own — and the base folds
-# them here so no consumer has to.
+# finding, the diagnostic dump), so the seam owes them a single line — and a
+# bounded one, since the table sizes its columns off the widest cell. psmux's
+# `-V` prints two lines — a `tmux X.Y.Z` compat line plus its own — and the base
+# folds them here so no consumer has to.
 
 
 def _version_stdout(monkeypatch, stdout: str):
@@ -366,6 +367,31 @@ def test_version_of_an_all_blank_probe_is_the_none_sentinel(monkeypatch):
     _version_stdout(monkeypatch, "\n  \n")
 
     assert TmuxMultiplexer().version() is None
+
+
+def test_version_is_bounded_not_just_flattened(monkeypatch):
+    # `mux` sizes every column off the widest cell, so an unbounded single line
+    # breaks the table exactly as the embedded newline did — length is half the
+    # seam's promise. The cut is at the tail, which the psmux gate's anchored
+    # parse never reads.
+    _version_stdout(monkeypatch, "tmux 3.4 " + "x" * 300)
+
+    got = TmuxMultiplexer().version()
+
+    assert got is not None
+    assert len(got) == multiplexer.VERSION_MAX_CHARS
+    assert got.startswith("tmux 3.4 ") and got.endswith("…")
+
+
+def test_version_of_a_real_probe_is_never_truncated(monkeypatch):
+    # The bound must clear the probes that actually exist by a wide margin —
+    # otherwise it trades one unreadable cell for a useless one.
+    _version_stdout(monkeypatch, "tmux 3.3.7\npsmux 3.3.7 (05cc5d4 2026-07-20)\n")
+
+    got = TmuxMultiplexer().version()
+
+    assert got == "tmux 3.3.7; psmux 3.3.7 (05cc5d4 2026-07-20)"
+    assert len(got) < multiplexer.VERSION_MAX_CHARS
 
 
 # ---------------------------------------------- _run seam: encoding + env (#40)

--- a/tests/test_multiplexer.py
+++ b/tests/test_multiplexer.py
@@ -315,6 +315,59 @@ def test_tmux_window_pane_pids_degrades_to_empty(monkeypatch, outcome):
     assert mux.window_pane_pids("@7") == []
 
 
+# ------------------------------------- version() is one line, always (#321)
+#
+# Consumers render version() inline (the `mux` table, validate's preflight
+# finding, the diagnostic dump), so the seam owes them a single line. psmux's
+# `-V` prints two — a `tmux X.Y.Z` compat line plus its own — and the base folds
+# them here so no consumer has to.
+
+
+def _version_stdout(monkeypatch, stdout: str):
+    monkeypatch.setattr(tmux_base.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(
+        tmux_base.subprocess,
+        "run",
+        lambda argv, **k: subprocess.CompletedProcess(argv, 0, stdout=stdout, stderr=""),
+    )
+
+
+def test_version_folds_a_multi_line_probe_onto_one_line(monkeypatch):
+    _version_stdout(monkeypatch, "tmux 3.3.7\npsmux 3.3.7 (05cc5d4 2026-07-20)\n")
+
+    got = TmuxMultiplexer().version()
+
+    assert got is not None and "\n" not in got
+    # Folded, not truncated: dropping the tail would hide which binary runs.
+    assert got == "tmux 3.3.7; psmux 3.3.7 (05cc5d4 2026-07-20)"
+    # Order is load-bearing — PsmuxMultiplexer.available() anchors its version
+    # match at position 0, so the compat line must stay first.
+    assert got.startswith("tmux 3.3.7")
+
+
+def test_version_of_a_single_line_probe_is_unchanged(monkeypatch):
+    # The POSIX path must stay byte-identical: no separator, no reformatting.
+    _version_stdout(monkeypatch, "tmux 3.4\n")
+
+    assert TmuxMultiplexer().version() == "tmux 3.4"
+
+
+def test_version_drops_blank_segments_and_strips_the_rest(monkeypatch):
+    # A blank line would otherwise fold into a bare "; ; " run, and an indented
+    # continuation line into "tmux 3.3.7;   psmux ...".
+    _version_stdout(monkeypatch, "tmux 3.3.7\n\n   \n  psmux 3.3.7\n")
+
+    assert TmuxMultiplexer().version() == "tmux 3.3.7; psmux 3.3.7"
+
+
+def test_version_of_an_all_blank_probe_is_the_none_sentinel(monkeypatch):
+    # A probe that exits 0 printing nothing reports "no version" — the sentinel
+    # this method documents — not a version that happens to be empty.
+    _version_stdout(monkeypatch, "\n  \n")
+
+    assert TmuxMultiplexer().version() is None
+
+
 # ---------------------------------------------- _run seam: encoding + env (#40)
 #
 # The spawn primitive carries the two knobs its docstring promises — output

--- a/tests/test_psmux_backend.py
+++ b/tests/test_psmux_backend.py
@@ -517,6 +517,30 @@ def test_available_composes_real_version_probe(monkeypatch):
     assert rec.argv == ["psmux", "-V"]
 
 
+def test_available_parses_the_gate_out_of_a_real_two_line_probe(monkeypatch):
+    # psmux -V really prints two lines. version() folds them (#321), and the
+    # gate reads the compat segment out of the fold — if a future change ever
+    # puts psmux's own line first, this fails instead of silently reporting the
+    # backend unavailable and taking psmux off Windows with no diagnostic.
+    # One stub, not two: psmux_backend.shutil IS tmux_base.shutil (both plain
+    # `import shutil`), so a second setattr would silently replace the first and
+    # leave available()'s psmux+pwsh probe unexercised. This one answers for the
+    # three binaries both layers ask about and refuses everything else.
+    monkeypatch.setattr(
+        psmux_backend.shutil,
+        "which",
+        lambda name: f"C:\\bin\\{name}.exe" if name in ("psmux", "pwsh", "tmux") else None,
+    )
+
+    for release, expected in (("3.3.7", True), ("3.3.6", False)):
+        rec = _RecordRun(stdout=f"tmux {release}\npsmux {release} (05cc5d4 2026-07-20)\n")
+        monkeypatch.setattr(tmux_base.subprocess, "run", rec)
+        mux = PsmuxMultiplexer()
+        assert mux.available() is expected
+        # The fold reached the gate whole — both segments, one line.
+        assert mux.version() == f"tmux {release}; psmux {release} (05cc5d4 2026-07-20)"
+
+
 def test_available_caches_version_gate_per_instance(monkeypatch):
     monkeypatch.setattr(
         psmux_backend.shutil,


### PR DESCRIPTION
## Summary

`TerminalMultiplexer.version()` could return something no consumer could render inline, and two of its four consumers rendered it as if it could. On native Windows `psmux -V` prints two lines — a `tmux X.Y.Z` compatibility line plus its own — so `bmad-loop mux` split every data row and stranded SELECTED on a line of its own, and `validate`'s preflight put a raw newline into a finding message and into its `--json` `version` detail.

**One bounded line becomes the seam's stated contract,** honored once in the tmux-family base. The probe's lines are folded with `"; "` rather than truncated — the tail is what names psmux as the answering binary — an all-blank probe reports the documented `None` rather than `""`, and the fold is capped at 80 characters. Order is load-bearing: the psmux version gate parses the compat segment with an anchored match, so the first segment stays first and the cap only ever cuts the tail.

**Length is half the promise, not a separate concern.** `cmd_mux` sizes every column off its widest cell, so one 300-character version pads the VERSION column to 306 and the row past 350 — the same unreadable table the newline produced, from the other direction. That is why the bound lives in `fold_version` beside the single-line promise rather than at any one call site: every inline consumer already routes through the fold, so the `mux` table, `validate`'s finding and both its `--json` detail shapes, the forced-backend warning, the unusable-backend refusal, and `diagnose`'s `tmux_version` all inherit it at once.

Since an out-of-tree backend can only be *asked* to keep the contract, the canonical fold is also applied defensively at each of those consumers.

**`diagnose`'s line cap is gone, deliberately.** It counted lines and never length, and its `"… (N more lines redacted)"` marker was itself a new line — re-introducing exactly what the cap existed to remove. The fold now owns both guarantees, and the scrub runs *before* it so home/email redaction reads the whole probe rather than a tail the fold already cut. (This also fixes the markdown dump, where the marker put a newline inside a key/value row.)

**The `mux` listing now explains the row operators misread:** a backend can be AVAILABLE because its binary answers here while the platform check still excludes it from automatic selection. A forced backend is exempt — it *is* selected, and the note would contradict the `*` marker one line above.

## Behavior changes worth naming

- On a psmux host the folded value **replaces** the previously truncated `env.tmux_version` in `diagnose --json`, and the `version` details of `validate --json`'s `mux.backend` and `mux.backends-detected` findings. Field shapes are unchanged (`str | None`).
- A backend whose `version()` returns a non-`str`, non-`None` value now raises inside the fold. At the four guarded sites that degrades to "no version" as before; at `platform_preflight` the outer handler turns it into a `mux.preflight` problem where it used to render as `b'tmux 3.4'`. That backend already violates the annotated seam type, and failing loud at the boundary is the house rule — flagging it as a decision, not an oversight.

## Testing

- Seam: fold, byte-identical single-line pass-through, blank-segment stripping, all-blank → `None`, the length bound, and a real probe left untruncated (`tests/test_multiplexer.py`)
- The helper directly — the `None`-over-`""` sentinel, the whitespace-only input, idempotence under the seam-plus-consumer double fold, the bound. None of these are visible through any consumer's rendering: `r.version or "-"` collapses both falsy values, and the tmux-family probe strips its capture (`tests/test_backend_registry.py`)
- The psmux version gate parses its anchored match out of the real two-line probe, pass and fail sides (`tests/test_psmux_backend.py`)
- Renderer defense with a duck-typed stub backend: multi-line and over-long rows, the note's presence/absence including the forced exemption and registration order, the preflight fold and bound in both the message and the `--json` detail, and the `make_adapters` refusal — the one site rendering a bare `{version}` (`tests/test_cli.py`)
- `collect_env().tmux_version` stays a single bounded scalar under a two-line and a chatty probe, and a home path past the bound is still redacted (`tests/test_diagnostics.py`)
- **15 ablations**, one per gate — the seam fold, the length bound, the `or None` tail, the `None` guard, all five defensive folds, the scrub ordering, the note, and each of the note predicate's three conjuncts plus its ordering. All red.
- `uv run pytest`: 4419 passed, 24 skipped; `uv run pyright` and `trunk check` clean.

Closes #321


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multiplexer versions now appear as concise, single-line values with consistent length limits.
  * `mux` listings clarify backend availability and identify backends that require forced selection.
  * Diagnostics and validation consistently display readable, normalized version information.

* **Bug Fixes**
  * Blank or failed version probes no longer produce misleading output.
  * Improved detection of compatible backend versions from multiline responses.

* **Documentation**
  * Clarified backend availability, platform selection, forced selection, and version formatting.

* **Tests**
  * Added coverage for multiline, blank, oversized, unsupported, and platform-limited backend scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->