### PR TITLE
fix(install): make provisioning total across filesystem faults

### DIFF
--- a/src/bmad_loop/install.py
+++ b/src/bmad_loop/install.py
@@ -324,9 +324,9 @@ def _absent_renderer_sources(skill_dir: Path) -> list[str]:
     would invent sources the renderer never loads and turn a guaranteed HALT green.
 
     Upstream keys nested sources by POSIX relative path and excludes every basename
-    ``SKILL.md``. Read/decode faults fail open because they have different remediation
-    from an absent declared source. Filesystem-totality hardening (including the FIFO
-    guard) belongs to phase 6G, not this validate-side presence contract.
+    ``SKILL.md``. :func:`_is_file` enforces filesystem totality, including the FIFO
+    guard, before any source is read. Remaining read/decode faults fail open because
+    they have different remediation from an absent declared source.
     """
     if not _is_renderer_stub(skill_dir):
         return []
@@ -1219,9 +1219,14 @@ def _is_dir(path) -> bool:
     return _probe_refused(path)
 
 
-# pathlib's version-dependent private ignored-errno set, copied here so absence and
-# refusal retain the same meaning on every supported interpreter.
+# pathlib's version-dependent private ignored-error sets, copied here so absence and
+# refusal retain the same meaning on every supported interpreter and platform.
 _ABSENCE_ERRNOS = (errno.ENOENT, errno.ENOTDIR, errno.EBADF, errno.ELOOP)
+_ABSENCE_WINERRORS = (
+    21,  # ERROR_NOT_READY: drive exists but is not accessible
+    123,  # ERROR_INVALID_NAME
+    1921,  # ERROR_CANT_RESOLVE_FILENAME: broken self-referential symlink
+)
 
 
 def _probe_refused(path) -> bool:
@@ -1232,7 +1237,10 @@ def _probe_refused(path) -> bool:
     try:
         path.stat()
     except OSError as exc:
-        return exc.errno not in _ABSENCE_ERRNOS
+        return (
+            exc.errno not in _ABSENCE_ERRNOS
+            and getattr(exc, "winerror", None) not in _ABSENCE_WINERRORS
+        )
     except ValueError:
         # Embedded-null and otherwise invalid paths are absent, not refused.
         return False
@@ -1304,6 +1312,8 @@ def _copy_traversable(
 
     def visit_dir(rel: str, entry) -> bool:
         nonlocal copied
+        # Recheck after enumeration: iterdir may block while a source or destination
+        # component is replaced, so the pre-walk containment result can go stale.
         if not should_descend(rel, entry):
             return False
         target = target_for(rel)

--- a/src/bmad_loop/install.py
+++ b/src/bmad_loop/install.py
@@ -16,15 +16,17 @@ orchestrator's signal watcher is CLI-agnostic.
 
 from __future__ import annotations
 
+import errno
 import json
 import os
 import re
 import shutil
 import subprocess
 import tomllib
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Iterator, Sequence
 from contextlib import ExitStack
 from importlib import resources
+from importlib.resources.abc import Traversable
 from pathlib import Path
 from typing import Any, NamedTuple
 
@@ -252,11 +254,11 @@ def resolve_dev_primitive(project: Path, tree: str) -> str | None:
     instead would make a truncated bmad-build-auto silently resolve to a legacy
     install (or to the shim's failure message), hiding the real problem.
     """
-    if (project / tree / DEV_PRIMITIVE_NEW / "SKILL.md").is_file():
+    if _is_file(project / tree / DEV_PRIMITIVE_NEW / "SKILL.md"):
         return DEV_PRIMITIVE_NEW
     legacy = project / tree / DEV_PRIMITIVE_LEGACY
