### PR TITLE
fix(worktree): seed and verify isolated BMAD surfaces

### DIFF
--- a/src/bmad_loop/worktree_flow.py
+++ b/src/bmad_loop/worktree_flow.py
@@ -39,12 +39,13 @@ from .install import (
     MODULE_SKILLS,
     RENDER_DIR_REL,
     RENDERER_SCRIPT_MARKER,
-    RENDERER_SCRIPT_REL,
+    RENDERER_SCRIPT_UNIT_REL,
     RENDERER_SEED_SENTINELS,
     _copy_traversable,
     _is_dir,
     _is_file,
     _occupied,
+    _renderer_unit_required,
     _walk_traversable_files,
     _worktree_local_exclude,
     dev_primitive_or_default,
@@ -139,19 +140,17 @@ def _seed_bmad_tree(worktree: Path, repo_root: Path) -> list[str]:
 
 
 def _bmad_scripts_seed_incomplete(worktree: Path, repo_root: Path) -> bool:
-    """Whether a repo renderer script unit reached the worktree incomplete.
+    """Whether a required repo renderer unit member missed the worktree.
 
-    The walk matches :func:`_seed_bmad_tree`, including child-directory symlinks.
-    A directory the walk could not inspect counts as incomplete: the seed cannot
-    deliver it, and silence would dispatch every story into the same renderer HALT.
+    Match the renderer preflight's content-keyed required-file predicate. Arbitrary
+    sibling scripts are still merge-seeded, but their absence cannot prove the
+    renderer will HALT and therefore must not arm the CRITICAL escalation gate.
     """
-    if not _is_file(repo_root / RENDERER_SCRIPT_REL):
-        return False
-    scripts = repo_root.joinpath(*BMAD_SCRIPTS_SEED_REL.split("/"))
-    dst_scripts = worktree.joinpath(*BMAD_SCRIPTS_SEED_REL.split("/"))
     return any(
-        (_is_file(src) or _is_dir(src)) and not _is_file(dst_scripts.joinpath(*rel.split("/")))
-        for rel, src in _walk_traversable_files(scripts)
+        _renderer_unit_required(repo_root, rel)
+        and _is_file(repo_root / rel)
+        and not _is_file(worktree / rel)
+        for rel in RENDERER_SCRIPT_UNIT_REL
     )
 
 
@@ -247,6 +246,35 @@ def worktree_seed_undelivered(
         except (OSError, RuntimeError):
             return False
 
+    def delivered(src: Path, dst: Path) -> bool:
+        """Whether every usable source descendant has a matching destination."""
+        if not contained(dst, worktree):
+            return False
+        if _is_file(src):
+            return _is_file(dst)
+        if not _is_dir(src) or not _is_dir(dst):
+            return False
+
+        complete = True
+
+        def visit_dir(rel: str, _src) -> bool:
+            nonlocal complete
+            target = dst.joinpath(*rel.split("/")) if rel else dst
+            if not contained(target, worktree) or not _is_dir(target):
+                complete = False
+            return True
+
+        for child_rel, child in _walk_traversable_files(src, _visit_dir=visit_dir):
+            target = dst.joinpath(*child_rel.split("/")) if child_rel else dst
+            if _is_file(child):
+                if not contained(target, worktree) or not _is_file(target):
+                    complete = False
+            elif _is_dir(child):
+                # Directories are yielded only when enumeration was refused, so
+                # their unknown descendants cannot be claimed as delivered.
+                complete = False
+        return complete
+
     undelivered: list[str] = []
     for rel in dict.fromkeys(rels):
         src = repo_root / rel
@@ -261,7 +289,7 @@ def worktree_seed_undelivered(
             if not contained(src, repo_root) or not contained(dst, worktree) or destination_is_link:
                 undelivered.append(rel)
             continue
-        if contained(dst, worktree) and (_is_file(dst) or _is_dir(dst)):
+        if delivered(src, dst):
             continue
         undelivered.append(rel)
     return undelivered

--- a/src/bmad_loop/worktree_flow.py
+++ b/src/bmad_loop/worktree_flow.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import json
 from collections.abc import Sequence
 from importlib import resources
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 from typing import TYPE_CHECKING, Callable, NoReturn
 
 from . import gates, verify
@@ -33,6 +33,7 @@ from .install import (
     BMAD_SCRIPTS_SEED_REL,
     BMAD_SEED_EXCLUDES,
     CENTRAL_CONFIG_REL,
+    DEV_PRIMITIVE_MARKERS,
     DEV_PRIMITIVE_ROLES,
     HOOK_SCRIPT_REL,
     MERGED_REVIEW_SKILL,
@@ -41,6 +42,7 @@ from .install import (
     RENDERER_SCRIPT_MARKER,
     RENDERER_SCRIPT_UNIT_REL,
     RENDERER_SEED_SENTINELS,
+    _absent_renderer_sources,
     _copy_traversable,
     _is_dir,
     _is_file,
@@ -50,6 +52,7 @@ from .install import (
     _worktree_local_exclude,
     dev_primitive_or_default,
     merge_hooks,
+    missing_stories_support,
     renderer_stub_resolved,
     resolve_review_layers,
 )
@@ -107,12 +110,6 @@ def _required_worktree_skills(repo_root: Path, tree: str) -> tuple[str, ...]:
     else:
         review_skills = tuple(sorted(_REVIEW_LAYER_SKILLS))
     return tuple(dict.fromkeys((dev_primitive_or_default(repo_root, tree), *review_skills)))
-
-
-def _is_under_bmad(rel: str) -> bool:
-    """Whether a user-authored seed rel names ``_bmad`` or a descendant."""
-    parts = PurePosixPath(rel.replace("\\", "/")).parts
-    return bool(parts) and parts[0] == BMAD_DIR
 
 
 def _seed_bmad_tree(worktree: Path, repo_root: Path) -> list[str]:
@@ -178,24 +175,8 @@ def _central_config_seed_incomplete(worktree: Path, repo_root: Path) -> bool:
     return _is_file(repo_root / CENTRAL_CONFIG_REL) and not _is_file(worktree / CENTRAL_CONFIG_REL)
 
 
-def _absent_skill_files(repo_skill: Path, worktree_skill: Path) -> list[str]:
-    """Repo skill files that the worktree lacks, as deterministic POSIX rels.
-
-    This asks the same Traversable walk the copier uses rather than maintaining a
-    named required-file list that can drift from upstream. A refused source subtree
-    is yielded as a leaf and named; a dangling link or FIFO is neither a file nor a
-    directory and is ignored by both the copier and this result check.
-    """
-    return [
-        rel
-        for rel, src in _walk_traversable_files(repo_skill)
-        if (_is_file(src) or _is_dir(src))
-        and not _is_file(worktree_skill.joinpath(*rel.split("/")))
-    ]
-
-
 def base_skills_seed_incomplete(worktree: Path, repo_root: Path, trees: Sequence[str]) -> list[str]:
-    """Upstream skill rels present in the repo but absent from the worktree.
+    """Required upstream skill rels present in the repo but absent in the worktree.
 
     ``BASE_SKILLS`` is a copy-if-present catalog, not a requirement set. Gate only
     the selected primitive and required review skills; advisory/conditional and
@@ -203,12 +184,20 @@ def base_skills_seed_incomplete(worktree: Path, repo_root: Path, trees: Sequence
     cannot prove the dev/review session will stall. Unknown review shapes use the
     same merged-or-standalone fallback as the run-start preflight.
 
-    A missing ``SKILL.md`` reports the coarse skill rel; once the skill is present,
-    every missing file is named. A repo directory without ``SKILL.md`` remains the
-    run-start preflight's concern and cannot produce a false CRITICAL escalation here.
+    Within those active skills, mirror the deterministic run-start contract rather
+    than treating every descendant as fatal: reviewers require ``SKILL.md``; the dev
+    primitive additionally requires its defined markers and any renderer snapshot
+    sources its worktree copy resolves. Other descendants still copy best-effort,
+    but their absence does not prove the outer session will write no artifact.
+
+    A missing ``SKILL.md`` reports the coarse skill rel. A repo directory without
+    ``SKILL.md`` remains the run-start preflight's concern and cannot produce a false
+    CRITICAL escalation here. Stories mode adds its content-keyed dispatch probe at
+    the caller, where the run mode is available.
     """
     missing: list[str] = []
     for tree in dict.fromkeys(trees):
+        primitive = dev_primitive_or_default(repo_root, tree)
         for skill in _required_worktree_skills(repo_root, tree):
             repo_skill = repo_root / tree / skill
             worktree_skill = worktree / tree / skill
@@ -221,8 +210,17 @@ def base_skills_seed_incomplete(worktree: Path, repo_root: Path, trees: Sequence
             if not _is_file(worktree_skill / "SKILL.md"):
                 missing.append(f"{tree}/{skill}")
                 continue
+            if skill != primitive:
+                continue
             missing.extend(
-                f"{tree}/{skill}/{rel}" for rel in _absent_skill_files(repo_skill, worktree_skill)
+                f"{tree}/{skill}/{rel}"
+                for rel in DEV_PRIMITIVE_MARKERS
+                if _is_file(repo_skill / rel) and not _is_file(worktree_skill / rel)
+            )
+            missing.extend(
+                f"{tree}/{skill}/{rel}"
+                for rel in _absent_renderer_sources(worktree_skill)
+                if _is_file(repo_skill.joinpath(*rel.split("/")))
             )
     return missing
 
@@ -236,10 +234,11 @@ def worktree_seed_undelivered(
 ) -> list[str]:
     """Seed rels the repo carries that never reached the worktree.
 
-    Source containment is deliberately *not* required: a source symlink resolving
-    outside the repo is the canonical entry the seed loop refuses and otherwise says
-    nothing about. Destination containment is required so a path outside the worktree
-    cannot masquerade as delivery.
+    Source containment is deliberately *not* an eligibility requirement: a source
+    symlink resolving outside the repo is the canonical entry the seed loop refuses
+    and this result check must report. Delivery does require every usable source
+    entry to remain within the repo, matching the copier. Destination containment is
+    likewise required so a path outside the worktree cannot masquerade as delivery.
 
     Hook configs need a different result question because provisioning writes the
     hook registration itself after seeding. For those rels, existence proves nothing;
@@ -263,7 +262,7 @@ def worktree_seed_undelivered(
 
     def delivered(src: Path, dst: Path) -> bool:
         """Whether every usable source descendant has a matching destination."""
-        if not contained(dst, worktree):
+        if not contained(src, repo_root) or not contained(dst, worktree):
             return False
         if _is_file(src):
             return _is_file(dst)
@@ -272,8 +271,11 @@ def worktree_seed_undelivered(
 
         complete = True
 
-        def visit_dir(rel: str, _src) -> bool:
+        def visit_dir(rel: str, source) -> bool:
             nonlocal complete
+            if not isinstance(source, Path) or not contained(source, repo_root):
+                complete = False
+                return False
             target = dst.joinpath(*rel.split("/")) if rel else dst
             if not contained(target, worktree) or not _is_dir(target):
                 complete = False
@@ -282,7 +284,12 @@ def worktree_seed_undelivered(
         for child_rel, child in _walk_traversable_files(src, _visit_dir=visit_dir):
             target = dst.joinpath(*child_rel.split("/")) if child_rel else dst
             if _is_file(child):
-                if not contained(target, worktree) or not _is_file(target):
+                if (
+                    not isinstance(child, Path)
+                    or not contained(child, repo_root)
+                    or not contained(target, worktree)
+                    or not _is_file(target)
+                ):
                     complete = False
             elif _is_dir(child):
                 # Directories are yielded only when enumeration was refused, so
@@ -487,8 +494,6 @@ def provision_worktree(
     # the repo's project-local BMAD surface after explicit seeds (operator intent wins
     # on collisions) and reserve the two renderer sentinels for result-side checks.
     seeded_bmad = _seed_bmad_tree(worktree, repo_root)
-    if seeded_bmad:
-        skipped = [rel for rel in skipped if not _is_under_bmad(rel)]
     skipped = [rel for rel in skipped if rel not in RENDERER_SEED_SENTINELS]
     if _bmad_scripts_seed_incomplete(worktree, repo_root):
         skipped.append(BMAD_SCRIPTS_SEED_REL)
@@ -856,24 +861,39 @@ class WorktreeFlow:
         absent_skills = base_skills_seed_incomplete(unit.path, self.paths.repo_root, trees)
         if absent_skills:
             reason = (
-                "the worktree is missing upstream skill files the repo has "
+                "the worktree is missing required upstream skill contract files the repo has "
                 f"({', '.join(absent_skills)}) — the session would stall having "
                 "written nothing: on `Unknown command` when the whole skill is "
-                "absent, or inside the workflow when the skill directory is short. "
-                "The usual cause is a skill directory, file, or sub-directory "
-                "symlinked to a shared BMad install outside the repo, which "
+                "absent, or at a required primitive marker or renderer source. "
+                "The usual cause is a required skill directory or file symlinked "
+                "to a shared BMad install outside the repo, which worktree seeding "
+                "cannot follow"
+            )
+            self.escalate_unit(task, reason)  # always raises RunPaused
+
+        # Stories mode has a stricter, content-keyed primitive contract than sprint
+        # mode. Re-run that exact preflight against the mounted worktree: a step-01
+        # through-link can pass in the main checkout yet be refused during copying,
+        # while a tracked stale worktree copy proves that existence alone is not
+        # enough. Either shape would HALT a folder+id dispatch before writing a spec.
+        stories_support = (
+            missing_stories_support(unit.path, trees) if self.state.source == "stories" else []
+        )
+        if stories_support:
+            short_dispatch = []
+            for finding in stories_support:
+                detail = finding.detail or {}
+                rel = f"{detail['tree']}/{detail['skill']}/{detail['file']}"
+                marker = detail.get("marker")
+                short_dispatch.append(f"{rel} (missing {marker!r})" if marker else rel)
+            reason = (
+                "the worktree's dev primitive does not satisfy stories-mode dispatch "
+                f"support ({', '.join(short_dispatch)}) — the folder+id session would "
+                "HALT without writing a spec. The usual cause is a required router "
+                "file symlinked to a shared BMad install outside the repo, which "
                 "worktree seeding cannot follow"
             )
-            task.phase = Phase.ESCALATED
-            self.journal.append("story-escalated", story_key=task.story_key, reason=reason)
-            gates.notify(
-                self.policy,
-                self.run_dir,
-                f"CRITICAL escalation: {task.story_key}",
-                f"{reason} — resolve, then `bmad-loop resume {self.state.run_id}`",
-            )
-            self._save()
-            self._pause(reason, task.story_key)
+            self.escalate_unit(task, reason)  # always raises RunPaused
 
         # Provisioning owns these exact sentinel strings, but only a content-confirmed
         # renderer stub consumes the surface. The conjunct is load-bearing: inline
@@ -887,16 +907,7 @@ class WorktreeFlow:
                 "writing a spec. The usual cause is a symlinked _bmad/ pointing "
                 "outside the repo, which worktree seeding cannot follow"
             )
-            task.phase = Phase.ESCALATED
-            self.journal.append("story-escalated", story_key=task.story_key, reason=reason)
-            gates.notify(
-                self.policy,
-                self.run_dir,
-                f"CRITICAL escalation: {task.story_key}",
-                f"{reason} — resolve, then `bmad-loop resume {self.state.run_id}`",
-            )
-            self._save()
-            self._pause(reason, task.story_key)
+            self.escalate_unit(task, reason)  # always raises RunPaused
 
         self._save()
         prev = self._workspace_get()
@@ -1077,8 +1088,11 @@ class WorktreeFlow:
         self.escalate_unit(task, reason)  # always raises RunPaused
 
     def escalate_unit(self, task: StoryTask, reason: str) -> None:
-        """Mark a DONE unit ESCALATED, notify, and pause the run. DONE has no
-        legal transition, so the phase is set directly rather than via advance()."""
+        """Mark a unit ESCALATED, notify, and pause the run.
+
+        Callers escalate outside a legal transition, before dispatch or after a
+        completed merge attempt, so the phase is set directly rather than advanced.
+        """
         task.phase = Phase.ESCALATED
         self.journal.append("story-escalated", story_key=task.story_key, reason=reason)
         gates.notify(

--- a/src/bmad_loop/worktree_flow.py
+++ b/src/bmad_loop/worktree_flow.py
@@ -22,22 +22,34 @@ from __future__ import annotations
 import json
 from collections.abc import Sequence
 from importlib import resources
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Callable, NoReturn
 
 from . import gates, verify
 from .install import (
     BASE_SKILLS,
-    CUSTOMIZE_DIR,
+    BMAD_DIR,
+    BMAD_SCRIPTS_SEED_REL,
+    BMAD_SEED_EXCLUDES,
+    CENTRAL_CONFIG_REL,
+    DEV_PRIMITIVE_LEGACY,
+    DEV_PRIMITIVE_NEW,
     DEV_PRIMITIVE_ROLES,
     HOOK_SCRIPT_REL,
     MODULE_SKILLS,
+    RENDER_DIR_REL,
+    RENDERER_SCRIPT_MARKER,
+    RENDERER_SCRIPT_REL,
+    RENDERER_SEED_SENTINELS,
     _copy_traversable,
     _is_dir,
     _is_file,
     _occupied,
+    _walk_traversable_files,
     _worktree_local_exclude,
+    dev_primitive_or_default,
     merge_hooks,
+    renderer_stub_resolved,
     resolve_review_layers,
 )
 from .model import Phase
@@ -69,6 +81,190 @@ _SETUP_MCP_AGENT_IDS = {"claude": "claude-code"}
 def _setup_mcp_agent_id(profile_name: str) -> str:
     """Map a CLI profile name to its Unity-MCP `setup-mcp` agent id."""
     return _SETUP_MCP_AGENT_IDS.get(profile_name, profile_name)
+
+
+def _required_worktree_skills(repo_root: Path, tree: str) -> tuple[str, ...]:
+    """Every upstream skill the dev/review sessions in ``tree`` may invoke."""
+    resolved = resolve_review_layers(repo_root, tree)
+    return tuple(dict.fromkeys((*BASE_SKILLS, *(resolved.skills() if resolved else ()))))
+
+
+def _is_under_bmad(rel: str) -> bool:
+    """Whether a user-authored seed rel names ``_bmad`` or a descendant."""
+    parts = PurePosixPath(rel.replace("\\", "/")).parts
+    return bool(parts) and parts[0] == BMAD_DIR
+
+
+def _seed_bmad_tree(worktree: Path, repo_root: Path) -> list[str]:
+    """Merge the repo's project-local BMAD surface into an isolated worktree.
+
+    Renderer-backed skills receive the worktree as their project root and do not
+    walk upward for ``_bmad``. Copy every usable file except generated render output,
+    per-file and without clobbering checkout content. The shared Traversable walk is
+    intentional: unlike ``rglob``, it descends a symlinked child directory, allowing
+    the result-side completeness predicates to see every file the copier considered.
+
+    Returns the paths that need the worktree-local git-add shield: the root when it
+    was absent before seeding, otherwise each file that actually landed.
+    """
+    src_root = repo_root / BMAD_DIR
+    if not _is_dir(src_root):
+        return []
+    dst_root = worktree / BMAD_DIR
+    had_bmad = _is_dir(dst_root)
+    try:
+        tops = sorted(src_root.iterdir(), key=lambda entry: entry.name)
+    except OSError:
+        return []
+
+    seeded: list[str] = []
+    for top in tops:
+        if top.name in BMAD_SEED_EXCLUDES:
+            continue
+        for rel, src in _walk_traversable_files(top, top.name):
+            if not _is_file(src):
+                continue
+            dst = dst_root.joinpath(*rel.split("/"))
+            if _copy_traversable(
+                src,
+                dst,
+                skip_existing=True,
+                worktree=worktree,
+                repo_root=repo_root,
+            ):
+                seeded.append(f"{BMAD_DIR}/{rel}")
+    if not seeded:
+        return []
+    return [BMAD_DIR] if not had_bmad else seeded
+
+
+def _bmad_scripts_seed_incomplete(worktree: Path, repo_root: Path) -> bool:
+    """Whether a repo renderer script unit reached the worktree incomplete.
+
+    The walk matches :func:`_seed_bmad_tree`, including child-directory symlinks.
+    A directory the walk could not inspect counts as incomplete: the seed cannot
+    deliver it, and silence would dispatch every story into the same renderer HALT.
+    """
+    if not _is_file(repo_root / RENDERER_SCRIPT_REL):
+        return False
+    scripts = repo_root.joinpath(*BMAD_SCRIPTS_SEED_REL.split("/"))
+    dst_scripts = worktree.joinpath(*BMAD_SCRIPTS_SEED_REL.split("/"))
+    return any(
+        (_is_file(src) or _is_dir(src)) and not _is_file(dst_scripts.joinpath(*rel.split("/")))
+        for rel, src in _walk_traversable_files(scripts)
+    )
+
+
+def _central_config_seed_incomplete(worktree: Path, repo_root: Path) -> bool:
+    """Whether the repo's required renderer config failed to reach the worktree."""
+    return _is_file(repo_root / CENTRAL_CONFIG_REL) and not _is_file(worktree / CENTRAL_CONFIG_REL)
+
+
+def _absent_skill_files(repo_skill: Path, worktree_skill: Path) -> list[str]:
+    """Repo skill files that the worktree lacks, as deterministic POSIX rels.
+
+    This asks the same Traversable walk the copier uses rather than maintaining a
+    named required-file list that can drift from upstream. A refused source subtree
+    is yielded as a leaf and named; a dangling link or FIFO is neither a file nor a
+    directory and is ignored by both the copier and this result check.
+    """
+    return [
+        rel
+        for rel, src in _walk_traversable_files(repo_skill)
+        if (_is_file(src) or _is_dir(src))
+        and not _is_file(worktree_skill.joinpath(*rel.split("/")))
+    ]
+
+
+def base_skills_seed_incomplete(worktree: Path, repo_root: Path, trees: Sequence[str]) -> list[str]:
+    """Upstream skill rels present in the repo but absent from the worktree.
+
+    ``BASE_SKILLS`` is a copy-if-present catalog containing both primitive eras,
+    not a requirement set. Only the era this project resolves is gated. Main also
+    provisions the project's resolved review layers, so those join the same parity
+    check rather than becoming an unguarded second copy leg.
+
+    A missing ``SKILL.md`` reports the coarse skill rel; once the skill is present,
+    every missing file is named. A repo directory without ``SKILL.md`` remains the
+    run-start preflight's concern and cannot produce a false CRITICAL escalation here.
+    """
+    missing: list[str] = []
+    for tree in dict.fromkeys(trees):
+        unused_era = {DEV_PRIMITIVE_NEW, DEV_PRIMITIVE_LEGACY} - {
+            dev_primitive_or_default(repo_root, tree)
+        }
+        for skill in _required_worktree_skills(repo_root, tree):
+            if skill in unused_era:
+                continue
+            repo_skill = repo_root / tree / skill
+            worktree_skill = worktree / tree / skill
+            if not _is_file(repo_skill / "SKILL.md"):
+                # Distinguish an unreadable directory from a skill the repo simply
+                # does not carry. The walk yields only the former as a directory leaf.
+                if any(_is_dir(src) for _, src in _walk_traversable_files(repo_skill)):
+                    missing.append(f"{tree}/{skill}")
+                continue
+            if not _is_file(worktree_skill / "SKILL.md"):
+                missing.append(f"{tree}/{skill}")
+                continue
+            missing.extend(
+                f"{tree}/{skill}/{rel}" for rel in _absent_skill_files(repo_skill, worktree_skill)
+            )
+    return missing
+
+
+def worktree_seed_undelivered(
+    worktree: Path,
+    repo_root: Path,
+    seed_files: Sequence[str] = (),
+    seed_globs: Sequence[str] = (),
+    config_paths: Sequence[str] = (),
+) -> list[str]:
+    """Seed rels the repo carries that never reached the worktree.
+
+    Source containment is deliberately *not* required: a source symlink resolving
+    outside the repo is the canonical entry the seed loop refuses and otherwise says
+    nothing about. Destination containment is required so a path outside the worktree
+    cannot masquerade as delivery.
+
+    Hook configs need a different result question because provisioning writes the
+    hook registration itself after seeding. For those rels, existence proves nothing;
+    source escape, a symlinked destination, or destination escape proves the seed was
+    refused. This report is informational and is never an escalation gate.
+    """
+    worktree = worktree.resolve()
+    repo_root = repo_root.resolve()
+    rels = [str(rel) for rel in seed_files]
+    for pattern in seed_globs:
+        rels.extend(
+            match.relative_to(repo_root).as_posix() for match in sorted(repo_root.glob(pattern))
+        )
+    hook_configs = {Path(rel) for rel in config_paths}
+
+    def contained(path: Path, root: Path) -> bool:
+        try:
+            return path.resolve().is_relative_to(root)
+        except (OSError, RuntimeError):
+            return False
+
+    undelivered: list[str] = []
+    for rel in dict.fromkeys(rels):
+        src = repo_root / rel
+        if not (_is_file(src) or _is_dir(src)):
+            continue
+        dst = worktree / rel
+        if Path(rel) in hook_configs:
+            try:
+                destination_is_link = dst.is_symlink()
+            except OSError:
+                destination_is_link = True
+            if not contained(src, repo_root) or not contained(dst, worktree) or destination_is_link:
+                undelivered.append(rel)
+            continue
+        if contained(dst, worktree) and (_is_file(dst) or _is_dir(dst)):
+            continue
+        undelivered.append(rel)
+    return undelivered
 
 
 def provision_worktree(
@@ -133,13 +329,16 @@ def provision_worktree(
     also a hook config_path (.claude/settings.json, .gemini/settings.json) keeps its
     real content and just gets the Stop hook merged in, rather than being created empty.
 
+    The repo's `_bmad/` surface is also merge-seeded, excluding generated render
+    output. Renderer and upstream-skill completeness failures share the return
+    channel with ordinary no-op seeds so they are journaled, but the caller re-probes
+    the skill result and content-gates the renderer sentinels before escalating.
+
     Returns the `seed_files` entries that copied NOTHING because everything they
-    name was already present — copy-when-absent turned them into no-ops. The caller
-    journals them: a user-authored `worktree_seed` entry that silently copies
-    nothing reads as applied configuration and is not. A directory entry that
-    seeded even one child is not reported: it is applied configuration.
+    name was already present, plus reserved completeness reports. A directory entry
+    that seeded even one child is not a no-op and is not reported.
     """
-    if not profiles and not seed_files and not seed_globs:
+    if not profiles and not seed_files and not seed_globs and not _is_dir(repo_root / BMAD_DIR):
         return []
     worktree = worktree.resolve()
     repo_root = repo_root.resolve()
@@ -241,6 +440,18 @@ def provision_worktree(
             # as_posix so the exclude pattern anchors on Windows too (os.sep would not)
             seeded.append(rel.as_posix())
 
+    # Renderer-backed skills are handed the worktree as their project root. Merge
+    # the repo's project-local BMAD surface after explicit seeds (operator intent wins
+    # on collisions) and reserve the two renderer sentinels for result-side checks.
+    seeded_bmad = _seed_bmad_tree(worktree, repo_root)
+    if seeded_bmad:
+        skipped = [rel for rel in skipped if not _is_under_bmad(rel)]
+    skipped = [rel for rel in skipped if rel not in RENDERER_SEED_SENTINELS]
+    if _bmad_scripts_seed_incomplete(worktree, repo_root):
+        skipped.append(BMAD_SCRIPTS_SEED_REL)
+    if _central_config_seed_incomplete(worktree, repo_root):
+        skipped.append(CENTRAL_CONFIG_REL)
+
     # bundled skills into each CLI's skill tree (deduped: codex+gemini share one);
     # never clobber a skill the checkout already carries (tracked or pre-existing).
     for tree in dict.fromkeys(p.skill_tree for p in profiles):
@@ -253,6 +464,12 @@ def provision_worktree(
                 skip_existing=True,
                 worktree=worktree,
             )
+        # Known gap, deliberately restated rather than folded into the CRITICAL gate
+        # below: wheel MODULE_SKILLS have no result-side completeness predicate. Story
+        # worktrees deterministically dispatch the upstream dev/review skills, while
+        # these bundled operator/triage skills are a different invocation surface; a
+        # partial wheel copy therefore cannot honestly reuse the guaranteed-stall gate.
+        # Closing that observability gap needs its own required-consumer contract.
         # The orchestrator-driven upstream skills are not in the wheel; copy them
         # from the MAIN REPO's installed tree (same tree path) so an isolated
         # worktree can still resolve the dev primitive and the review layers. Skip
@@ -273,9 +490,7 @@ def provision_worktree(
         # Validating a skill here and then not copying it is how preflight passes in
         # the main checkout while the isolated review fails on a skill that was
         # never there.
-        resolved = resolve_review_layers(repo_root, tree)
-        required = dict.fromkeys((*BASE_SKILLS, *(resolved.skills() if resolved else ())))
-        for skill in required:
+        for skill in _required_worktree_skills(repo_root, tree):
             dst = tree_dir / skill
             src = (repo_root / tree / skill).resolve()
             if not src.is_relative_to(repo_root) or not _is_dir(src):
@@ -288,35 +503,13 @@ def provision_worktree(
                 repo_root=repo_root,
             )
 
-    # The project's customization of those upstream skills (_bmad/custom/*.toml).
-    # The preflight resolves review layers through these files, but the run inside
-    # the worktree resolves them again from ITS OWN project root — and they are
-    # routinely absent from a fresh checkout: the upstream installer gitignores
-    # `*.user.toml`, and plenty of projects gitignore `_bmad/` whole. Without this
-    # the two disagree, and validate approves a layer set the isolated run never
-    # runs. Copy-when-absent at file granularity, so a checkout that tracks its
-    # own customization keeps every tracked file untouched.
-    #
-    # Deliberately NOT routed through seed_files: `skipped` reports user-authored
-    # `worktree_seed` entries that silently no-op, and this internal seed is not
-    # one of those — journaling it would read as a project misconfiguration.
-    customize_seeded = False
-    src_customize = (repo_root / CUSTOMIZE_DIR).resolve()
-    raw_customize = worktree / CUSTOMIZE_DIR
-    dst_customize = raw_customize.resolve()
-    if (
-        _is_dir(src_customize)
-        and src_customize.is_relative_to(repo_root)
-        and dst_customize.is_relative_to(worktree)
-        and dst_customize == raw_customize
-    ):
-        customize_seeded = _copy_traversable(
-            src_customize,
-            raw_customize,
-            skip_existing=True,
-            worktree=worktree,
-            repo_root=repo_root,
+    # Re-ask the result rather than trusting copy bookkeeping. A user-authored seed
+    # can happen to spell a skill rel, so only this disk predicate may arm the gate.
+    skipped.extend(
+        base_skills_seed_incomplete(
+            worktree, repo_root, [profile.skill_tree for profile in profiles]
         )
+    )
 
     # per-CLI signal-hook registration, baked to the main repo's relay (absolute).
     # Hookless profiles (HTTP/SSE transport) have no config to merge.
@@ -369,8 +562,15 @@ def provision_worktree(
     # as the pattern "/", git-excluding the entire worktree.
     patterns |= {f"/{p.hooks.config_path}" for p in profiles if not p.hookless}
     patterns |= {f"/{rel}" for rel in seeded}
-    if customize_seeded:
-        patterns.add(f"/{CUSTOMIZE_DIR.as_posix()}")
+    patterns |= {f"/{rel}" for rel in seeded_bmad}
+    if f"/{BMAD_DIR}" not in patterns:
+        # The renderer may create or rewrite this generated directory during the
+        # session, after provisioning has finished. Give it a dedicated transient
+        # shield unless the blanket root shield already subsumes it: `/_bmad` prunes
+        # the directory before git descends, so `/_bmad/render/` would provably never
+        # be consulted. Avoiding that inert sibling keeps the worktree-local exclude
+        # precise; the file and its lines disappear with this worktree.
+        patterns.add(f"/{RENDER_DIR_REL}/")
     reason = _worktree_local_exclude(worktree, sorted(patterns))
     if reason is not None and on_degraded is not None:
         on_degraded(reason)
@@ -546,6 +746,9 @@ class WorktreeFlow:
             self._save()
             return
         task.worktree_path = str(unit.path)
+        self.journal.append(
+            "worktree-opened", story_key=task.story_key, branch=unit.branch, path=str(unit.path)
+        )
         task.branch = unit.branch
         # A worktree checks out tracked files only, but the bmad-loop-* skill
         # trees + signal-hook config are typically gitignored, so they are absent
@@ -565,12 +768,14 @@ class WorktreeFlow:
         # config so the worktree's Editor MCP is reachable. Aggregate every loaded
         # plugin's declared seeds.
         seeds.extend(self._registry.seed_files())
+        seed_files = list(dict.fromkeys(seeds))  # dedupe, preserve order
+        seed_globs = self._registry.seed_globs()
         skipped_seeds = provision_worktree(
             unit.path,
             profiles,
             self.paths.repo_root,
-            seed_files=list(dict.fromkeys(seeds)),  # dedupe, preserve order
-            seed_globs=self._registry.seed_globs(),
+            seed_files=seed_files,
+            seed_globs=seed_globs,
             on_degraded=lambda msg: self._exclude_degraded(task.story_key, msg),
         )
         if skipped_seeds:
@@ -582,9 +787,74 @@ class WorktreeFlow:
             self.journal.append(
                 "worktree-seed-skipped", story_key=task.story_key, entries=skipped_seeds
             )
-        self.journal.append(
-            "worktree-opened", story_key=task.story_key, branch=unit.branch, path=str(unit.path)
+
+        # A dropped arbitrary seed is observable but not fatal. Unlike the two gates
+        # below, bmad-loop cannot know that a user/plugin config is required by the
+        # session, and its usual trigger is a healthy shared/dotfile-managed config.
+        # Hook config destinations cannot prove delivery because provisioning writes
+        # the Stop registration itself after the seed step.
+        undelivered_seeds = worktree_seed_undelivered(
+            unit.path,
+            self.paths.repo_root,
+            seed_files=seed_files,
+            seed_globs=seed_globs,
+            config_paths=[p.hooks.config_path for p in profiles if not p.hookless],
         )
+        if undelivered_seeds:
+            self.journal.append(
+                "worktree-seed-dropped", story_key=task.story_key, entries=undelivered_seeds
+            )
+
+        # Missing upstream skill content is a determinate stall for both inline and
+        # renderer-era primitives. Re-probe disk rather than trusting skipped_seeds,
+        # which a user-authored seed rel could otherwise forge. Check this first so a
+        # wholly absent primitive is not misdiagnosed as a renderer-surface problem.
+        trees = [p.skill_tree for p in profiles]
+        absent_skills = base_skills_seed_incomplete(unit.path, self.paths.repo_root, trees)
+        if absent_skills:
+            reason = (
+                "the worktree is missing upstream skill files the repo has "
+                f"({', '.join(absent_skills)}) — the session would stall having "
+                "written nothing: on `Unknown command` when the whole skill is "
+                "absent, or inside the workflow when the skill directory is short. "
+                "The usual cause is a skill directory, file, or sub-directory "
+                "symlinked to a shared BMad install outside the repo, which "
+                "worktree seeding cannot follow"
+            )
+            task.phase = Phase.ESCALATED
+            self.journal.append("story-escalated", story_key=task.story_key, reason=reason)
+            gates.notify(
+                self.policy,
+                self.run_dir,
+                f"CRITICAL escalation: {task.story_key}",
+                f"{reason} — resolve, then `bmad-loop resume {self.state.run_id}`",
+            )
+            self._save()
+            self._pause(reason, task.story_key)
+
+        # Provisioning owns these exact sentinel strings, but only a content-confirmed
+        # renderer stub consumes the surface. The conjunct is load-bearing: inline
+        # pre-#2601 SKILL.md projects may carry the same repo paths and must proceed.
+        short_surface = [rel for rel in RENDERER_SEED_SENTINELS if rel in skipped_seeds]
+        if short_surface and renderer_stub_resolved(self.paths.project, trees):
+            reason = (
+                f"the dev primitive renders via {RENDERER_SCRIPT_MARKER} but the "
+                "worktree's renderer surface came up short of the repo's "
+                f"({', '.join(short_surface)}) — the session would HALT without "
+                "writing a spec. The usual cause is a symlinked _bmad/ pointing "
+                "outside the repo, which worktree seeding cannot follow"
+            )
+            task.phase = Phase.ESCALATED
+            self.journal.append("story-escalated", story_key=task.story_key, reason=reason)
+            gates.notify(
+                self.policy,
+                self.run_dir,
+                f"CRITICAL escalation: {task.story_key}",
+                f"{reason} — resolve, then `bmad-loop resume {self.state.run_id}`",
+            )
+            self._save()
+            self._pause(reason, task.story_key)
+
         self._save()
         prev = self._workspace_get()
         self._workspace_set(unit.workspace)

--- a/src/bmad_loop/worktree_flow.py
+++ b/src/bmad_loop/worktree_flow.py
@@ -27,15 +27,15 @@ from typing import TYPE_CHECKING, Callable, NoReturn
 
 from . import gates, verify
 from .install import (
+    _REVIEW_LAYER_SKILLS,
     BASE_SKILLS,
     BMAD_DIR,
     BMAD_SCRIPTS_SEED_REL,
     BMAD_SEED_EXCLUDES,
     CENTRAL_CONFIG_REL,
-    DEV_PRIMITIVE_LEGACY,
-    DEV_PRIMITIVE_NEW,
     DEV_PRIMITIVE_ROLES,
     HOOK_SCRIPT_REL,
+    MERGED_REVIEW_SKILL,
     MODULE_SKILLS,
     RENDER_DIR_REL,
     RENDERER_SCRIPT_MARKER,
@@ -84,10 +84,29 @@ def _setup_mcp_agent_id(profile_name: str) -> str:
     return _SETUP_MCP_AGENT_IDS.get(profile_name, profile_name)
 
 
-def _required_worktree_skills(repo_root: Path, tree: str) -> tuple[str, ...]:
-    """Every upstream skill the dev/review sessions in ``tree`` may invoke."""
+def _worktree_skill_copy_candidates(repo_root: Path, tree: str) -> tuple[str, ...]:
+    """Every upstream skill worth best-effort copying into ``tree``."""
     resolved = resolve_review_layers(repo_root, tree)
     return tuple(dict.fromkeys((*BASE_SKILLS, *(resolved.skills() if resolved else ()))))
+
+
+def _required_worktree_skills(repo_root: Path, tree: str) -> tuple[str, ...]:
+    """Upstream skills whose absence deterministically stalls this tree's run.
+
+    Match :func:`install.missing_base_skills`: gate the selected dev primitive and
+    resolved required review skills only. If the review shape is unknown, prefer a
+    present merged reviewer; otherwise require the standalone fallback reviewers.
+    Catalog-only and advisory skills remain copy candidates but never arm the fatal
+    pre-dispatch completeness gate.
+    """
+    resolved = resolve_review_layers(repo_root, tree)
+    if resolved is not None:
+        review_skills = tuple(resolved.required)
+    elif (repo_root / tree / MERGED_REVIEW_SKILL / "SKILL.md").is_file():
+        review_skills = (MERGED_REVIEW_SKILL,)
+    else:
+        review_skills = tuple(sorted(_REVIEW_LAYER_SKILLS))
+    return tuple(dict.fromkeys((dev_primitive_or_default(repo_root, tree), *review_skills)))
 
 
 def _is_under_bmad(rel: str) -> bool:
@@ -178,10 +197,11 @@ def _absent_skill_files(repo_skill: Path, worktree_skill: Path) -> list[str]:
 def base_skills_seed_incomplete(worktree: Path, repo_root: Path, trees: Sequence[str]) -> list[str]:
     """Upstream skill rels present in the repo but absent from the worktree.
 
-    ``BASE_SKILLS`` is a copy-if-present catalog containing both primitive eras,
-    not a requirement set. Only the era this project resolves is gated. Main also
-    provisions the project's resolved review layers, so those join the same parity
-    check rather than becoming an unguarded second copy leg.
+    ``BASE_SKILLS`` is a copy-if-present catalog, not a requirement set. Gate only
+    the selected primitive and required review skills; advisory/conditional and
+    inactive catalog entries are still provisioned best-effort, but their absence
+    cannot prove the dev/review session will stall. Unknown review shapes use the
+    same merged-or-standalone fallback as the run-start preflight.
 
     A missing ``SKILL.md`` reports the coarse skill rel; once the skill is present,
     every missing file is named. A repo directory without ``SKILL.md`` remains the
@@ -189,12 +209,7 @@ def base_skills_seed_incomplete(worktree: Path, repo_root: Path, trees: Sequence
     """
     missing: list[str] = []
     for tree in dict.fromkeys(trees):
-        unused_era = {DEV_PRIMITIVE_NEW, DEV_PRIMITIVE_LEGACY} - {
-            dev_primitive_or_default(repo_root, tree)
-        }
         for skill in _required_worktree_skills(repo_root, tree):
-            if skill in unused_era:
-                continue
             repo_skill = repo_root / tree / skill
             worktree_skill = worktree / tree / skill
             if not _is_file(repo_skill / "SKILL.md"):
@@ -518,7 +533,7 @@ def provision_worktree(
         # Validating a skill here and then not copying it is how preflight passes in
         # the main checkout while the isolated review fails on a skill that was
         # never there.
-        for skill in _required_worktree_skills(repo_root, tree):
+        for skill in _worktree_skill_copy_candidates(repo_root, tree):
             dst = tree_dir / skill
             src = (repo_root / tree / skill).resolve()
             if not src.is_relative_to(repo_root) or not _is_dir(src):

--- a/tests/test_engine_worktree.py
+++ b/tests/test_engine_worktree.py
@@ -194,9 +194,8 @@ def journal_kinds(engine):
 def ignore_before_commit(project, *patterns):
     gitignore = project.project / ".gitignore"
     existing = gitignore.read_text(encoding="utf-8")
-    gitignore.write_text(
-        existing + "".join(f"{pattern}\n" for pattern in patterns), encoding="utf-8"
-    )
+    prefix = existing if not existing or existing.endswith("\n") else existing + "\n"
+    gitignore.write_text(prefix + "".join(f"{pattern}\n" for pattern in patterns), encoding="utf-8")
 
 
 # ----------------------------------------------------------------- happy path

--- a/tests/test_engine_worktree.py
+++ b/tests/test_engine_worktree.py
@@ -9,6 +9,8 @@ adapter (no tmux, no LLM).
 from __future__ import annotations
 
 import shutil
+import sys
+from pathlib import Path
 
 import pytest
 from conftest import (
@@ -17,7 +19,9 @@ from conftest import (
     _seeded_then_touch,
     _spec_baseline,
     _touch_run,
+    attach_profile,
     git,
+    install_build_auto_skill,
     set_sprint,
     write_spec,
     write_sprint,
@@ -27,6 +31,11 @@ from bmad_loop import verify, worktree_flow
 from bmad_loop.adapters.base import SessionResult
 from bmad_loop.adapters.mock import MockAdapter
 from bmad_loop.engine import Engine
+from bmad_loop.install import (
+    BMAD_SCRIPTS_SEED_REL,
+    CENTRAL_CONFIG_REL,
+    DEV_PRIMITIVE_NEW,
+)
 from bmad_loop.journal import Journal, load_state
 from bmad_loop.model import Phase, RunState, SessionRecord, StoryTask, TokenUsage
 from bmad_loop.policy import GatesPolicy, LimitsPolicy, NotifyPolicy, Policy, ScmPolicy
@@ -182,6 +191,14 @@ def journal_kinds(engine):
     return [e["kind"] for e in engine.journal.entries()]
 
 
+def ignore_before_commit(project, *patterns):
+    gitignore = project.project / ".gitignore"
+    existing = gitignore.read_text(encoding="utf-8")
+    gitignore.write_text(
+        existing + "".join(f"{pattern}\n" for pattern in patterns), encoding="utf-8"
+    )
+
+
 # ----------------------------------------------------------------- happy path
 
 
@@ -209,6 +226,119 @@ def test_worktree_happy_path_merges_to_target(project):
     assert "worktree-opened" in kinds and "unit-merged" in kinds
     # a clean teardown degrades nothing (gh-139): no warning event is emitted
     assert "worktree-teardown-degraded" not in kinds
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlinks")
+def test_missing_upstream_skill_seed_escalates_before_dispatch_and_records_mount(project, tmp_path):
+    """A shared install outside the repo passes main's through-link resolution but
+    cannot be copied into the worktree. The flow pauses before invoking the adapter,
+    with the mount journaled early enough for the operator to inspect it."""
+    tree = ".claude/skills"
+    ignore_before_commit(project, ".claude/")
+    commit_sprint(project, {"1-1-a": "ready-for-dev"})
+    shared_skills = install_build_auto_skill(tmp_path / "shared", tree)
+    linked_skill = project.project / tree / DEV_PRIMITIVE_NEW
+    linked_skill.parent.mkdir(parents=True)
+    linked_skill.symlink_to(shared_skills / DEV_PRIMITIVE_NEW, target_is_directory=True)
+
+    engine, adapter = make_engine(
+        project,
+        [wt_dev_effect(project, "1-1-a"), wt_review_effect(project, "1-1-a", clean=True)],
+    )
+    attach_profile(adapter)
+
+    summary = engine.run()
+
+    assert summary.paused and adapter.sessions == []
+    task = engine.state.tasks["1-1-a"]
+    assert task.phase == Phase.ESCALATED
+    assert f"{tree}/{DEV_PRIMITIVE_NEW}" in (engine.state.paused_reason or "")
+    entries = engine.journal.entries()
+    kinds = [entry["kind"] for entry in entries]
+    assert kinds.index("worktree-opened") < kinds.index("story-escalated")
+    opened = next(entry for entry in entries if entry["kind"] == "worktree-opened")
+    assert opened["path"] == task.worktree_path
+    assert Path(task.worktree_path).is_dir(), "an escalated worktree stays mounted"
+
+
+def _install_short_renderer_case(project, tmp_path, *, renderer_stub):
+    """Install a complete primitive beside renderer scripts the seed cannot follow."""
+    tree = ".claude/skills"
+    ignore_before_commit(project, ".claude/", f"{BMAD_SCRIPTS_SEED_REL}", CENTRAL_CONFIG_REL)
+    commit_sprint(project, {"1-1-a": "ready-for-dev"})
+    install_build_auto_skill(project.project, tree, renderer_stub=renderer_stub)
+    shared_scripts = tmp_path / "shared-scripts"
+    shared_scripts.mkdir()
+    (shared_scripts / "render_skill.py").write_text("import config_utils\n", encoding="utf-8")
+    (shared_scripts / "config_utils.py").write_text("# config\n", encoding="utf-8")
+    scripts_link = project.project / BMAD_SCRIPTS_SEED_REL
+    scripts_link.parent.mkdir(parents=True, exist_ok=True)
+    scripts_link.symlink_to(shared_scripts, target_is_directory=True)
+    central = project.project / CENTRAL_CONFIG_REL
+    central.write_text("[core]\n", encoding="utf-8")
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlinks")
+def test_short_renderer_seed_escalates_in_worktree_flow(project, tmp_path):
+    _install_short_renderer_case(project, tmp_path, renderer_stub=True)
+    engine, adapter = make_engine(
+        project,
+        [wt_dev_effect(project, "1-1-a"), wt_review_effect(project, "1-1-a", clean=True)],
+    )
+    attach_profile(adapter)
+
+    summary = engine.run()
+
+    assert summary.paused and adapter.sessions == []
+    task = engine.state.tasks["1-1-a"]
+    assert task.phase == Phase.ESCALATED
+    assert BMAD_SCRIPTS_SEED_REL in (engine.state.paused_reason or "")
+    assert Path(task.worktree_path).is_dir()
+    assert "worktree-opened" in journal_kinds(engine)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlinks")
+def test_short_renderer_seed_does_not_escalate_an_inline_skill(project, tmp_path):
+    """The exact consumer-side era conjunct: a pre-#2601 inline SKILL.md never
+    reads the renderer surface, even when the provisioning predicate emits a sentinel."""
+    _install_short_renderer_case(project, tmp_path, renderer_stub=False)
+    engine, adapter = make_engine(
+        project,
+        [wt_dev_effect(project, "1-1-a"), wt_review_effect(project, "1-1-a", clean=True)],
+    )
+    attach_profile(adapter)
+
+    summary = engine.run()
+
+    assert summary.done == 1 and not summary.paused
+    assert "story-escalated" not in journal_kinds(engine)
+    skipped = [
+        entry for entry in engine.journal.entries() if entry["kind"] == "worktree-seed-skipped"
+    ]
+    assert skipped and BMAD_SCRIPTS_SEED_REL in skipped[0]["entries"]
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlinks")
+def test_undelivered_arbitrary_seed_is_journaled_never_escalated(project, tmp_path):
+    ignore_before_commit(project, ".mcp.json")
+    commit_sprint(project, {"1-1-a": "ready-for-dev"})
+    shared = tmp_path / "shared-mcp.json"
+    shared.write_text("{}\n", encoding="utf-8")
+    (project.project / ".mcp.json").symlink_to(shared)
+    engine, _ = make_engine(
+        project,
+        [wt_dev_effect(project, "1-1-a"), wt_review_effect(project, "1-1-a", clean=True)],
+        policy=wt_policy(worktree_seed=(".mcp.json",)),
+    )
+
+    summary = engine.run()
+
+    assert summary.done == 1 and not summary.paused
+    dropped = [
+        entry for entry in engine.journal.entries() if entry["kind"] == "worktree-seed-dropped"
+    ]
+    assert len(dropped) == 1 and dropped[0]["entries"] == [".mcp.json"]
+    assert "story-escalated" not in journal_kinds(engine)
 
 
 @pytest.mark.parametrize("merge_strategy", ["merge", "ff"])

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -5,6 +5,7 @@ import json
 import os
 import re
 import shlex
+import shutil
 import stat
 import subprocess
 import sys
@@ -25,6 +26,8 @@ from bmad_loop import verify
 from bmad_loop.adapters.profile import get_profile
 from bmad_loop.install import (
     BASE_SKILLS,
+    BMAD_DIR,
+    BMAD_SCRIPTS_SEED_REL,
     CENTRAL_CONFIG_REL,
     CUSTOMIZE_DIR,
     DEV_BASE_SKILLS,
@@ -53,6 +56,13 @@ from bmad_loop.install import (
     renderer_stub_resolved,
     resolve_dev_primitive,
     resolve_review_layers,
+)
+from bmad_loop.worktree_flow import (
+    _bmad_scripts_seed_incomplete,
+    _central_config_seed_incomplete,
+    _seed_bmad_tree,
+    base_skills_seed_incomplete,
+    worktree_seed_undelivered,
 )
 
 
@@ -2315,7 +2325,10 @@ def test_provision_worktree_bmad_custom_shielded_in_local_exclude(project, tmp_p
 
     assert (wt / "_bmad" / "custom" / "bmad-dev-auto.user.toml").is_file()
     exclude = _wt_private_exclude(wt).read_text(encoding="utf-8")
-    assert "/_bmad/custom" in exclude.splitlines()
+    # The whole `_bmad` seed now owns customization too. Its root shield subsumes
+    # both custom and render descendants without redundant sibling patterns.
+    assert "/_bmad" in exclude.splitlines()
+    assert "/_bmad/custom" not in exclude.splitlines()
     assert shared.read_bytes() == before
 
 
@@ -6640,3 +6653,173 @@ def test_copy_traversable_skip_existing_never_mkdirs_over_file(tmp_path):
 
     assert _copy_traversable(src, dst, skip_existing=True) is False
     assert (dst / "d").read_text() == "A FILE, NOT A DIR"
+
+
+# -------------------------------------------------------- worktree seed completeness
+
+
+def _write_worktree_renderer_surface(repo):
+    scripts = repo / BMAD_SCRIPTS_SEED_REL
+    scripts.mkdir(parents=True)
+    (scripts / "render_skill.py").write_text("import config_utils\n", encoding="utf-8")
+    (scripts / "config_utils.py").write_text("# config\n", encoding="utf-8")
+    (repo / CENTRAL_CONFIG_REL).write_text("[core]\n", encoding="utf-8")
+
+
+def test_seed_bmad_tree_merges_per_file_and_excludes_render_output(tmp_path):
+    repo, wt = tmp_path / "repo", tmp_path / "wt"
+    _write_worktree_renderer_surface(repo)
+    (repo / BMAD_DIR / "custom").mkdir()
+    (repo / BMAD_DIR / "custom" / "style.toml").write_text("x = 1\n", encoding="utf-8")
+    (repo / RENDER_DIR_REL).mkdir()
+    (repo / RENDER_DIR_REL / "generated.md").write_text("machine local\n", encoding="utf-8")
+    carried = wt / CENTRAL_CONFIG_REL
+    carried.parent.mkdir(parents=True)
+    carried.write_text("[checkout]\n", encoding="utf-8")
+
+    seeded = _seed_bmad_tree(wt, repo)
+
+    assert carried.read_text(encoding="utf-8") == "[checkout]\n"
+    assert (wt / BMAD_SCRIPTS_SEED_REL / "render_skill.py").is_file()
+    assert (wt / BMAD_DIR / "custom" / "style.toml").is_file()
+    assert not (wt / RENDER_DIR_REL).exists()
+    assert seeded == [
+        f"{BMAD_DIR}/custom/style.toml",
+        f"{BMAD_SCRIPTS_SEED_REL}/config_utils.py",
+        f"{BMAD_SCRIPTS_SEED_REL}/render_skill.py",
+    ]
+
+
+def test_render_shield_is_omitted_when_root_shield_subsumes_it(tmp_path, monkeypatch):
+    import bmad_loop.worktree_flow as worktree_flow
+
+    repo, wt = tmp_path / "repo", tmp_path / "wt"
+    _write_worktree_renderer_surface(repo)
+    captured = []
+    monkeypatch.setattr(
+        worktree_flow,
+        "_worktree_local_exclude",
+        lambda _worktree, patterns: captured.extend(patterns),
+    )
+
+    provision_worktree(wt, [], repo)
+
+    assert f"/{BMAD_DIR}" in captured
+    assert f"/{RENDER_DIR_REL}/" not in captured
+
+
+def test_render_shield_does_not_depend_on_bmad_provisioning_order(tmp_path, monkeypatch):
+    """No `_bmad` directory is needed to arm the transient render shield.
+
+    `_seed_bmad_tree` may create the directory, so gating on its post-seed existence
+    makes protection depend on provisioning order. The only suppression is the root
+    pattern's structural subsumption.
+    """
+    import bmad_loop.worktree_flow as worktree_flow
+
+    repo, wt = tmp_path / "repo", tmp_path / "wt"
+    repo.mkdir()
+    captured = []
+    monkeypatch.setattr(
+        worktree_flow,
+        "_worktree_local_exclude",
+        lambda _worktree, patterns: captured.extend(patterns),
+    )
+
+    provision_worktree(wt, [get_profile("claude")], repo)
+
+    assert not (wt / BMAD_DIR).exists()
+    assert f"/{BMAD_DIR}" not in captured
+    assert f"/{RENDER_DIR_REL}/" in captured
+
+
+def test_base_skills_seed_incomplete_uses_the_resolved_primitive_era(tmp_path):
+    wt, repo = tmp_path / "wt", tmp_path / "repo"
+    tree = ".claude/skills"
+    catalog = {
+        DEV_PRIMITIVE_NEW: DEV_PRIMITIVE_MARKERS,
+        DEV_PRIMITIVE_LEGACY: DEV_PRIMITIVE_MARKERS,
+    }
+    for root in (repo, wt):
+        _install_skills(root, tree, catalog)
+    shutil.rmtree(wt / tree / DEV_PRIMITIVE_LEGACY)
+
+    assert resolve_dev_primitive(repo, tree) == DEV_PRIMITIVE_NEW
+    assert base_skills_seed_incomplete(wt, repo, [tree]) == []
+
+
+def test_base_skills_seed_incomplete_names_a_short_skill_file(tmp_path):
+    wt, repo = tmp_path / "wt", tmp_path / "repo"
+    tree = ".claude/skills"
+    catalog = {DEV_PRIMITIVE_NEW: DEV_PRIMITIVE_MARKERS}
+    for root in (repo, wt):
+        _install_skills(root, tree, catalog)
+        skill = root / tree / DEV_PRIMITIVE_NEW
+        (skill / "review-prompts").mkdir()
+        (skill / "review-prompts" / "adversarial.md").write_text("x\n", encoding="utf-8")
+    (wt / tree / DEV_PRIMITIVE_NEW / "review-prompts" / "adversarial.md").unlink()
+
+    assert base_skills_seed_incomplete(wt, repo, [tree]) == [
+        f"{tree}/{DEV_PRIMITIVE_NEW}/review-prompts/adversarial.md"
+    ]
+
+
+def test_renderer_seed_predicates_report_only_missing_repo_content(tmp_path):
+    repo, wt = tmp_path / "repo", tmp_path / "wt"
+    _write_worktree_renderer_surface(repo)
+    _write_worktree_renderer_surface(wt)
+
+    assert not _bmad_scripts_seed_incomplete(wt, repo)
+    assert not _central_config_seed_incomplete(wt, repo)
+
+    (wt / BMAD_SCRIPTS_SEED_REL / "config_utils.py").unlink()
+    (wt / CENTRAL_CONFIG_REL).unlink()
+    assert _bmad_scripts_seed_incomplete(wt, repo)
+    assert _central_config_seed_incomplete(wt, repo)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlinks")
+def test_provision_reports_a_symlinked_out_renderer_scripts_seed(tmp_path):
+    repo, wt = tmp_path / "repo", tmp_path / "wt"
+    (repo / BMAD_DIR).mkdir(parents=True)
+    shared = tmp_path / "shared-scripts"
+    shared.mkdir()
+    (shared / "render_skill.py").write_text("import config_utils\n", encoding="utf-8")
+    (shared / "config_utils.py").write_text("# config\n", encoding="utf-8")
+    (repo / BMAD_SCRIPTS_SEED_REL).symlink_to(shared, target_is_directory=True)
+    (repo / CENTRAL_CONFIG_REL).write_text("[core]\n", encoding="utf-8")
+
+    skipped = provision_worktree(wt, [], repo)
+
+    assert skipped == [BMAD_SCRIPTS_SEED_REL]
+    assert not (wt / BMAD_SCRIPTS_SEED_REL).exists()
+    assert (wt / CENTRAL_CONFIG_REL).is_file()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlinks")
+def test_worktree_seed_undelivered_names_a_symlinked_out_source(tmp_path):
+    repo, wt = tmp_path / "repo", tmp_path / "wt"
+    repo.mkdir()
+    shared = tmp_path / "shared-mcp.json"
+    shared.write_text("{}\n", encoding="utf-8")
+    (repo / ".mcp.json").symlink_to(shared)
+
+    assert provision_worktree(wt, [], repo, seed_files=[".mcp.json"]) == []
+    assert worktree_seed_undelivered(wt, repo, seed_files=[".mcp.json"]) == [".mcp.json"]
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlinks")
+def test_hook_config_cannot_supply_its_dropped_seed_alibi(tmp_path):
+    profile = get_profile("claude")
+    rel = profile.hooks.config_path
+    repo, wt = tmp_path / "repo", tmp_path / "wt"
+    (repo / rel).parent.mkdir(parents=True)
+    shared = tmp_path / "shared-settings.json"
+    shared.write_text('{"env": {"FROM_REPO": "1"}}\n', encoding="utf-8")
+    (repo / rel).symlink_to(shared)
+
+    provision_worktree(wt, [profile], repo, seed_files=[rel])
+
+    assert (wt / rel).is_file(), "the hook registration itself creates this path"
+    assert worktree_seed_undelivered(wt, repo, seed_files=[rel]) == []
+    assert worktree_seed_undelivered(wt, repo, seed_files=[rel], config_paths=[rel]) == [rel]

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -6778,6 +6778,33 @@ def test_renderer_seed_predicates_report_only_missing_repo_content(tmp_path):
     assert _central_config_seed_incomplete(wt, repo)
 
 
+@pytest.mark.parametrize(
+    ("renderer_body", "missing_name"),
+    [
+        ("# standalone renderer\n", "config_utils.py"),
+        ("import config_utils\n", "unrelated.py"),
+    ],
+)
+def test_renderer_scripts_seed_ignores_files_the_renderer_does_not_require(
+    tmp_path, renderer_body, missing_name
+):
+    repo, wt = tmp_path / "repo", tmp_path / "wt"
+    _write_worktree_renderer_surface(repo)
+    _write_worktree_renderer_surface(wt)
+    for root in (repo, wt):
+        (root / BMAD_SCRIPTS_SEED_REL / "render_skill.py").write_text(
+            renderer_body, encoding="utf-8"
+        )
+    if missing_name == "unrelated.py":
+        (repo / BMAD_SCRIPTS_SEED_REL / missing_name).write_text(
+            "# not imported by the renderer\n", encoding="utf-8"
+        )
+    else:
+        (wt / BMAD_SCRIPTS_SEED_REL / missing_name).unlink()
+
+    assert not _bmad_scripts_seed_incomplete(wt, repo)
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlinks")
 def test_provision_reports_a_symlinked_out_renderer_scripts_seed(tmp_path):
     repo, wt = tmp_path / "repo", tmp_path / "wt"
@@ -6806,6 +6833,27 @@ def test_worktree_seed_undelivered_names_a_symlinked_out_source(tmp_path):
 
     assert provision_worktree(wt, [], repo, seed_files=[".mcp.json"]) == []
     assert worktree_seed_undelivered(wt, repo, seed_files=[".mcp.json"]) == [".mcp.json"]
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlinks")
+@pytest.mark.parametrize("seed_kind", ["files", "globs"])
+def test_worktree_seed_undelivered_names_a_partial_directory_seed(tmp_path, seed_kind):
+    repo, wt = tmp_path / "repo", tmp_path / "wt"
+    seed_dir = repo / "plugins" / "tool"
+    seed_dir.mkdir(parents=True)
+    (seed_dir / "copied.json").write_text("{}\n", encoding="utf-8")
+    shared = tmp_path / "shared-config"
+    shared.mkdir()
+    (shared / "dropped.json").write_text("{}\n", encoding="utf-8")
+    (seed_dir / "shared").symlink_to(shared, target_is_directory=True)
+    seed_args = (
+        {"seed_files": ["plugins/tool"]} if seed_kind == "files" else {"seed_globs": ["plugins/*"]}
+    )
+
+    provision_worktree(wt, [], repo, **seed_args)
+
+    assert (wt / "plugins" / "tool" / "copied.json").is_file()
+    assert worktree_seed_undelivered(wt, repo, **seed_args) == ["plugins/tool"]
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlinks")

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -2455,6 +2455,25 @@ def test_provision_worktree_reports_seed_skipped_as_noop(tmp_path):
     assert provision_worktree(wt, [], repo, seed_files=[".mcp.json"]) == [".mcp.json"]
 
 
+def test_provision_preserves_unrelated_bmad_noop_when_internal_sibling_lands(tmp_path):
+    """An internal BMAD copy cannot erase an unrelated user-seed no-op report."""
+    wt, repo = tmp_path / "wt", tmp_path / "repo"
+    rel = f"{BMAD_DIR}/custom/already.toml"
+    for root, content in ((repo, "FROM_REPO\n"), (wt, "IN_WORKTREE\n")):
+        target = root / rel
+        target.parent.mkdir(parents=True)
+        target.write_text(content, encoding="utf-8")
+    sibling = repo / BMAD_SCRIPTS_SEED_REL / "unrelated.py"
+    sibling.parent.mkdir(parents=True)
+    sibling.write_text("# best-effort sibling\n", encoding="utf-8")
+
+    skipped = provision_worktree(wt, [], repo, seed_files=[rel])
+
+    assert skipped == [rel]
+    assert (wt / rel).read_text(encoding="utf-8") == "IN_WORKTREE\n"
+    assert (wt / BMAD_SCRIPTS_SEED_REL / "unrelated.py").is_file()
+
+
 def test_provision_worktree_seeds_absent_children_of_existing_dir(tmp_path):
     """The case that motivated #230: a worktree checks out tracked files, so a seed
     DIRECTORY with any tracked child already exists. Its absent children are seeded
@@ -6801,6 +6820,29 @@ def test_advisory_review_skill_is_copied_best_effort_but_not_fatal(tmp_path):
     assert base_skills_seed_incomplete(wt, repo, [tree]) == []
 
 
+@pytest.mark.parametrize("skill", [DEV_PRIMITIVE_NEW, "bmad-review"])
+def test_required_skill_unreferenced_auxiliary_is_best_effort_not_fatal(tmp_path, skill):
+    """A refused note in an active skill does not prove the session will stall."""
+    wt, repo = tmp_path / "wt", tmp_path / "repo"
+    tree = ".claude/skills"
+    _install_dev_auto(
+        repo,
+        tree,
+        skill=DEV_PRIMITIVE_NEW,
+        customize="[workflow]\n" + _layer("blind", "bmad-review"),
+    )
+    _install_skills(repo, tree, {"bmad-review": ()})
+    shared = tmp_path / f"shared-{skill}.md"
+    shared.write_text("# unreferenced note\n", encoding="utf-8")
+    (repo / tree / skill / "README.md").symlink_to(shared)
+
+    assert missing_base_skills(repo, [tree]) == []
+    assert provision_worktree(wt, [get_profile("claude")], repo) == []
+
+    assert not (wt / tree / skill / "README.md").exists()
+    assert base_skills_seed_incomplete(wt, repo, [tree]) == []
+
+
 @pytest.mark.parametrize("merged_fallback", [True, False])
 def test_base_skills_seed_incomplete_preserves_unknown_review_fallback(tmp_path, merged_fallback):
     """An unknown review shape gates the same fallback topology as preflight."""
@@ -6842,20 +6884,33 @@ def test_base_skills_seed_incomplete_preserves_unknown_review_fallback(tmp_path,
     assert base_skills_seed_incomplete(wt, repo, [tree]) == expected
 
 
-def test_base_skills_seed_incomplete_names_a_short_skill_file(tmp_path):
+def test_base_skills_seed_incomplete_names_a_missing_primitive_marker(tmp_path):
     wt, repo = tmp_path / "wt", tmp_path / "repo"
     tree = ".claude/skills"
     catalog = {DEV_PRIMITIVE_NEW: DEV_PRIMITIVE_MARKERS}
     for root in (repo, wt):
         _install_skills(root, tree, catalog)
-        skill = root / tree / DEV_PRIMITIVE_NEW
-        (skill / "review-prompts").mkdir()
-        (skill / "review-prompts" / "adversarial.md").write_text("x\n", encoding="utf-8")
-    (wt / tree / DEV_PRIMITIVE_NEW / "review-prompts" / "adversarial.md").unlink()
+    (wt / tree / DEV_PRIMITIVE_NEW / "customize.toml").unlink()
 
     assert base_skills_seed_incomplete(wt, repo, [tree]) == [
-        f"{tree}/{DEV_PRIMITIVE_NEW}/review-prompts/adversarial.md"
+        f"{tree}/{DEV_PRIMITIVE_NEW}/customize.toml"
     ]
+
+
+def test_base_skills_seed_incomplete_names_a_missing_renderer_snapshot(tmp_path):
+    wt, repo = tmp_path / "wt", tmp_path / "repo"
+    tree = ".claude/skills"
+    target = "sources/plan.md"
+    for root in (repo, wt):
+        install_build_auto_skill(root, tree, renderer_stub=True)
+        (root / tree / DEV_PRIMITIVE_NEW / "workflow.md").write_text(
+            f"Read [[bmad-snapshot:{target}]].\n", encoding="utf-8"
+        )
+    source = repo / tree / DEV_PRIMITIVE_NEW / target
+    source.parent.mkdir()
+    source.write_text("# plan\n", encoding="utf-8")
+
+    assert base_skills_seed_incomplete(wt, repo, [tree]) == [f"{tree}/{DEV_PRIMITIVE_NEW}/{target}"]
 
 
 def test_renderer_seed_predicates_report_only_missing_repo_content(tmp_path):
@@ -6918,15 +6973,44 @@ def test_provision_reports_a_symlinked_out_renderer_scripts_seed(tmp_path):
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlinks")
-def test_worktree_seed_undelivered_names_a_symlinked_out_source(tmp_path):
+def test_worktree_seed_undelivered_names_an_escaped_source_despite_stale_destination(tmp_path):
     repo, wt = tmp_path / "repo", tmp_path / "wt"
     repo.mkdir()
     shared = tmp_path / "shared-mcp.json"
     shared.write_text("{}\n", encoding="utf-8")
     (repo / ".mcp.json").symlink_to(shared)
+    wt.mkdir()
+    (wt / ".mcp.json").write_text("STALE\n", encoding="utf-8")
 
     assert provision_worktree(wt, [], repo, seed_files=[".mcp.json"]) == []
+    assert (wt / ".mcp.json").read_text(encoding="utf-8") == "STALE\n"
     assert worktree_seed_undelivered(wt, repo, seed_files=[".mcp.json"]) == [".mcp.json"]
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlinks")
+@pytest.mark.parametrize("escaped_kind", ["file", "directory"])
+def test_worktree_seed_undelivered_rejects_stale_nested_escaped_source(tmp_path, escaped_kind):
+    repo, wt = tmp_path / "repo", tmp_path / "wt"
+    rel = "plugins/tool"
+    source = repo / rel
+    source.mkdir(parents=True)
+    (source / "copied.json").write_text("{}\n", encoding="utf-8")
+    destination = wt / rel
+    destination.mkdir(parents=True)
+    shared = tmp_path / "shared"
+    if escaped_kind == "file":
+        shared.write_text("CURRENT\n", encoding="utf-8")
+        (source / "escaped.json").symlink_to(shared)
+        (destination / "escaped.json").write_text("STALE\n", encoding="utf-8")
+    else:
+        shared.mkdir()
+        (source / "escaped").symlink_to(shared, target_is_directory=True)
+        (destination / "escaped").mkdir()
+
+    provision_worktree(wt, [], repo, seed_files=[rel])
+
+    assert (destination / "copied.json").is_file()
+    assert worktree_seed_undelivered(wt, repo, seed_files=[rel]) == [rel]
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlinks")
@@ -6955,13 +7039,16 @@ def test_hook_config_cannot_supply_its_dropped_seed_alibi(tmp_path):
     profile = get_profile("claude")
     rel = profile.hooks.config_path
     repo, wt = tmp_path / "repo", tmp_path / "wt"
-    (repo / rel).parent.mkdir(parents=True)
-    shared = tmp_path / "shared-settings.json"
-    shared.write_text('{"env": {"FROM_REPO": "1"}}\n', encoding="utf-8")
-    (repo / rel).symlink_to(shared)
+    source = repo / rel
+    source.parent.mkdir(parents=True)
+    source.write_text('{"env": {"FROM_REPO": "1"}}\n', encoding="utf-8")
+    stale = wt / ".claude/stale-settings.json"
+    stale.parent.mkdir(parents=True)
+    stale.write_text('{"env": {"STALE": "1"}}\n', encoding="utf-8")
+    (wt / rel).symlink_to(stale)
 
     provision_worktree(wt, [profile], repo, seed_files=[rel])
 
-    assert (wt / rel).is_file(), "the hook registration itself creates this path"
+    assert (wt / rel).is_file(), "the in-worktree link looks delivered generically"
     assert worktree_seed_undelivered(wt, repo, seed_files=[rel]) == []
     assert worktree_seed_undelivered(wt, repo, seed_files=[rel], config_paths=[rel]) == [rel]

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -6748,6 +6748,100 @@ def test_base_skills_seed_incomplete_uses_the_resolved_primitive_era(tmp_path):
     assert base_skills_seed_incomplete(wt, repo, [tree]) == []
 
 
+def test_base_skills_seed_incomplete_ignores_inactive_catalog_symlink(tmp_path):
+    """An obsolete copy-if-present reviewer is not a fatal session requirement.
+
+    A shared-install symlink passes the main-checkout preflight but is deliberately
+    refused by worktree provisioning's source-containment guard. Modern layers invoke
+    only the merged reviewer, so that unused refusal must not pause the run.
+    """
+    wt, repo = tmp_path / "wt", tmp_path / "repo"
+    tree = ".claude/skills"
+    obsolete = "bmad-review-edge-case-hunter"
+    _install_dev_auto(
+        repo,
+        tree,
+        skill=DEV_PRIMITIVE_NEW,
+        customize="[workflow]\n" + _layer("blind", "bmad-review"),
+    )
+    _install_skills(repo, tree, {"bmad-review": ()})
+    shared_skill = tmp_path / "shared" / obsolete
+    shared_skill.mkdir(parents=True)
+    (shared_skill / "SKILL.md").write_text("# obsolete\n", encoding="utf-8")
+    (repo / tree / obsolete).symlink_to(shared_skill, target_is_directory=True)
+
+    assert missing_base_skills(repo, [tree]) == []
+    provision_worktree(wt, [get_profile("claude")], repo)
+
+    assert not (wt / tree / obsolete).exists()
+    assert base_skills_seed_incomplete(wt, repo, [tree]) == []
+
+
+def test_advisory_review_skill_is_copied_best_effort_but_not_fatal(tmp_path):
+    """Conditional review skills remain copy candidates, never hard requirements."""
+    wt, repo = tmp_path / "wt", tmp_path / "repo"
+    tree = ".claude/skills"
+    advisory = "bmad-review-performance"
+    _install_dev_auto(
+        repo,
+        tree,
+        skill=DEV_PRIMITIVE_NEW,
+        customize="[workflow]\n"
+        + _layer("blind", "bmad-review")
+        + _layer("perf", advisory, when="the diff touches hot paths"),
+    )
+    _install_skills(repo, tree, {"bmad-review": (), advisory: ()})
+
+    assert missing_base_skills(repo, [tree]) == []
+    provision_worktree(wt, [get_profile("claude")], repo)
+
+    copied = wt / tree / advisory
+    assert (copied / "SKILL.md").is_file()
+    shutil.rmtree(copied)
+    assert base_skills_seed_incomplete(wt, repo, [tree]) == []
+
+
+@pytest.mark.parametrize("merged_fallback", [True, False])
+def test_base_skills_seed_incomplete_preserves_unknown_review_fallback(tmp_path, merged_fallback):
+    """An unknown review shape gates the same fallback topology as preflight."""
+    wt, repo = tmp_path / "wt", tmp_path / "repo"
+    tree = ".claude/skills"
+    obsolete = "bmad-review-edge-case-hunter"
+    _install_dev_auto(
+        repo,
+        tree,
+        skill=DEV_PRIMITIVE_NEW,
+        customize="this is not = valid toml [[[",
+    )
+    if merged_fallback:
+        _install_skills(repo, tree, {"bmad-review": ()})
+        shared_skill = tmp_path / "shared" / obsolete
+        shared_skill.mkdir(parents=True)
+        (shared_skill / "SKILL.md").write_text("# obsolete\n", encoding="utf-8")
+        (repo / tree / obsolete).symlink_to(shared_skill, target_is_directory=True)
+    else:
+        _install_skills(
+            repo,
+            tree,
+            {
+                "bmad-review-adversarial-general": (),
+                obsolete: (),
+            },
+        )
+
+    assert resolve_review_layers(repo, tree) is None
+    assert missing_base_skills(repo, [tree]) == []
+    provision_worktree(wt, [get_profile("claude")], repo)
+
+    if merged_fallback:
+        assert not (wt / tree / obsolete).exists()
+        expected = []
+    else:
+        shutil.rmtree(wt / tree / obsolete)
+        expected = [f"{tree}/{obsolete}"]
+    assert base_skills_seed_incomplete(wt, repo, [tree]) == expected
+
+
 def test_base_skills_seed_incomplete_names_a_short_skill_file(tmp_path):
     wt, repo = tmp_path / "wt", tmp_path / "repo"
     tree = ".claude/skills"

--- a/tests/test_stories_e2e.py
+++ b/tests/test_stories_e2e.py
@@ -37,6 +37,10 @@ the invoked primitive off disk instead of spelling a constant.
 project-global or skill-relative inputs are refused before tmux can spawn the
 fake, dry-run stays diagnostic, and the complete surface reaches the same
 zero-token real-tmux success path.
+
+(11) runs that complete renderer project under worktree isolation after removing
+the renderer script unit and central config from the index. The real tmux session
+can start only if runtime provisioning reconstructs the ignored `_bmad` surface.
 """
 
 from __future__ import annotations
@@ -59,6 +63,7 @@ from conftest import (
 )
 
 from bmad_loop.install import (
+    BMAD_SCRIPTS_SEED_REL,
     CENTRAL_CONFIG_REL,
     DEV_PRIMITIVE_NEW,
     RENDERER_CONFIG_UTILS_REL,
@@ -659,6 +664,46 @@ def test_e2e_renderer_complete_surface_reaches_real_tmux_fake_cli(tmp_path):
     dispatched = list((run_dir / "tasks").glob("*/fake-prompt.txt"))
     assert len(dispatched) == 1, dispatched
     assert dispatched[0].read_text(encoding="utf-8").startswith("/bmad-build-auto Spec folder: ")
+
+
+def test_e2e_renderer_surface_is_seeded_into_isolated_real_tmux_session(tmp_path):
+    """The required sandbox E2E for the runtime half of renderer support.
+
+    The main checkout keeps the renderer files as ignored working-tree content,
+    while the linked worktree starts without them. A green completion crosses the
+    real CLI, worktree provision, completeness gates, tmux fake, verification and
+    merge path; no LLM is invoked.
+    """
+    root = tmp_path / "sbx"
+    _scaffold_renderer(root)
+    gitignore = root / ".gitignore"
+    gitignore.write_text(
+        gitignore.read_text(encoding="utf-8") + f"{BMAD_SCRIPTS_SEED_REL}/\n{CENTRAL_CONFIG_REL}\n",
+        encoding="utf-8",
+    )
+    policy = root / ".bmad-loop" / "policy.toml"
+    policy.write_text(
+        policy.read_text(encoding="utf-8") + '\n[scm]\nisolation = "worktree"\n',
+        encoding="utf-8",
+    )
+    _git(root, "rm", "-r", "--cached", "--", BMAD_SCRIPTS_SEED_REL, CENTRAL_CONFIG_REL)
+    _git(root, "add", ".gitignore", ".bmad-loop/policy.toml")
+    _git(root, "commit", "-q", "-m", "ignore renderer runtime surface")
+    base = _commit_count(root)
+
+    run = _run(root, "run")
+
+    assert run.returncode == 0, run.stderr or run.stdout
+    assert _status(root, "1") == "done"
+    # Isolation records the unit commit and the local integration commit.
+    assert _commit_count(root) == base + 2
+    run_dir = root / ".bmad-loop" / "runs" / _run_id(root)
+    kinds = [
+        json.loads(line)["kind"]
+        for line in (run_dir / "journal.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    assert "worktree-opened" in kinds and "unit-merged" in kinds
+    assert "story-escalated" not in kinds
 
 
 def test_e2e_spec_checkpoint_two_leg(tmp_path):

--- a/tests/test_stories_e2e.py
+++ b/tests/test_stories_e2e.py
@@ -677,8 +677,10 @@ def test_e2e_renderer_surface_is_seeded_into_isolated_real_tmux_session(tmp_path
     root = tmp_path / "sbx"
     _scaffold_renderer(root)
     gitignore = root / ".gitignore"
+    existing = gitignore.read_text(encoding="utf-8")
+    prefix = existing if not existing or existing.endswith("\n") else existing + "\n"
     gitignore.write_text(
-        gitignore.read_text(encoding="utf-8") + f"{BMAD_SCRIPTS_SEED_REL}/\n{CENTRAL_CONFIG_REL}\n",
+        prefix + f"{BMAD_SCRIPTS_SEED_REL}/\n{CENTRAL_CONFIG_REL}\n",
         encoding="utf-8",
     )
     policy = root / ".bmad-loop" / "policy.toml"

--- a/tests/test_stories_engine.py
+++ b/tests/test_stories_engine.py
@@ -1107,7 +1107,9 @@ def test_worktree_reprobes_stories_dispatch_support_before_session(
     summary = engine.run()
 
     assert summary.paused and adapter.sessions == []
-    assert STORIES_PROBE_FILE in (engine.state.paused_reason or "")
+    reason = engine.state.paused_reason or ""
+    assert STORIES_PROBE_FILE in reason
+    assert (STORIES_PROBE_TEXT in reason) is (checkout_probe == "stale")
     assert Path(engine.state.tasks["1"].worktree_path).is_dir()
 
 

--- a/tests/test_stories_engine.py
+++ b/tests/test_stories_engine.py
@@ -3,6 +3,7 @@ adapter — no tmux, no LLM. Mirrors test_engine.py / test_sweep.py conventions.
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 import pytest
@@ -11,6 +12,12 @@ from conftest import attach_profile, git, install_build_auto_skill, write_spec
 
 from bmad_loop.adapters.base import SessionResult
 from bmad_loop.adapters.mock import MockAdapter
+from bmad_loop.install import (
+    DEV_PRIMITIVE_NEW,
+    STORIES_PROBE_FILE,
+    STORIES_PROBE_TEXT,
+    missing_stories_support,
+)
 from bmad_loop.journal import Journal, load_state, save_state
 from bmad_loop.model import (
     PAUSE_ESCALATION,
@@ -1063,6 +1070,45 @@ def test_worktree_isolation_two_stories(project):
     assert dev and all(Path(s.cwd) != project.project for s in dev)
     assert status_of(read_frontmatter(story_spec(project, "1"))) == "done"
     assert status_of(read_frontmatter(story_spec(project, "2"))) == "done"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlinks")
+@pytest.mark.parametrize("checkout_probe", ["missing", "stale"])
+def test_worktree_reprobes_stories_dispatch_support_before_session(
+    project, tmp_path, checkout_probe
+):
+    """The main checkout's valid through-link cannot alibi a short worktree router."""
+    setup_stories(project, [entry("1")])
+    tree = ".claude/skills"
+    skills = install_build_auto_skill(project.project, tree, folder_id=True)
+    probe = skills / DEV_PRIMITIVE_NEW / STORIES_PROBE_FILE
+    if checkout_probe == "stale":
+        probe.write_text("old router without the required protocol\n", encoding="utf-8")
+        git(
+            project.project,
+            "add",
+            "-f",
+            str(probe.relative_to(project.project)),
+        )
+        git(project.project, "commit", "-q", "-m", "tracked stale stories router")
+    probe.unlink()
+    shared = tmp_path / STORIES_PROBE_FILE
+    shared.write_text(f"This is a **{STORIES_PROBE_TEXT}** router.\n", encoding="utf-8")
+    probe.symlink_to(shared)
+
+    assert missing_stories_support(project.project, [tree]) == []
+    engine, adapter = make_engine(
+        project,
+        [stories_dev_effect()],
+        policy=_stories_policy(scm=ScmPolicy(isolation="worktree")),
+    )
+    attach_profile(adapter)
+
+    summary = engine.run()
+
+    assert summary.paused and adapter.sessions == []
+    assert STORIES_PROBE_FILE in (engine.state.paused_reason or "")
+    assert Path(engine.state.tasks["1"].worktree_path).is_dir()
 
 
 # ---------------------- item 10: MINOR/NOTE batch (Session 3) ----------------


### PR DESCRIPTION
## Summary

- merge-seed the project-local `_bmad/` surface into isolated worktrees, per file and without clobbering checkout content, while excluding generated render output
- re-probe upstream skill and renderer completeness in `WorktreeFlow.run_isolated`; CRITICAL-escalate only deterministic session stalls, while journaling arbitrary undelivered seeds as `worktree-seed-dropped`
- record `worktree-opened` immediately after assigning the mount path so a provisioning escalation leaves an inspectable location in the journal
- add focused unit/engine coverage and a real-tmux sandbox E2E for an ignored renderer surface reconstructed inside an isolated worktree

Reference: #433 (Phase 6H).

## D-H1 render shield

The render shield is worktree-local and transient. It is added without consulting whether `worktree/_bmad` exists, so protection does not depend on provisioning order. The only suppression is structural: when `/_bmad` is already present in the exclude patterns, Git prunes that directory before descending, so a separate `/_bmad/render/` line can never be consulted. Omitting that inert line keeps the private exclude precise.

## Known gap

Wheel-provided `MODULE_SKILLS` still have no result-side completeness predicate. This remains explicit rather than being folded into the CRITICAL upstream-skill gate: story worktrees have a determinate dev/review consumer contract for upstream skills, but there is no equivalent required story-session consumer contract for the bundled operator/triage surface. Reusing the deterministic-stall gate would risk refusing healthy runs.

## Validation

- Python 3.13.13 and 3.14.6 ablation matrix: both lanes imported from their own disposable repository copy, collected the same six witnesses, and each paired test failed when its source guard was removed; after restoration both copies matched the original source checksum and passed 6/6
- `uv run pytest tests/test_install.py -q`: 329 passed
- `uv run pytest tests/test_engine_worktree.py -q`: 56 passed
- `uv run pytest tests/test_stories_e2e.py -q`: 14 passed
- the new stories sandbox E2E crosses the real tmux transport with a scripted fake CLI and consumes zero LLM tokens
- earlier full suite on this diff: 4022 passed, 24 skipped, with the same four known local-only seeded-fork drift failures in `.claude/skills` and `.agents/skills`
- `uv run pyright`: 0 errors, warnings, or information
- `trunk check --no-fix`: clean
- `git diff --check`: clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically provisions required project files, skills, renderer tools, and configuration in isolated worktrees.
  * Added validation for setup completeness before execution.
  * Added journaling for worktree creation, delivered seeds, and undelivered files.

* **Bug Fixes**
  * Prevented incomplete environments from starting execution unexpectedly.
  * Prevented existing files from being overwritten during provisioning.
  * Protected provisioned files from accidental commits.
  * Improved renderer and story execution reliability in isolated sessions.
  * Preserved worktrees and recorded escalation details when required setup is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->