### PR TITLE
chore(ci): run CI and auto-publish on release/* maintenance branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, release/*]
   pull_request:
 
 # Cancel superseded runs for the same ref.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,13 @@
 name: Release
 
-# Auto-publish on merge: when a version bump lands on `main`, create the matching
-# `vX.Y.Z` tag and GitHub release with notes from CHANGELOG.md. Idempotent —
-# `release.py publish` is a no-op when the tag already exists, so merges that
-# don't bump the version do nothing.
+# Auto-publish on merge: when a version bump lands on `main` or a `release/*`
+# maintenance branch, create the matching `vX.Y.Z` tag and GitHub release with
+# notes from CHANGELOG.md. Idempotent — `release.py publish` is a no-op when the
+# tag already exists, so merges that don't bump the version do nothing, and
+# whichever branch carries a given version first wins the tag.
 on:
   push:
-    branches: [main]
+    branches: [main, release/*]
 
 concurrency:
   group: release-${{ github.ref }}


### PR DESCRIPTION
## Problem

Both workflows on this branch fire only on `push: branches: [main]`:

- `.github/workflows/ci.yml`
- `.github/workflows/release.yml`

So the 0.9.1 hotfix merge (#406, merge commit `33a754f`) landed on
`release/0.9.x` with **zero checks**, and `release.py publish` — the thing that
creates the `v0.9.1` tag + GitHub release from the `## [0.9.1]` CHANGELOG
section — has no trigger at all outside trunk. Left alone, v0.9.1 never
publishes and the only alternative is a hand-created tag.

## Change

Add `release/*` to the push branch filter in both workflows, and correct
`release.yml`'s header comment, which claimed the trigger was a version bump
landing on `main`.

Nothing else moves — `setup-uv` stays at `v8.3.2`, which is what `ci.yml`
already pins on this branch.

## Effect

Merging this pushes to `release/0.9.x`, which fires:

- **CI** on the merge commit — the first checks this branch has ever run.
- **Release** → `release.py publish`, which reads the canonical version
  (`0.9.1`), sees no `v0.9.1` tag, and creates the tag + GitHub release
  targeting the branch head with the curated CHANGELOG notes.

`publish` is idempotent (no-op when the tag exists), so whichever branch
carries a given version first wins the tag and the other side's run does
nothing. That preserves the property the 0.9.1 hotfix plan depends on: main
can never re-tag 0.9.1 once this branch has published it.

The tag will point at this PR's merge commit rather than `33a754f`. The two
trees are identical across `src/`, `CHANGELOG.md`, `pyproject.toml`, and
`uv.lock` — only workflow files differ — so the released content is exactly
what #406 reviewed. Verified after merge.

Refs #405.