### PR TITLE
fix: small independent contracts + pyright canary (#433, 6C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -260,6 +260,26 @@ story <id>`, the same annotation a sweep bundle writes. Both sprint and stories 
 
 ### Fixed
 
+- **An undecodable `policy.toml` or `_bmad/bmm/config.yaml` is reported, not a crash.**
+  `UnicodeDecodeError` is a `ValueError`, not an `OSError`, so a config file saved in UTF-16 or
+  latin-1 escaped every `except (PolicyError, OSError)` handler in the codebase — and those handlers
+  are the ones whose whole job is to degrade to defaults rather than take the process down. It hit
+  `_configure_mux`, which runs before argument dispatch on **every** command, and the TUI dashboard's
+  constructor, which runs before the app can draw anything. `policy.load` and `bmadconfig.load_paths`
+  convert it to their own typed errors, so `validate` names the file under its `policy` /
+  `bmad-config` finding and the TUI degrades to defaults.
+
+- **`diagnose` pseudonymizes the spec name, and gives one spec one alias.** A journal record's
+  `spec` field carries the customer's feature name; a bare basename is identifier-shaped, so the
+  scrub fallback shipped it verbatim in a dump, and the egress backstop could not rescue it — it
+  only repairs values already in the legend. `spec` is now aliased in a namespace of its own, not
+  `story`, where a filename would render as an epic-less `story-<hex>` indistinguishable from a
+  story key whose epic could not be resolved. The value is reduced to its basename first, because
+  the producers disagree on shape — `engine.py` journals an absolute path, `stories_engine.py` the
+  worktree-relative one — so without it a single spec drew two aliases in one dump and an absolute
+  home path landed in the local `--legend` file. The split handles both separators, so a journal
+  written on Windows normalizes when it is diagnosed on POSIX.
+
 - **The upstream `bmad-dev-auto` → `bmad-build-auto` rename no longer breaks a project (#393).**
   The dev primitive is resolved on disk — `bmad-build-auto` preferred, a marker-complete
   `bmad-dev-auto` accepted — so `validate`/`run`/`sweep`/`resume` pass on either era with no

--- a/src/bmad_loop/bmadconfig.py
+++ b/src/bmad_loop/bmadconfig.py
@@ -73,7 +73,14 @@ def load_paths(project: Path) -> ProjectPaths:
     if not config_path.is_file():
         raise BmadConfigError(f"BMAD config not found: {config_path} (is BMAD installed here?)")
     try:
-        doc = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+        # UnicodeDecodeError is a ValueError, not an OSError, so an undecodable file
+        # would otherwise escape every caller's `except BmadConfigError` and crash
+        # them. Same reasoning as `policy.load`.
+        raw = config_path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as e:
+        raise BmadConfigError(f"{config_path} is not valid UTF-8: {e}") from e
+    try:
+        doc = yaml.safe_load(raw) or {}
     except yaml.YAMLError as e:
         raise BmadConfigError(f"invalid YAML in {config_path}: {e}") from e
 

--- a/src/bmad_loop/diagnostics.py
+++ b/src/bmad_loop/diagnostics.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import json
 import platform
+import re
 from collections import Counter
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -78,7 +79,39 @@ _JOURNAL_ALIAS_FIELDS = {
     "target_branch": "branch",
     "commit": "commit",
     "baseline": "commit",
+    # A spec name IS the customer's feature name — `Pseudonymizer`'s own docstring
+    # has always listed "spec filenames" among what it exists to alias, so the
+    # omission here was a routing gap, not a policy. A producer that journals a
+    # bare basename passes a value `looks_like_identifier` waves through verbatim
+    # on the scrub_json fallback — and the egress backstop cannot rescue it,
+    # because it only repairs values already in the legend, so it happens to
+    # catch `1.2-Acme….md` (the story key is in there) and misses
+    # `AcmeVaultRotation.md` entirely. Its OWN namespace, not "story": the epic
+    # lookup below is keyed on ns == "story", so a filename aliased there would
+    # render as an epic-less `story-<hex>` — indistinguishable from a story key
+    # whose epic could not be resolved. See `_JOURNAL_BASENAME_NAMESPACES` for why
+    # the value is normalized first: the producers do NOT agree on a bare basename.
+    "spec": "spec",
 }
+# Namespaces whose journalled value arrives in more than one shape and must be
+# reduced to its basename before it is aliased. `spec` is one: engine.py's
+# reconcile and marker-repair kinds journal `str(spec_path)` (absolute —
+# `verify.resolve_spec_path` returns an absolute path), while stories_engine's
+# `checkpoint-pause` journals `task.spec_file`, which `StoryTask` persists
+# worktree-relative (a bare basename for a spec at the worktree root). Aliasing
+# the raw string would give ONE spec TWO aliases in a single dump, defeating the
+# correlation these fields are aliased rather than dropped to preserve, and would
+# park an absolute home path in the local `--legend` file (before `spec` was
+# routed such a value died at `scrub_json` and never entered the map at all).
+#
+# Split on BOTH separators rather than using `PurePath(...).name`: a journal
+# written on Windows is routinely diagnosed on POSIX, where `PurePath` treats a
+# backslash as an ordinary character and would keep the whole path. The cost is
+# that a POSIX filename containing a literal backslash aliases on its tail —
+# a pathological name, and the consequence is a shorter legend entry, never a
+# leak, since the alias is still stable and the raw value still never ships.
+_JOURNAL_BASENAME_NAMESPACES = frozenset({"spec"})
+_PATH_SEP_RE = re.compile(r"[\\/]")
 # Journal fields that carry free text (LLM/merge prose, prompts, errors). Never
 # emitted — replaced with a boolean presence marker so a maintainer still learns
 # the field was set without seeing it.
@@ -336,6 +369,18 @@ def _alias_in_entry(entry: dict, pseudo: sanitize.Pseudonymizer, epic_by_key: di
     return None
 
 
+def _alias_input(value: Any, ns: str) -> Any:
+    """The string an alias is computed over: the basename for the path-shaped
+    namespaces, the value unchanged for every other one (and for any non-string,
+    which :meth:`Pseudonymizer.alias` handles itself)."""
+    if ns not in _JOURNAL_BASENAME_NAMESPACES or not isinstance(value, str):
+        return value
+    # `or value`: a value ending in a separator splits to an empty tail, and an
+    # empty string is the one input `alias()` passes through unaliased — so it
+    # would render as `""` and lose the event's only reference to the spec.
+    return _PATH_SEP_RE.split(value)[-1] or value
+
+
 def _scrub_entry(
     entry: dict,
     pseudo: sanitize.Pseudonymizer,
@@ -361,6 +406,7 @@ def _scrub_entry(
             out[k] = [pseudo.alias(x, ns=ns, epic=epic_by_key.get(str(x))) for x in v]
         elif k in _JOURNAL_ALIAS_FIELDS:
             ns = _JOURNAL_ALIAS_FIELDS[k]
+            v = _alias_input(v, ns)
             epic = epic_by_key.get(str(v)) if ns == "story" else None
             out[k] = pseudo.alias(v, ns=ns, epic=epic)
         else:

--- a/src/bmad_loop/policy.py
+++ b/src/bmad_loop/policy.py
@@ -671,11 +671,22 @@ def _validate_plugin_settings(name: str, raw: dict[str, Any], specs: Any) -> Non
 
 
 def load(path: Path | None) -> Policy:
-    """Load policy from a TOML file; a missing file yields all defaults."""
+    """Load policy from a TOML file; a missing file yields all defaults.
+
+    An undecodable file is a `PolicyError` like a malformed one. `read_text` raises
+    `UnicodeDecodeError`, which is a `ValueError` and not an `OSError`, so left raw it
+    escapes every `except (PolicyError, OSError)` handler in the codebase — and those
+    handlers are the ones whose whole job is to degrade to defaults rather than take
+    the process down. Converting here fixes them all at once instead of asking each
+    to name a second exception type it has no other reason to know about."""
     if path is None or not path.is_file():
         return loads("")
     try:
-        return loads(path.read_text(encoding="utf-8"))
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as e:
+        raise PolicyError(f"{path}: not valid UTF-8: {e}") from e
+    try:
+        return loads(text)
     except PolicyError as e:
         raise PolicyError(f"{path}: {e}") from e
 

--- a/src/bmad_loop/tui/app.py
+++ b/src/bmad_loop/tui/app.py
@@ -217,10 +217,16 @@ class BmadLoopApp(App[None]):
 
     def _stories_defaults(self) -> tuple[str, str]:
         """The [stories] policy source + spec_folder to prefill the start-run
-        modal, or the sprint-mode default when policy is unreadable."""
+        modal, or the sprint-mode default when policy is unreadable — including
+        undecodable, which `policy.load` reports as a `PolicyError` rather than
+        letting a raw `UnicodeDecodeError` past this handler.
+
+        `ParseError` is not in the tuple: `policy.load` parses with `tomllib`, so
+        the tomlkit error can only arrive from the `PolicyDoc` path in
+        :meth:`action_settings`, which catches it there."""
         try:
             pol = policy.load(self.project / POLICY_FILE)
-        except (policy.PolicyError, OSError, ParseError):
+        except (policy.PolicyError, OSError):
             return "sprint-status", ""
         return pol.stories.source, pol.stories.spec_folder
 

--- a/src/bmad_loop/tui/screens/dashboard.py
+++ b/src/bmad_loop/tui/screens/dashboard.py
@@ -179,7 +179,10 @@ class DashboardScreen(Screen[None]):
         super().__init__()
         self.project = project
         # Persisted pane sizes to seed on first layout; a malformed or unreadable
-        # policy file degrades to defaults rather than blocking the dashboard.
+        # policy file degrades to defaults rather than blocking the dashboard. That
+        # now covers a file whose BYTES are unreadable too — `policy.load` converts
+        # the `UnicodeDecodeError` rather than letting a ValueError past a handler
+        # that runs before the app can draw anything.
         try:
             self._tui_policy = policy_mod.load(project / policy_mod.POLICY_FILE).tui
         except (policy_mod.PolicyError, OSError):

--- a/tests/test_bmadconfig.py
+++ b/tests/test_bmadconfig.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from conftest import install_bmad_config
 
 from bmad_loop import bmadconfig
@@ -44,6 +45,20 @@ def test_load_paths_reads_repo_root_key(project) -> None:
     cfg.write_text(cfg.read_text() + "repo_root: '{project-root}/sub'\n")
     loaded = bmadconfig.load_paths(project.project)
     assert loaded.repo_root == (project.project / "sub").resolve()
+
+
+def test_load_paths_non_utf8_config_raises_bmad_config_error(project) -> None:
+    """An undecodable config.yaml is as much a BmadConfigError as malformed YAML.
+    `read_text` raises UnicodeDecodeError, which is a ValueError and NOT an OSError,
+    so raw it slips past every `except (BmadConfigError, OSError)` degrade handler —
+    the `cli` command tails, `tui/data.py`'s project scans — and kills the process
+    instead of reporting a bad config. Asserting the type is the point:
+    UnicodeDecodeError is an exception too."""
+    install_bmad_config(project)
+    cfg = project.project / "_bmad" / "bmm" / "config.yaml"
+    cfg.write_bytes(b"implementation_artifacts: '\xff\xfe'\n")
+    with pytest.raises(bmadconfig.BmadConfigError, match="not valid UTF-8"):
+        bmadconfig.load_paths(project.project)
 
 
 def test_rebased_reroots_project_and_artifacts(tmp_path: Path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4000,6 +4000,43 @@ def test_validate_json_failing_check_emits_whole_document_at_rc_1(project, capsy
     assert "bmad-config" in {f["check"] for f in failed}
 
 
+def test_validate_reports_an_undecodable_policy_instead_of_crashing(project, capsys):
+    """`read_text` raises `UnicodeDecodeError` on a policy.toml saved as UTF-16 or
+    latin-1 — a ValueError, not an OSError, so it used to escape every
+    `except (PolicyError, OSError)` in the codebase, including `_configure_mux`,
+    which runs before argument dispatch on EVERY command. The result was a bare
+    `error:` line at startup in place of the named findings validate exists to print.
+    `policy.load` converts it, so the file is reported like any other bad policy.
+
+    Routed through `machine_json` deliberately: `main`'s bare `except Exception`
+    backstop also returns 1, so an rc-only assertion is green with the conversion
+    reverted. What bites is the document — stderr carries the backstop's line and
+    stdout carries nothing to parse."""
+    _write_policy(project.project, CLAUDE_ONLY_POLICY)
+    (project.project / ".bmad-loop" / "policy.toml").write_bytes(b'[scm]\nisolation = "\xff\xfe"\n')
+
+    doc = machine_json(["validate", "--project", str(project.project), "--json"], capsys, rc=1)
+    finding = next(f for f in doc["findings"] if f["check"] == "policy")
+    assert finding["severity"] == "problem"
+    assert "not valid UTF-8" in finding["message"]
+
+
+def test_validate_reports_an_undecodable_bmad_config_instead_of_crashing(project, capsys):
+    """The `config.yaml` half of the same conversion. Separate from the policy leg
+    because they are separate loaders with separate typed errors, and the callers that
+    first exposed this call BOTH — a fix to one would leave the other raising a raw
+    ValueError straight through the handler."""
+    _write_policy(project.project, CLAUDE_ONLY_POLICY)
+    install_bmad_config(project)
+    config = project.project / "_bmad" / "bmm" / "config.yaml"
+    config.write_bytes(b"implementation_artifacts: '\xff\xfe'\n")
+
+    doc = machine_json(["validate", "--project", str(project.project), "--json"], capsys, rc=1)
+    finding = next(f for f in doc["findings"] if f["check"] == "bmad-config")
+    assert finding["severity"] == "problem"
+    assert "not valid UTF-8" in finding["message"]
+
+
 def test_validate_json_counts_and_ok_agree_with_findings(project, capsys):
     """`ok` mirrors the exit code exactly: problems clear it, warnings never do."""
     install_bmad_config(project)

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -27,6 +27,17 @@ SECRET_AWS = "AKIACANARY0123456789"
 HOME_PATH = "/home/canaryuser/secret/proj"
 CODE = "def steal_creds(token): return token"
 SHA = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0"
+# Deliberately does NOT embed STORY_KEY: `checkpoint-pause` journals
+# `task.spec_file`, which `StoryTask._serialized_spec_file` persists
+# worktree-relative — a bare basename for a spec at the worktree root — and a
+# spec is free to be named after the feature rather than the story. Such a name
+# is identifier-shaped, so the scrub_json fallback emits it verbatim, and the
+# egress backstop cannot repair what was never aliased — only per-field routing
+# can. A name like `1.2-Acme….md` would be rescued by the story key inside it
+# and would prove nothing.
+SPEC_NAME = "AcmeVaultRotation.md"
+# The same spec as the reconcile kinds journal it: absolute, under the home path.
+SPEC_ABS = f"{HOME_PATH}/docs/stories/{SPEC_NAME}"
 
 CANARIES = [
     EMAIL,
@@ -48,6 +59,7 @@ CANARIES = [
     "CANARY_FEEDBACK",
     "CANARY_PATCH",
     SHA,
+    "AcmeVaultRotation",
 ]
 
 
@@ -128,6 +140,14 @@ def _seed_run(root, run_id="20260627-120000-aaaa", *, extra_journal=None, sweeps
     )
     j.append("story-done", story_key=STORY_KEY, commit=SHA)
     j.append("sprint-status-unknown-keys", keys=[STORY_KEY, "9.9-OtherSecret"])
+    j.append("checkpoint-pause", story_key=STORY_KEY, checkpoint="plan", spec=SPEC_NAME)
+    # The SAME spec, in the other shape a producer emits: engine.py's reconcile
+    # and marker-repair kinds journal `str(spec_path)`, which
+    # `verify.resolve_spec_path` returns absolute, while `checkpoint-pause` above
+    # journals `task.spec_file` — persisted worktree-relative, so a bare basename
+    # for a root-level spec. Seeded here rather than in one test so the canary
+    # sweep covers the path shape too.
+    j.append("spec-status-reconciled", story_key=STORY_KEY, spec=SPEC_ABS)
     for kind, fields in extra_journal or []:
         j.append(kind, **fields)
 
@@ -185,6 +205,88 @@ def test_pseudonymization_is_stable_and_correlates(project):
     # the same alias appears in the per-task journal event counts (correlation)
     assert alias in run.journal.per_alias_event_counts
     assert alias in combined
+
+
+def test_spec_name_is_aliased_in_its_own_namespace(project):
+    """The spec-carrying journal kinds carry the spec's name, which is the
+    customer's feature name. `test_no_canary_leaks_anywhere` already proves it does
+    not ship; this pins HOW — a per-field alias in a `spec` namespace of its own,
+    so it never renders in the epic-less `story-<hex>` shape a reused "story"
+    namespace would give a filename. Nothing else can cover it: the value is not
+    in the legend until it is routed, so the egress backstop has no alias to
+    substitute.
+
+    The namespace, not just the routing, is what this pins: `fullmatch` on the
+    `spec-` prefix is what fails if the field is moved to "story". (Correlation
+    across the two shapes a producer emits is a separate contract with its own
+    witness below — this test's run seeds both, but neither of its assertions can
+    see the difference.)"""
+    run_dir = _seed_run(project.project)
+    diag, pseudo, combined = _render_all([run_dir])
+    alias = next(a for _ns, orig, a in pseudo.entries() if orig == SPEC_NAME)
+    assert re.fullmatch(r"spec-[0-9a-f]{12}", alias), alias
+    assert alias in combined
+    # distinct from the story alias, and not wearing its shape
+    assert alias != diag.runs[0].tasks[0].alias
+
+
+def test_one_spec_gets_one_alias_whichever_shape_it_was_journalled_in(project):
+    """A spec journalled as a bare basename by `checkpoint-pause` and as an
+    absolute path by the reconcile kinds is ONE spec, and must read as one.
+
+    Aliasing is chosen over dropping precisely so a maintainer can follow one
+    identifier across events (`_JOURNAL_ALIAS_FIELDS`' own docstring says so), so
+    two aliases for one spec is not cosmetic — it is the feature failing silently
+    in a dump that looks correct. The seeded run carries both shapes; the fixture
+    can express the failure because `SPEC_ABS` and `SPEC_NAME` are different
+    strings that must nonetheless collapse to a single alias.
+
+    The legend assertion is the second half of the same fix and needs its own
+    line: normalizing to the basename is also what keeps the user's absolute home
+    path out of the `--legend` file. Before `spec` was routed at all, a path-shaped
+    value was rejected by `scrub_json` and never entered the map; routing it
+    without normalizing would have put it there."""
+    run_dir = _seed_run(project.project)
+    _diag, pseudo, _combined = _render_all([run_dir])
+    aliases = {a for _ns, orig, a in pseudo.entries() if SPEC_NAME in orig}
+    assert len(aliases) == 1, pseudo.entries()
+    originals = [orig for _ns, orig, _a in pseudo.entries() if SPEC_NAME in orig]
+    assert originals == [SPEC_NAME], originals
+    assert HOME_PATH not in str(pseudo.legend())
+
+
+def test_a_windows_spec_path_normalizes_to_the_same_alias():
+    """The basename split handles backslashes, on every platform.
+
+    A journal written on Windows is routinely read by `diagnose` on POSIX, where
+    `PurePath(r"C:\\Users\\a\\x.md").name` is the WHOLE string — so the split is
+    separator-agnostic by hand rather than delegated to pathlib. This test is the
+    Windows witness that runs on the POSIX lanes too: it asserts on strings, never
+    on the filesystem, so it must NOT be skipped off Windows — which is the only
+    reason the divergence is covered at all."""
+    pseudo = sanitize.Pseudonymizer(salt=b"fixed")
+    posix = diagnostics._scrub_entry(
+        {"kind": "spec-status-reconciled", "spec": f"/home/u/docs/{SPEC_NAME}"}, pseudo, {}, None
+    )
+    windows = diagnostics._scrub_entry(
+        {"kind": "spec-status-reconciled", "spec": f"C:\\Users\\u\\docs\\{SPEC_NAME}"},
+        pseudo,
+        {},
+        None,
+    )
+    bare = diagnostics._scrub_entry(
+        {"kind": "checkpoint-pause", "spec": SPEC_NAME}, pseudo, {}, None
+    )
+    assert posix["spec"] == windows["spec"] == bare["spec"]
+    assert list(pseudo.legend().values()) == [SPEC_NAME]
+    # Totality: a value ending in a separator has an empty tail, and `alias()`
+    # passes "" through unaliased — the event would lose its only reference to
+    # the spec rather than gain one. The `or value` fallback owns this line.
+    trailing = diagnostics._scrub_entry(
+        {"kind": "spec-status-reconciled", "spec": "docs/"}, pseudo, {}, None
+    )
+    assert trailing["spec"] != ""
+    assert re.fullmatch(r"spec-[0-9a-f]{12}", trailing["spec"])
 
 
 def test_structure_is_preserved(project):

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -323,6 +323,20 @@ def test_bad_toml(tmp_path):
         policy.load(p)
 
 
+def test_non_utf8_file_raises_policy_error(tmp_path):
+    """An undecodable policy.toml is as much a PolicyError as a malformed one.
+    `read_text` raises UnicodeDecodeError, which is a ValueError and NOT an OSError,
+    so raw it slips past every `except (PolicyError, OSError)` degrade handler —
+    `cli._configure_mux` (which runs before argument dispatch on every command),
+    `tui/app.py`, and the dashboard constructor — and kills the process instead of
+    falling back to defaults. Asserting the type is the point: UnicodeDecodeError is
+    an exception too."""
+    p = tmp_path / "policy.toml"
+    p.write_bytes(b'[gates]\nmode = "\xff\xfe"\n')
+    with pytest.raises(policy.PolicyError, match="not valid UTF-8"):
+        policy.load(p)
+
+
 def test_loads_defaults_and_text():
     assert policy.loads("").gates.mode == policy.GatesPolicy.mode
     assert policy.loads('[gates]\nmode = "none"\n').gates.mode == "none"

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -3067,6 +3067,52 @@ async def test_start_run_modal_stories_source_blank_folder_errors(project, monke
         assert not calls
 
 
+def _write_undecodable_policy(root: Path, text: str) -> Path:
+    """Write `text` to policy.toml followed by bytes no UTF-8 decoder accepts.
+
+    0xff/0xfe are illegal as UTF-8 lead bytes anywhere in a stream, so
+    `read_text(encoding="utf-8")` — what `policy.load` calls — raises
+    `UnicodeDecodeError` over the whole file however valid the leading TOML is.
+    Real bytes, not a monkeypatched raiser: the decode is the thing under test."""
+    bmad = root / ".bmad-loop"
+    bmad.mkdir(parents=True, exist_ok=True)
+    path = bmad / "policy.toml"
+    path.write_bytes(text.encode("utf-8") + b"# \xff\xfe\n")
+    with pytest.raises(UnicodeDecodeError):  # the fixture is genuinely undecodable
+        path.read_text(encoding="utf-8")
+    return path
+
+
+async def test_start_run_modal_prefill_degrades_on_undecodable_policy(project, monkeypatch):
+    """Pins the `except (PolicyError, OSError)` handler in BmadLoopApp._stories_defaults
+    against a policy.toml whose *bytes* won't decode: the modal prefills sprint mode.
+
+    `UnicodeDecodeError` is a `ValueError`, so before `policy.load` converted it to
+    `PolicyError` it walked past that handler untouched. It never even got that far in
+    practice — BmadLoopApp.__init__ eagerly builds DashboardScreen, which loads the same
+    file, so the failure mode was a crash at app CONSTRUCTION rather than a degraded
+    prefill: the operator could not reach the modal at all. This is the direct oracle for
+    the prefill half; the dashboard half is test_dashboard_survives_undecodable_policy_bytes."""
+    text = '[stories]\nsource = "stories"\nspec_folder = "_bmad-output/epic-1"\n'
+    # Precondition: decodable, this file would prefill stories mode + that folder. So the
+    # sprint-mode assertions below show the *decode* was refused, not an inert fixture.
+    pol = policy_mod.loads(text)
+    assert (pol.stories.source, pol.stories.spec_folder) == ("stories", "_bmad-output/epic-1")
+    _write_undecodable_policy(project.project, text)
+    # action_start_run bails on _mux_missing() before it can push the modal — see the
+    # comment on test_start_run_modal_stories_preview_validates.
+    monkeypatch.setattr(launch, "mux_available", lambda: True)
+    app = BmadLoopApp(project.project)
+    async with app.run_test() as pilot:
+        await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
+        await pilot.press("r")
+        await until(pilot, lambda: isinstance(app.screen, StartRunModal))
+        await ready(pilot, "#ok")
+        modal = app.screen
+        assert modal.query_one("#source", Select).value == "sprint-status"
+        assert modal.query_one("#spec-folder", Input).value == ""
+
+
 # --------------------------------------------------------------- pane resizing
 
 
@@ -3308,6 +3354,29 @@ async def test_dashboard_survives_policy_read_oserror(project, monkeypatch):
         screen = await _seeded(pilot, app)
         assert screen._tui_policy == policy_mod.TuiPolicy()
         assert screen.query_one("#left").size.width == 34  # CSS default, unseeded
+        assert not screen._left_frozen and not screen._detail_frozen
+
+
+async def test_dashboard_survives_undecodable_policy_bytes(project):
+    """Pins the `except (PolicyError, OSError)` handler in DashboardScreen.__init__
+    against a policy.toml whose *bytes* won't decode.
+
+    `UnicodeDecodeError` is a `ValueError`, so before `policy.load` converted it to
+    `PolicyError` it walked straight past that handler — and since BmadLoopApp.__init__
+    eagerly constructs DashboardScreen, the failure was a crash at app CONSTRUCTION,
+    before run_test ever mounted a screen or a key was pressed. Not a degraded render:
+    no render at all. The sibling OSError test monkeypatches its raiser; this one uses
+    real bytes, which is what makes it a decode test rather than a duplicate."""
+    text = "[tui]\nleft_width = 50\n"
+    # Precondition: decodable, this file would seed a 50-column sidebar. So asserting
+    # the CSS default below shows the *decode* was refused, not that the file was inert.
+    assert policy_mod.loads(text).tui.left_width == 50
+    _write_undecodable_policy(project.project, text)
+    app = BmadLoopApp(project.project)
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = await _seeded(pilot, app)
+        assert screen._tui_policy == policy_mod.TuiPolicy()
+        assert screen.query_one("#left").size.width == 34  # CSS default, not the file's 50
         assert not screen._left_frozen and not screen._detail_frozen
 
 


### PR DESCRIPTION
Forward-port of the 0.9.1 hotfix to `main`, sub-phase 6C. Part of #433.

Three unrelated one-file robustness fixes, landed together because they are independent of the
rest of the program and clear noise from the sub-phases that follow. The other reason they go
first is the **pyright canary** — see below.

## What lands

**1. An undecodable `policy.toml` / `config.yaml` is reported, not a crash.** `UnicodeDecodeError`
is a `ValueError`, not an `OSError`, so a config saved in UTF-16 or latin-1 escaped every
`except (PolicyError, OSError)` / `except BmadConfigError` handler in the codebase — and those
handlers exist precisely to degrade to defaults rather than take the process down. It reached
`cli._configure_mux`, which runs before argument dispatch on **every** command, and
`DashboardScreen.__init__`, which runs before the TUI can draw anything: the app died at
construction, not at a keypress. `policy.load` and `bmadconfig.load_paths` convert it to their own
typed errors, fixing every handler at once instead of asking each to name a second exception type
it has no other reason to know about.

**2. `_stories_defaults` drops the unreachable `ParseError` leg.** `policy.py` parses with
`tomllib`; tomlkit's `ParseError` has never been reachable from that call. With the conversion
above, `(PolicyError, OSError)` is total there. The import stays — `action_settings` catches a
genuine tomlkit `ParseError` from `PolicyDoc.load`.

**3. `diagnose` aliases the spec name, and gives one spec one alias.** A journal record's `spec`
field carries the customer's feature name. A bare basename is identifier-shaped, so `scrub_json`
waved it through **verbatim**, and the egress backstop could not rescue it — it only repairs
values already in the legend, and an unrouted value never enters one.

`spec` gets a namespace of its **own**, not `story`: the epic lookup is keyed on `ns == "story"`,
so a filename aliased there always misses and renders as an epic-less `story-<hex>`,
indistinguishable from a story key whose epic could not be resolved.

Routing alone would have been half a fix, and on the path shape strictly worse than today. The
producers disagree on shape — `engine.py` journals `str(spec_path)` (absolute), `stories_engine.py`
journals `task.spec_file`, which `StoryTask` persists worktree-relative — so one spec drew **two**
aliases in a single dump, defeating the correlation these fields are aliased rather than dropped to
preserve, and parked an absolute home path in the local `--legend` file. `_alias_input` reduces the
value to its basename first, splitting on **both** separators, because a journal written on Windows
is routinely diagnosed on POSIX, where `PurePath` treats a backslash as an ordinary character and
the normalization would silently no-op. The `or value` fallback covers a trailing separator, whose
empty tail `alias()` passes through unaliased — the event would render a blank `spec` and lose its
only reference, with no `<redacted:str>` marker to show anything was removed.

## The pyright canary — the reason 6C is early

`policy.py` is in pyright's **strict** list, and none of this code had ever been typechecked:
`pyright` is configured and gated on `main`, and was not configured at all on `release/0.9.x`.
Landing the 8-line strict change here means any 0.9.x→main strict surprise surfaces on 8 lines
rather than confounded with `model.py`'s ~110 in 6I.

Baseline extracted from `origin/main` before any edit: **0 errors, 0 warnings, 0 informations**.
After: **0 / 0 / 0** — zero delta, not zero-compared-to-nothing. The gate was proven to still bite
by appending `def _gate_probe(x: int) -> str: return x` to `policy.py`, confirming it reported
(`reportUnusedFunction` + `reportReturnType`), and reverting. `pyright==1.1.411` is untouched —
its pin comment declares it the single pin keeping CI and local identical, and a forward-port is
not the change that renegotiates a gate.

## Ablation matrix — whole suite, both lanes

`origin/main` baseline: **3929 collected** (3901 passed / 24 skipped / 4 pre-existing
`test_module_skills_sync` failures from local dev-box skill drift, identical on a clean checkout).
This branch: **3938 collected** (+9 tests). Every row below was run against the **whole** suite,
`__pycache__` cleared between flips, and the source digest verified byte-identical after each
revert. The 3.14 lane is a separate checkout with its own `--all-extras` venv, import sentinel
confirmed, and **3938 collected** there too.

| ablation | new reds (3.13) | new reds (3.14) | which tests |
| --- | --- | --- | --- |
| A `policy.load` decode conversion reverted | 4 | 4 | policy unit, validate `--json`, both TUI |
| B `bmadconfig.load_paths` reverted | 2 | 2 | bmadconfig unit, validate `--json` |
| C `"spec": "spec"` routing deleted | 8 | 8 | 3 new + `no_canary_leaks` + `routing_gap_repaired` + 3 in `test_cli.py` |
| D `spec` aliased under `story` | 3 | 3 | the namespace `fullmatch` and both correlation legs |
| E `_alias_input` call deleted | 2 | 2 | correlation + Windows witness |
| F `[\\/]` → `/` | 1 | 1 | Windows witness alone |
| G `or value` fallback dropped | 1 | 1 | Windows witness alone (the totality assert) |
| H `_stories_defaults` narrowed to `except OSError` | 1 | 1 | modal prefill alone |
| I `ParseError` restored to the tuple | **0** | **0** | — |

**Row I is reported, not hidden.** Restoring the removed leg reddens nothing on either lane,
because a wider-but-unreachable except tuple is behaviorally identical. Naming which kind of
finding that is: **redundant code**, not an unpinned claim — no test can distinguish the two
tuples, and one that appeared to would be reading a coincidence. (A single red did appear in row I
on the first 3.13 run, `test_decision_modal_scrolls_when_content_long`; re-running the whole row
gave 0. It is the known modal-scroll flake, not an effect of the ablation.)

Two rows worth reading because they did **not** move: `test_no_repairs_on_fully_routed_run` stays
green under row C — the backstop cannot repair a value that was never routed, which is exactly why
the three new tests exist and why the backstop could not substitute for them. And row C's red in
`test_routing_gap_is_repaired_end_to_end` was **not** predicted: it fails with
`LEAK after repair: 'AcmeVaultRotation'`, a second independent canary witness of the same leak.

## Test notes

The command-level decode tests go through `machine_json`, not an rc assertion — `cli.main`'s bare
`except Exception` backstop already returns 1, so an rc-only test is green with the conversion
reverted.

`SPEC_NAME` deliberately does **not** embed `STORY_KEY`: a name like `1.2-Acme….md` would be
rescued by the story key already in the legend, and the fixture could not express the failure.

The Windows witness asserts on strings only, never the filesystem, so it runs unguarded on the
POSIX lanes — that is the only reason the separator divergence is covered at all.

Both TUI tests carry a precondition asserting the same policy text, when decodable, *would* have
produced a different result — so the degraded-default assertions cannot pass on an inert fixture.

## Port adaptations

`_findings_by_check` does not exist on `main`; the tests use main's inline
`next(f for f in doc["findings"] if …)` idiom rather than importing a helper that isn't there.

0.9.x seeds the fixture with journal kind `spec-deferrals-harvested`, which **does not exist on
`main`** — it arrives with the harvest slice in a later sub-phase. The fixture uses kinds main
actually emits (`checkpoint-pause`, `spec-status-reconciled`). The routing is keyed on the field
name, not the kind, so nothing is weakened; the comment naming the producers was re-provenanced to
main accordingly.

## Gates

`pytest` **3910 passed / 24 skipped** · `pyright` **0 errors / 0 warnings / 0 informations**
(baseline delta zero) · `trunk fmt` and full `trunk check --no-fix` clean · full ablation matrix on
the 3.13 and 3.14 lanes.

The 4 `tests/test_module_skills_sync.py` failures are pre-existing local dev-box skill drift,
present identically on a clean `origin/main`, and are not reproduced in CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid UTF-8 in policy and configuration files now produces clear validation errors instead of crashes.
  - The TUI falls back to safe default settings when policy files cannot be decoded.
  - Diagnostic output now consistently pseudonymizes specification names across path formats while preserving alias correlation.
- **Tests**
  - Added regression coverage for invalid file encoding, TUI fallbacks, and cross-platform diagnostic pseudonymization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->