### PR TITLE
fix(adapters): seam-owned psmux option-key namespace, kill-order containment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ Two orthogonal seams: **which CLI** (adapter axis: `adapters/base.py` `CodingCLI
 - Flat `tests/` mirrors src modules by name; `asyncio_mode=auto`; no custom markers.
 - Use the conftest sandbox fixtures (`project` copies a session-scoped template repo per test — never hand-roll temp repos or touch the template). Mock adapter drives engine tests without tmux or an LLM; caveat: it exercises the generic adapter path only.
 - Pin the backend with the `force_tmux_backend` fixture when asserting tmux argv through the mux seam.
-- E2E gates: `tests/test_stories_e2e.py` (real tmux on Linux + a scripted fake-claude profile, zero LLM tokens) and `tests/test_opencode_live.py` (zero-token invariant — never sends a prompt). Never "fix" these to call real CLIs.
+- E2E gates: `tests/test_stories_e2e.py` (real tmux on Linux + a scripted fake-claude profile, zero LLM tokens), `tests/test_opencode_live.py` (zero-token invariant — never sends a prompt), and `tests/test_psmux_live.py` (real psmux on Windows, parked windows only, zero tokens). Never "fix" these to call real CLIs.
 - Ablation rule: for any test asserting "X is refused/absent", delete the gating code and confirm the test FAILS before trusting it — negative assertions pass for every reason a value could be absent.
 - New behavior lands with a test at the lowest layer that can catch its regression: pure-core unit > seam > sandbox E2E.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -600,6 +600,18 @@ whose seams had diverged enough that several ports needed a different fix, and t
   rather than a vacuous `True` when that is unobservable. Out-of-tree backends still returning
   `None` read as "nothing detached" — degraded, not broken.
 
+- **Harden the psmux option channel's safety core (#313).** The cleanup sweeps matched any
+  `<name>_@<digits>` key, so a hand-written `@theme_@3` died with window `@3`; keys now carry a
+  seam-owned marker (`@bmad_project__blw@3`) only a deliberate imitation collides with.
+  `kill_window` kills first and frees the keys only once a liveness listing proves the kill landed,
+  so a failed kill no longer strips a live window's project tag and return key; a free that fails
+  now warns instead of leaking silently. The launcher's ctl-window consumers resolve the window id
+  once and replay it, so duplicate-named ctl windows cannot take another's option write or kill
+  (`launch.ctl_window`/`select_ctl_window` fold into `ctl_window_id`/`select_ctl_window_id`), and a
+  Windows-local zero-token gate proves cross-project prune isolation on a real psmux server. Dev
+  builds only: pre-marker keys read as foreign and are never swept — restart the ctl psmux server
+  after upgrading.
+
 - **Gate the psmux session project tag on transportability (#320).** The session tag rode psmux's
   CLI→server control line ungated, which stores some project paths corrupted at rc 0 — and a
   corrupted tag never equals the caller's again, so the prune skipped that session forever.
@@ -613,7 +625,7 @@ whose seams had diverged enough that several ports needed a different fix, and t
   server and answers `''` to any `-w` read of an `@`-prefixed name, so the ctl-window project tag
   bled across rows — letting a prune in one project `kill-window` another's — and the parked-return
   option always read empty. Both now use a session-scoped key carrying the window id
-  (`@bmad_project_@3`), routed with `-t <session>` and freed on `kill_window`; the `switch-client`
+  (`@bmad_project__blw@3`), routed with `-t <session>` and freed on `kill_window`; the `switch-client`
   leg stays inert on builds predating psmux/psmux#483 — still inert at 3.3.7.
 
 - **Session-qualify the psmux TUI-side window ids (#291).** #254 covered the engine seam but left

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -606,11 +606,12 @@ whose seams had diverged enough that several ports needed a different fix, and t
   `kill_window` kills first and frees the keys only once a liveness listing proves the kill landed,
   so a failed kill no longer strips a live window's project tag and return key; a free that fails
   now warns instead of leaking silently. The launcher's ctl-window consumers resolve the window id
-  once and replay it, so duplicate-named ctl windows cannot take another's option write or kill
-  (`launch.ctl_window`/`select_ctl_window` fold into `ctl_window_id`/`select_ctl_window_id`), and a
-  Windows-local zero-token gate proves cross-project prune isolation on a real psmux server. Dev
-  builds only: pre-marker keys read as foreign and are never swept — restart the ctl psmux server
-  after upgrading.
+  once and replay it (`launch.ctl_window`/`select_ctl_window` fold into
+  `ctl_window_id`/`select_ctl_window_id`), so a rename or a window minted between two verbs can no
+  longer re-point the second, and a Windows-local zero-token gate proves cross-project prune
+  isolation on a real psmux server. Dev builds only: a window parked by a pre-marker build keeps
+  reading its old-format keys, so it reads as untagged (the prune falls back to the run dir) and its
+  return move stops firing — restart the ctl psmux server after upgrading.
 
 - **Gate the psmux session project tag on transportability (#320).** The session tag rode psmux's
   CLI→server control line ungated, which stores some project paths corrupted at rc 0 — and a

--- a/docs/multiplexer-backends.md
+++ b/docs/multiplexer-backends.md
@@ -63,20 +63,23 @@ Two model differences matter if you port a backend or read psmux argv. psmux run
 per session, so window ids are minted per server and the backend session-qualifies every id it
 hands out (`session:@N`). And psmux has no per-window user options — one scope exists per
 server — so the window-option verbs and the `@`-prefixed columns of `list_windows` are served
-by a session-scoped option whose key carries the window id (`@bmad_project_@3` for window `@3`).
-Both are properties of psmux's model, not gaps awaiting an upstream release. Practical
-consequence: such a value is **not** readable via `psmux show-options -w` by hand — read it with
-`psmux show-options -qv -t <session> "@bmad_project_@N"` instead. Session-scoped options need no
-such substitute — one server per session means that server's single map _is_ the session's — but
-they cross the same control line, so the session project tag is gated the same way. One visible
-limit: a value that cannot survive psmux's control-line transport verbatim is refused with a
-stderr warning at every launch, and that project's windows and agent sessions stay untagged —
-the prune then scopes them through the run-dir fallback instead of the tag. Which paths those
-are is counter-intuitive, because the psmux client quotes a value only when it contains an ASCII
-space and `'` is literal inside those quotes: `C:\Users\O'Brien\dev` is **refused** while
-`C:\Users\O'Brien Files\dev` is accepted, and a spaced UNC path (`\\server\share\My Proj`) is
-refused while the spaceless `\\server\share\proj` is accepted. The fallback that catches those
-refusals has a lifecycle ceiling
+by a session-scoped option whose key carries a seam-owned marker plus the window id
+(`@bmad_project__blw@3` for window `@3`; no real-world naming convention collides with the
+marker, so the channel's cleanup sweeps stay off hand-written user options unless one
+deliberately imitates the seam). Both are properties of psmux's model, not gaps awaiting an
+upstream release. Practical consequence: such a value is **not** readable via
+`psmux show-options -w` by hand — read it with
+`psmux show-options -qv -t <session> "@bmad_project__blw@N"` instead. Session-scoped options need
+no such substitute — one server per session means that server's single map _is_ the session's —
+but they cross the same control line, so the session project tag is gated the same way. One
+visible limit: a value that cannot survive psmux's control-line transport verbatim is refused
+with a stderr warning at every launch, and that project's windows and agent sessions stay
+untagged — the prune then scopes them through the run-dir fallback instead of the tag. Which
+paths those are is counter-intuitive, because the psmux client quotes a value only when it
+contains an ASCII space and `'` is literal inside those quotes: `C:\Users\O'Brien\dev` is
+**refused** while `C:\Users\O'Brien Files\dev` is accepted, and a spaced UNC path
+(`\\server\share\My Proj`) is refused while the spaceless `\\server\share\proj` is accepted. The
+fallback that catches those refusals has a lifecycle ceiling
 ([#419](https://github.com/bmad-code-org/bmad-loop/issues/419)): an untagged session whose run
 directory is later removed by `clean` or `archive` can no longer be pruned by any project.
 

--- a/src/bmad_loop/adapters/psmux_backend.py
+++ b/src/bmad_loop/adapters/psmux_backend.py
@@ -407,7 +407,18 @@ class PsmuxMultiplexer(BaseTmuxBackend):
     # The seam-owned key marker ("bmad-loop window"): every key this channel
     # mints ends in `<marker><digits>`, and both cleanup sweeps match keys by
     # it — keep the mint (_scoped_option_key, _parked_trailer) and the matchers
-    # (_KEY_SUFFIX, kill_window) derived from this one literal.
+    # (_KEY_SUFFIX, kill_window) derived from this one literal (within this
+    # class: _KEY_SUFFIX binds at class-body time and _scoped_option_key is
+    # static, so a subclass rebinding the marker would split mint from match).
+    #
+    # No transition rule for the pre-marker `_@<digits>` keys, deliberately
+    # (#313 floated one): a sweep matching the old shape would delete the very
+    # `@theme_@3` the marker exists to protect. They just read as foreign. The
+    # channel is unreleased, so only a dev build holds any, and the cost falls
+    # on windows parked BEFORE the upgrade: their trailer is baked in at mint
+    # (tmux_base.new_parked_window) and still reads the old key, so their tag
+    # reads unset (the prune falls back to the run dir) and their return move
+    # stops firing. Restarting the ctl server clears the map.
     _SCOPE_MARKER = "__blw@"
 
     @staticmethod
@@ -661,7 +672,16 @@ class PsmuxMultiplexer(BaseTmuxBackend):
             if not live:
                 # A session being swept just minted a window, so an empty live
                 # list is a failed probe, not an empty session — treating it as
-                # truth would sweep every key, live windows included.
+                # truth would sweep every key, live windows included. Warned for
+                # the same reason the listing failure above is, and this is the
+                # branch that actually fires: list_window_ids RAISES on a
+                # transport fault (caught below) and answers [] only on rc != 0,
+                # so silence here is a server failing every launch with no signal.
+                print(
+                    f"warning: orphan-key sweep on {session} could not list live "
+                    "windows; orphaned keys unswept until the next launch",
+                    file=sys.stderr,
+                )
                 return
             for name in options:
                 match = self._KEY_SUFFIX.search(name)

--- a/src/bmad_loop/adapters/psmux_backend.py
+++ b/src/bmad_loop/adapters/psmux_backend.py
@@ -144,7 +144,8 @@ class PsmuxMultiplexer(BaseTmuxBackend):
             # A failed probe skips the return AND the key free; the orphan
             # sweep at a later parked-window launch reclaims the key once the
             # window is gone.
-            f"if ($wid) {{ $key = {_pwsh_quote(return_opt + '_')} + $wid; "
+            # $wid arrives as `@N` — it supplies _SCOPE_MARKER's trailing `@`.
+            f"if ($wid) {{ $key = {_pwsh_quote(return_opt + self._SCOPE_MARKER[:-1])} + $wid; "
             f"$ret = {read_key}; "
             f"if ($ret -eq '{PARKED_RETURN_DETACH}') {{ {mux} detach-client 2>$null }} "
             # The switch leg is still inert at 3.3.7 (psmux/psmux#483: the
@@ -311,8 +312,7 @@ class PsmuxMultiplexer(BaseTmuxBackend):
             # captures stderr for the app's whole run (tui/app.py's run_tui
             # note) — the select_window precedent below, same deliberate ceiling.
             print(
-                f"warning: show-options listing failed on {session}; "
-                "option columns read as unset",
+                f"warning: show-options listing failed on {session}; option columns read as unset",
                 file=sys.stderr,
             )
         out: list[tuple[str, ...]] = []
@@ -345,21 +345,22 @@ class PsmuxMultiplexer(BaseTmuxBackend):
     # psmux/psmux#321 — a boundary to route around, not a bug to wait out.
     #
     # Substitute: a SESSION-scoped option whose key carries the window id
-    # (`@bmad_project_@3` for `@3`). Two rules keep it correct —
+    # (`@bmad_project__blw@3` for `@3`). Two rules keep it correct —
     #   - `-t <session>` on every out-of-pane write and read (the parked
     #     trailer runs in-pane and rides `$TMUX` instead — see
     #     `_parked_trailer`). psmux picks the server from the target, and
     #     without an explicit session it falls back to $TMUX / most-recent —
     #     i.e. some other server. The session comes from the qualified ids
     #     this backend already mints, which is why #310 lands after #291.
-    #   - the key ends with the full id (`_@3`, never bare digits): the ctl
-    #     server loads the user's psmux config, so the map is shared, and the
-    #     `_@` shape is what keeps foreign config options out of the generic
-    #     cleanup sweeps. Not airtight — psmux accepts any `@` name, so a
-    #     hand-written `@theme_@3` WOULD match — but no naming convention in
-    #     the tmux/psmux ecosystem puts `@` mid-name, and a bmad-owned prefix
-    #     guard would hardcode caller names into the backend. The session
-    #     stays out of the key; routing already carries it.
+    #   - the key carries the seam-owned `__blw@` marker plus the full id
+    #     (`__blw@3`, never bare digits): the ctl server loads the user's
+    #     psmux config, so the map is shared, and the generic cleanup sweeps
+    #     delete every key matching their suffix. No real-world naming
+    #     convention collides with the marker — a user option only matches by
+    #     deliberately imitating the seam (`@theme__blw@3` would; the old
+    #     hazard shapes `@theme_@3` / `@color_3` cannot) — and it keeps caller
+    #     names out of the backend (a bmad-owned prefix guard would hardcode
+    #     them). The session stays out of the key; routing already carries it.
     #
     # Builtin window options keep the base's `-w` argv — psmux accepts those
     # allowlisted names (only `automatic-rename` has true per-window storage;
@@ -368,7 +369,8 @@ class PsmuxMultiplexer(BaseTmuxBackend):
 
     # A window target as the seam composes it: `session:@N`, `=session:@N`, or
     # `=session:<window-name>`. Deliberately looser than _QUALIFIED_ID, which
-    # only admits the id form — set_return_pane passes a name token.
+    # only admits the id form — the seam's option/kill verbs accept name
+    # tokens even though today's launch.py callers all pass ids.
     _SESSION_WINDOW = re.compile(r"^(?P<session>[^:]+):(?P<window>.+)$")
 
     @staticmethod
@@ -402,14 +404,21 @@ class PsmuxMultiplexer(BaseTmuxBackend):
                 return win_id
         return None
 
+    # The seam-owned key marker ("bmad-loop window"): every key this channel
+    # mints ends in `<marker><digits>`, and both cleanup sweeps match keys by
+    # it — keep the mint (_scoped_option_key, _parked_trailer) and the matchers
+    # (_KEY_SUFFIX, kill_window) derived from this one literal.
+    _SCOPE_MARKER = "__blw@"
+
     @staticmethod
     def _scoped_option_key(option: str, digits: str) -> str:
-        return f"{option}_@{digits}"
+        return f"{option}{PsmuxMultiplexer._SCOPE_MARKER}{digits}"
 
-    # The channel's key suffix. Anchored: `@bmad_project_@13` must not read as
-    # a key of window `@3`, and a foreign `@color_3` (no `_@` shape) never
-    # matches (see the namespace note in the channel comment above).
-    _KEY_SUFFIX = re.compile(r"_@(\d+)$")
+    # The channel's key suffix. Anchored: `@bmad_project__blw@13` must not read
+    # as a key of window `@3`, and a key without the marker — `@color_3`, a
+    # hand-written `@theme_@3` — never matches (see the namespace note in the
+    # channel comment above).
+    _KEY_SUFFIX = re.compile(re.escape(_SCOPE_MARKER) + r"(\d+)$")
 
     def _read_scoped(self, session: str, option: str, digits: str) -> str | None:
         # No `-w`: the session-scoped read is the one that reaches the map.
@@ -617,11 +626,23 @@ class PsmuxMultiplexer(BaseTmuxBackend):
             options[name] = rest
         return options
 
+    def _free_scoped_key(self, session: str, name: str) -> None:
+        # The one unset path both sweeps share. rc-0 is not proof the key is
+        # gone on psmux's write side, but a nonzero rc IS proof it is not —
+        # silence here would leak a key for the server's life with no signal.
+        proc = self._run(["set-option", "-u", "-t", session, name], check=False)
+        if proc.returncode != 0:
+            print(
+                f"warning: could not free option {name} on {session}: {proc.stderr.strip()}",
+                file=sys.stderr,
+            )
+
     def _sweep_orphan_keys(self, session: str) -> None:
-        # Free `_@N` keys whose window no longer exists (Enter-dismissed parked
-        # windows never pass through kill_window). The `_@` shape keeps foreign
-        # config options out of the sweep; window ids are never recycled within
-        # a server, so a swept key cannot belong to a future window.
+        # Free seam-minted (`__blw@N`) keys whose window no longer exists
+        # (Enter-dismissed parked windows never pass through kill_window). The
+        # marker keeps every foreign config option out of the sweep; window ids
+        # are never recycled within a server, so a swept key cannot belong to a
+        # future window.
         #
         # Order matters: keys are snapshotted BEFORE the live-window listing, so
         # a window minted-and-tagged between the two calls has its key outside
@@ -629,6 +650,13 @@ class PsmuxMultiplexer(BaseTmuxBackend):
         try:
             options = self._scoped_options(session)
             if options is None:
+                # Transport failure, not "no keys": a sweep that silently fails
+                # every launch leaks keys with no signal anywhere.
+                print(
+                    f"warning: orphan-key sweep on {session} could not list "
+                    "options; orphaned keys unswept until the next launch",
+                    file=sys.stderr,
+                )
                 return
             live = set(super().list_window_ids(session))  # base = bare ids
             if not live:
@@ -639,7 +667,7 @@ class PsmuxMultiplexer(BaseTmuxBackend):
             for name in options:
                 match = self._KEY_SUFFIX.search(name)
                 if match and f"@{match.group(1)}" not in live:
-                    self._run(["set-option", "-u", "-t", session, name], check=False)
+                    self._free_scoped_key(session, name)
         except (subprocess.SubprocessError, OSError, TmuxError) as exc:
             # Reconcile is opportunistic; the mint must never fail on it. But a
             # sweep that fails every launch leaks keys for the server's whole
@@ -647,28 +675,49 @@ class PsmuxMultiplexer(BaseTmuxBackend):
             print(f"warning: orphan-key sweep failed on {session}: {exc}", file=sys.stderr)
 
     def kill_window(self, target: str) -> None:
-        # Free the window's id-keyed session options before the kill: the ctl
+        # Kill first, clean only once the window is verifiably gone: the ctl
         # session outlives every run, so a leaked key lives as long as the
-        # server. Discovery is generic by the `_@<digits>` suffix — the backend
-        # must not know which option names callers use. Best-effort throughout:
-        # cleanup failure never blocks the kill. Known ceiling, accepted: the
-        # kill itself is best-effort, so a kill that then fails leaves a live
-        # window without its keys — the prune's untagged run-dir fallback still
-        # scopes the retry, and a lost return key just parks the window as-is.
-        # Cost, accepted: one listing round-trip per kill, two for a name target
-        # (name-resolve, then keys; agent-window kills pay it too, for
-        # nothing); skip-by-session-name if that ever measures.
+        # server — but a kill that FAILS must leave the live window its keys
+        # (the project tag scopes the prune retry; the return key keeps the
+        # detach return armed — the switch leg is inert at 3.3.7 either way,
+        # see _parked_trailer). Scope resolves before the kill because a name
+        # token cannot be resolved once the window is dead. An empty liveness
+        # listing is ambiguous — a failed probe, or a session that died with
+        # its last window — so it degrades toward retaining the keys; the
+        # launch-time orphan sweep reclaims them once the window is provably
+        # gone. Discovery is generic by the seam's marker — the backend must
+        # not know which option names callers use. Best-effort throughout:
+        # cleanup failure warns (the sweep precedent) but never blocks or
+        # fails the kill.
+        # Cost, accepted: two listing round-trips per kill, three for a name
+        # target (name-resolve, liveness, then keys; agent-window kills pay it
+        # too, for nothing — and prune_ctl_windows fans it out once per stale
+        # window); skip-by-session-name if that ever measures.
         scope = self._option_scope(target)
-        if scope is not None:
-            session, digits = scope
-            suffix = f"_@{digits}"
-            try:
-                for name in self._scoped_options(session) or ():
-                    if name.endswith(suffix):
-                        self._run(["set-option", "-u", "-t", session, name], check=False)
-            except (subprocess.SubprocessError, OSError):
-                pass
         super().kill_window(target)
+        if scope is None:
+            return
+        session, digits = scope
+        try:
+            live = super().list_window_ids(session)  # base = bare ids
+            if not live or f"@{digits}" in live:
+                return
+            options = self._scoped_options(session)
+            if options is None:
+                # Transport failure, not "no keys" — the keys of a verified-
+                # dead window are now stranded until the orphan sweep.
+                print(
+                    f"warning: kill-window key cleanup on {session} could not "
+                    "list options; stranded keys await the orphan sweep",
+                    file=sys.stderr,
+                )
+                return
+            suffix = f"{self._SCOPE_MARKER}{digits}"
+            for name in options:
+                if name.endswith(suffix):
+                    self._free_scoped_key(session, name)
+        except (subprocess.SubprocessError, OSError, TmuxError) as exc:
+            print(f"warning: kill-window key cleanup failed on {session}: {exc}", file=sys.stderr)
 
     # What _qualified_window_id composes: `<session>:@<n>`. The session part
     # excludes `:` because that is exactly when qualification degrades to a bare
@@ -714,15 +763,14 @@ class PsmuxMultiplexer(BaseTmuxBackend):
                 # attach shows whichever window happens to be current. Guessing
                 # an index instead could focus an unrelated window, so warn and
                 # send: the pipe-pane sidecar precedent, but a weaker one, and
-                # deliberately not load-bearing. Today's only caller of the
-                # qualified-id path (select_ctl_window_id, from the TUI's resolve
-                # launch) runs inside the Textual app, which captures stderr for
-                # the app's whole run — see the run_tui note in tui/app.py, which
-                # pre-trips the forced-backend warning for exactly this reason —
-                # so this emission is invisible there. It is kept for the CLI-side
-                # callers tui/launch.py is textual-free to allow; a TUI-visible
-                # miss would need a return value, which is more seam than a
-                # best-effort focus change is worth.
+                # deliberately not load-bearing. The qualified-id path's callers
+                # (select_ctl_window_id) split by surface: under the Textual app
+                # this emission is invisible — the app captures stderr for its
+                # whole run, see the run_tui note in tui/app.py, which pre-trips
+                # the forced-backend warning for exactly this reason — while the
+                # textual-free CLI attach path (launch.attach_plan via cli.py)
+                # does show it. A TUI-visible miss would need a return value,
+                # which is more seam than a best-effort focus change is worth.
                 print(
                     f"warning: select-window could not resolve {target} to a "
                     "window index; the window will not be focused",

--- a/src/bmad_loop/adapters/psmux_backend.py
+++ b/src/bmad_loop/adapters/psmux_backend.py
@@ -627,15 +627,14 @@ class PsmuxMultiplexer(BaseTmuxBackend):
         return options
 
     def _free_scoped_key(self, session: str, name: str) -> None:
-        # The one unset path both sweeps share. rc-0 is not proof the key is
+        # The one unset path both sweeps share, routed through the same warn-
+        # never-raise body as every other write. rc-0 is not proof the key is
         # gone on psmux's write side, but a nonzero rc IS proof it is not —
         # silence here would leak a key for the server's life with no signal.
-        proc = self._run(["set-option", "-u", "-t", session, name], check=False)
-        if proc.returncode != 0:
-            print(
-                f"warning: could not free option {name} on {session}: {proc.stderr.strip()}",
-                file=sys.stderr,
-            )
+        # Delegating also contains a dead round-trip to its own key: the outer
+        # guard in either sweep would otherwise catch it and abandon the keys
+        # after it in the batch.
+        self._write_scoped(["set-option", "-u", "-t", session, name], f"{name} on {session}")
 
     def _sweep_orphan_keys(self, session: str) -> None:
         # Free seam-minted (`__blw@N`) keys whose window no longer exists

--- a/src/bmad_loop/tui/app.py
+++ b/src/bmad_loop/tui/app.py
@@ -415,19 +415,16 @@ class BmadLoopApp(App[None]):
             self.notify("no run selected", severity="warning")
             return
         session = runs.session_name(run_id)
-        window = launch.ctl_window(run_id)
+        win_id = launch.ctl_window_id(run_id)
         ok, agent_live = self._mux_guarded(lambda: launch.session_exists(session))
         if not ok:
             return
         # A sweep blocked on a decision prompt has no agent session — the
         # human answers in the orchestrator's ctl window. Otherwise prefer the
         # live agent session, falling back to the ctl window between sessions.
-        if window is not None and (self._dashboard.decision_pending is not None or not agent_live):
-            launch.select_ctl_window(window)
-            self._attach_to_target(
-                launch.ctl_target(),
-                return_window=launch.ctl_target(window),
-            )
+        if win_id is not None and (self._dashboard.decision_pending is not None or not agent_live):
+            launch.select_ctl_window_id(win_id)
+            self._attach_to_target(launch.ctl_target(), return_window=win_id)
             return
         elif agent_live:
             target = runs.session_target(run_id)

--- a/src/bmad_loop/tui/launch.py
+++ b/src/bmad_loop/tui/launch.py
@@ -43,34 +43,36 @@ def session_exists(session: str) -> bool:
     return get_multiplexer().has_session(session)
 
 
-def ctl_window(run_id: str) -> str | None:
-    """Name of the control-session window hosting this run's orchestrator
-    process (start_detached names windows <kind>-<run_id>), or None when the
-    run was not launched from the TUI or the session is gone."""
+def ctl_window_id(run_id: str) -> str | None:
+    """Stable window id (bare `@N` on tmux, session-qualified on psmux) of the
+    control-session window hosting this run's orchestrator process
+    (start_detached names windows <kind>-<run_id>), or None when the run was
+    not launched from the TUI or the session is gone. An id, not a name:
+    window names collide when several kinds share a run_id, and every consumer
+    replays the value as a select/kill/option target, where re-resolving a
+    name first-match can land each verb on a different duplicate."""
     if not mux_available():
         return None
-    for (name,) in get_multiplexer().list_windows(CTL_SESSION, ["window_name"]):
-        if name.endswith(f"-{run_id}"):
-            return name
+    for win_id, name in get_multiplexer().list_windows(CTL_SESSION, ["window_id", "window_name"]):
+        # win_id can be "": the base pads short rows, and psmux's qualifier
+        # passes falsy ids through. An empty id must never become a target —
+        # an empty `-t` resolves against the *current* window.
+        if win_id and name.endswith(f"-{run_id}"):
+            return win_id
     return None
 
 
-def ctl_target(window: str | None = None) -> str:
-    """Seam-canonical target token for the control session (optionally one of
-    its windows, by name); see :meth:`TerminalMultiplexer.target`."""
-    return get_multiplexer().target(CTL_SESSION, window)
-
-
-def select_ctl_window(window: str) -> None:
-    """Make `window` the control session's current window, so a plain attach
-    to the session lands on it (attach-session itself takes no window)."""
-    get_multiplexer().select_window(ctl_target(window))
+def ctl_target() -> str:
+    """Seam-canonical target token for the control session; see
+    :meth:`TerminalMultiplexer.target`. Windows are targeted by stable id
+    (ctl_window_id), never by name through this token."""
+    return get_multiplexer().target(CTL_SESSION)
 
 
 def select_ctl_window_id(window_id: str) -> None:
-    """Like select_ctl_window but by the backend's stable window id (bare `@N` on
-    tmux, session-qualified on psmux), as returned by start_detached. Immune to
-    the by-name first-match ambiguity in ctl_window and to tmux auto-rename."""
+    """Make the window with this id (from start_detached/ctl_window_id) the
+    control session's current window, so a plain attach to the session lands
+    on it (attach-session itself takes no window)."""
     get_multiplexer().select_window(window_id)
 
 
@@ -103,8 +105,9 @@ def set_return_pane(window_target: str, target: str) -> None:
     """Record `target` (a current_return_target value or RETURN_DETACH) as the
     return move on a control-session window, so its trailing shell sends the
     client back there when the window's command exits. `window_target` is any
-    window spec the backend accepts (e.g. `=bmad-loop-ctl:run-…`, or a stable id
-    from start_detached — bare `@N` on tmux, session-qualified on psmux)."""
+    window spec the backend accepts; callers pass the id from
+    start_detached/ctl_window_id so the write cannot land on a
+    duplicate-named window."""
     get_multiplexer().set_window_option(window_target, RETURN_OPTION, target)
 
 
@@ -221,13 +224,13 @@ def attach_plan(project: Path, run_id: str) -> tuple[list[str], str | None] | No
     live agent session. Returns (tmux argv, return_window) or None when there is
     nothing to attach to."""
     session = runs.session_name(run_id)
-    window = ctl_window(run_id)
+    win_id = ctl_window_id(run_id)
     agent_live = session_exists(session)
-    if window is not None and (
+    if win_id is not None and (
         decision_pending(runs.run_dir_for(project, run_id)) or not agent_live
     ):
-        select_ctl_window(window)
-        return runs.attach_target_argv(ctl_target()), ctl_target(window)
+        select_ctl_window_id(win_id)
+        return runs.attach_target_argv(ctl_target()), win_id
     if agent_live:
         return runs.attach_target_argv(runs.session_target(run_id)), None
     return None
@@ -236,9 +239,9 @@ def attach_plan(project: Path, run_id: str) -> tuple[list[str], str | None] | No
 def kill_ctl_window(run_id: str) -> None:
     """Kill the control-session window hosting this run's orchestrator process,
     if any. A no-op when the run was not launched from the TUI or tmux is gone."""
-    window = ctl_window(run_id)
-    if window is not None:
-        get_multiplexer().kill_window(ctl_target(window))
+    win_id = ctl_window_id(run_id)
+    if win_id is not None:
+        get_multiplexer().kill_window(win_id)
 
 
 def _ctl_window_candidates(project: Path) -> list[tuple[str, str]]:

--- a/src/bmad_loop/tui/launch.py
+++ b/src/bmad_loop/tui/launch.py
@@ -47,16 +47,22 @@ def ctl_window_id(run_id: str) -> str | None:
     """Stable window id (bare `@N` on tmux, session-qualified on psmux) of the
     control-session window hosting this run's orchestrator process
     (start_detached names windows <kind>-<run_id>), or None when the run was
-    not launched from the TUI or the session is gone. An id, not a name:
-    window names collide when several kinds share a run_id, and every consumer
-    replays the value as a select/kill/option target, where re-resolving a
-    name first-match can land each verb on a different duplicate."""
+    not launched from the TUI or the session is gone.
+
+    An id, not a name, because every consumer replays the value as a
+    select/kill/option target: one resolve feeds all of them, so a rename or a
+    window minted between two verbs cannot send them to different windows, and
+    the value survives tmux's automatic-rename. It does NOT disambiguate the
+    run_id — `<kind>-<run_id>` is not unique (a resume launched over a still-
+    parked run window shares it), and this scan takes the first match, the
+    same window a by-name lookup returned."""
     if not mux_available():
         return None
     for win_id, name in get_multiplexer().list_windows(CTL_SESSION, ["window_id", "window_name"]):
-        # win_id can be "": the base pads short rows, and psmux's qualifier
-        # passes falsy ids through. An empty id must never become a target —
-        # an empty `-t` resolves against the *current* window.
+        # win_id can be "": psmux's qualifier passes a falsy id through. An
+        # empty id must never become a target — an empty `-t` resolves against
+        # the *current* window. (The base's short-row padding cannot produce it
+        # here: it fills TRAILING fields, and window_id is field 0 of 2.)
         if win_id and name.endswith(f"-{run_id}"):
             return win_id
     return None
@@ -106,8 +112,8 @@ def set_return_pane(window_target: str, target: str) -> None:
     return move on a control-session window, so its trailing shell sends the
     client back there when the window's command exits. `window_target` is any
     window spec the backend accepts; callers pass the id from
-    start_detached/ctl_window_id so the write cannot land on a
-    duplicate-named window."""
+    start_detached/ctl_window_id so the write lands on the window the caller
+    already resolved, not on whatever a fresh by-name lookup answers."""
     get_multiplexer().set_window_option(window_target, RETURN_OPTION, target)
 
 

--- a/tests/test_psmux_backend.py
+++ b/tests/test_psmux_backend.py
@@ -1087,16 +1087,24 @@ def test_kill_window_unverifiable_liveness_retains_the_keys(monkeypatch):
 
 def test_failed_kill_leaves_ownership_readable_for_the_prune_retry(monkeypatch):
     # The retained key is not just unswept — it must still answer a read,
-    # because the prune retry re-identifies ownership through it.
+    # because the prune retry re-identifies ownership through it. The fake is
+    # STATEFUL on purpose: answering the read from a constant would pass even
+    # with the liveness guard deleted, since a listing that never offers the key
+    # leaves the cleanup nothing to free. `-qv` is the targeted read, bare `-q`
+    # the full listing the cleanup sweeps.
     key = "@bmad_project__blw@3"
+    store = {key: "tag-a"}
 
     def fake(argv, **kwargs):
+        out = ""
         if argv[1] == "list-windows":
             out = "@1\n@3\n"  # the kill did not land
-        elif argv[1] == "show-options" and argv[-1] == key:
-            out = "tag-a"
-        else:
-            out = ""
+        elif argv[1] == "set-option" and "-u" in argv:
+            store.pop(argv[-1], None)
+        elif argv[1] == "show-options" and "-qv" in argv:
+            out = store.get(argv[-1], "")
+        elif argv[1] == "show-options":
+            out = "".join(f'{k} "{v}"\n' for k, v in store.items())
         return subprocess.CompletedProcess(argv, 0, stdout=out, stderr="")
 
     monkeypatch.setattr(tmux_base.subprocess, "run", fake)
@@ -1106,8 +1114,10 @@ def test_failed_kill_leaves_ownership_readable_for_the_prune_retry(monkeypatch):
 
 
 def test_stranded_keys_after_cleanup_crash_are_reclaimed_by_the_sweep(monkeypatch):
-    # The matrix sequence end to end: a landed kill whose key-free step dies
-    # strands the keys, and the next launch-time sweep actually claims them.
+    # The two halves of the strand-then-reclaim contract: a landed kill whose
+    # key-free step dies strands the keys, and a later sweep claims them. The
+    # sweep is driven directly here; new_parked_window's wiring to it is pinned
+    # by test_new_parked_window_sweeps_orphan_keys.
     key = "@bmad_project__blw@3"
     state = {"healed": False}
     freed = []
@@ -1457,10 +1467,12 @@ def test_sweep_unlistable_options_warns(monkeypatch, capsys):
     assert "orphan-key sweep on ctl could not list options" in capsys.readouterr().err
 
 
-def test_sweep_treats_empty_live_list_as_failed_probe(monkeypatch, tmp_path):
+def test_sweep_treats_empty_live_list_as_failed_probe(monkeypatch, tmp_path, capsys):
     # We just minted a window in this session, so an empty live listing is a
     # failed probe, not an empty session — believing it would sweep every key,
-    # live windows included.
+    # live windows included. It is also said out loud: list_window_ids raises on
+    # a transport fault and answers [] only on rc != 0, so this branch is a
+    # server failing every launch, and silence would leak keys with no signal.
     listing = '@bmad_project__blw@2 "live"\n@bmad_project__blw@7 "gone"\n'
     calls = []
 
@@ -1474,6 +1486,7 @@ def test_sweep_treats_empty_live_list_as_failed_probe(monkeypatch, tmp_path):
     monkeypatch.setattr(tmux_base.subprocess, "run", fake)
     PsmuxMultiplexer().new_parked_window("ctl", "run-x", tmp_path, ["prog"], "@ret")
     assert not [c for c in calls if c[1] == "set-option"]
+    assert "orphan-key sweep on ctl could not list live windows" in capsys.readouterr().err
 
 
 def test_sweep_transport_exception_never_fails_the_mint(monkeypatch, tmp_path, capsys):

--- a/tests/test_psmux_backend.py
+++ b/tests/test_psmux_backend.py
@@ -407,7 +407,12 @@ def test_new_parked_window_composes_pwsh_source(rec, tmp_path):
         " '#{window_id}' 2>$null)\".Trim(); " in source
     )
     assert "if ($wid) { " in source
-    assert "$key = '%3_' + $wid; " in source
+    # Derived, not hardcoded: the trailer must compose the same key
+    # _scoped_option_key mints, and the splice only works because $wid (`@N`)
+    # supplies the marker's trailing `@` — pin both halves of that coupling.
+    marker = PsmuxMultiplexer._SCOPE_MARKER
+    assert marker.endswith("@")
+    assert f"$key = '%3{marker[:-1]}' + $wid; " in source
     assert '$ret = "$(psmux show-options -qv $key 2>$null)".Trim(); ' in source
     assert "if ($ret -eq 'detach') { psmux detach-client 2>$null }" in source
     assert "psmux switch-client -t $ret 2>$null" in source
@@ -638,7 +643,7 @@ def test_list_windows_qualifies_only_the_window_id_column(monkeypatch):
 
 
 def test_list_windows_without_id_column_is_untouched(monkeypatch):
-    # ctl_window() asks for names only; nothing there may be rewritten.
+    # A names-only listing must pass through unrewritten.
     _rows_fake(monkeypatch, "shell\nrun-x\n")
     assert PsmuxMultiplexer().list_windows("ctl", ["window_name"]) == [("shell",), ("run-x",)]
 
@@ -815,7 +820,7 @@ def test_set_window_option_writes_id_keyed_session_option(monkeypatch):
     # with the window id in the KEY, routed by an explicit `-t <session>`.
     rec_ = _option_fake(monkeypatch)
     PsmuxMultiplexer().set_window_option("ctl:@3", "@bmad_project", "C:/p")
-    assert rec_.argv[1:] == ["set-option", "-t", "ctl", "@bmad_project_@3", "C:/p"]
+    assert rec_.argv[1:] == ["set-option", "-t", "ctl", "@bmad_project__blw@3", "C:/p"]
     assert "-w" not in rec_.argv
 
 
@@ -825,7 +830,7 @@ def test_set_window_option_resolves_a_name_token(monkeypatch):
     rec_ = _option_fake(monkeypatch, rows="@1\tshell\n@4\trun-abc\n")
     PsmuxMultiplexer().set_window_option("=ctl:run-abc", "@bmad_return_pane", "=ctl:%7")
     assert rec_.calls[0][0][1] == "list-windows"
-    assert rec_.argv[1:] == ["set-option", "-t", "ctl", "@bmad_return_pane_@4", "=ctl:%7"]
+    assert rec_.argv[1:] == ["set-option", "-t", "ctl", "@bmad_return_pane__blw@4", "=ctl:%7"]
 
 
 def test_set_window_option_value_with_spaces_stays_one_argv_element(monkeypatch):
@@ -838,7 +843,7 @@ def test_set_window_option_value_with_spaces_stays_one_argv_element(monkeypatch)
 def test_show_window_option_reads_the_id_keyed_session_option(monkeypatch):
     rec_ = _option_fake(monkeypatch, value="C:/p\n")
     assert PsmuxMultiplexer().show_window_option("ctl:@3", "@bmad_project") == "C:/p"
-    assert rec_.argv[1:] == ["show-options", "-qv", "-t", "ctl", "@bmad_project_@3"]
+    assert rec_.argv[1:] == ["show-options", "-qv", "-t", "ctl", "@bmad_project__blw@3"]
 
 
 def test_show_window_option_miss_reads_empty(monkeypatch, capsys):
@@ -871,7 +876,7 @@ def test_unset_window_option_frees_the_key(monkeypatch):
     # "unset" rather than an empty value that still occupies the map.
     rec_ = _option_fake(monkeypatch)
     PsmuxMultiplexer().unset_window_option("ctl:@3", "@bmad_return_pane")
-    assert rec_.argv[1:] == ["set-option", "-u", "-t", "ctl", "@bmad_return_pane_@3"]
+    assert rec_.argv[1:] == ["set-option", "-u", "-t", "ctl", "@bmad_return_pane__blw@3"]
 
 
 @pytest.mark.parametrize("target", ["@3", "", "run-abc"])
@@ -930,7 +935,7 @@ def test_list_windows_fills_option_columns_per_window(monkeypatch):
     # for it hands every row the same value and the prune cannot discriminate.
     # The column is filled per window id instead, from ONE full option listing
     # (a flat extra call however many rows or `@` columns there are).
-    listing = '@bmad_project_@2 "proj-b"\n@bmad_project_@3 "proj-a"\n'
+    listing = '@bmad_project__blw@2 "proj-b"\n@bmad_project__blw@3 "proj-a"\n'
     seen = []
 
     def fake(argv, **kwargs):
@@ -974,43 +979,187 @@ def test_tmux_backend_keeps_real_window_options(monkeypatch):
 
 
 def test_kill_window_frees_only_that_windows_keys(monkeypatch):
-    # Generic by `_@<digits>` suffix: both bmad keys of @3 go, @13's key (a
-    # suffix near-miss), @1's key and a foreign config option (`@color_3`, no
-    # `_@` shape) stay, and the kill itself still fires.
+    # Generic by the seam's `__blw@<digits>` marker: both bmad keys of @3 go;
+    # @13's key (a suffix near-miss), @1's key, a foreign config option
+    # (`@color_3`) and even a hand-written old-convention `@theme_@3` stay.
+    # Order is kill-then-verify-then-clean: the kill fires first, the liveness
+    # listing (without @3) proves it landed, then the keys are freed.
     listing = (
-        '@bmad_project_@3 "proj-a"\n'
-        '@bmad_return_pane_@3 "=ctl:%7"\n'
-        '@bmad_project_@13 "proj-b"\n'
-        '@bmad_project_@1 "proj-c"\n'
+        '@bmad_project__blw@3 "proj-a"\n'
+        '@bmad_return_pane__blw@3 "=ctl:%7"\n'
+        '@bmad_project__blw@13 "proj-b"\n'
+        '@bmad_project__blw@1 "proj-c"\n'
         '@color_3 "cfg"\n'
+        '@theme_@3 "user"\n'
         "mouse on\n"
     )
     recorder = _RecordRun()
 
     def fake(argv, **kwargs):
         recorder.calls.append((argv, kwargs))
-        out = listing if argv[1] == "show-options" else ""
+        out = {"show-options": listing, "list-windows": "@1\n@13\n"}.get(argv[1], "")
         return subprocess.CompletedProcess(argv, 0, stdout=out, stderr="")
 
     monkeypatch.setattr(tmux_base.subprocess, "run", fake)
     PsmuxMultiplexer().kill_window("ctl:@3")
+    assert recorder.calls[0][0][1:] == ["kill-window", "-t", "ctl:@3"]
     unset = [c[0][5] for c in recorder.calls if c[0][1] == "set-option"]
-    assert sorted(unset) == ["@bmad_project_@3", "@bmad_return_pane_@3"]
-    assert recorder.argv[1:] == ["kill-window", "-t", "ctl:@3"]
+    assert sorted(unset) == ["@bmad_project__blw@3", "@bmad_return_pane__blw@3"]
 
 
-def test_kill_window_cleanup_failure_never_blocks_the_kill(monkeypatch):
+def test_kill_window_name_target_resolves_scope_before_the_kill(monkeypatch):
+    # A name token is only resolvable while the window lives — the scope
+    # lookup must precede the kill, and the freed keys must be the resolved
+    # id's, not the name's.
+    calls = []
+
+    def fake(argv, **kwargs):
+        calls.append(argv)
+        if argv[1] == "list-windows":
+            # name-resolve asks for id+name; the liveness probe for ids only
+            out = "@3\trun-abc\n@1\tshell\n" if "#{window_name}" in argv[-1] else "@1\n"
+        elif argv[1] == "show-options":
+            out = '@bmad_project__blw@3 "proj"\n'
+        else:
+            out = ""
+        return subprocess.CompletedProcess(argv, 0, stdout=out, stderr="")
+
+    monkeypatch.setattr(tmux_base.subprocess, "run", fake)
+    PsmuxMultiplexer().kill_window("=ctl:run-abc")
+    verbs = [c[1] for c in calls]
+    assert verbs[0] == "list-windows"  # the name resolve, before the kill
+    assert verbs[1] == "kill-window"
+    assert [c[5] for c in calls if c[1] == "set-option"] == ["@bmad_project__blw@3"]
+
+
+def test_kill_window_failed_kill_retains_the_keys(monkeypatch):
+    # The containment flip: a kill that did not land (the window is still in
+    # the liveness listing) must leave the live window its keys — a key-less
+    # live window loses its project tag (prune retry degrades to the run-dir
+    # fallback) and its return key (an attached client parks with no way back).
+    recorder = _RecordRun()
+
+    def fake(argv, **kwargs):
+        recorder.calls.append((argv, kwargs))
+        out = "@1\n@3\n" if argv[1] == "list-windows" else ""
+        return subprocess.CompletedProcess(argv, 0, stdout=out, stderr="")
+
+    monkeypatch.setattr(tmux_base.subprocess, "run", fake)
+    PsmuxMultiplexer().kill_window("ctl:@3")
+    assert not [c for c in recorder.calls if c[0][1] in ("set-option", "show-options")]
+
+
+def test_kill_window_unverifiable_liveness_retains_the_keys(monkeypatch):
+    # An empty liveness listing is a failed probe, not proof of death (the ctl
+    # session always keeps its shell window) — retaining beats freeing a live
+    # window's keys; the launch-time orphan sweep reclaims real orphans later.
+    recorder = _RecordRun()
+
+    def fake(argv, **kwargs):
+        recorder.calls.append((argv, kwargs))
+        rc = 1 if argv[1] == "list-windows" else 0
+        return subprocess.CompletedProcess(argv, rc, stdout="", stderr="")
+
+    monkeypatch.setattr(tmux_base.subprocess, "run", fake)
+    PsmuxMultiplexer().kill_window("ctl:@3")
+    assert [c[0][1] for c in recorder.calls] == ["kill-window", "list-windows"]
+
+
+def test_failed_kill_leaves_ownership_readable_for_the_prune_retry(monkeypatch):
+    # The retained key is not just unswept — it must still answer a read,
+    # because the prune retry re-identifies ownership through it.
+    key = "@bmad_project__blw@3"
+
+    def fake(argv, **kwargs):
+        if argv[1] == "list-windows":
+            out = "@1\n@3\n"  # the kill did not land
+        elif argv[1] == "show-options" and argv[-1] == key:
+            out = "tag-a"
+        else:
+            out = ""
+        return subprocess.CompletedProcess(argv, 0, stdout=out, stderr="")
+
+    monkeypatch.setattr(tmux_base.subprocess, "run", fake)
+    mux = PsmuxMultiplexer()
+    mux.kill_window("ctl:@3")
+    assert mux.show_window_option("ctl:@3", "@bmad_project") == "tag-a"
+
+
+def test_stranded_keys_after_cleanup_crash_are_reclaimed_by_the_sweep(monkeypatch):
+    # The matrix sequence end to end: a landed kill whose key-free step dies
+    # strands the keys, and the next launch-time sweep actually claims them.
+    key = "@bmad_project__blw@3"
+    state = {"healed": False}
+    freed = []
+
+    def fake(argv, **kwargs):
+        if argv[1] == "show-options":
+            if not state["healed"]:
+                raise subprocess.TimeoutExpired(argv, 1)
+            return subprocess.CompletedProcess(argv, 0, stdout=f"{key} tag-a\n", stderr="")
+        if argv[1] == "list-windows":
+            return subprocess.CompletedProcess(argv, 0, stdout="@1\n", stderr="")
+        if argv[1] == "set-option" and "-u" in argv:
+            freed.append(argv[-1])
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(tmux_base.subprocess, "run", fake)
+    mux = PsmuxMultiplexer()
+    mux.kill_window("ctl:@3")  # kill lands, then the key listing dies
+    assert not freed
+    state["healed"] = True
+    mux._sweep_orphan_keys("ctl")
+    assert freed == [key]
+
+
+def test_kill_window_cleanup_failure_never_fails_the_kill(monkeypatch):
+    # The key listing dying after a landed kill must not raise; the orphan
+    # sweep reclaims the stranded keys at the next parked-window launch.
     sent = []
 
     def fake(argv, **kwargs):
         if argv[1] == "show-options":
             raise subprocess.TimeoutExpired(argv, 1)
         sent.append(argv)
-        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+        out = "@1\n" if argv[1] == "list-windows" else ""
+        return subprocess.CompletedProcess(argv, 0, stdout=out, stderr="")
 
     monkeypatch.setattr(tmux_base.subprocess, "run", fake)
     PsmuxMultiplexer().kill_window("ctl:@3")  # must not raise
-    assert sent and sent[-1][1:] == ["kill-window", "-t", "ctl:@3"]
+    assert sent[0][1:] == ["kill-window", "-t", "ctl:@3"]
+
+
+def test_kill_window_unlistable_options_warns_and_strands_the_keys(monkeypatch, capsys):
+    # show-options rc!=0 after a verified kill is a transport failure, not "no
+    # keys": nothing is freed, nothing raises, and the strand is visible.
+    recorder = _RecordRun()
+
+    def fake(argv, **kwargs):
+        recorder.calls.append((argv, kwargs))
+        rc = 1 if argv[1] == "show-options" else 0
+        out = "@1\n" if argv[1] == "list-windows" else ""
+        return subprocess.CompletedProcess(argv, rc, stdout=out, stderr="")
+
+    monkeypatch.setattr(tmux_base.subprocess, "run", fake)
+    PsmuxMultiplexer().kill_window("ctl:@3")  # must not raise
+    assert not [c for c in recorder.calls if c[0][1] == "set-option"]
+    assert "stranded keys await the orphan sweep" in capsys.readouterr().err
+
+
+def test_kill_window_unfreeable_key_warns(monkeypatch, capsys):
+    # A nonzero rc from `set-option -u` IS proof the key was not freed —
+    # silence would leak it for the server's life with no signal.
+    def fake(argv, **kwargs):
+        rc = 1 if argv[1] == "set-option" else 0
+        out = {
+            "list-windows": "@1\n",
+            "show-options": '@bmad_project__blw@3 "proj"\n',
+        }.get(argv[1], "")
+        return subprocess.CompletedProcess(argv, rc, stdout=out, stderr="denied")
+
+    monkeypatch.setattr(tmux_base.subprocess, "run", fake)
+    PsmuxMultiplexer().kill_window("ctl:@3")  # must not raise
+    assert "could not free option @bmad_project__blw@3" in capsys.readouterr().err
 
 
 def test_kill_window_unroutable_target_skips_cleanup_but_kills(monkeypatch):
@@ -1186,9 +1335,16 @@ def test_list_windows_option_fill_declines_on_unroutable_session(monkeypatch):
 
 def test_new_parked_window_sweeps_orphan_keys(monkeypatch, tmp_path):
     # Enter-dismissing a parked window closes it without kill_window, so its
-    # keys outlive it; launch reconciles. `_@7` has no window → freed. `_@2` is
-    # live → kept. `@color_3` is a foreign config option (no `_@`) → untouched.
-    listing = '@bmad_project_@7 "gone"\n@bmad_project_@2 "live"\n@color_3 "cfg"\n'
+    # keys outlive it; launch reconciles. `__blw@7` has no window → freed.
+    # `__blw@2` is live → kept. Foreign options are untouched — `@color_3`,
+    # and even a hand-written `@theme_@3`, whose window `@3` is long gone: the
+    # sweep matches the seam's own marker, not a naming convention.
+    listing = (
+        '@bmad_project__blw@7 "gone"\n'
+        '@bmad_project__blw@2 "live"\n'
+        '@color_3 "cfg"\n'
+        '@theme_@3 "user"\n'
+    )
     calls = []
 
     def fake(argv, **kwargs):
@@ -1202,7 +1358,7 @@ def test_new_parked_window_sweeps_orphan_keys(monkeypatch, tmp_path):
     win = PsmuxMultiplexer().new_parked_window("ctl", "run-x", tmp_path, ["prog"], "@ret")
     assert win == "ctl:@2"
     unset = [c[5] for c in calls if c[1] == "set-option"]
-    assert unset == ["@bmad_project_@7"]
+    assert unset == ["@bmad_project__blw@7"]
 
 
 def test_tmux_backend_forwards_option_columns_to_format(monkeypatch):
@@ -1245,11 +1401,23 @@ def test_sweep_snapshots_keys_before_live_windows(monkeypatch, tmp_path):
     assert sweep == ["show-options", "list-windows"]
 
 
+def test_sweep_unlistable_options_warns(monkeypatch, capsys):
+    # show-options rc!=0 aborts the sweep: a sweep that silently fails every
+    # launch leaks keys for the server's whole life with no signal anywhere.
+    def fake(argv, **kwargs):
+        rc = 1 if argv[1] == "show-options" else 0
+        return subprocess.CompletedProcess(argv, rc, stdout="", stderr="")
+
+    monkeypatch.setattr(tmux_base.subprocess, "run", fake)
+    PsmuxMultiplexer()._sweep_orphan_keys("ctl")
+    assert "orphan-key sweep on ctl could not list options" in capsys.readouterr().err
+
+
 def test_sweep_treats_empty_live_list_as_failed_probe(monkeypatch, tmp_path):
     # We just minted a window in this session, so an empty live listing is a
     # failed probe, not an empty session — believing it would sweep every key,
     # live windows included.
-    listing = '@bmad_project_@2 "live"\n@bmad_project_@7 "gone"\n'
+    listing = '@bmad_project__blw@2 "live"\n@bmad_project__blw@7 "gone"\n'
     calls = []
 
     def fake(argv, **kwargs):
@@ -1271,7 +1439,9 @@ def test_sweep_transport_exception_never_fails_the_mint(monkeypatch, tmp_path, c
     def fake(argv, **kwargs):
         if argv[1] == "list-windows":
             raise subprocess.TimeoutExpired(argv, 1)
-        out = {"new-window": "@2\n", "show-options": '@bmad_project_@7 "gone"\n'}.get(argv[1], "")
+        out = {"new-window": "@2\n", "show-options": '@bmad_project__blw@7 "gone"\n'}.get(
+            argv[1], ""
+        )
         return subprocess.CompletedProcess(argv, 0, stdout=out, stderr="")
 
     monkeypatch.setattr(tmux_base.subprocess, "run", fake)
@@ -1289,9 +1459,9 @@ def test_accepted_values_round_trip_through_the_listing_parse(monkeypatch, value
     # every accepted value must read back IDENTICAL from the `@key "value"`
     # listing shape psmux emits — else the prune's equality compare breaks.
     assert PsmuxMultiplexer._transportable(value)
-    _option_fake(monkeypatch, value=f'@bmad_project_@3 "{value}"\n')
+    _option_fake(monkeypatch, value=f'@bmad_project__blw@3 "{value}"\n')
     options = PsmuxMultiplexer()._scoped_options("ctl")
-    assert options == {"@bmad_project_@3": value}
+    assert options == {"@bmad_project__blw@3": value}
 
 
 def test_ctl_prune_scan_discriminates_projects_end_to_end(monkeypatch, tmp_path):
@@ -1302,7 +1472,7 @@ def test_ctl_prune_scan_discriminates_projects_end_to_end(monkeypatch, tmp_path)
     from bmad_loop.tui import launch
 
     mine = str(tmp_path.resolve())
-    listing = f'@bmad_project_@2 "{mine}"\n@bmad_project_@3 "C:/elsewhere"\n'
+    listing = f'@bmad_project__blw@2 "{mine}"\n@bmad_project__blw@3 "C:/elsewhere"\n'
 
     def fake(argv, **kwargs):
         if argv[1] == "list-windows":

--- a/tests/test_psmux_backend.py
+++ b/tests/test_psmux_backend.py
@@ -1032,6 +1032,26 @@ def test_kill_window_name_target_resolves_scope_before_the_kill(monkeypatch):
     assert [c[5] for c in calls if c[1] == "set-option"] == ["@bmad_project__blw@3"]
 
 
+def test_kill_window_sends_the_kill_when_the_scope_lookup_dies(monkeypatch):
+    # Resolving a name target costs a listing round-trip, and it happens BEFORE
+    # the kill (a name is unresolvable once the window is dead) — so a dead
+    # probe there must not cost the kill. It cannot: the base list_windows
+    # swallows transport failures to [], so the scope degrades to None and the
+    # kill goes out unscoped, leaving the keys to the orphan sweep. Pinned
+    # because the ordering makes the opposite reading plausible on sight.
+    sent = []
+
+    def fake(argv, **kwargs):
+        if argv[1] == "list-windows":
+            raise subprocess.TimeoutExpired(argv, 1)
+        sent.append(argv)
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(tmux_base.subprocess, "run", fake)
+    PsmuxMultiplexer().kill_window("=ctl:run-abc")  # must not raise
+    assert [c[1] for c in sent] == ["kill-window"]
+
+
 def test_kill_window_failed_kill_retains_the_keys(monkeypatch):
     # The containment flip: a kill that did not land (the window is still in
     # the liveness listing) must leave the live window its keys — a key-less
@@ -1159,7 +1179,31 @@ def test_kill_window_unfreeable_key_warns(monkeypatch, capsys):
 
     monkeypatch.setattr(tmux_base.subprocess, "run", fake)
     PsmuxMultiplexer().kill_window("ctl:@3")  # must not raise
-    assert "could not free option @bmad_project__blw@3" in capsys.readouterr().err
+    assert "set-option -u @bmad_project__blw@3 on ctl failed" in capsys.readouterr().err
+
+
+def test_a_dead_free_round_trip_does_not_abandon_the_rest_of_the_batch(monkeypatch, capsys):
+    # Every free is contained to its own key. A transport failure on key N used
+    # to escape to the sweep's outer guard, which warned once and left keys
+    # N+1..M stranded — one intermittent round-trip costing the whole batch.
+    attempted = []
+
+    def fake(argv, **kwargs):
+        if argv[1] == "show-options":
+            out = '@bmad_project__blw@7 "gone"\n@bmad_return_pane__blw@7 "%9"\n'
+            return subprocess.CompletedProcess(argv, 0, stdout=out, stderr="")
+        if argv[1] == "list-windows":
+            return subprocess.CompletedProcess(argv, 0, stdout="@1\n", stderr="")
+        if argv[1] == "set-option":
+            attempted.append(argv[-1])
+            if len(attempted) == 1:
+                raise subprocess.TimeoutExpired(argv, 1)
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(tmux_base.subprocess, "run", fake)
+    PsmuxMultiplexer()._sweep_orphan_keys("ctl")
+    assert attempted == ["@bmad_project__blw@7", "@bmad_return_pane__blw@7"]
+    assert "set-option -u @bmad_project__blw@7 on ctl failed" in capsys.readouterr().err
 
 
 def test_kill_window_unroutable_target_skips_cleanup_but_kills(monkeypatch):

--- a/tests/test_psmux_live.py
+++ b/tests/test_psmux_live.py
@@ -1,0 +1,95 @@
+"""Live psmux gate: cross-project ctl-window prune isolation on a real server.
+
+The unit acceptance test (test_psmux_backend) proves the candidate scan with a
+faked subprocess; what no unit layer can prove is the transport half — a real
+psmux server holding two projects' windows on one shared control session, a
+prune in one project, and the other project's window *and its option keys*
+surviving the kill. Same zero-token contract as test_opencode_live: parked
+windows run a plain `exit 0`, no coding CLI is ever launched.
+
+Windows-local by construction (psmux registers for win32 only); skipped
+everywhere else, and when psmux is absent or an unsupported version.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+from bmad_loop import runs
+from bmad_loop.adapters.psmux_backend import PsmuxMultiplexer
+from bmad_loop.adapters.tmux_base import TmuxError
+from bmad_loop.tui import launch
+
+HAVE_PSMUX = sys.platform == "win32" and shutil.which("psmux") is not None
+pytestmark = pytest.mark.skipif(not HAVE_PSMUX, reason="requires Windows with psmux on PATH")
+
+PARKED_ARGV = ["pwsh", "-NoProfile", "-Command", "exit 0"]  # zero tokens, parks on read
+
+
+def test_prune_kills_only_the_owning_projects_window(tmp_path: Path, monkeypatch):
+    mux = PsmuxMultiplexer()
+    if not mux.available():
+        pytest.skip("psmux present but not an admitted version")
+    session = f"bmad-loop-test-{uuid.uuid4().hex[:8]}"
+    proj_a = tmp_path / "proj-a"
+    proj_b = tmp_path / "proj-b"
+    proj_a.mkdir()
+    proj_b.mkdir()
+    try:
+        mux.new_session(session, tmp_path)
+        win_a = mux.new_parked_window(session, "run-20260726-1", proj_a, PARKED_ARGV, "@r")
+        win_b = mux.new_parked_window(session, "run-20260726-2", proj_b, PARKED_ARGV, "@r")
+        # A degraded mint hands back "" or a bare id — fail loud here rather
+        # than let rsplit or a mis-scoped option write misdiagnose the prune.
+        assert re.fullmatch(r"[^:]+:@\d+", win_a), win_a
+        assert re.fullmatch(r"[^:]+:@\d+", win_b), win_b
+        mux.set_window_option(win_a, runs.PROJECT_OPTION, runs.project_tag(proj_a))
+        mux.set_window_option(win_b, runs.PROJECT_OPTION, runs.project_tag(proj_b))
+        # set_window_option declines silently (warn-only): prove the tags
+        # landed before asserting anything about the prune's discrimination.
+        assert mux.show_window_option(win_a, runs.PROJECT_OPTION) == runs.project_tag(proj_a)
+        assert mux.show_window_option(win_b, runs.PROJECT_OPTION) == runs.project_tag(proj_b)
+        # A hand-written user option carrying window A's digits in the OLD
+        # (pre-marker) shape: the seam's sweeps must never claim it.
+        digits_a = win_a.rsplit("@", 1)[1]
+        foreign = f"@theme_@{digits_a}"
+        proc = mux._run(["set-option", "-t", session, foreign, "user"], check=False)
+        assert proc.returncode == 0, proc.stderr
+
+        monkeypatch.setattr(launch, "CTL_SESSION", session)
+        monkeypatch.setattr(launch, "get_multiplexer", lambda: mux)
+        # Pin "outside any pane": when pytest itself runs inside psmux the
+        # target-less probe can resolve the test's own window and exclude it.
+        monkeypatch.setattr(mux, "current_window_id", lambda: None)
+        monkeypatch.setattr(runs, "engine_alive", lambda _dir: False)
+
+        assert launch.prune_ctl_windows(proj_a) == ["run-20260726-1"]
+
+        live = mux.list_window_ids(session)
+        assert win_a not in live
+        assert win_b in live
+        options = mux._scoped_options(session) or {}
+        key_a = mux._scoped_option_key(runs.PROJECT_OPTION, digits_a)
+        key_b = mux._scoped_option_key(runs.PROJECT_OPTION, win_b.rsplit("@", 1)[1])
+        assert key_a not in options  # freed by the verified kill
+        assert options.get(key_b) == runs.project_tag(proj_b)  # untouched
+        assert options.get(foreign) == "user"  # foreign key survives every sweep
+    finally:
+        # kill_session is a best-effort backstop; verify it worked so a real
+        # server never leaks silently off a green (or already-failing) run.
+        mux.kill_session(session)
+        try:
+            leaked = mux.has_session(session)
+        except TmuxError:
+            leaked = True
+        if leaked:
+            print(
+                f"warning: live-gate session {session} survived teardown; kill it manually",
+                file=sys.stderr,
+            )

--- a/tests/test_psmux_live.py
+++ b/tests/test_psmux_live.py
@@ -41,6 +41,7 @@ def test_prune_kills_only_the_owning_projects_window(tmp_path: Path, monkeypatch
     proj_b = tmp_path / "proj-b"
     proj_a.mkdir()
     proj_b.mkdir()
+    body_ok = False
     try:
         mux.new_session(session, tmp_path)
         win_a = mux.new_parked_window(session, "run-20260726-1", proj_a, PARKED_ARGV, "@r")
@@ -80,6 +81,7 @@ def test_prune_kills_only_the_owning_projects_window(tmp_path: Path, monkeypatch
         assert key_a not in options  # freed by the verified kill
         assert options.get(key_b) == runs.project_tag(proj_b)  # untouched
         assert options.get(foreign) == "user"  # foreign key survives every sweep
+        body_ok = True
     finally:
         # kill_session is a best-effort backstop; verify it worked so a real
         # server never leaks silently off a green (or already-failing) run.
@@ -89,7 +91,11 @@ def test_prune_kills_only_the_owning_projects_window(tmp_path: Path, monkeypatch
         except TmuxError:
             leaked = True
         if leaked:
-            print(
-                f"warning: live-gate session {session} survived teardown; kill it manually",
-                file=sys.stderr,
-            )
+            note = f"live-gate session {session} survived teardown; kill it manually"
+            # Only raise when the body passed. pytest.fail() here on an
+            # already-failing run replaces the real diagnostic — the leak takes
+            # over the summary line and the assertion drops to a chained
+            # "during handling" frame — so that run keeps the warning instead.
+            if body_ok:
+                pytest.fail(note)
+            print(f"warning: {note}", file=sys.stderr)

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -2082,7 +2082,7 @@ async def test_attach_without_mux_notifies(project, monkeypatch):
 async def test_attach_without_agent_session_notifies(project, monkeypatch):
     monkeypatch.setattr(launch, "mux_available", lambda: True)
     monkeypatch.setattr(launch, "session_exists", lambda session: False)
-    monkeypatch.setattr(launch, "ctl_window", lambda run_id: None)
+    monkeypatch.setattr(launch, "ctl_window_id", lambda run_id: None)
     make_run(project.project, "20260611-100000-aaaa")
     app = BmadLoopApp(project.project)
     async with app.run_test() as pilot:
@@ -2099,7 +2099,7 @@ async def test_attach_multiplexer_error_notifies(project, monkeypatch):
     # TUI must surface the error as a toast, not crash the app.
     monkeypatch.setattr(launch, "mux_available", lambda: True)
     monkeypatch.setattr(launch, "session_exists", lambda session: True)
-    monkeypatch.setattr(launch, "ctl_window", lambda run_id: None)
+    monkeypatch.setattr(launch, "ctl_window_id", lambda run_id: None)
 
     def boom(_target):
         raise MultiplexerError("backend server not reachable")
@@ -2123,7 +2123,7 @@ async def test_attach_session_probe_error_notifies(project, monkeypatch):
     # torn down in between). action_attach routes it through _mux_guarded, so the
     # TUI toasts the error and aborts the attach instead of crashing the app.
     monkeypatch.setattr(launch, "mux_available", lambda: True)
-    monkeypatch.setattr(launch, "ctl_window", lambda run_id: None)
+    monkeypatch.setattr(launch, "ctl_window_id", lambda run_id: None)
 
     def boom(_session):
         raise MultiplexerError("session probe unreachable")
@@ -2214,8 +2214,8 @@ async def test_attach_targets_ctl_window_when_decision_pending(project, monkeypa
     selected: list[str] = []
     monkeypatch.setattr(launch, "mux_available", lambda: True)
     monkeypatch.setattr(launch, "session_exists", lambda session: True)  # agent up too
-    monkeypatch.setattr(launch, "ctl_window", lambda run_id: f"sweep-{run_id}")
-    monkeypatch.setattr(launch, "select_ctl_window", lambda w: selected.append(w))
+    monkeypatch.setattr(launch, "ctl_window_id", lambda run_id: "@5")
+    monkeypatch.setattr(launch, "select_ctl_window_id", lambda w: selected.append(w))
     calls, stamps = _patch_attach_exec(monkeypatch)
     app = BmadLoopApp(project.project)
     async with app.run_test() as pilot:
@@ -2223,10 +2223,10 @@ async def test_attach_targets_ctl_window_when_decision_pending(project, monkeypa
         await until(pilot, lambda: dashboard(app).decision_pending is not None)
         await pilot.press("a")
         await until(pilot, lambda: bool(calls))
-    assert selected == ["sweep-20260611-100000-aaaa"]
+    assert selected == ["@5"]
     assert calls == [["tmux", "switch-client", "-t", "=bmad-loop-ctl"]]
     # the ctl window is stamped with our pane so it switches us back on exit
-    assert stamps == [("=bmad-loop-ctl:sweep-20260611-100000-aaaa", "=main:%9")]
+    assert stamps == [("@5", "=main:%9")]
 
 
 @pytest.mark.usefixtures("force_tmux_backend")  # pin tmux against win32-matching externals
@@ -2240,8 +2240,8 @@ async def test_attach_outside_tmux_stamps_detach(project, monkeypatch):
     stamps: list[tuple[str, str]] = []
     monkeypatch.setattr(launch, "mux_available", lambda: True)
     monkeypatch.setattr(launch, "session_exists", lambda session: True)
-    monkeypatch.setattr(launch, "ctl_window", lambda run_id: f"sweep-{run_id}")
-    monkeypatch.setattr(launch, "select_ctl_window", lambda w: None)
+    monkeypatch.setattr(launch, "ctl_window_id", lambda run_id: "@5")
+    monkeypatch.setattr(launch, "select_ctl_window_id", lambda w: None)
     monkeypatch.setattr(launch, "set_return_pane", lambda w, p: stamps.append((w, p)))
     app = BmadLoopApp(project.project)
     async with app.run_test() as pilot:
@@ -2249,7 +2249,7 @@ async def test_attach_outside_tmux_stamps_detach(project, monkeypatch):
         await until(pilot, lambda: dashboard(app).decision_pending is not None)
         await pilot.press("a")
         await until(pilot, lambda: bool(stamps))
-    assert stamps == [("=bmad-loop-ctl:sweep-20260611-100000-aaaa", "detach")]
+    assert stamps == [("@5", "detach")]
 
 
 @pytest.mark.usefixtures("force_tmux_backend")  # pin tmux against win32-matching externals
@@ -2257,7 +2257,7 @@ async def test_attach_prefers_agent_session_without_decision(project, monkeypatc
     make_run(project.project, "20260611-100000-aaaa", alive=True)
     monkeypatch.setattr(launch, "mux_available", lambda: True)
     monkeypatch.setattr(launch, "session_exists", lambda session: True)
-    monkeypatch.setattr(launch, "ctl_window", lambda run_id: f"run-{run_id}")
+    monkeypatch.setattr(launch, "ctl_window_id", lambda run_id: "@5")
     calls, stamps = _patch_attach_exec(monkeypatch)
     app = BmadLoopApp(project.project)
     async with app.run_test() as pilot:
@@ -2276,8 +2276,8 @@ async def test_attach_falls_back_to_ctl_window(project, monkeypatch):
     selected: list[str] = []
     monkeypatch.setattr(launch, "mux_available", lambda: True)
     monkeypatch.setattr(launch, "session_exists", lambda session: False)
-    monkeypatch.setattr(launch, "ctl_window", lambda run_id: f"run-{run_id}")
-    monkeypatch.setattr(launch, "select_ctl_window", lambda w: selected.append(w))
+    monkeypatch.setattr(launch, "ctl_window_id", lambda run_id: "@5")
+    monkeypatch.setattr(launch, "select_ctl_window_id", lambda w: selected.append(w))
     calls, stamps = _patch_attach_exec(monkeypatch)
     app = BmadLoopApp(project.project)
     async with app.run_test() as pilot:
@@ -2285,9 +2285,9 @@ async def test_attach_falls_back_to_ctl_window(project, monkeypatch):
         await until(pilot, lambda: dashboard(app).selected_run_id is not None)
         await pilot.press("a")
         await until(pilot, lambda: bool(calls))
-    assert selected == ["run-20260611-100000-aaaa"]
+    assert selected == ["@5"]
     assert calls == [["tmux", "switch-client", "-t", "=bmad-loop-ctl"]]
-    assert stamps == [("=bmad-loop-ctl:run-20260611-100000-aaaa", "=main:%9")]
+    assert stamps == [("@5", "=main:%9")]
 
 
 @pytest.mark.usefixtures("force_tmux_backend")  # pin tmux against win32-matching externals

--- a/tests/test_tui_launch.py
+++ b/tests/test_tui_launch.py
@@ -270,8 +270,8 @@ def test_ctl_window_id_matches_run_id_suffix(monkeypatch):
 
 
 def test_ctl_window_id_skips_empty_id_rows(monkeypatch):
-    # The base pads short listing rows with "" — an empty id must never be
-    # returned as a target (an empty `-t` resolves against the current window).
+    # An empty id must never be returned as a target — an empty `-t` resolves
+    # against the current window. psmux's qualifier passes a falsy id through.
     def fake(argv, **kwargs):
         out = "\tsweep-RID\n@7\tsweep-RID\n" if argv[1] == "list-windows" else ""
         return subprocess.CompletedProcess(argv, 0, stdout=out, stderr="")
@@ -281,10 +281,11 @@ def test_ctl_window_id_skips_empty_id_rows(monkeypatch):
     assert launch.ctl_window_id("RID") == "@7"
 
 
-def test_kill_ctl_window_kills_by_id_not_first_name_match(monkeypatch):
-    # Two ctl windows can share a name (kinds share a run_id); the kill must
-    # replay the id resolved from the listing, never re-resolve by name —
-    # a name token would land first-match on whichever duplicate lists first.
+def test_kill_ctl_window_kills_by_resolved_id_not_a_name_token(monkeypatch):
+    # The kill replays the id this listing resolved, never a `=session:name`
+    # token the backend would resolve again. Which of two same-named windows
+    # the scan picks is unchanged (first match, `@7`); what the id buys is that
+    # a rename or a new window between two verbs cannot re-point the second.
     calls: list[list[str]] = []
 
     def fake(argv, **kwargs):

--- a/tests/test_tui_launch.py
+++ b/tests/test_tui_launch.py
@@ -256,31 +256,57 @@ def test_session_exists(monkeypatch):
     assert fake.calls[0] == ["tmux", "has-session", "-t", "=bmad-loop-x"]
 
 
-def test_ctl_window_matches_run_id_suffix(monkeypatch):
+def test_ctl_window_id_matches_run_id_suffix(monkeypatch):
+    # The id, not the name: consumers replay the value as select/kill/option
+    # targets, where a by-name resolve can land on a duplicate.
     def fake(argv, **kwargs):
-        out = "run-AAAA\nsweep-RID\nresume-BBBB\n" if argv[1] == "list-windows" else ""
+        out = "@1\trun-AAAA\n@2\tsweep-RID\n@3\tresume-BBBB\n" if argv[1] == "list-windows" else ""
         return subprocess.CompletedProcess(argv, 0, stdout=out, stderr="")
 
     monkeypatch.setattr(tmux_base.subprocess, "run", fake)
     monkeypatch.setattr(tmux_base.shutil, "which", lambda name: f"/usr/bin/{name}")
-    assert launch.ctl_window("RID") == "sweep-RID"
-    assert launch.ctl_window("CCCC") is None
+    assert launch.ctl_window_id("RID") == "@2"
+    assert launch.ctl_window_id("CCCC") is None
 
 
-def test_ctl_window_no_session_or_tmux(monkeypatch):
+def test_ctl_window_id_skips_empty_id_rows(monkeypatch):
+    # The base pads short listing rows with "" — an empty id must never be
+    # returned as a target (an empty `-t` resolves against the current window).
+    def fake(argv, **kwargs):
+        out = "\tsweep-RID\n@7\tsweep-RID\n" if argv[1] == "list-windows" else ""
+        return subprocess.CompletedProcess(argv, 0, stdout=out, stderr="")
+
+    monkeypatch.setattr(tmux_base.subprocess, "run", fake)
+    monkeypatch.setattr(tmux_base.shutil, "which", lambda name: f"/usr/bin/{name}")
+    assert launch.ctl_window_id("RID") == "@7"
+
+
+def test_kill_ctl_window_kills_by_id_not_first_name_match(monkeypatch):
+    # Two ctl windows can share a name (kinds share a run_id); the kill must
+    # replay the id resolved from the listing, never re-resolve by name —
+    # a name token would land first-match on whichever duplicate lists first.
+    calls: list[list[str]] = []
+
+    def fake(argv, **kwargs):
+        calls.append(list(argv))
+        out = "@2\trun-x\n@7\tsweep-RID\n@9\tsweep-RID\n" if argv[1] == "list-windows" else ""
+        return subprocess.CompletedProcess(argv, 0, stdout=out, stderr="")
+
+    monkeypatch.setattr(tmux_base.subprocess, "run", fake)
+    monkeypatch.setattr(tmux_base.shutil, "which", lambda name: f"/usr/bin/{name}")
+    launch.kill_ctl_window("RID")
+    assert ["tmux", "kill-window", "-t", "@7"] in calls
+
+
+def test_ctl_window_id_no_session_or_tmux(monkeypatch):
     def fake(argv, **kwargs):
         return subprocess.CompletedProcess(argv, 1, stdout="", stderr="no session")
 
     monkeypatch.setattr(tmux_base.subprocess, "run", fake)
     monkeypatch.setattr(tmux_base.shutil, "which", lambda name: f"/usr/bin/{name}")
-    assert launch.ctl_window("RID") is None
+    assert launch.ctl_window_id("RID") is None
     monkeypatch.setattr(tmux_base.shutil, "which", lambda name: None)
-    assert launch.ctl_window("RID") is None  # no subprocess call attempted
-
-
-def test_select_ctl_window_argv(fake_run):
-    launch.select_ctl_window("sweep-RID")
-    assert fake_run.calls == [["tmux", "select-window", "-t", "=bmad-loop-ctl:sweep-RID"]]
+    assert launch.ctl_window_id("RID") is None  # no subprocess call attempted
 
 
 def test_set_return_pane_argv(fake_run):
@@ -603,31 +629,31 @@ def test_decision_pending_false_when_empty(tmp_path: Path):
 
 def test_attach_plan_prefers_ctl_when_decision_pending(monkeypatch):
     monkeypatch.delenv("TMUX", raising=False)
-    monkeypatch.setattr(launch, "ctl_window", lambda rid: "sweep-RID")
+    monkeypatch.setattr(launch, "ctl_window_id", lambda rid: "@2")
     monkeypatch.setattr(launch, "session_exists", lambda s: True)
     monkeypatch.setattr(launch, "decision_pending", lambda rd: True)
     selected: list[str] = []
-    monkeypatch.setattr(launch, "select_ctl_window", lambda w: selected.append(w))
+    monkeypatch.setattr(launch, "select_ctl_window_id", lambda w: selected.append(w))
     argv, return_window = launch.attach_plan(Path("/proj"), "RID")
     assert argv == ["tmux", "attach", "-t", "=bmad-loop-ctl"]
-    assert return_window == "=bmad-loop-ctl:sweep-RID"
-    assert selected == ["sweep-RID"]
+    assert return_window == "@2"
+    assert selected == ["@2"]
 
 
 def test_attach_plan_prefers_ctl_when_no_agent_session(monkeypatch):
     monkeypatch.delenv("TMUX", raising=False)
-    monkeypatch.setattr(launch, "ctl_window", lambda rid: "sweep-RID")
+    monkeypatch.setattr(launch, "ctl_window_id", lambda rid: "@2")
     monkeypatch.setattr(launch, "session_exists", lambda s: False)
     monkeypatch.setattr(launch, "decision_pending", lambda rd: False)
-    monkeypatch.setattr(launch, "select_ctl_window", lambda w: None)
+    monkeypatch.setattr(launch, "select_ctl_window_id", lambda w: None)
     argv, return_window = launch.attach_plan(Path("/proj"), "RID")
     assert argv == ["tmux", "attach", "-t", "=bmad-loop-ctl"]
-    assert return_window == "=bmad-loop-ctl:sweep-RID"
+    assert return_window == "@2"
 
 
 def test_attach_plan_agent_session_when_no_decision(monkeypatch):
     monkeypatch.delenv("TMUX", raising=False)
-    monkeypatch.setattr(launch, "ctl_window", lambda rid: None)
+    monkeypatch.setattr(launch, "ctl_window_id", lambda rid: None)
     monkeypatch.setattr(launch, "session_exists", lambda s: True)
     monkeypatch.setattr(launch, "decision_pending", lambda rd: False)
     assert launch.attach_plan(Path("/proj"), "RID") == (
@@ -637,7 +663,7 @@ def test_attach_plan_agent_session_when_no_decision(monkeypatch):
 
 
 def test_attach_plan_none_when_nothing_to_attach(monkeypatch):
-    monkeypatch.setattr(launch, "ctl_window", lambda rid: None)
+    monkeypatch.setattr(launch, "ctl_window_id", lambda rid: None)
     monkeypatch.setattr(launch, "session_exists", lambda s: False)
     monkeypatch.setattr(launch, "decision_pending", lambda rd: False)
     assert launch.attach_plan(Path("/proj"), "RID") is None


### PR DESCRIPTION
Hardens the psmux option channel's safety core — the three ceilings accepted when the channel landed (#310):

- **Seam-owned key namespace.** Keys now carry a `__blw@` marker (`@bmad_project__blw@3`, was `@bmad_project_@3`), so the generic cleanup sweeps can no longer delete a hand-written user option like `@theme_@3` when window `@3` dies. Colliding now requires deliberately imitating the seam's marker.
- **Kill-order containment.** `kill_window` kills first and frees the window's keys only after a liveness listing proves the kill landed. A failed kill leaves the live window its project tag and return key; keys stranded by a cleanup failure are reclaimed by the launch-time orphan sweep. Every silent key-cleanup failure now warns.
- **Ctl windows resolved by id.** The launcher's ctl-window consumers (attach return-pane stamps, per-run window kill) resolve the stable window id once and replay it instead of re-resolving a first-match name per verb, so duplicate-named ctl windows cannot take another window's option write or kill (`ctl_window`/`select_ctl_window` fold into `ctl_window_id`/`select_ctl_window_id`).

Cross-project prune isolation is proven live: a Windows-local zero-token gate (`tests/test_psmux_live.py`) runs two projects' parked windows on one real psmux server and asserts a prune in one leaves the other's window, tag, and foreign options untouched.

Note for dev-build users: keys minted by the unreleased pre-marker build read as foreign and are never swept — restart the ctl psmux server after upgrading.

Closes #313

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window handling when names are duplicated by using stable window identifiers.
  * Prevented accidental removal of options or windows when cleanup cannot be verified.
  * Improved isolation when pruning project windows and preserved unrelated project data.
  * Added warnings and safer retry behavior for failed cleanup operations.
  * Improved attach and control-window targeting reliability.

* **Documentation**
  * Updated psmux option-key documentation and examples to reflect the safer naming format.
  * Documented additional live end-to-end coverage for Windows environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->