### PR TITLE
fix(verify): force literal git pathspecs, and read status stdout alone (#433, 6D)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -260,6 +260,25 @@ story <id>`, the same annotation a sweep bundle writes. Both sprint and stories 
 
 ### Fixed
 
+- **A configured path carrying `[`, `]`, `*` or `?` no longer makes git act on the wrong files
+  (#423).** `implementation_artifacts` reaches git verbatim out of the operator's
+  `_bmad/bmm/config.yaml`, and git reads a positional operand as a _pathspec_, not a path — so such
+  a name matched a wider set than the one it named, always on the over-match side. `commit_paths`
+  broke its own "commit exactly these paths (and nothing else)" promise, staging an unrelated
+  sibling's edit under a story's name; with the ledger gitignored it could also exit clean having
+  committed nothing, where the fixed form leaves a record. `has_changes_since` and `attempt_dirty`
+  excluded a sibling tree along with the artifacts dir and reported a changed attempt as CLEAN, and
+  their git half disagreed with the Python half about what "under the artifact dir" means.
+  `safe_rollback`'s preserve restore reached siblings too, handing back a change the reset had just
+  discarded. Every operand is now literal, and the two halves agree.
+
+- **A noisy git config no longer makes a pristine tree read as dirty.** `worktree_clean` compared
+  git's stdout and stderr merged, so `status` exiting 0 while warning about an unexecutable
+  `core.fsmonitor` hook or an unknown `core.fsyncMethod` was indistinguishable from a porcelain
+  record. Seven callers gate on it and three of them refuse the command outright, so such a host
+  could never start a run — and the message named no file. Only stdout is read now; the error path
+  still reports both.
+
 - **An undecodable `policy.toml` or `_bmad/bmm/config.yaml` is reported, not a crash.**
   `UnicodeDecodeError` is a `ValueError`, not an `OSError`, so a config file saved in UTF-16 or
   latin-1 escaped every `except (PolicyError, OSError)` handler in the codebase — and those handlers

--- a/src/bmad_loop/verify.py
+++ b/src/bmad_loop/verify.py
@@ -211,15 +211,40 @@ def last_commit_for(repo: Path, path: Path) -> str:
 
 
 def worktree_clean(repo: Path) -> bool:
-    # The orchestrator's own config file (.bmad-loop/policy.toml) is excluded:
-    # the TUI settings editor rewrites it, and a tracked config edit must not
-    # count as a "dirty tree" that blocks run/sweep/validate or forces a commit.
-    # Scope is policy.toml only — the deferred-work ledger also lives under
-    # .bmad-loop/ and is meant to be committed (see sweep._commit_ledger).
-    rc, out = _git(repo, "status", "--porcelain", "--", ".", f":(exclude){POLICY_FILE_REL}")
-    if rc != 0:
-        raise GitError(f"git status failed in {repo}: {out}")
-    return out == ""
+    """True when the tree holds no change git would report.
+
+    The orchestrator's own config file (.bmad-loop/policy.toml) is excluded: the TUI
+    settings editor rewrites it, and a tracked config edit must not count as a "dirty
+    tree" that blocks run/sweep/validate or forces a commit. Scope is policy.toml only
+    — the deferred-work ledger also lives under .bmad-loop/ and is meant to be
+    committed (see sweep._commit_ledger).
+
+    Reads `stdout` ALONE rather than `_git`'s stdout+stderr merge, for the reason
+    :func:`path_tracked` spells out: `status` exits 0 while still writing to stderr (a
+    `core.fsmonitor` hook that cannot exec, an unknown `core.fsyncMethod`, a stale
+    index advisory), and against the merged stream that chatter is indistinguishable
+    from a porcelain record — a pristine tree answers DIRTY. That direction is not
+    benign here: seven callers gate on it, and `cli.py`'s three refuse the command
+    outright, so a host with a noisy git config could never start a run and the
+    message would name no file. The error path keeps the merge, where stderr is the
+    only informative half."""
+    proc = _run_git(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "status",
+            "--porcelain",
+            "--",
+            ".",
+            f":(exclude){POLICY_FILE_REL}",
+        ],
+        repo,
+    )
+    if proc.returncode != 0:
+        merged = (proc.stdout + proc.stderr).strip()
+        raise GitError(f"git status failed in {repo}: {merged}")
+    return proc.stdout.strip() == ""
 
 
 def same_commit(a: str, b: str) -> bool:
@@ -317,12 +342,47 @@ def attempt_dirty(
 
 
 def _exclude_specs(dirs: tuple[str, ...]) -> list[str]:
-    """git pathspec `:(exclude)<dir>` args for each repo-relative dir prefix."""
-    return [f":(exclude){d}" for d in dirs]
+    """git pathspec `:(exclude,literal)<dir>` args for each repo-relative dir prefix.
+
+    `literal` for the same reason as :func:`_literal_specs` — git reads a positional
+    operand as a PATHSPEC, so `[`, `]`, `*` and `?` in an operator-configured dir are
+    wildmatch metacharacters — but the harm here runs the other way: an over-matching
+    exclusion HIDES a diff instead of exposing a file. `has_changes_since` and
+    `attempt_dirty` both spend these on `diff --quiet . :(exclude)<dir>`, so a dir
+    whose name carries a `*` excludes a sibling tree as well and the attempt reads
+    CLEAN when it changed — the same false "no changes" that a dev attempt's dirtiness
+    check exists to prevent (#423 item 3).
+
+    It also realigns this half with :func:`_path_under_any`, the Python `startswith`
+    that filters the untracked half of the very same `has_changes_since` call. The two
+    disagreed on exactly the shapes that glob (#423 item 4): the tracked half excluded
+    a path the untracked half still counted, so one function's two branches answered
+    differently about what "under the artifact dir" means. Literal is the reading
+    `_path_under_any` already implements, which is why fixing the git half is the right
+    direction and not a coin flip.
+
+    Measured, not read off the docs: only a `*` (which crosses `/`) reaches a sibling
+    DIRECTORY's contents; a same-length `[…]`/`?` collision reaches a sibling FILE
+    only, because the pathspec has to match the whole path. Both magic words go in ONE
+    comma-separated `:(...)` prefix — the global `--literal-pathspecs` /
+    `GIT_LITERAL_PATHSPECS` form would disarm the `:(exclude)` magic too and silently
+    stop excluding anything at all. Verified identical at git 2.20.4 (the floor
+    `install._WORKTREE_CONFIG_GIT` declares) and 2.55.0."""
+    return [f":(exclude,literal){d}" for d in dirs]
+
+
+def _literal_specs(rels: list[str]) -> list[str]:
+    """git pathspec `:(literal)<rel>` for each repo-relative posix path — the operand
+    form that means "this path", not "this glob". See `path_tracked` for why."""
+    return [f":(literal){r}" for r in rels]
 
 
 def _path_under_any(path: str, prefixes: tuple[str, ...]) -> bool:
-    """True if repo-relative posix `path` equals or sits under any `prefixes` dir."""
+    """True if repo-relative posix `path` equals or sits under any `prefixes` dir.
+
+    The literal reading of "under", and since #423 item 4 the one `_exclude_specs`
+    agrees with — the two filter the tracked and untracked halves of a single
+    `has_changes_since` answer and must not disagree."""
     return any(path == p or path.startswith(p.rstrip("/") + "/") for p in prefixes)
 
 
@@ -334,6 +394,68 @@ def untracked_files(repo: Path) -> set[str]:
     if rc != 0:
         raise GitError(f"git ls-files --others failed in {repo}: {out}")
     return {line.strip() for line in out.splitlines() if line.strip()}
+
+
+def path_tracked(repo: Path, rel: str) -> bool:
+    """True when repo-relative posix ``rel`` has an index entry — i.e. git OWNS the
+    path, so a `reset --hard` restores it and no caller should delete it by hand.
+
+    The single-path complement of :func:`untracked_files`, and the pair is what makes
+    the third state legible: neither tracked nor in that set means IGNORED, which no
+    rollback step touches at all (`reset --hard` skips it, and this module never runs
+    `git clean`). A caller that reasons only over "tracked vs untracked" silently
+    files every ignored path under whichever branch it wrote last.
+
+    Only the output's EMPTINESS is read, never its text: `core.quotePath` mangles
+    non-ASCII names, and a tracked-but-deleted-from-the-worktree path still lists (the
+    index entry outlives the file), which is exactly the state a caller must not
+    mistake for "not git's". Not `--error-unmatch`, which reports "not tracked" and
+    "git blew up" with the same non-zero rc; not `check-ignore`, which answers whether
+    a RULE matches rather than whether git owns the path — a `git add -f`'d file under
+    an ignore rule has to read tracked here.
+
+    Reads `stdout` ALONE, not `_git`'s stdout+stderr merge: `ls-files` exits 0 while
+    still writing to stderr — a `core.fsmonitor` hook that cannot exec, an unknown
+    `core.fsyncMethod` — and against the merged stream that chatter reads as an index
+    entry for a path git does not track at all. The failure is silent and inverted
+    (untracked answers "tracked"), so callers act on the opposite of the truth. The
+    error path keeps the merge, where stderr is the only informative half.
+
+    The pathspec is forced LITERAL, because git reads a positional operand as a
+    PATHSPEC and not as a path: `[`, `]`, `*` and `?` in ``rel`` are wildmatch
+    metacharacters, so a probe for an ABSENT path answers True the moment some OTHER
+    tracked path happens to match the glob. The error is one-directional —
+    `match_pathspec_item` compares literally before it falls through to fnmatch, so a
+    genuinely tracked path never reads untracked — and it runs toward the answer that
+    authorizes leaving a file alone, which is how a harvested ledger under an
+    operator-named `implementation_artifacts` (`bmadconfig._resolve` takes that key
+    verbatim, metacharacters and all) outlived the rollback that discarded the code it
+    described. Not the global `--literal-pathspecs` / `GIT_LITERAL_PATHSPECS` form,
+    which would also disarm the `:(exclude)` magic `worktree_clean`, `has_changes_since`
+    and `attempt_dirty` are built on; the per-operand prefix is scoped to this call. It
+    costs the callers nothing: that same literal comparison is what matches a DIRECTORY
+    prefix, so `_bmad/render` still lists everything beneath it (`cmd_validate`'s
+    render-tracked warning), and it additionally disarms a ``rel`` that itself begins
+    with `:`, which git would otherwise parse as magic and answer the empty set for.
+    Measured identical at git 2.20.4 — the floor `install._WORKTREE_CONFIG_GIT`
+    declares — and at 2.55.0; below a version that understands the prefix it would read
+    as a literal FILENAME, match nothing and answer False, which is the one direction
+    that authorizes a delete.
+
+    Raises GitError like every other probe in this module. Callers inside a rollback
+    `finally` catch it and degrade toward leaving the file alone: uncertainty must
+    never authorize a delete. The message keeps the BARE ``rel``: the operator's path is
+    its informative half and the magic prefix is our own plumbing.
+
+    Ships with no caller — `git.render-tracked` (`cmd_validate`) and
+    `_ledger_is_gits_to_restore` (the harvest revert) are its consumers and land in
+    later sub-phases of #433. Inert, not silent: neither ruff's `E4,E7,E9,F` set nor
+    pyright basic reports an unused module-level function."""
+    proc = _run_git(["git", "-C", str(repo), "ls-files", "--", *_literal_specs([rel])], repo)
+    if proc.returncode != 0:
+        merged = (proc.stdout + proc.stderr).strip()
+        raise GitError(f"git ls-files -- {rel} failed in {repo}: {merged}")
+    return bool(proc.stdout.strip())
 
 
 def commits_above(repo: Path, baseline: str) -> list[str]:
@@ -666,8 +788,16 @@ def safe_rollback(
         # corrected spec (which would regress the re-drive into a recovery loop).
         # `_run_git` pins LC_ALL=C, so this English substring is stable under a
         # localized git (#236) — never translated out from under the match.
+        #
+        # The operand is LITERAL (#423 item 5). `preserve` carries operator-configured
+        # dirs, and this is a WRITE: a glob-matching neighbour is not merely restored
+        # alongside the target, it is reverted to the snapshot — measured, a plain
+        # `checkout <snap> -- 'doc*'` reverts an unrelated `docsa/f.md` edit, which is
+        # the operator's own uncommitted work destroyed by a step whose entire job is
+        # to preserve. `:(literal)` still matches a directory prefix, so each preserve
+        # dir restores everything beneath it exactly as before.
         for d in preserve:
-            rc, out = _git(repo, "checkout", snapshot, "--", d)
+            rc, out = _git(repo, "checkout", snapshot, "--", *_literal_specs([d]))
             if rc != 0 and "did not match" not in out:
                 raise GitError(f"git checkout {snapshot[:12]} -- {d} failed: {out}")
     if policy_content is not None:
@@ -2065,28 +2195,55 @@ def commit_paths(repo: Path, message: str, paths: list[Path]) -> str | None:
     repo_root = repo.resolve()
     for p in paths:
         try:
-            rels.append(str(Path(p).resolve().relative_to(repo_root)))
+            # `.as_posix()`, not `str()`: every rel here becomes a git pathspec and is
+            # compared against git-derived output, and git speaks posix separators on
+            # every platform. `str()` yields backslashes on Windows, which git reads as
+            # wildmatch ESCAPES rather than separators.
+            rels.append(Path(p).resolve().relative_to(repo_root).as_posix())
         except ValueError:
             continue
     missing = [r for r in rels if not ((repo_root / r).exists() or (repo_root / r).is_symlink())]
     if missing:
-        rc, out = _git_raw(repo, "ls-files", "-z", "--", *missing)
+        rc, out = _git_raw(repo, "ls-files", "-z", "--", *_literal_specs(missing))
         if rc != 0:
             raise GitError(f"git ls-files failed: {out}")
         tracked = {t for t in out.split("\0") if t}
-        rels = [r for r in rels if r not in missing or r.replace("\\", "/") in tracked]
+        rels = [r for r in rels if r not in missing or r in tracked]
     if not rels:
         return None
-    rc, out = _git(repo, "add", "--", *rels)
+    # Every operand is forced LITERAL: git reads a positional operand as a PATHSPEC,
+    # and `implementation_artifacts` reaches here verbatim out of the operator's
+    # `_bmad/bmm/config.yaml` (`bmadconfig._resolve` substitutes and resolves it, and
+    # nothing sanitizes it), so a `[`, `]`, `*` or `?` in a configured path is a
+    # wildmatch metacharacter. Unescaped, this function breaks its own first promise —
+    # "commit exactly `paths` (and nothing else)": `add -- docs[a]/f.md` also stages
+    # `docsa/f.md`, and the operator's unrelated edit is committed under a story's
+    # name. The operand is a SUPERSET (git compares literally before falling through
+    # to fnmatch), which is why the over-match direction is the only one possible.
+    #
+    # A second, quieter harm with the ledger GITIGNORED — the shape
+    # `_carry_harvested_deferrals` is built to hit: `git add` refuses an explicitly
+    # named ignored path (rc 1) but SKIPS a globbed one, so the plain form could exit
+    # rc 0 having staged nothing, `status` find no change, and the carry report success
+    # having committed no ledger and journalled no `harvest-carry-uncommitted` — a
+    # silent loss where the literal form leaves a record. Note the `ls-files` operands
+    # above are literalised too: that leg reads membership rather than acting, so its
+    # failure direction is to DROP a rel (the glob returns the neighbour's name, which
+    # never equals `r`), but leaving one bare operand beside three fixed ones is the
+    # next reader's trap. It is also why the `r.replace("\\", "/")` that used to guard
+    # this comparison is gone: `.as_posix()` above fixes the separator at the source,
+    # and a dead normalizer beside a glob operand reads as protection that isn't there.
+    specs = _literal_specs(rels)
+    rc, out = _git(repo, "add", "--", *specs)
     if rc != 0:
         raise GitError(f"git add failed: {out}")
-    rc, out = _git(repo, "status", "--porcelain", "--", *rels)
+    rc, out = _git(repo, "status", "--porcelain", "--", *specs)
     if rc != 0:
         raise GitError(f"git status failed: {out}")
     if not out:
         return None  # nothing changed in these paths
     # pathspec form commits only `rels`, ignoring any other staged changes
-    rc, out = _git(repo, "commit", "-m", message, "--", *rels)
+    rc, out = _git(repo, "commit", "-m", message, "--", *specs)
     if rc != 0:
         raise GitError(f"git commit failed: {out}")
     return rev_parse_head(repo)

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1898,6 +1898,236 @@ def test_worktree_clean_flags_untracked_non_policy(project):
     assert not verify.worktree_clean(project.project)
 
 
+# ------------------------------------------------- git pathspec hardening (#423)
+#
+# Every fixture below is built in PYTHON, never through a shell: fish and zsh
+# glob-expand `docs[a]` / `a*b` / `q?r` into non-existence, and `git rm --cached
+# '<glob>'` takes its argument as a pathspec too — both produced void fixtures
+# (a test that passes because it tested nothing) on the 0.9.1 hotfix.
+#
+# `*` and `?` are illegal in Windows FILENAMES, so a fixture that must create a
+# directory carrying one is Linux-only. `[` and `]` are legal everywhere — and
+# per #423's reachability analysis they are also the realistic carrier, since
+# `implementation_artifacts` comes out of the operator's config — so the
+# bracket rows stay unmarked and cover both CI platforms. Note this constrains
+# only fixture FILENAMES: a pathspec STRING containing `*` is just a string, so
+# the tests that merely pass `doc*` as a configured prefix run everywhere.
+NO_GLOB_FILENAMES = pytest.mark.skipif(
+    sys.platform == "win32", reason="`*` and `?` are illegal in Windows filenames"
+)
+
+
+def _metachar_pair(repo, meta: str, victim: str):
+    """A metachar dir and the sibling its glob collides with, both committed.
+
+    Returns the two `f.md` paths. `doc*` is the shape that matters most: `*`
+    crosses `/`, so it is the only one that reaches a sibling DIRECTORY's
+    contents — `[…]`/`?` are same-length and reach a sibling FILE only.
+    """
+    for d in (meta, victim):
+        (repo / d).mkdir(parents=True, exist_ok=True)
+        (repo / d / "f.md").write_text("v1\n")
+    git(repo, "add", "-A")
+    git(repo, "commit", "-q", "-m", "metachar fixture")
+    return repo / meta / "f.md", repo / victim / "f.md"
+
+
+def test_path_tracked_reports_index_membership(project):
+    """The basic contract: an index entry is True, an untracked file is False."""
+    repo = project.project
+    assert verify.path_tracked(repo, "src.txt")
+    (repo / "stray.txt").write_text("untracked\n")
+    assert not verify.path_tracked(repo, "stray.txt")
+    assert not verify.path_tracked(repo, "never_existed.txt")
+
+
+@pytest.mark.parametrize(
+    ("meta", "neighbour"),
+    [
+        ("docs[a]", "docsa"),
+        pytest.param("a*b", "axb", marks=NO_GLOB_FILENAMES),
+        pytest.param("q?r", "qxr", marks=NO_GLOB_FILENAMES),
+    ],
+)
+def test_path_tracked_refuses_a_glob_match_from_a_neighbour(project, meta, neighbour):
+    """An ABSENT path whose name carries pathspec metacharacters must not read as
+    tracked just because some OTHER tracked path matches it as a glob.
+
+    This is the inverted, silent failure: `_ledger_is_gits_to_restore` answers
+    "git owns it" for a ledger git has never seen, so the harvest revert skips
+    its `unlink()` and a finding about discarded code stays open. Ablating the
+    `:(literal)` prefix flips the first assertion to True."""
+    repo = project.project
+    _metachar_pair(repo, meta, neighbour)
+    # Untrack ONLY the metachar path; its glob-colliding neighbour stays tracked.
+    git(repo, "rm", "-r", "-q", "--cached", "--", f":(literal){meta}")
+    assert not verify.path_tracked(repo, f"{meta}/f.md")
+    assert verify.path_tracked(repo, f"{neighbour}/f.md")
+
+
+def test_path_tracked_still_matches_a_directory_prefix(project):
+    """`:(literal)` must not cost the callers the prefix match they rely on —
+    `cmd_validate`'s render-tracked warning probes a DIRECTORY, not a file."""
+    repo = project.project
+    (repo / "_bmad" / "render").mkdir(parents=True, exist_ok=True)
+    (repo / "_bmad" / "render" / "render_skill.py").write_text("# renderer\n")
+    git(repo, "add", "-A")
+    git(repo, "commit", "-q", "-m", "render")
+    assert verify.path_tracked(repo, "_bmad/render")
+
+
+def test_path_tracked_reads_a_rel_beginning_with_a_colon(project):
+    """A leading `:` is pathspec magic. Bare, git parses it as an (unknown) magic
+    word and answers the empty set — i.e. "untracked", the direction that
+    authorizes a delete. The literal prefix disarms it."""
+    repo = project.project
+    odd = repo / ":weird"
+    odd.mkdir(exist_ok=True)
+    (odd / "f.md").write_text("v1\n")
+    git(repo, "add", "-A")
+    git(repo, "commit", "-q", "-m", "colon dir")
+    assert verify.path_tracked(repo, ":weird/f.md")
+
+
+def test_path_tracked_keeps_a_tracked_but_deleted_path(project):
+    """The index entry outlives the file, and that is exactly the state a caller
+    must not mistake for "not git's" — `reset --hard` will bring it back."""
+    repo = project.project
+    (repo / "src.txt").unlink()
+    assert verify.path_tracked(repo, "src.txt")
+
+
+def test_path_tracked_ignores_stderr_chatter_on_success(project, monkeypatch):
+    """`ls-files` exits 0 while still writing to stderr (an unexecutable
+    `core.fsmonitor` hook, an unknown `core.fsyncMethod`). Read against `_git`'s
+    stdout+stderr MERGE that chatter is indistinguishable from an index entry, so
+    an untracked path answers "tracked" — silent and inverted. Only stdout counts."""
+    real = verify._run_git
+
+    def noisy(cmd, repo, **kw):
+        proc = real(cmd, repo, **kw)
+        if "ls-files" in cmd:
+            proc.stderr = "warning: unable to access '.git/hooks/fsmonitor': no such file\n"
+        return proc
+
+    monkeypatch.setattr(verify, "_run_git", noisy)
+    assert not verify.path_tracked(project.project, "never_existed.txt")
+
+
+def test_path_tracked_raises_on_git_failure(project):
+    """Raises GitError like every other probe here — callers inside a rollback
+    `finally` degrade toward leaving the file alone."""
+    with pytest.raises(verify.GitError, match="ls-files"):
+        verify.path_tracked(project.project / "not-a-repo", "src.txt")
+
+
+def test_worktree_clean_ignores_stderr_chatter_on_success(project, monkeypatch):
+    """A pristine tree must not read DIRTY because git wrote to stderr while
+    exiting 0. Seven callers gate on this and `cli.py`'s three refuse the command
+    outright, so the merged-stream read made a noisy git config unable to start a
+    run — with no file named in the message."""
+    real = verify._run_git
+
+    def noisy(cmd, repo, **kw):
+        proc = real(cmd, repo, **kw)
+        if "status" in cmd:
+            proc.stderr = "warning: core.fsyncMethod unknown value\n"
+        return proc
+
+    monkeypatch.setattr(verify, "_run_git", noisy)
+    assert verify.worktree_clean(project.project)
+    (project.project / "stray.txt").write_text("real change\n")
+    assert not verify.worktree_clean(project.project)  # a genuine change still shows
+
+
+def test_commit_paths_refuses_to_stage_a_glob_neighbour(project):
+    """`commit_paths` promises "exactly `paths` (and nothing else)". Unescaped, a
+    configured artifacts dir carrying `[` also stages the operator's unrelated
+    edit in the colliding sibling — committed under a story's name."""
+    repo = project.project
+    target, victim = _metachar_pair(repo, "docs[a]", "docsa")
+    target.write_text("the artifact this commit is for\n")
+    victim.write_text("the operator's own uncommitted work\n")
+
+    sha = verify.commit_paths(repo, "chore: artifact only", [target])
+
+    assert sha is not None
+    status = git(repo, "status", "--porcelain")
+    assert "docsa/f.md" in status  # the neighbour is STILL uncommitted
+    assert "docs[a]" not in status  # the named path did land
+    assert victim.read_text() == "the operator's own uncommitted work\n"
+
+
+def test_commit_paths_leaves_a_record_for_a_gitignored_path(project):
+    """With the ledger gitignored — the shape `_carry_harvested_deferrals` hits —
+    `git add` REFUSES an explicitly named ignored path (rc 1) but SKIPS a globbed
+    one. Bare, the call could exit rc 0 having staged nothing and report success
+    having committed no ledger; the literal operand raises instead, so the caller
+    still has a record."""
+    repo = project.project
+    gitignore = repo / ".gitignore"
+    gitignore.write_text(gitignore.read_text() + "ignored-dir/\n")
+    git(repo, "add", ".gitignore")
+    git(repo, "commit", "-q", "-m", "ignore")
+    (repo / "ignored-dir").mkdir(exist_ok=True)
+    ledger = repo / "ignored-dir" / "deferred-work.md"
+    ledger.write_text("# ledger\n")
+
+    with pytest.raises(verify.GitError, match="git add failed"):
+        verify.commit_paths(repo, "chore: ledger", [ledger])
+
+
+def test_exclude_specs_does_not_hide_a_siblings_diff(project):
+    """An artifacts dir whose name carries `*` must not also exclude the sibling
+    tree it glob-matches: `has_changes_since` would answer "no changes" for a dev
+    attempt that changed real code, the false-green direction (#423 item 3)."""
+    repo = project.project
+    _metachar_pair(repo, "doc-x", "doc-y")  # committed, both under the `doc*` glob
+    baseline = verify.rev_parse_head(repo)
+    (repo / "doc-y" / "f.md").write_text("a real change outside the artifacts dir\n")
+
+    assert verify.has_changes_since(repo, baseline, exclude=("doc*",))
+
+
+def test_exclude_specs_agrees_with_path_under_any(project):
+    """The two halves of ONE `has_changes_since` answer — the git exclusion over
+    tracked changes and `_path_under_any` over untracked ones — must not disagree
+    about what "under the artifact dir" means (#423 item 4)."""
+    for prefix, path in (("docs[a]", "docsa"), ("q?r", "qxr"), ("doc*", "docsa/f.md")):
+        git_excludes = verify._exclude_specs((prefix,)) == [f":(exclude,literal){prefix}"]
+        python_under = verify._path_under_any(path, (prefix,))
+        assert git_excludes and not python_under, f"{prefix} vs {path}"
+
+
+def test_safe_rollback_preserve_does_not_restore_a_glob_neighbour(project):
+    """`preserve` restores operator-configured dirs from the snapshot, and this leg
+    WRITES. Bare, `checkout <snap> -- 'doc*'` also restores every sibling the glob
+    reaches — and because the snapshot is a `stash create` of the DIRTY tree, that
+    hands the dev attempt's change back after the reset was supposed to discard it.
+    The rollback silently under-reverts, and the next preflight sees a tree the
+    engine believes it rolled back (#423 item 5)."""
+    repo = project.project
+    # Only the NEIGHBOUR exists on disk; `doc*` is the operator's configured
+    # preserve dir, which the literal reading matches nothing for (a benign
+    # "pathspec did not match"). Keeping it absent is what makes the assertion
+    # discriminating AND lets the row run on Windows, where `*` cannot be a
+    # filename: bare, the glob reaches `docsa` and hands its change back.
+    (repo / "docsa").mkdir(parents=True, exist_ok=True)
+    neighbour = repo / "docsa" / "f.md"
+    neighbour.write_text("v1\n")
+    git(repo, "add", "-A")
+    git(repo, "commit", "-q", "-m", "neighbour")
+    baseline = verify.rev_parse_head(repo)
+    snap = sorted(verify.untracked_files(repo))
+    neighbour.write_text("the dev attempt's change\n")  # outside preserve — must revert
+
+    verify.safe_rollback(
+        repo, baseline, baseline_untracked=snap, keep=(".bmad-loop",), preserve=("doc*",)
+    )
+
+    assert neighbour.read_text() == "v1\n"  # reverted, not resurrected by the glob
+
+
 def test_commit_story(project):
     task = make_task(project)
     (project.project / "src.txt").write_text("done work\n")

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1905,15 +1905,17 @@ def test_worktree_clean_flags_untracked_non_policy(project):
 # '<glob>'` takes its argument as a pathspec too — both produced void fixtures
 # (a test that passes because it tested nothing) on the 0.9.1 hotfix.
 #
-# `*` and `?` are illegal in Windows FILENAMES, so a fixture that must create a
-# directory carrying one is Linux-only. `[` and `]` are legal everywhere — and
-# per #423's reachability analysis they are also the realistic carrier, since
-# `implementation_artifacts` comes out of the operator's config — so the
-# bracket rows stay unmarked and cover both CI platforms. Note this constrains
-# only fixture FILENAMES: a pathspec STRING containing `*` is just a string, so
-# the tests that merely pass `doc*` as a configured prefix run everywhere.
-NO_GLOB_FILENAMES = pytest.mark.skipif(
-    sys.platform == "win32", reason="`*` and `?` are illegal in Windows filenames"
+# `*`, `?` and `:` are all reserved in Windows FILENAMES (`:` is the drive
+# separator), so a fixture that must CREATE a directory carrying one is
+# Linux-only — `mkdir` raises WinError 123 before the test can assert anything.
+# `[` and `]` are legal everywhere, and per #423's reachability analysis they are
+# also the realistic carrier since `implementation_artifacts` comes out of the
+# operator's config, so the bracket rows stay unmarked and cover both CI
+# platforms. Note this constrains only fixture FILENAMES: a pathspec STRING
+# containing `*` is just a string, so the rows that merely pass `doc*` as a
+# configured prefix run everywhere.
+RESERVED_IN_WINDOWS_FILENAMES = pytest.mark.skipif(
+    sys.platform == "win32", reason="`*`, `?` and `:` are reserved in Windows filenames"
 )
 
 
@@ -1945,8 +1947,8 @@ def test_path_tracked_reports_index_membership(project):
     ("meta", "neighbour"),
     [
         ("docs[a]", "docsa"),
-        pytest.param("a*b", "axb", marks=NO_GLOB_FILENAMES),
-        pytest.param("q?r", "qxr", marks=NO_GLOB_FILENAMES),
+        pytest.param("a*b", "axb", marks=RESERVED_IN_WINDOWS_FILENAMES),
+        pytest.param("q?r", "qxr", marks=RESERVED_IN_WINDOWS_FILENAMES),
     ],
 )
 def test_path_tracked_refuses_a_glob_match_from_a_neighbour(project, meta, neighbour):
@@ -1976,6 +1978,7 @@ def test_path_tracked_still_matches_a_directory_prefix(project):
     assert verify.path_tracked(repo, "_bmad/render")
 
 
+@RESERVED_IN_WINDOWS_FILENAMES
 def test_path_tracked_reads_a_rel_beginning_with_a_colon(project):
     """A leading `:` is pathspec magic. Bare, git parses it as an (unknown) magic
     word and answers the empty set — i.e. "untracked", the direction that


### PR DESCRIPTION
Sub-phase **6D** of the #433 forward-port. Independent of 6C (merged as #439); branched from `main`.

`implementation_artifacts` is read verbatim out of the operator's `_bmad/bmm/config.yaml`
(`bmadconfig._resolve` only `{project-root}`-substitutes and resolves it — nothing sanitizes it),
and git reads a positional operand as a **pathspec**, not a path. So a configured name carrying
`[`, `]`, `*` or `?` matched a wider set than the one it named. Every affected call is on the
over-match side; none under-matches, because `match_pathspec_item` compares literally before
falling through to fnmatch.

## What changed

- **`commit_paths`** — all four operands (`ls-files -z`, `add`, `status`, `commit`) literalised, so
  it keeps its own first promise, "commit exactly `paths` (and nothing else)", instead of staging a
  glob-colliding sibling's edit under a story's name. A second, quieter harm with the ledger
  **gitignored** (the shape `_carry_harvested_deferrals` hits): `git add` refuses an explicitly
  named ignored path but *skips* a globbed one, so the bare form could exit rc 0 having staged
  nothing and report success having committed no ledger.
- **`.as_posix()`** replaces `str()` when building the rels, which makes the hand-rolled
  `r.replace("\\", "/")` at the membership test dead. Deleted in the same change — a dead
  normalizer beside a glob operand reads as protection that isn't there.
- **`_exclude_specs`** — now `:(exclude,literal)`. An artifacts dir whose name carries `*` was
  excluding the sibling tree it glob-matches, so `has_changes_since`/`attempt_dirty` reported a
  changed dev attempt as CLEAN. This also realigns the git half with `_path_under_any`, the Python
  `startswith` filtering the untracked half of the *same* `has_changes_since` answer — the two
  disagreed on exactly the shapes that glob (#423 items 3–4). Literal is the reading
  `_path_under_any` already implements, so agreeing on it is a fix, not a coin flip.
- **`safe_rollback`** — the preserve `checkout` is a **write**, so a glob reaching a sibling hands
  back a change the reset had just discarded (item 5).
- **`worktree_clean`** — rewritten onto `_run_git`, reading **stdout alone**. See below.
- **New `_literal_specs` and `path_tracked`**, ported from `release/0.9.x`.

## `worktree_clean` — a second bug found while porting

`_git` returns `(proc.stdout + proc.stderr).strip()`. `status` exits 0 while still writing to
stderr — an unexecutable `core.fsmonitor` hook, an unknown `core.fsyncMethod` — and against the
merged stream that chatter is indistinguishable from a porcelain record, so a **pristine tree
answers DIRTY**. Seven callers gate on this and three of them (`cli.py:268`, `:1023`, `:1261`)
refuse the command outright, so a host with a noisy git config could never start a run and the
message named no file. `path_tracked` carries the same stdout-alone rule for the same reason; the
error path keeps the merge, where stderr is the only informative half.

## `path_tracked` ships with zero callers

Deliberate, and constraint 4 of the program's hard ordering: `git.render-tracked` (**6F**) and
`_ledger_is_gits_to_restore` (**6K**) are its consumers, and both need it to exist first. That is
*inert*, not silent — neither ruff's `E4,E7,E9,F` set nor pyright basic reports an unused
module-level function.

## Version floor

`:(literal)` **and** the combined `:(exclude,literal)` are measured identical at **git 2.20.4**
(the floor `install._WORKTREE_CONFIG_GIT` declares, via `alpine:3.9`) and at **2.55.0**. #423 had
measured only the plain `:(literal)` form; the combined one this PR introduces was unmeasured, so
that gap is now closed. This matters more than it looks: below a git that understands the prefix it
reads as a literal *filename*, matches nothing and answers `False` — which **authorizes an unlink**,
inverting the failure direction from "skip a delete" to "delete a tracked file". The floor must not
drop.

## Verification

`pytest` 3953 collected, green apart from 4 pre-existing `test_module_skills_sync` failures that are
local dev-box skill drift (identical on a clean `main` checkout). `pyright` 0/0/0 — unchanged from
the `origin/main` baseline. `trunk check --all --no-fix`: 242 files, no issues.

**Ablation matrix, run on both the 3.13 and 3.14 lanes** (whole suite each row; every row's total
3953, so no baseline drift, and the src digest was verified against the known-clean value before
each row). Both lanes returned **identical** results:

| Row | Ablation | New reds |
| --- | --- | --- |
| R1 | `:(exclude,literal)` → `:(exclude)` | 2 |
| R2 | `path_tracked` literal operand → bare | 4 |
| R3 | `path_tracked` stdout → stdout+stderr | 1 |
| R4 | `worktree_clean` stdout → stdout+stderr | 1 |
| R5 | `commit_paths` add/status/commit literal → bare | 1 |
| R6 | `commit_paths` `ls-files` literal → bare | **0** |
| R7 | `safe_rollback` preserve literal → bare | 1 |
| R8 | `.as_posix()` → `str()` | **0** |

The two zero-red rows are reported rather than papered over, since an edit no ablation reddens and
a test no ablation reddens are the same signal:

- **R8 is unpinnable on this platform, not unpinned.** `str(PosixPath("a/b"))` and `.as_posix()` are
  byte-identical on POSIX; the change only bites where `str()` yields backslashes. **Windows CI is
  its sole oracle** — and both Windows jobs run this suite.
- **R6 is redundant-by-design.** #423 measured this operand safe and the mechanism holds: the
  membership test is `r in tracked`, so a glob over-match returns the *neighbour's* name and `r` is
  **dropped**, never wrongly kept. Kept anyway — three literal operands beside one bare one is the
  next reader's trap — and the code comment says exactly that rather than implying it fixes a bug.

## Notes for review

- Metachar fixtures are built in **Python, never a shell**: fish/zsh glob-expand `docs[a]` / `a*b` /
  `q?r` into non-existence, and `git rm --cached '<glob>'` takes a pathspec too — both produced void
  fixtures (tests passing because they tested nothing) on #406.
- `*` and `?` are **illegal in Windows filenames**, so only those fixture rows are Linux-skipped.
  The `[…]` rows run on both platforms, and per #423's reachability analysis brackets are also the
  realistic carrier, since the value comes from operator config.
- The `safe_rollback` test asserts the **under**-revert direction, not #423's. The issue's fixture
  snapshots *before* the operator's edit, so the bare operand destroys it; `safe_rollback`'s
  snapshot is a `stash create` of the *dirty* tree, so the real harm inverts — the glob hands the
  dev attempt's change back after the reset was meant to discard it.

Refs #433. Closes #423.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of configured file paths containing wildcard or special characters during Git operations.
  * Prevented harmless Git warnings from incorrectly marking clean working trees as modified.
  * Improved reliability of tracking checks, targeted commits, exclusions, and rollback restoration.
  * Preserved correct error reporting when Git commands genuinely fail.

* **Tests**
  * Added coverage for special-character paths, ignored files, deleted tracked files, rollback behavior, and Git diagnostic output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->