-    if (legacy / "SKILL.md").is_file() and all(
-        (legacy / marker).is_file() for marker in DEV_PRIMITIVE_MARKERS
+    if _is_file(legacy / "SKILL.md") and all(
+        _is_file(legacy / marker) for marker in DEV_PRIMITIVE_MARKERS
     ):
         return DEV_PRIMITIVE_LEGACY
     return None
@@ -331,7 +333,7 @@ def _absent_renderer_sources(skill_dir: Path) -> list[str]:
     sources = {
         path.relative_to(skill_dir).as_posix(): path
         for path in skill_dir.rglob("*.md")
-        if path.name != "SKILL.md"
+        if path.name != "SKILL.md" and _is_file(path)
     }
     absent = [] if RENDERER_ENTRY_REL in sources else [RENDERER_ENTRY_REL]
     for path in sources.values():
@@ -1133,54 +1135,214 @@ def _register_hooks(project: Path, profile: CLIProfile) -> int:
     return 0
 
 
-def _copy_traversable(src, dst: Path, *, skip_existing: bool = False) -> bool:
-    """Recursively copy a packaged resource tree to a filesystem path.
+def _walk_traversable_files(
+    src,
+    rel: str = "",
+    _seen: frozenset[str] = frozenset(),
+    _should_descend=None,
+    _visit_dir=None,
+    _suppress_errors: bool = True,
+) -> Iterator[tuple[str, Traversable]]:
+    """Yield the leaves of a Traversable tree as deterministic POSIX rels.
 
-    Walks via the Traversable API (.iterdir/.read_bytes) rather than resolving a
-    filesystem path, so it works even when the package is zip-imported.
+    ``iterdir`` recursion deliberately descends symlinked source directories, unlike
+    the renderer's ``rglob`` enumeration in :func:`_absent_renderer_sources`. A
+    branch-local real-path set terminates cycles without dropping a second sibling
+    that points at the same shared tree.
 
-    Its ``iterdir`` recursion deliberately descends a symlinked source directory.
-    Do not unify this walk with :func:`_absent_renderer_sources`, whose ``rglob``
-    mirrors the renderer and does not descend one. The copier asks what it can carry;
-    the renderer gate asks what upstream will enumerate.
+    A directory the filesystem refuses to list is yielded as a leaf. That lets a
+    copier decline content it cannot confirm while a result-side completeness check
+    can still name the unreadable rel. Wheel Traversables have no real-path cycle leg.
 
-    ``skip_existing`` makes the copy no-clobber at FILE granularity: an existing
-    destination file is left untouched and its siblings are still copied — even
-    when it stands where the source has a directory (that subtree is skipped
-    whole rather than mkdir'd over the file). It is
-    opt-in because the `--force-skills` path (`install_into`) rmtree's the
-    destination precisely to overwrite it, and a guard baked into this helper
-    would silently regress that. Only the worktree-seed caller passes it.
-
-    Returns whether anything was actually written, so a caller seeding into an
-    existing directory can tell a partial seed (something landed) from a total
-    no-op (every child was already present). Every other call site ignores it.
+    ``_should_descend`` and ``_visit_dir`` are private copier plumbing. The first may
+    prune before ``iterdir`` (preserving no-clobber when a destination file stands
+    where the source has a directory); the second sees every successfully enumerated
+    directory, including empty ones. Keeping materialization after enumeration means
+    an unreadable source directory never leaves an empty destination behind.
     """
-    if src.is_dir():
-        if skip_existing and dst.exists() and not dst.is_dir():
-            # a FILE sits where the source has a directory: mkdir would raise
-            # FileExistsError. Under the no-clobber contract the file wins and
-            # the whole subtree is skipped, like any existing destination.
-            return False
-        # creating a missing directory IS a write: an empty dir seeded into an
-        # existing tree must count, or the entry is misreported as a total no-op.
-        copied = not dst.exists()
-        dst.mkdir(parents=True, exist_ok=True)
-        # `any(...)` would short-circuit and skip the remaining children.
-        for child in src.iterdir():
-            if _copy_traversable(child, dst / child.name, skip_existing=skip_existing):
-                copied = True
-        return copied
-    if skip_existing and dst.exists():
+    if _is_dir(src):
+        real = str(src.resolve()) if isinstance(src, Path) else None
+        if real is not None and real in _seen:
+            return
+        if _should_descend is not None and not _should_descend(rel, src):
+            return
+        try:
+            children = sorted(src.iterdir(), key=lambda entry: entry.name)
+        except OSError:
+            if not _suppress_errors:
+                raise
+            yield rel, src
+            return
+        if _visit_dir is not None and not _visit_dir(rel, src):
+            return
+        inner = _seen if real is None else _seen | {real}
+        for child in children:
+            child_rel = f"{rel}/{child.name}" if rel else child.name
+            yield from _walk_traversable_files(
+                child,
+                child_rel,
+                inner,
+                _should_descend,
+                _visit_dir,
+                _suppress_errors,
+            )
+        return
+    yield rel, src
+
+
+def _is_file(path) -> bool:
+    """Answer whether ``path`` is a usable file, total over filesystem faults.
+
+    A refused probe and an absent/non-file path all mean the same thing to a reader
+    or copier: there are no bytes it can promise to consume. Python <=3.13 raises on
+    an entry below an unsearchable parent while 3.14 answers false; both fold to false
+    here. The directory reading is deliberately different — see :func:`_is_dir`.
+    """
+    try:
+        return path.is_file()
+    except OSError:
         return False
-    if isinstance(src, Path):
-        # real filesystem source (worktree seeds, non-zip package data): copy2
-        # preserves the mode so a seeded vendor/bin/* keeps +x (issue #126)
-        shutil.copy2(src, dst)
-    else:
-        # zip-imported Traversable exposes no stat: content-only copy
-        dst.write_bytes(src.read_bytes())
-    return True
+
+
+def _is_dir(path) -> bool:
+    """Answer whether a walk may have unseen content below ``path``.
+
+    Refusal is true, not false: an unreadable source must reach the walk as a named
+    leaf instead of collapsing into absence. Python 3.14 made ``Path.is_dir`` return
+    false for faults older interpreters raise, so a false is re-asked with ``stat``.
+    """
+    try:
+        if path.is_dir():
+            return True
+    except OSError:
+        return True
+    return _probe_refused(path)
+
+
+# pathlib's version-dependent private ignored-errno set, copied here so absence and
+# refusal retain the same meaning on every supported interpreter.
+_ABSENCE_ERRNOS = (errno.ENOENT, errno.ENOTDIR, errno.EBADF, errno.ELOOP)
+
+
+def _probe_refused(path) -> bool:
+    """True when a false pathlib convenience probe actually means I/O refusal."""
+    if not isinstance(path, Path):
+        # A wheel Traversable has no stat() method and no permission mode to recover.
+        return False
+    try:
+        path.stat()
+    except OSError as exc:
+        return exc.errno not in _ABSENCE_ERRNOS
+    except ValueError:
+        # Embedded-null and otherwise invalid paths are absent, not refused.
+        return False
+    return False
+
+
+def _occupied(path: Path) -> bool:
+    """Whether a destination slot is taken, dangling symlinks included."""
+    try:
+        return path.exists() or path.is_symlink()
+    except OSError:
+        # A slot that cannot even be inspected is not safe to write through.
+        return True
+
+
+def _copy_traversable(
+    src,
+    dst: Path,
+    *,
+    skip_existing: bool = False,
+    worktree: Path | None = None,
+    repo_root: Path | None = None,
+) -> bool:
+    """Recursively copy a Traversable tree, optionally confined to a worktree.
+
+    ``skip_existing`` remains the install helper's opt-in per-file no-clobber mode.
+    Supplying ``worktree`` makes no-clobber mandatory and adds destination
+    containment plus per-entry OSError degradation: provisioning never escapes the
+    worktree through a link or crashes the run because one entry cannot be read.
+    ``repo_root`` additionally refuses real source entries resolving outside the main
+    checkout. Wheel Traversables have no source containment leg.
+
+    The shared walk classifies every source leaf through :func:`_is_file`; FIFOs,
+    dangling links, and refused entries therefore have no copy/read path. Directory
+    visits preserve main's existing empty-directory behavior and its boolean result:
+    true means at least one directory or file actually landed, false means total no-op.
+    """
+    copied = False
+    no_clobber = skip_existing or worktree is not None
+
+    def source_contained(entry) -> bool:
+        if repo_root is None or not isinstance(entry, Path):
+            return True
+        try:
+            return entry.resolve().is_relative_to(repo_root)
+        except (OSError, RuntimeError):
+            return False
+
+    def target_for(rel: str) -> Path:
+        return dst.joinpath(*rel.split("/"))
+
+    def target_contained(target: Path) -> bool:
+        if worktree is None:
+            return True
+        try:
+            return target.resolve().is_relative_to(worktree)
+        except (OSError, RuntimeError):
+            return False
+
+    def should_descend(rel: str, entry) -> bool:
+        target = target_for(rel)
+        if not source_contained(entry) or not target_contained(target):
+            return False
+        if no_clobber and _occupied(target) and not _is_dir(target):
+            # A file or dangling link sits where the source has a directory. It wins;
+            # mkdir must never replace it or write through its target.
+            return False
+        return True
+
+    def visit_dir(rel: str, entry) -> bool:
+        nonlocal copied
+        if not should_descend(rel, entry):
+            return False
+        target = target_for(rel)
+        existed = _occupied(target)
+        try:
+            target.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            if worktree is None:
+                raise
+            return False
+        if not existed:
+            copied = True
+        return True
+
+    for rel, child in _walk_traversable_files(
+        src,
+        _should_descend=should_descend,
+        _visit_dir=visit_dir,
+        _suppress_errors=worktree is not None,
+    ):
+        if not _is_file(child) or not source_contained(child):
+            continue
+        target = target_for(rel)
+        if not target_contained(target) or (no_clobber and _occupied(target)):
+            continue
+        try:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            if isinstance(child, Path):
+                # Preserve modes for filesystem sources (notably vendor/bin/*).
+                shutil.copy2(child, target)
+            else:
+                # Zip-imported Traversables expose no stat: content only.
+                target.write_bytes(child.read_bytes())
+        except OSError:
+            if worktree is None:
+                raise
+            continue
+        copied = True
+    return copied
 
 
 # The git that introduced `extensions.worktreeConfig` and `git config --worktree`,

--- a/src/bmad_loop/worktree_flow.py
+++ b/src/bmad_loop/worktree_flow.py
@@ -33,6 +33,9 @@ from .install import (
     HOOK_SCRIPT_REL,
     MODULE_SKILLS,
     _copy_traversable,
+    _is_dir,
+    _is_file,
+    _occupied,
     _worktree_local_exclude,
     merge_hooks,
     resolve_review_layers,
@@ -156,24 +159,37 @@ def provision_worktree(
     skipped: list[str] = []
     for rel in seed_files:
         src = (repo_root / rel).resolve()
-        dst = (worktree / rel).resolve()
+        raw = worktree / rel
+        dst = raw.resolve()
         if not src.is_relative_to(repo_root) or not dst.is_relative_to(worktree):
             continue
-        if not src.exists():
+        if not (_is_file(src) or _is_dir(src)):
             continue
-        if dst.exists():
+        if _occupied(dst):
+            # A live symlink remains the ordinary existing-destination no-op. This
+            # arm must precede the raw-vs-resolved refusal below so it stays named in
+            # `skipped` rather than turning into a silent drop.
+            if dst != raw:
+                skipped.append(str(rel))
+                continue
             # File entries keep the classic copy-when-absent skip. A destination
             # that is not a directory while the source is (the checkout carries a
             # FILE where the seed names a dir) is a type mismatch: recursing would
             # try to mkdir over the file, so the entry is skipped whole instead.
-            if not src.is_dir() or not dst.is_dir():
+            if not _is_dir(src) or not _is_dir(raw):
                 skipped.append(str(rel))
                 continue
             # A DIRECTORY whose destination exists is the case #230 reported: the
             # checkout carries some tracked child, so the whole entry used to be a
             # no-op — including the gitignored children that are absent and would
             # clobber nothing. Recurse instead, copying only what is missing.
-            if not _copy_traversable(src, dst, skip_existing=True):
+            if not _copy_traversable(
+                src,
+                raw,
+                skip_existing=True,
+                worktree=worktree,
+                repo_root=repo_root,
+            ):
                 # every child was already present: still a total no-op, still
                 # reported. Only a PARTIAL seed stops being reported.
                 skipped.append(str(rel))
@@ -184,9 +200,19 @@ def provision_worktree(
             # untrack the tracked children that were already there.
             seeded.append(rel)
             continue
-        dst.parent.mkdir(parents=True, exist_ok=True)
-        _copy_traversable(src, dst)
-        seeded.append(rel)
+        # `resolve()` is non-strict, so a dangling leaf or parent link answers for
+        # its target. Never mkdir/copy through it. Existing live links were handled
+        # by the skip arm above, preserving copy-when-absent reporting.
+        if dst != raw:
+            continue
+        if _copy_traversable(
+            src,
+            raw,
+            skip_existing=True,
+            worktree=worktree,
+            repo_root=repo_root,
+        ):
+            seeded.append(rel)
 
     # glob-seeded trees (e.g. an engine plugin's MCP skill dirs): expand each
     # pattern against the main repo and copy matches in, same contain guard +
@@ -196,13 +222,22 @@ def provision_worktree(
         for match in sorted(repo_root.glob(pattern)):
             rel = match.relative_to(repo_root)
             src = match.resolve()
-            dst = (worktree / rel).resolve()
+            raw = worktree / rel
+            dst = raw.resolve()
             if not src.is_relative_to(repo_root) or not dst.is_relative_to(worktree):
                 continue
-            if not src.exists() or dst.exists():
+            if not (_is_file(src) or _is_dir(src)) or _occupied(dst):
                 continue
-            dst.parent.mkdir(parents=True, exist_ok=True)
-            _copy_traversable(src, dst)
+            if dst != raw:
+                continue
+            if not _copy_traversable(
+                src,
+                raw,
+                skip_existing=True,
+                worktree=worktree,
+                repo_root=repo_root,
+            ):
+                continue
             # as_posix so the exclude pattern anchors on Windows too (os.sep would not)
             seeded.append(rel.as_posix())
 
@@ -212,9 +247,12 @@ def provision_worktree(
         tree_dir = worktree / tree
         for skill in MODULE_SKILLS:
             dst = tree_dir / skill
-            if dst.exists():
-                continue
-            _copy_traversable(skills_root.joinpath(skill), dst)
+            _copy_traversable(
+                skills_root.joinpath(skill),
+                dst,
+                skip_existing=True,
+                worktree=worktree,
+            )
         # The orchestrator-driven upstream skills are not in the wheel; copy them
         # from the MAIN REPO's installed tree (same tree path) so an isolated
         # worktree can still resolve the dev primitive and the review layers. Skip
@@ -239,12 +277,16 @@ def provision_worktree(
         required = dict.fromkeys((*BASE_SKILLS, *(resolved.skills() if resolved else ())))
         for skill in required:
             dst = tree_dir / skill
-            if dst.exists():
-                continue
             src = (repo_root / tree / skill).resolve()
-            if not src.is_relative_to(repo_root) or not src.is_dir():
+            if not src.is_relative_to(repo_root) or not _is_dir(src):
                 continue
-            _copy_traversable(src, dst)
+            _copy_traversable(
+                src,
+                dst,
+                skip_existing=True,
+                worktree=worktree,
+                repo_root=repo_root,
+            )
 
     # The project's customization of those upstream skills (_bmad/custom/*.toml).
     # The preflight resolves review layers through these files, but the run inside
@@ -260,28 +302,49 @@ def provision_worktree(
     # one of those — journaling it would read as a project misconfiguration.
     customize_seeded = False
     src_customize = (repo_root / CUSTOMIZE_DIR).resolve()
-    dst_customize = (worktree / CUSTOMIZE_DIR).resolve()
+    raw_customize = worktree / CUSTOMIZE_DIR
+    dst_customize = raw_customize.resolve()
     if (
-        src_customize.is_dir()
+        _is_dir(src_customize)
         and src_customize.is_relative_to(repo_root)
         and dst_customize.is_relative_to(worktree)
+        and dst_customize == raw_customize
     ):
-        if not dst_customize.exists():
-            dst_customize.parent.mkdir(parents=True, exist_ok=True)
-            _copy_traversable(src_customize, dst_customize)
-            customize_seeded = True
-        elif dst_customize.is_dir():
-            customize_seeded = _copy_traversable(src_customize, dst_customize, skip_existing=True)
+        customize_seeded = _copy_traversable(
+            src_customize,
+            raw_customize,
+            skip_existing=True,
+            worktree=worktree,
+            repo_root=repo_root,
+        )
 
     # per-CLI signal-hook registration, baked to the main repo's relay (absolute).
     # Hookless profiles (HTTP/SSE transport) have no config to merge.
     for profile in profiles:
         if profile.hookless:
             continue
-        config_path = worktree / profile.hooks.config_path
+        raw_config_path = worktree / profile.hooks.config_path
+        # Refuse before mkdir, read, or write: hook commands are worktree-specific
+        # and must never mutate a shared dotfile through a live or dangling link.
+        # Inspect every component because Python 3.14's non-strict resolve leaves a
+        # symlink cycle unresolved (and therefore textually equal to the raw path).
+        # The resolved comparison additionally refuses ``..`` and absolute profiles.
+        refused = not raw_config_path.is_relative_to(worktree)
+        cursor = raw_config_path
+        try:
+            while not refused and cursor != worktree:
+                if cursor.is_symlink():
+                    refused = True
+                    break
+                cursor = cursor.parent
+            config_path = raw_config_path.resolve()
+        except (OSError, RuntimeError):
+            continue
+        if refused or config_path != raw_config_path or not config_path.is_relative_to(worktree):
+            continue
         config_path.parent.mkdir(parents=True, exist_ok=True)
         config: dict = {}
-        if config_path.is_file():
+        if _is_file(config_path):
             try:
                 config = json.loads(config_path.read_text(encoding="utf-8"))
             except json.JSONDecodeError:

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -527,6 +527,7 @@ def test_provision_refuses_a_live_hook_config_symlink(tmp_path):
     provision_worktree(wt, [claude], repo)
 
     assert outside.read_bytes() == before
+    assert (wt / claude.hooks.config_path).is_symlink()
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX symlinks")
@@ -6341,6 +6342,19 @@ def test_probe_refused_distinguishes_absence_from_refusal(monkeypatch, fault_err
 
     monkeypatch.setattr(Path, "stat", refused)
     assert _probe_refused(Path("probe")) is expected
+
+
+@pytest.mark.parametrize("fault_winerror", [21, 123, 1921])
+def test_probe_refused_recognizes_windows_absence_codes(fault_winerror):
+    from bmad_loop.install import _probe_refused
+
+    class FaultPath(type(Path())):
+        def stat(self, *args, **kwargs):
+            fault = OSError(errno.EIO, os.strerror(errno.EIO))
+            fault.winerror = fault_winerror
+            raise fault
+
+    assert _probe_refused(FaultPath("probe")) is False
 
 
 def test_probe_refused_is_total_for_non_paths_and_invalid_paths():

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,4 +1,5 @@
 import contextlib
+import errno
 import io
 import json
 import os
@@ -512,6 +513,65 @@ def test_provision_worktree_does_not_clobber_existing_skill(tmp_path):
     assert (wt / claude.skill_tree / "bmad-loop-resolve" / "SKILL.md").is_file()
 
 
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlinks")
+def test_provision_refuses_a_live_hook_config_symlink(tmp_path):
+    wt, repo = tmp_path / "wt", tmp_path / "repo"
+    claude = get_profile("claude")
+    repo.mkdir()
+    (wt / ".claude").mkdir(parents=True)
+    outside = tmp_path / "outside-settings.json"
+    outside.write_text('{"env":{"KEEP":"BYTE-IDENTICAL"}}\n', encoding="utf-8")
+    before = outside.read_bytes()
+    (wt / claude.hooks.config_path).symlink_to(outside)
+
+    provision_worktree(wt, [claude], repo)
+
+    assert outside.read_bytes() == before
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlinks")
+def test_provision_refuses_a_dangling_hook_config_symlink(tmp_path):
+    wt, repo = tmp_path / "wt", tmp_path / "repo"
+    claude = get_profile("claude")
+    repo.mkdir()
+    (wt / ".claude").mkdir(parents=True)
+    target = wt / "not-checked-out.json"
+    (wt / claude.hooks.config_path).symlink_to(target)
+
+    provision_worktree(wt, [claude], repo)
+
+    assert not target.exists()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlinks")
+def test_provision_refuses_a_hook_config_below_a_symlinked_parent(tmp_path):
+    wt, repo = tmp_path / "wt", tmp_path / "repo"
+    claude = get_profile("claude")
+    repo.mkdir()
+    wt.mkdir()
+    outside = tmp_path / "outside-config"
+    outside.mkdir()
+    (wt / ".claude").symlink_to(outside, target_is_directory=True)
+
+    provision_worktree(wt, [claude], repo)
+
+    assert list(outside.iterdir()) == []
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlinks")
+def test_provision_refuses_a_cyclic_hook_config_symlink(tmp_path):
+    wt, repo = tmp_path / "wt", tmp_path / "repo"
+    claude = get_profile("claude")
+    repo.mkdir()
+    config = wt / claude.hooks.config_path
+    config.parent.mkdir(parents=True)
+    config.symlink_to(config)
+
+    provision_worktree(wt, [claude], repo)
+
+    assert config.is_symlink()
+
+
 def test_provision_worktree_empty_profiles_is_noop(tmp_path):
     provision_worktree(tmp_path / "wt", [], tmp_path / "repo")
     assert not (tmp_path / "wt").exists()
@@ -907,6 +967,52 @@ def test_renderer_source_read_fault_fails_open(tmp_path, monkeypatch):
     fault_read_text(monkeypatch, workflow)
 
     assert _renderer_checks(tmp_path, (tree,)) == []
+
+
+def test_renderer_workflow_directory_is_not_a_source(tmp_path):
+    """A directory named ``workflow.md`` is portable and not renderer input."""
+    tree = ".claude/skills"
+    install_build_auto_skill(tmp_path, tree, renderer_stub=True)
+    _write_renderer_surface(tmp_path)
+    workflow = tmp_path / tree / DEV_PRIMITIVE_NEW / RENDERER_ENTRY_REL
+    workflow.unlink()
+    workflow.mkdir()
+
+    findings = _renderer_checks(tmp_path, (tree,))
+
+    assert [finding.check for finding in findings] == ["skills.dev-renderer-sources"]
+    assert findings[0].detail["missing_sources"] == [RENDERER_ENTRY_REL]
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="POSIX FIFOs")
+def test_renderer_fifo_is_filtered_without_an_unbounded_read(tmp_path):
+    """The preflight must never call ``read_text`` on a FIFO (issue #422).
+
+    Run the real helper in a child with a timeout: deleting its ``_is_file`` filter
+    blocks that child on ``pipe.md``, but can never hang the pytest worker or CI.
+    """
+    tree = ".claude/skills"
+    install_build_auto_skill(tmp_path, tree, renderer_stub=True)
+    _write_renderer_surface(tmp_path)
+    skill = tmp_path / tree / DEV_PRIMITIVE_NEW
+    os.mkfifo(skill / "pipe.md")
+    code = (
+        "import json, sys\n"
+        "from pathlib import Path\n"
+        "from bmad_loop.install import _absent_renderer_sources\n"
+        "print(json.dumps(_absent_renderer_sources(Path(sys.argv[1]))))\n"
+    )
+
+    child = subprocess.run(
+        [sys.executable, "-c", code, str(skill)],
+        capture_output=True,
+        text=True,
+        timeout=5,
+        check=False,
+    )
+
+    assert child.returncode == 0, child.stderr
+    assert json.loads(child.stdout) == []
 
 
 def test_renderer_binary_source_fails_open_without_losing_its_declaration(tmp_path):
@@ -2443,6 +2549,137 @@ def test_provision_worktree_seed_rejects_escaping_path(tmp_path):
     (tmp_path / "outside.txt").write_text("SECRET", encoding="utf-8")
     provision_worktree(wt, [], repo, seed_files=["../outside.txt"])
     assert not wt.exists()  # nothing copied, no dirs created
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlinks")
+def test_seed_files_refuses_a_dangling_destination_leaf_without_excluding_it(tmp_path, monkeypatch):
+    import bmad_loop.worktree_flow as worktree_flow
+
+    repo, wt = tmp_path / "repo", tmp_path / "wt"
+    repo.mkdir()
+    wt.mkdir()
+    (repo / ".mcp.json").write_text("FROM_REPO", encoding="utf-8")
+    stray = wt / "stray.json"
+    (wt / ".mcp.json").symlink_to(stray)
+    patterns = []
+    monkeypatch.setattr(
+        worktree_flow,
+        "_worktree_local_exclude",
+        lambda _worktree, entries: patterns.extend(entries),
+    )
+    monkeypatch.setattr(
+        worktree_flow,
+        "_copy_traversable",
+        lambda *_args, **_kwargs: pytest.fail("seed copied through a dangling link"),
+    )
+
+    skipped = provision_worktree(wt, [], repo, seed_files=[".mcp.json"])
+
+    assert skipped == []
+    assert not stray.exists()
+    assert "/.mcp.json" not in patterns
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlinks")
+def test_seed_files_refuses_a_dangling_destination_parent_without_excluding_it(
+    tmp_path, monkeypatch
+):
+    import bmad_loop.worktree_flow as worktree_flow
+
+    repo, wt = tmp_path / "repo", tmp_path / "wt"
+    source = repo / "vendor" / "config.json"
+    source.parent.mkdir(parents=True)
+    source.write_text("FROM_REPO", encoding="utf-8")
+    wt.mkdir()
+    stray = wt / "stray-parent"
+    (wt / "vendor").symlink_to(stray, target_is_directory=True)
+    patterns = []
+    monkeypatch.setattr(
+        worktree_flow,
+        "_worktree_local_exclude",
+        lambda _worktree, entries: patterns.extend(entries),
+    )
+    monkeypatch.setattr(
+        worktree_flow,
+        "_copy_traversable",
+        lambda *_args, **_kwargs: pytest.fail("seed copied through a dangling parent"),
+    )
+
+    skipped = provision_worktree(wt, [], repo, seed_files=["vendor/config.json"])
+
+    assert skipped == []
+    assert not stray.exists()
+    assert "/vendor/config.json" not in patterns
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlinks")
+def test_seed_globs_refuses_a_dangling_destination_leaf_without_excluding_it(tmp_path, monkeypatch):
+    import bmad_loop.worktree_flow as worktree_flow
+
+    repo, wt = tmp_path / "repo", tmp_path / "wt"
+    source = repo / "plugins" / "config.json"
+    source.parent.mkdir(parents=True)
+    source.write_text("FROM_REPO", encoding="utf-8")
+    (wt / "plugins").mkdir(parents=True)
+    stray = wt / "stray.json"
+    (wt / "plugins" / "config.json").symlink_to(stray)
+    patterns = []
+    monkeypatch.setattr(
+        worktree_flow,
+        "_worktree_local_exclude",
+        lambda _worktree, entries: patterns.extend(entries),
+    )
+    monkeypatch.setattr(
+        worktree_flow,
+        "_copy_traversable",
+        lambda *_args, **_kwargs: pytest.fail("glob copied through a dangling link"),
+    )
+
+    provision_worktree(wt, [], repo, seed_globs=["plugins/*.json"])
+
+    assert not stray.exists()
+    assert "/plugins/config.json" not in patterns
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlinks")
+def test_seed_files_keeps_a_live_symlink_as_an_existing_noop(tmp_path):
+    repo, wt = tmp_path / "repo", tmp_path / "wt"
+    repo.mkdir()
+    wt.mkdir()
+    (repo / ".mcp.json").write_text("FROM_REPO", encoding="utf-8")
+    live = wt / "live.json"
+    live.write_text("IN_WORKTREE", encoding="utf-8")
+    (wt / ".mcp.json").symlink_to(live)
+
+    skipped = provision_worktree(wt, [], repo, seed_files=[".mcp.json"])
+
+    assert skipped == [".mcp.json"]
+    assert live.read_text() == "IN_WORKTREE"
+
+
+@pytest.mark.parametrize("seed_kind", ["files", "globs"])
+def test_failed_explicit_copy_never_enters_exclude_bookkeeping(tmp_path, monkeypatch, seed_kind):
+    import bmad_loop.worktree_flow as worktree_flow
+
+    repo, wt = tmp_path / "repo", tmp_path / "wt"
+    source = repo / "plugins" / "config.json"
+    source.parent.mkdir(parents=True)
+    source.write_text("FROM_REPO", encoding="utf-8")
+    patterns = []
+    monkeypatch.setattr(
+        worktree_flow,
+        "_worktree_local_exclude",
+        lambda _worktree, entries: patterns.extend(entries),
+    )
+    monkeypatch.setattr(worktree_flow, "_copy_traversable", lambda *_args, **_kwargs: False)
+
+    if seed_kind == "files":
+        provision_worktree(wt, [], repo, seed_files=["plugins/config.json"])
+    else:
+        provision_worktree(wt, [], repo, seed_globs=["plugins/*.json"])
+
+    assert "/plugins/config.json" not in patterns
+    assert not (wt / "plugins" / "config.json").exists()
 
 
 def test_provision_worktree_seed_then_hook_merge_preserves_settings(tmp_path):
@@ -6010,6 +6247,329 @@ def test_provision_worktree_seed_globs_preserve_exec_bit(tmp_path):
     provision_worktree(wt, [], repo, seed_globs=["node_modules/*"])
 
     assert (wt / "node_modules" / ".bin" / "eslint").stat().st_mode & 0o111
+
+
+# ------------------------------------------------ provisioning filesystem totality
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX file modes")
+def test_walk_yields_an_unlistable_directory_as_a_named_leaf(tmp_path):
+    from bmad_loop.install import _walk_traversable_files
+
+    root = tmp_path / "tree"
+    locked = root / "locked"
+    locked.mkdir(parents=True)
+    (locked / "deep.md").write_text("deep\n", encoding="utf-8")
+    (root / "sibling.md").write_text("sibling\n", encoding="utf-8")
+    locked.chmod(0o000)
+    try:
+        walked = dict(_walk_traversable_files(root))
+    finally:
+        locked.chmod(0o755)
+
+    assert sorted(walked) == ["locked", "sibling.md"]
+    assert walked["locked"].is_dir()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX file modes")
+def test_walk_yields_names_below_a_listable_but_unsearchable_directory(tmp_path):
+    from bmad_loop.install import _walk_traversable_files
+
+    root = tmp_path / "tree"
+    listable = root / "listable"
+    listable.mkdir(parents=True)
+    (listable / "deep.md").write_text("deep\n", encoding="utf-8")
+    (root / "sibling.md").write_text("sibling\n", encoding="utf-8")
+    listable.chmod(0o444)
+    try:
+        rels = sorted(rel for rel, _ in _walk_traversable_files(root))
+    finally:
+        listable.chmod(0o755)
+
+    assert rels == ["listable/deep.md", "sibling.md"]
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX file modes")
+def test_total_probes_keep_the_refusal_asymmetry(tmp_path):
+    from bmad_loop.install import _is_dir, _is_file
+
+    child = tmp_path / "unsearchable" / "child.md"
+    child.parent.mkdir()
+    child.write_text("child\n", encoding="utf-8")
+    child.parent.chmod(0o444)
+    try:
+        assert _is_dir(child) is True
+        assert _is_file(child) is False
+    finally:
+        child.parent.chmod(0o755)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX file modes")
+def test_is_dir_reasks_a_python_314_false_probe(tmp_path, monkeypatch):
+    from bmad_loop.install import _is_dir
+
+    child = tmp_path / "unsearchable" / "child.md"
+    child.parent.mkdir()
+    child.write_text("child\n", encoding="utf-8")
+    child.parent.chmod(0o444)
+    try:
+        with pytest.raises(PermissionError):
+            child.stat()
+        monkeypatch.setattr(Path, "is_dir", lambda self: False)
+        assert _is_dir(child) is True
+        assert _is_dir(tmp_path / "absent") is False
+    finally:
+        child.parent.chmod(0o755)
+
+
+@pytest.mark.parametrize(
+    ("fault_errno", "expected"),
+    [
+        (errno.ENOENT, False),
+        (errno.ENOTDIR, False),
+        (errno.EBADF, False),
+        (errno.ELOOP, False),
+        (errno.EACCES, True),
+        (errno.EIO, True),
+    ],
+)
+def test_probe_refused_distinguishes_absence_from_refusal(monkeypatch, fault_errno, expected):
+    from bmad_loop.install import _probe_refused
+
+    def refused(_self):
+        raise OSError(fault_errno, os.strerror(fault_errno))
+
+    monkeypatch.setattr(Path, "stat", refused)
+    assert _probe_refused(Path("probe")) is expected
+
+
+def test_probe_refused_is_total_for_non_paths_and_invalid_paths():
+    from bmad_loop.install import _probe_refused
+
+    assert _probe_refused(object()) is False
+    assert _probe_refused(Path("embedded\0nul")) is False
+
+
+def test_is_dir_keeps_an_absent_path_false(tmp_path):
+    from bmad_loop.install import _is_dir
+
+    assert _is_dir(tmp_path / "absent") is False
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlinks")
+def test_walk_terminates_a_symlink_cycle(tmp_path):
+    from bmad_loop.install import _walk_traversable_files
+
+    root = tmp_path / "tree"
+    scripts = root / "scripts"
+    scripts.mkdir(parents=True)
+    (scripts / "render_skill.py").write_text("renderer\n", encoding="utf-8")
+    (scripts / "loop").symlink_to(root, target_is_directory=True)
+
+    assert [rel for rel, _ in _walk_traversable_files(root)] == ["scripts/render_skill.py"]
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlinks")
+def test_walk_keeps_sibling_symlinks_to_one_shared_tree(tmp_path):
+    from bmad_loop.install import _walk_traversable_files
+
+    shared = tmp_path / "shared"
+    shared.mkdir()
+    (shared / "tool.py").write_text("tool\n", encoding="utf-8")
+    root = tmp_path / "tree"
+    root.mkdir()
+    (root / "first").symlink_to(shared, target_is_directory=True)
+    (root / "second").symlink_to(shared, target_is_directory=True)
+
+    assert [rel for rel, _ in _walk_traversable_files(root)] == [
+        "first/tool.py",
+        "second/tool.py",
+    ]
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlinks")
+def test_guarded_copy_treats_a_dangling_destination_leaf_as_occupied(tmp_path):
+    repo, wt = tmp_path / "repo", tmp_path / "wt"
+    repo.mkdir()
+    wt.mkdir()
+    source = repo / "source.txt"
+    source.write_text("source\n", encoding="utf-8")
+    stray = wt / "stray.txt"
+    destination = wt / "destination.txt"
+    destination.symlink_to(stray)
+
+    copied = _copy_traversable(source, destination, worktree=wt, repo_root=repo)
+
+    assert copied is False
+    assert destination.is_symlink()
+    assert not stray.exists()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlinks")
+def test_guarded_copy_degrades_a_dangling_destination_parent(tmp_path):
+    repo, wt = tmp_path / "repo", tmp_path / "wt"
+    repo.mkdir()
+    wt.mkdir()
+    source = repo / "source.txt"
+    source.write_text("source\n", encoding="utf-8")
+    missing = wt / "missing-parent"
+    (wt / "linked-parent").symlink_to(missing, target_is_directory=True)
+
+    copied = _copy_traversable(
+        source,
+        wt / "linked-parent" / "destination.txt",
+        worktree=wt,
+        repo_root=repo,
+    )
+
+    assert copied is False
+    assert not missing.exists()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX file modes")
+def test_guarded_copy_skips_an_unreadable_file_and_keeps_its_sibling(tmp_path):
+    repo, wt = tmp_path / "repo", tmp_path / "wt"
+    source = repo / "source"
+    source.mkdir(parents=True)
+    (source / "readable.txt").write_text("readable\n", encoding="utf-8")
+    locked = source / "locked.txt"
+    locked.write_text("locked\n", encoding="utf-8")
+    locked.chmod(0o000)
+    try:
+        copied = _copy_traversable(
+            source,
+            wt / "destination",
+            worktree=wt,
+            repo_root=repo,
+        )
+    finally:
+        locked.chmod(0o644)
+
+    assert copied is True
+    assert (wt / "destination" / "readable.txt").read_text() == "readable\n"
+    assert not (wt / "destination" / "locked.txt").exists()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX file modes")
+def test_guarded_copy_does_not_materialize_an_unlistable_source_directory(tmp_path):
+    repo, wt = tmp_path / "repo", tmp_path / "wt"
+    source = repo / "source"
+    locked = source / "locked"
+    locked.mkdir(parents=True)
+    (locked / "deep.txt").write_text("deep\n", encoding="utf-8")
+    (source / "sibling.txt").write_text("sibling\n", encoding="utf-8")
+    locked.chmod(0o000)
+    try:
+        _copy_traversable(
+            source,
+            wt / "destination",
+            worktree=wt,
+            repo_root=repo,
+        )
+    finally:
+        locked.chmod(0o755)
+
+    assert not (wt / "destination" / "locked").exists()
+    assert (wt / "destination" / "sibling.txt").is_file()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX file modes")
+def test_guarded_copy_accepts_a_read_only_searchable_source_directory(tmp_path):
+    repo, wt = tmp_path / "repo", tmp_path / "wt"
+    source = repo / "source"
+    readonly = source / "readonly"
+    readonly.mkdir(parents=True)
+    (readonly / "child.txt").write_text("child\n", encoding="utf-8")
+    readonly.chmod(0o555)
+    try:
+        copied = _copy_traversable(
+            source,
+            wt / "destination",
+            worktree=wt,
+            repo_root=repo,
+        )
+    finally:
+        readonly.chmod(0o755)
+
+    assert copied is True
+    assert (wt / "destination" / "readonly" / "child.txt").is_file()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX file modes")
+def test_no_clobber_prunes_a_source_directory_before_enumerating_it(tmp_path):
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "child.txt").write_text("child\n", encoding="utf-8")
+    destination = tmp_path / "destination"
+    destination.write_text("KEEP\n", encoding="utf-8")
+    source.chmod(0o000)
+    try:
+        copied = _copy_traversable(source, destination, skip_existing=True)
+    finally:
+        source.chmod(0o755)
+
+    assert copied is False
+    assert destination.read_text() == "KEEP\n"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlinks")
+def test_guarded_copy_refuses_a_source_child_escaping_the_repo(tmp_path):
+    repo, wt = tmp_path / "repo", tmp_path / "wt"
+    source = repo / "source"
+    source.mkdir(parents=True)
+    outside = tmp_path / "outside.txt"
+    outside.write_text("outside\n", encoding="utf-8")
+    (source / "escaped.txt").symlink_to(outside)
+
+    _copy_traversable(
+        source,
+        wt / "destination",
+        worktree=wt,
+        repo_root=repo,
+    )
+
+    assert not (wt / "destination" / "escaped.txt").exists()
+    assert outside.read_text() == "outside\n"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlinks")
+def test_guarded_copy_refuses_a_destination_tree_escaping_the_worktree(tmp_path):
+    repo, wt = tmp_path / "repo", tmp_path / "wt"
+    source = repo / "source"
+    source.mkdir(parents=True)
+    (source / "child.txt").write_text("child\n", encoding="utf-8")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    wt.mkdir()
+    (wt / "destination").symlink_to(outside, target_is_directory=True)
+
+    copied = _copy_traversable(
+        source,
+        wt / "destination",
+        worktree=wt,
+        repo_root=repo,
+    )
+
+    assert copied is False
+    assert list(outside.iterdir()) == []
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="POSIX FIFOs")
+def test_guarded_copy_filters_a_fifo_before_materializing_its_parent(tmp_path):
+    repo, wt = tmp_path / "repo", tmp_path / "wt"
+    repo.mkdir()
+    source = repo / "pipe.md"
+    os.mkfifo(source)
+
+    copied = _copy_traversable(
+        source,
+        wt / "nested" / "pipe.md",
+        worktree=wt,
+        repo_root=repo,
+    )
+
+    assert copied is False
+    assert not (wt / "nested").exists()
 
 
 def test_copy_traversable_zip_source_copies_content(tmp_path):


### PR DESCRIPTION
## Summary

- make renderer and provisioning probes total across filesystem faults and Python 3.14 semantics
- confine no-clobber seeding to source and destination roots, refuse symlinked hook-config writes, and preserve accurate copied/exclude bookkeeping
- add portable and POSIX witnesses for unreadable paths, cycles, links, empty directories, zip Traversables, and FIFOs

## Testing

- Python 3.13.13: 4006 passed, 30 skipped; 4036 collected
- Python 3.14.6: 4006 passed, 30 skipped; 4036 collected
- 29-row dual-lane whole-suite ablation matrix; every row collected 4033
- review-fix ablations: red on Python 3.13.13 and Python 3.14.6
- `uv run pyright`
- `trunk check`
- focused tests: 338 passed
- sandbox zero-token E2E: 13 passed

Closes #421
Closes #422

Tracking: #433

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worktree provisioning reliability across symlinks, inaccessible paths, cyclic directories, dangling links, and unusual filesystem entries.
  * Prevented files from being copied outside the intended worktree or through unsafe destinations.
  * Preserved existing files and permissions where appropriate, while maintaining expected no-op behavior.
  * Improved handling of bundled resources, renderer discovery, seed files, skills, and hook configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->