### PR TITLE
feat(core): add inert Phase 6I deferral primitives

### DIFF
--- a/src/bmad_loop/deferredwork.py
+++ b/src/bmad_loop/deferredwork.py
@@ -302,7 +302,21 @@ def _require_canonical_status(status: str) -> None:
     raise ValueError(f"status must be 'open' or 'done YYYY-MM-DD': {status!r}")
 
 
-def _apply_done(text: str, dw_id: str, date: str, note: str) -> str | None:
+def _operation_digest(operation_id: str) -> str:
+    """Encode a stable close-operation id as one ledger-safe token."""
+    if not operation_id:
+        raise ValueError("operation_id must not be empty")
+    return hashlib.sha256(operation_id.encode("utf-8")).hexdigest()
+
+
+def _apply_done(
+    text: str,
+    dw_id: str,
+    date: str,
+    note: str,
+    *,
+    undo_owner: str | None = None,
+) -> str | None:
     """Flip one entry to `status: done <date>` + a resolution note *within* `text`.
     None when the entry is missing or not open. The entry is re-located after the
     status rewrite because that edit shifts every later span offset.
@@ -320,10 +334,52 @@ def _apply_done(text: str, dw_id: str, date: str, note: str) -> str | None:
     assert status_m is not None  # open implies a status line
     start = entry.span[0] + status_m.start()
     end = entry.span[0] + status_m.end()
-    text = text[:start] + f"status: done {date}" + text[end:]
+    previous_status_line = status_m.group(0)
+    if undo_owner is not None and LINE_BREAK_RE.search(previous_status_line):
+        # An undo marker must never preserve a value that becomes more than one line
+        # under the ledger readers' shared splitlines semantics. Standard closes
+        # retain their existing behavior; the undo-capable path refuses the mark.
+        return None
+    done_status_line = f"status: done {date}"
+    text = text[:start] + done_status_line + text[end:]
     entry = _find_entry(text, dw_id)
     assert entry is not None
-    return _insert_after_status(text, entry, f"resolution: {note}")
+    tail = f"resolution: {note}"
+    if undo_owner is not None:
+        # The owner digest makes this close distinguishable from an earlier run
+        # that reused its human-readable note. The encoded prior line makes the
+        # undo lossless for parser-accepted spacing and annotations. Hex keeps
+        # every payload on one ASCII line, including Unicode annotations.
+        previous_status_hex = previous_status_line.encode("utf-8").hex()
+        tail += f"\nresolution-undo: {undo_owner} {date} {previous_status_hex}"
+    return _insert_after_status(text, entry, tail)
+
+
+def _mark_done_many(
+    path: Path,
+    dw_ids: Sequence[str],
+    date: str,
+    note: str,
+    *,
+    operation_id: str | None = None,
+) -> list[str]:
+    """Shared atomic implementation for the public close operations."""
+    _require_iso_date(date)
+    undo_owner = _operation_digest(operation_id) if operation_id is not None else None
+    if not path.is_file():
+        return []
+    text = path.read_text(encoding="utf-8")
+    marked: list[str] = []
+    for dw_id in dw_ids:
+        updated = _apply_done(text, dw_id, date, note, undo_owner=undo_owner)
+        if updated is None:
+            continue
+        text = updated
+        marked.append(dw_id)
+    if not marked:
+        return []
+    atomic_write_text(path, text)
+    return marked
 
 
 def mark_done_many(path: Path, dw_ids: Sequence[str], date: str, note: str) -> list[str]:
@@ -345,21 +401,28 @@ def mark_done_many(path: Path, dw_ids: Sequence[str], date: str, note: str) -> l
     ``date`` is validated before the ``is_file`` short-circuit so a programmer bug
     fails the same way whether or not a ledger happens to exist — a guard that
     only fires when the file is present is one an absent fixture hides."""
-    _require_iso_date(date)
-    if not path.is_file():
-        return []
-    text = path.read_text(encoding="utf-8")
-    marked: list[str] = []
-    for dw_id in dw_ids:
-        updated = _apply_done(text, dw_id, date, note)
-        if updated is None:
-            continue
-        text = updated
-        marked.append(dw_id)
-    if not marked:
-        return []
-    atomic_write_text(path, text)
-    return marked
+    return _mark_done_many(path, dw_ids, date, note)
+
+
+def mark_done_many_reopenable(
+    path: Path,
+    dw_ids: Sequence[str],
+    date: str,
+    note: str,
+    operation_id: str,
+) -> list[str]:
+    """Close entries atomically with a durable, operation-specific undo marker.
+
+    ``operation_id`` must be stable and recomputable across crash/replay from
+    already-persisted identity (for example ``run_id`` + ``story_key``), never an
+    ephemeral random value. Only entries actually flipped receive its marker;
+    skipped, already-done ids therefore cannot be reopened by this operation.
+
+    The ordinary :func:`mark_done_many` deliberately emits no marker and retains
+    its existing ledger format. Use this variant only for a transaction with a
+    later rollback leg.
+    """
+    return _mark_done_many(path, dw_ids, date, note, operation_id=operation_id)
 
 
 def mark_done(path: Path, dw_id: str, date: str, note: str) -> bool:
@@ -368,16 +431,22 @@ def mark_done(path: Path, dw_id: str, date: str, note: str) -> bool:
     return bool(mark_done_many(path, [dw_id], date, note))
 
 
-_MARK_DONE_TAIL_RE = re.compile(r"\nresolution:[ \t]*(.*)$", re.MULTILINE)
+_MARK_DONE_TAIL_RE = re.compile(
+    r"\nresolution:[ \t]*(.*)"
+    r"\nresolution-undo:[ \t]*([0-9a-f]{64})[ \t]+"
+    r"([0-9]{4}-[0-9]{2}-[0-9]{2})[ \t]+([0-9a-f]+)$",
+    re.MULTILINE,
+)
 
 
-def mark_open(path: Path, dw_id: str, note: str) -> bool:
-    """Undo one specific :func:`mark_done` operation.
+def mark_open(path: Path, dw_id: str, note: str, operation_id: str) -> bool:
+    """Undo one close written by :func:`mark_done_many_reopenable`.
 
-    The entry must be closed and the line immediately below its status must be
-    the resolution note this caller identifies. A close from another run, the
-    legacy writer, or a human is never reopened by resemblance alone.
+    The entry must still carry the operation's adjacent resolution and undo-marker
+    lines. A standard or earlier close has no matching marker and cannot be
+    reopened merely because it reused the same human-readable note.
     """
+    undo_owner = _operation_digest(operation_id)
     if not path.is_file():
         return False
     text = path.read_text(encoding="utf-8")
@@ -397,11 +466,25 @@ def mark_open(path: Path, dw_id: str, note: str) -> bool:
         # Preserve malformed or human-authored statuses for validation/reporting.
         return False
     res_m = _MARK_DONE_TAIL_RE.match(entry.body, status_m.end())
-    if res_m is None or res_m.group(1).strip() != _one_line(note).strip():
+    if res_m is None:
+        return False
+    if res_m.group(1).strip() != _one_line(note).strip() or res_m.group(2) != undo_owner:
+        return False
+    if status_m.group(0) != f"status: done {res_m.group(3)}":
+        return False
+    try:
+        previous_status_line = bytes.fromhex(res_m.group(4)).decode("utf-8")
+    except (UnicodeDecodeError, ValueError):
+        return False
+    if LINE_BREAK_RE.search(previous_status_line):
+        return False
+    previous_status_m = STATUS_RE.fullmatch(previous_status_line)
+    previous_status = previous_status_m.group(1).strip() if previous_status_m else ""
+    if not previous_status or previous_status.split()[0] != "open":
         return False
     start = entry.span[0] + status_m.start()
     end = entry.span[0] + res_m.end()
-    atomic_write_text(path, text[:start] + "status: open" + text[end:])
+    atomic_write_text(path, text[:start] + previous_status_line + text[end:])
     return True
 
 

--- a/src/bmad_loop/deferredwork.py
+++ b/src/bmad_loop/deferredwork.py
@@ -390,6 +390,12 @@ def mark_open(path: Path, dw_id: str, note: str) -> bool:
         # is later called from _defer, where an AttributeError would crash the run
         # instead of completing the deferral.
         return False
+    try:
+        _require_canonical_status(entry.status)
+    except ValueError:
+        # Only a canonical status written by mark_done is eligible for undo.
+        # Preserve malformed or human-authored statuses for validation/reporting.
+        return False
     res_m = _MARK_DONE_TAIL_RE.match(entry.body, status_m.end())
     if res_m is None or res_m.group(1).strip() != _one_line(note).strip():
         return False

--- a/src/bmad_loop/deferredwork.py
+++ b/src/bmad_loop/deferredwork.py
@@ -368,6 +368,37 @@ def mark_done(path: Path, dw_id: str, date: str, note: str) -> bool:
     return bool(mark_done_many(path, [dw_id], date, note))
 
 
+_MARK_DONE_TAIL_RE = re.compile(r"\nresolution:[ \t]*(.*)$", re.MULTILINE)
+
+
+def mark_open(path: Path, dw_id: str, note: str) -> bool:
+    """Undo one specific :func:`mark_done` operation.
+
+    The entry must be closed and the line immediately below its status must be
+    the resolution note this caller identifies. A close from another run, the
+    legacy writer, or a human is never reopened by resemblance alone.
+    """
+    if not path.is_file():
+        return False
+    text = path.read_text(encoding="utf-8")
+    entry = _find_entry(text, dw_id)
+    if entry is None or entry.open:
+        return False
+    status_m = STATUS_RE.search(entry.body)
+    if status_m is None:
+        # parse_ledger deliberately tolerates status-less entries. This primitive
+        # is later called from _defer, where an AttributeError would crash the run
+        # instead of completing the deferral.
+        return False
+    res_m = _MARK_DONE_TAIL_RE.match(entry.body, status_m.end())
+    if res_m is None or res_m.group(1).strip() != _one_line(note).strip():
+        return False
+    start = entry.span[0] + status_m.start()
+    end = entry.span[0] + res_m.end()
+    atomic_write_text(path, text[:start] + "status: open" + text[end:])
+    return True
+
+
 def append_decision(path: Path, dw_id: str, date: str, label: str, detail: str) -> bool:
     """Record a human decision on an entry without changing its status.
 

--- a/src/bmad_loop/devcontract.py
+++ b/src/bmad_loop/devcontract.py
@@ -212,7 +212,15 @@ class DeferredFinding:
 
 
 def harvest_fingerprint(*parts: str) -> str:
-    """Return a stable short identity over NUL-separated ledger values."""
+    """Return a stable short identity over NUL-separated ledger values.
+
+    A NUL inside a value is indistinguishable from the separator, so refuse it
+    rather than assigning two distinct findings the same structural identity.
+    The frontmatter parser reports such values as malformed before calling this
+    helper; the guard also keeps direct callers from creating an ambiguous key.
+    """
+    if any("\0" in part for part in parts):
+        raise ValueError("fingerprint parts must not contain NUL characters")
     return hashlib.sha1(
         "\0".join(parts).encode("utf-8"),
         usedforsecurity=False,
@@ -238,14 +246,21 @@ def _is_yaml_scalar(value: Any) -> bool:
     return isinstance(value, (str, bytes)) or not isinstance(value, (Mapping, Sequence, Set))
 
 
+def _contains_nul(value: Any) -> bool:
+    """Whether a YAML text scalar contains a NUL before normalization/clamping."""
+    return (isinstance(value, str) and "\0" in value) or (
+        isinstance(value, bytes) and b"\0" in value
+    )
+
+
 def parse_deferred_findings(fm: dict[str, Any]) -> tuple[list[DeferredFinding], list[str]]:
     """Parse a frontmatter ``deferred:`` list into findings and malformed notes.
 
     Missing, null, and empty lists mean no findings. Malformed items cost only
     themselves; well-formed siblings still parse. Text fields accept YAML
     scalars (numeric and boolean scalars are string-normalized), never
-    collections. This observation path never raises for the YAML shapes it
-    accepts.
+    collections or embedded NULs. This observation path never raises for the
+    YAML shapes it accepts.
     """
     raw = fm.get(DEFERRED_FIELD)
     if raw is None:
@@ -265,10 +280,6 @@ def parse_deferred_findings(fm: dict[str, Any]) -> tuple[list[DeferredFinding], 
                 f"item {i}: `summary` is not a scalar (got {type(summary_raw).__name__})"
             )
             continue
-        summary = _flatten(summary_raw, _SUMMARY_LIMIT)
-        if not summary:
-            malformed.append(f"item {i}: no usable `summary`")
-            continue
         bad_optional = next(
             (field for field in ("evidence", "location") if not _is_yaml_scalar(item.get(field))),
             None,
@@ -279,11 +290,27 @@ def parse_deferred_findings(fm: dict[str, Any]) -> tuple[list[DeferredFinding], 
                 f"item {i}: `{bad_optional}` is not a scalar (got {type(value).__name__})"
             )
             continue
+        raw_text_values = {
+            "summary": summary_raw,
+            "evidence": item.get("evidence"),
+            "location": item.get("location"),
+        }
+        bad_nul = next(
+            (field for field, value in raw_text_values.items() if _contains_nul(value)), None
+        )
+        if bad_nul is not None:
+            malformed.append(f"item {i}: `{bad_nul}` contains a NUL character")
+            continue
+        summary = _flatten(summary_raw, _SUMMARY_LIMIT)
+        if not summary:
+            malformed.append(f"item {i}: no usable `summary`")
+            continue
+        evidence = _flatten(item.get("evidence"), _EVIDENCE_LIMIT)
         location = _flatten(item.get("location"), _LOCATION_LIMIT)
         findings.append(
             DeferredFinding(
                 summary=summary,
-                evidence=_flatten(item.get("evidence"), _EVIDENCE_LIMIT),
+                evidence=evidence,
                 location=location,
                 severity=deferredwork.SEVERITY_ALIASES.get(
                     str(item.get("severity", "")).strip().lower(), ""

--- a/src/bmad_loop/devcontract.py
+++ b/src/bmad_loop/devcontract.py
@@ -20,12 +20,14 @@ match) still runs in verify.py against actual on-disk state.
 
 from __future__ import annotations
 
+import hashlib
 import re
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from . import deferredwork
 from .frontmatter import _edit_frontmatter_block, status_of
 from .platform_util import atomic_replace
 from .verify import DEV_WORKFLOW, operator_actions_of, read_frontmatter
@@ -185,6 +187,86 @@ def parse_auto_run_result(text: str) -> AutoRunResult:
     status_m = STATUS_LINE_RE.search(body)
     status = status_m.group(1).strip().lower() if status_m else ""
     return AutoRunResult(present=True, status=status, detail=body.strip())
+
+
+# ------------------------------------------------ deferred review findings
+#
+# Since BMAD-METHOD #2640 the dev primitive records findings triaged as `defer`
+# in its spec's frontmatter. The parser stays content-keyed so an older skill
+# (field absent) and a newer skill with no findings are indistinguishable.
+DEFERRED_FIELD = "deferred"
+_SUMMARY_LIMIT = 200
+_EVIDENCE_LIMIT = 1000
+_LOCATION_LIMIT = 200
+
+
+@dataclass(frozen=True)
+class DeferredFinding:
+    """One well-formed deferred finding, normalized for a ledger entry."""
+
+    summary: str
+    evidence: str
+    location: str
+    severity: str
+    fingerprint: str
+
+
+def harvest_fingerprint(*parts: str) -> str:
+    """Return a stable short identity over NUL-separated ledger values."""
+    return hashlib.sha1(
+        "\0".join(parts).encode("utf-8"),
+        usedforsecurity=False,
+    ).hexdigest()[:12]
+
+
+def _flatten(value: Any, limit: int) -> str:
+    """Collapse a YAML scalar to one clamped line.
+
+    Strip after clamping because the cut can land on a join space. Keeping that
+    cleanup here makes the value written to the ledger and the value used in its
+    fingerprint identical.
+    """
+    if value is None:
+        return ""
+    return " ".join(str(value).split())[:limit].strip()
+
+
+def parse_deferred_findings(fm: dict[str, Any]) -> tuple[list[DeferredFinding], list[str]]:
+    """Parse a frontmatter ``deferred:`` list into findings and malformed notes.
+
+    Missing, null, and empty lists mean no findings. Malformed items cost only
+    themselves; well-formed siblings still parse. This observation path never
+    raises for the YAML shapes it accepts.
+    """
+    raw = fm.get(DEFERRED_FIELD)
+    if raw is None:
+        return [], []
+    if not isinstance(raw, list):
+        return [], [f"`{DEFERRED_FIELD}:` is not a list (got {type(raw).__name__})"]
+
+    findings: list[DeferredFinding] = []
+    malformed: list[str] = []
+    for i, item in enumerate(raw, start=1):
+        if not isinstance(item, dict):
+            malformed.append(f"item {i}: not a mapping (got {type(item).__name__})")
+            continue
+        summary = _flatten(item.get("summary"), _SUMMARY_LIMIT)
+        if not summary:
+            malformed.append(f"item {i}: no usable `summary`")
+            continue
+        location = _flatten(item.get("location"), _LOCATION_LIMIT)
+        findings.append(
+            DeferredFinding(
+                summary=summary,
+                evidence=_flatten(item.get("evidence"), _EVIDENCE_LIMIT),
+                location=location,
+                severity=deferredwork.SEVERITY_ALIASES.get(
+                    str(item.get("severity", "")).strip().lower(), ""
+                ),
+                fingerprint=harvest_fingerprint(summary, location),
+            )
+        )
+    return findings, malformed
 
 
 @dataclass(frozen=True)

--- a/src/bmad_loop/devcontract.py
+++ b/src/bmad_loop/devcontract.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 import hashlib
 import re
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence, Set
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -231,12 +231,21 @@ def _flatten(value: Any, limit: int) -> str:
     return " ".join(str(value).split())[:limit].strip()
 
 
+def _is_yaml_scalar(value: Any) -> bool:
+    """Whether PyYAML's loaded value came from a scalar-shaped node."""
+    # str/bytes are Sequences in Python but scalar values in YAML. SafeLoader's
+    # collection nodes otherwise become mappings, sequences, or sets.
+    return isinstance(value, (str, bytes)) or not isinstance(value, (Mapping, Sequence, Set))
+
+
 def parse_deferred_findings(fm: dict[str, Any]) -> tuple[list[DeferredFinding], list[str]]:
     """Parse a frontmatter ``deferred:`` list into findings and malformed notes.
 
     Missing, null, and empty lists mean no findings. Malformed items cost only
-    themselves; well-formed siblings still parse. This observation path never
-    raises for the YAML shapes it accepts.
+    themselves; well-formed siblings still parse. Text fields accept YAML
+    scalars (numeric and boolean scalars are string-normalized), never
+    collections. This observation path never raises for the YAML shapes it
+    accepts.
     """
     raw = fm.get(DEFERRED_FIELD)
     if raw is None:
@@ -250,9 +259,25 @@ def parse_deferred_findings(fm: dict[str, Any]) -> tuple[list[DeferredFinding], 
         if not isinstance(item, dict):
             malformed.append(f"item {i}: not a mapping (got {type(item).__name__})")
             continue
-        summary = _flatten(item.get("summary"), _SUMMARY_LIMIT)
+        summary_raw = item.get("summary")
+        if not _is_yaml_scalar(summary_raw):
+            malformed.append(
+                f"item {i}: `summary` is not a scalar (got {type(summary_raw).__name__})"
+            )
+            continue
+        summary = _flatten(summary_raw, _SUMMARY_LIMIT)
         if not summary:
             malformed.append(f"item {i}: no usable `summary`")
+            continue
+        bad_optional = next(
+            (field for field in ("evidence", "location") if not _is_yaml_scalar(item.get(field))),
+            None,
+        )
+        if bad_optional is not None:
+            value = item[bad_optional]
+            malformed.append(
+                f"item {i}: `{bad_optional}` is not a scalar (got {type(value).__name__})"
+            )
             continue
         location = _flatten(item.get("location"), _LOCATION_LIMIT)
         findings.append(

--- a/src/bmad_loop/model.py
+++ b/src/bmad_loop/model.py
@@ -13,6 +13,7 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
@@ -407,7 +408,7 @@ class StoryTask:
             pre_harvest_ledger_captured=bool(d.get("pre_harvest_ledger_captured", False)),
             harvest_wrote_ledger=bool(d.get("harvest_wrote_ledger", False)),
             ledger_changed_before_harvest=bool(d.get("ledger_changed_before_harvest", False)),
-            harvested_deferrals=[dict(item) for item in d.get("harvested_deferrals", [])],
+            harvested_deferrals=[deepcopy(dict(item)) for item in d.get("harvested_deferrals", [])],
             bundle_closes_intended=[str(i) for i in d.get("bundle_closes_intended", [])],
             isolated_ledger_carried=bool(d.get("isolated_ledger_carried", False)),
             spec_file=d.get("spec_file"),

--- a/src/bmad_loop/model.py
+++ b/src/bmad_loop/model.py
@@ -182,6 +182,19 @@ class StoryTask:
     # user already had on disk are never deleted. None = pre-upgrade run (no
     # snapshot); rollback then removes no untracked files at all.
     baseline_untracked: list[str] | None = None
+    # Deferred-work bookkeeping is persisted before its readers land so an older
+    # state.json remains resumable throughout the forward-port.  The nullable
+    # snapshot text and its captured flag are deliberately separate: None means
+    # "no ledger existed", while False means "no snapshot was taken".
+    baseline_ledger_digest: str | None = None
+    pre_harvest_ledger: str | None = None
+    pre_harvest_ledger_captured: bool = False
+    harvest_wrote_ledger: bool = False
+    ledger_changed_before_harvest: bool = False
+    # JSON-native containers only; callers persist these through state.json.
+    harvested_deferrals: list[dict[str, Any]] = field(default_factory=list)
+    bundle_closes_intended: list[str] = field(default_factory=list)
+    isolated_ledger_carried: bool = False
     spec_file: str | None = None
     commit_sha: str | None = None
     # the external, human-only actions this story still owes when it parks at
@@ -322,6 +335,14 @@ class StoryTask:
             "followup_review_recommended": self.followup_review_recommended,
             "baseline_commit": self.baseline_commit,
             "baseline_untracked": self.baseline_untracked,
+            "baseline_ledger_digest": self.baseline_ledger_digest,
+            "pre_harvest_ledger": self.pre_harvest_ledger,
+            "pre_harvest_ledger_captured": self.pre_harvest_ledger_captured,
+            "harvest_wrote_ledger": self.harvest_wrote_ledger,
+            "ledger_changed_before_harvest": self.ledger_changed_before_harvest,
+            "harvested_deferrals": self.harvested_deferrals,
+            "bundle_closes_intended": self.bundle_closes_intended,
+            "isolated_ledger_carried": self.isolated_ledger_carried,
             "spec_file": self._serialized_spec_file(),
             "commit_sha": self.commit_sha,
             "operator_actions": self.operator_actions,
@@ -373,6 +394,22 @@ class StoryTask:
                 if d.get("baseline_untracked") is not None
                 else None
             ),
+            baseline_ledger_digest=(
+                str(d.get("baseline_ledger_digest"))
+                if d.get("baseline_ledger_digest") is not None
+                else None
+            ),
+            pre_harvest_ledger=(
+                str(d.get("pre_harvest_ledger"))
+                if d.get("pre_harvest_ledger") is not None
+                else None
+            ),
+            pre_harvest_ledger_captured=bool(d.get("pre_harvest_ledger_captured", False)),
+            harvest_wrote_ledger=bool(d.get("harvest_wrote_ledger", False)),
+            ledger_changed_before_harvest=bool(d.get("ledger_changed_before_harvest", False)),
+            harvested_deferrals=[dict(item) for item in d.get("harvested_deferrals", [])],
+            bundle_closes_intended=[str(i) for i in d.get("bundle_closes_intended", [])],
+            isolated_ledger_carried=bool(d.get("isolated_ledger_carried", False)),
             spec_file=d.get("spec_file"),
             commit_sha=d.get("commit_sha"),
             operator_actions=[str(a) for a in d.get("operator_actions", [])],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,6 +100,19 @@ def _file_exists_cmd(path) -> str:
     return f'test -f "{path}"'
 
 
+def passes_once(marker) -> str:
+    """Return a host-shell command that succeeds once, then fails.
+
+    ``marker`` must be an explicit absolute path outside the worktree. Verify
+    commands receive no ``BMAD_LOOP_RUN_DIR`` environment variable, and a marker
+    inside the worktree can be removed by rollback between the two executions.
+    """
+    if sys.platform == "win32":
+        win = str(marker).replace("/", "\\")
+        return f'if exist "{win}" (exit 1) else (type nul > "{win}")'
+    return f'test ! -f "{marker}" && touch "{marker}"'
+
+
 # A tool no host has: sh exits 127, cmd exits 1 with "is not recognized" (#302).
 # Both classify as verify environment faults — the point of the tests using it.
 MISSING_TOOL_CMD = "definitely-not-a-real-cmd-302"
@@ -457,6 +470,41 @@ def set_sprint(paths: ProjectPaths, key: str, status: str) -> None:
     doc = yaml.safe_load(paths.sprint_status.read_text())
     doc["development_status"][key] = status
     paths.sprint_status.write_text(yaml.safe_dump(doc, sort_keys=False))
+
+
+def render_deferred(items) -> str:
+    """Render the post-#2640 ``deferred:`` frontmatter shape.
+
+    Free-form values use the real YAML block scalars: ``>-`` for folded
+    summary/location and ``|-`` for literal evidence. A non-dict list item and a
+    dict missing ``summary`` intentionally remain expressible for malformed-item
+    tests.
+    """
+    if not items:
+        return "deferred: []\n"
+    lines = ["deferred:"]
+    for item in items:
+        if not isinstance(item, dict):
+            lines.append(f"  - {item}")
+            continue
+        rendered = False
+        for key in ("summary", "evidence", "location", "severity"):
+            if key not in item:
+                continue
+            lead = "    " if rendered else "  - "
+            rendered = True
+            value = str(item[key])
+            if not value:
+                lines.append(f"{lead}{key}: ''")
+            elif key == "severity":
+                lines.append(f"{lead}{key}: {value}")
+            else:
+                style = "|-" if key == "evidence" else ">-"
+                lines.append(f"{lead}{key}: {style}")
+                lines.extend(f"      {line}" for line in value.splitlines())
+        if not rendered:
+            lines.append("  - {}")
+    return "\n".join(lines) + "\n"
 
 
 def write_spec(

--- a/tests/test_deferredwork.py
+++ b/tests/test_deferredwork.py
@@ -17,6 +17,7 @@ from bmad_loop.deferredwork import (
     has_legacy,
     mark_done,
     mark_done_many,
+    mark_done_many_reopenable,
     mark_open,
     next_seq,
     open_ids,
@@ -24,6 +25,8 @@ from bmad_loop.deferredwork import (
     parse_ledger,
     parse_legacy,
 )
+
+OPERATION_ID = "run-20260803T120000/dw-fix"
 
 LEDGER = """\
 # Deferred Work
@@ -56,6 +59,16 @@ def write_ledger(tmp_path: Path, text: str = LEDGER) -> Path:
     path = tmp_path / "deferred-work.md"
     path.write_text(text, encoding="utf-8")
     return path
+
+
+def close_reopenable(
+    path: Path,
+    dw_id: str,
+    note: str,
+    date: str = "2026-06-11",
+    operation_id: str = OPERATION_ID,
+) -> None:
+    assert mark_done_many_reopenable(path, [dw_id], date, note, operation_id) == [dw_id]
 
 
 def test_parse_ledger_entries():
@@ -123,20 +136,62 @@ def test_mark_done_missing_entry(tmp_path):
     assert path.read_text(encoding="utf-8") == snapshot
 
 
-def test_mark_open_round_trips_one_mark_done_character_for_character(tmp_path):
+def test_mark_open_round_trips_one_reopenable_close_character_for_character(tmp_path):
     path = write_ledger(tmp_path)
     before = path.read_text(encoding="utf-8")
     note = "resolved by sweep bundle dw-fix"
-    assert mark_done(path, "DW-1", "2026-06-11", note)
-    assert mark_open(path, "DW-1", note)
+    close_reopenable(path, "DW-1", note)
+    assert mark_open(path, "DW-1", note, OPERATION_ID)
     assert path.read_text(encoding="utf-8") == before
+
+
+@pytest.mark.parametrize(
+    "status_line",
+    ["status:   open", "status: open # keep this annotation", "status:\topen   # annotated"],
+)
+def test_mark_open_restores_the_original_parser_accepted_status_line(tmp_path, status_line):
+    text = f"### DW-1: formatted\n\norigin: session\n{status_line}\n"
+    path = write_ledger(tmp_path, text)
+
+    close_reopenable(path, "DW-1", "by dw-a")
+    assert mark_open(path, "DW-1", "by dw-a", OPERATION_ID)
+
+    assert path.read_text(encoding="utf-8") == text
+
+
+def test_reopenable_close_persists_adjacent_resolution_and_undo_marker(tmp_path):
+    path = write_ledger(tmp_path)
+    close_reopenable(path, "DW-1", "by dw-a")
+
+    lines = parse_ledger(path.read_text(encoding="utf-8"))[0].body.splitlines()
+    status_at = lines.index("status: done 2026-06-11")
+    assert lines[status_at + 1] == "resolution: by dw-a"
+    assert lines[status_at + 2].startswith("resolution-undo: ")
+    assert len(lines[status_at + 2].split()) == 4
+
+
+def test_standard_close_retains_its_existing_ledger_shape(tmp_path):
+    path = write_ledger(tmp_path, "### DW-1: standard\n\nstatus: open\n")
+    assert mark_done_many(path, ["DW-1"], "2026-06-11", "by dw-a") == ["DW-1"]
+
+    assert path.read_text(encoding="utf-8") == (
+        "### DW-1: standard\n\nstatus: done 2026-06-11\nresolution: by dw-a\n"
+    )
+
+
+def test_reopenable_close_refuses_an_original_status_with_a_splitlines_break(tmp_path):
+    text = "### DW-1: unsafe\n\nstatus: open\u2028injected: value\n"
+    path = write_ledger(tmp_path, text)
+
+    assert mark_done_many_reopenable(path, ["DW-1"], "2026-06-11", "by dw-a", OPERATION_ID) == []
+    assert path.read_text(encoding="utf-8") == text
 
 
 def test_mark_open_touches_only_the_target_entry(tmp_path):
     path = write_ledger(tmp_path)
-    assert mark_done(path, "DW-1", "2026-06-11", "by dw-a")
-    assert mark_done(path, "DW-3", "2026-06-11", "by dw-a")
-    assert mark_open(path, "DW-1", "by dw-a")
+    close_reopenable(path, "DW-1", "by dw-a")
+    close_reopenable(path, "DW-3", "by dw-a")
+    assert mark_open(path, "DW-1", "by dw-a", OPERATION_ID)
 
     entries = {e.id: e for e in parse_ledger(path.read_text(encoding="utf-8"))}
     assert entries["DW-1"].open
@@ -146,13 +201,13 @@ def test_mark_open_touches_only_the_target_entry(tmp_path):
 
 
 def test_mark_open_refuses_a_missing_ledger(tmp_path):
-    assert not mark_open(tmp_path / "nope.md", "DW-1", "by dw-a")
+    assert not mark_open(tmp_path / "nope.md", "DW-1", "by dw-a", OPERATION_ID)
 
 
 def test_mark_open_refuses_a_missing_entry(tmp_path):
     path = write_ledger(tmp_path)
     snapshot = path.read_text(encoding="utf-8")
-    assert not mark_open(path, "DW-99", "by dw-a")
+    assert not mark_open(path, "DW-99", "by dw-a", OPERATION_ID)
     assert path.read_text(encoding="utf-8") == snapshot
 
 
@@ -164,7 +219,7 @@ def test_mark_open_refuses_an_entry_that_is_still_open(tmp_path):
         "### DW-1: partially handled\n\nstatus: open\nresolution: by dw-a\n",
     )
     snapshot = path.read_text(encoding="utf-8")
-    assert not mark_open(path, "DW-1", "by dw-a")
+    assert not mark_open(path, "DW-1", "by dw-a", OPERATION_ID)
     assert path.read_text(encoding="utf-8") == snapshot
 
 
@@ -177,7 +232,7 @@ def test_mark_open_refuses_a_status_less_entry(tmp_path):
     )
     snapshot = path.read_text(encoding="utf-8")
     assert parse_ledger(snapshot)[0].status == ""
-    assert not mark_open(path, "DW-1", "by dw-a")
+    assert not mark_open(path, "DW-1", "by dw-a", OPERATION_ID)
     assert path.read_text(encoding="utf-8") == snapshot
 
 
@@ -188,44 +243,156 @@ def test_mark_open_refuses_a_noncanonical_status(tmp_path, status):
         f"### DW-1: malformed but tolerated\n\nstatus: {status}\nresolution: by dw-a\n",
     )
     snapshot = path.read_text(encoding="utf-8")
-    assert not mark_open(path, "DW-1", "by dw-a")
+    assert not mark_open(path, "DW-1", "by dw-a", OPERATION_ID)
     assert path.read_text(encoding="utf-8") == snapshot
 
 
 def test_mark_open_refuses_a_closed_entry_without_a_resolution(tmp_path):
     path = write_ledger(tmp_path)
     snapshot = path.read_text(encoding="utf-8")
-    assert not mark_open(path, "DW-2", "")
+    assert not mark_open(path, "DW-2", "", OPERATION_ID)
     assert path.read_text(encoding="utf-8") == snapshot
 
 
-def test_mark_open_refuses_a_close_with_another_callers_note(tmp_path):
+def test_mark_open_refuses_a_legacy_close_with_the_same_note_but_no_marker(tmp_path):
     path = write_ledger(tmp_path)
-    assert mark_done(path, "DW-1", "2026-06-11", "by dw-other")
+    assert mark_done(path, "DW-1", "2026-06-11", "by dw-a")
     snapshot = path.read_text(encoding="utf-8")
-    assert not mark_open(path, "DW-1", "by dw-mine")
+    assert not mark_open(path, "DW-1", "by dw-a", OPERATION_ID)
+    assert path.read_text(encoding="utf-8") == snapshot
+
+
+def test_mark_open_reopens_only_closes_from_this_operation(tmp_path):
+    """A reused story note does not make an earlier run's close ours to undo."""
+    path = write_ledger(tmp_path)
+    note = "resolved by story 1-1"
+    close_reopenable(path, "DW-1", note, operation_id="earlier-run/dw-fix")
+
+    marked = mark_done_many_reopenable(path, ["DW-1", "DW-3"], "2026-06-11", note, OPERATION_ID)
+    assert marked == ["DW-3"]
+    assert not mark_open(path, "DW-1", note, OPERATION_ID)
+    assert mark_open(path, "DW-3", note, OPERATION_ID)
+
+    entries = {e.id: e for e in parse_ledger(path.read_text(encoding="utf-8"))}
+    assert entries["DW-1"].status == "done 2026-06-11"
+    assert entries["DW-3"].open
+
+
+def test_mark_open_refuses_the_wrong_operation_id(tmp_path):
+    path = write_ledger(tmp_path)
+    close_reopenable(path, "DW-1", "by dw-a")
+    snapshot = path.read_text(encoding="utf-8")
+
+    assert not mark_open(path, "DW-1", "by dw-a", "another-run/dw-fix")
+    assert path.read_text(encoding="utf-8") == snapshot
+
+
+def test_mark_open_recomputes_operation_identity_after_a_crash(tmp_path):
+    """No return-side receipt is needed after the close has reached disk."""
+    path = write_ledger(tmp_path)
+    operation_id = f"run-20260803T120000/{'dw-fix'}"
+    assert mark_done_many_reopenable(path, ["DW-1"], "2026-06-11", "by dw-a", operation_id) == [
+        "DW-1"
+    ]
+
+    # Simulate rehydration from already-persisted run + task identity. The marker
+    # on disk, not the close call's returned list, carries the original line.
+    replay_operation_id = "/".join(["run-20260803T120000", "dw-fix"])
+    assert mark_open(path, "DW-1", "by dw-a", replay_operation_id)
+
+
+def test_operation_id_line_breaks_are_encoded_inside_the_marker(tmp_path):
+    path = write_ledger(tmp_path)
+    operation_id = "run-20260803\nreview\u2028dw-fix"
+    close_reopenable(path, "DW-1", "by dw-a", operation_id=operation_id)
+    text = path.read_text(encoding="utf-8")
+
+    assert operation_id not in text
+    assert sum(line.startswith("resolution-undo: ") for line in text.splitlines()) == 1
+    assert mark_open(path, "DW-1", "by dw-a", operation_id)
+
+
+def test_reopenable_close_refuses_an_empty_operation_id_without_writing(tmp_path):
+    path = write_ledger(tmp_path)
+    snapshot = path.read_text(encoding="utf-8")
+
+    with pytest.raises(ValueError, match="operation_id must not be empty"):
+        mark_done_many_reopenable(path, ["DW-1"], "2026-06-11", "by dw-a", "")
+    assert path.read_text(encoding="utf-8") == snapshot
+
+
+@pytest.mark.parametrize(
+    "prior_status_payload",
+    [
+        "not-hex",
+        b"\xff".hex(),
+        "status: done 2026-06-11".encode().hex(),
+        "status: open\ninjected: value".encode().hex(),
+        "status: open\u2028injected: value".encode().hex(),
+    ],
+)
+def test_mark_open_refuses_a_malformed_or_non_open_prior_status_payload(
+    tmp_path, prior_status_payload
+):
+    path = write_ledger(tmp_path)
+    close_reopenable(path, "DW-1", "by dw-a")
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines(keepends=True)
+    marker_at = next(i for i, line in enumerate(lines) if line.startswith("resolution-undo: "))
+    marker_prefix = lines[marker_at].rstrip("\n").rsplit(" ", 1)[0]
+    lines[marker_at] = f"{marker_prefix} {prior_status_payload}\n"
+    path.write_text("".join(lines), encoding="utf-8")
+    snapshot = path.read_text(encoding="utf-8")
+
+    assert not mark_open(path, "DW-1", "by dw-a", OPERATION_ID)
+    assert path.read_text(encoding="utf-8") == snapshot
+
+
+@pytest.mark.parametrize("tamper", ["status-date", "marker-date", "marker-adjacency"])
+def test_mark_open_refuses_a_tampered_done_status_or_marker(tmp_path, tamper):
+    path = write_ledger(tmp_path)
+    close_reopenable(path, "DW-1", "by dw-a")
+    text = path.read_text(encoding="utf-8")
+    if tamper == "status-date":
+        text = text.replace("status: done 2026-06-11", "status: done 2026-06-12", 1)
+    elif tamper == "marker-date":
+        marker = next(line for line in text.splitlines() if line.startswith("resolution-undo: "))
+        text = text.replace(marker, marker.replace("2026-06-11", "2026-06-12"), 1)
+    else:
+        text = text.replace(
+            "\nresolution-undo:", "\ndecision: 2026-06-11 keep\nresolution-undo:", 1
+        )
+    path.write_text(text, encoding="utf-8")
+    snapshot = path.read_text(encoding="utf-8")
+
+    assert not mark_open(path, "DW-1", "by dw-a", OPERATION_ID)
     assert path.read_text(encoding="utf-8") == snapshot
 
 
 def test_mark_open_requires_the_resolution_directly_below_status(tmp_path):
     """A later matching resolution belongs to a different annotation. Searching
     the whole entry would turn this specific undo into a general reopen."""
-    path = write_ledger(
-        tmp_path,
-        "### DW-1: closed elsewhere\n\nstatus: done 2026-06-11\n"
-        "decision: 2026-06-11 keep\nresolution: by dw-a\n",
+    path = write_ledger(tmp_path, "### DW-1: closed elsewhere\n\nstatus: open\n")
+    close_reopenable(path, "DW-1", "by dw-a")
+    path.write_text(
+        path.read_text(encoding="utf-8").replace(
+            "\nresolution: by dw-a", "\ndecision: 2026-06-11 keep\nresolution: by dw-a", 1
+        ),
+        encoding="utf-8",
     )
     snapshot = path.read_text(encoding="utf-8")
-    assert not mark_open(path, "DW-1", "by dw-a")
+    assert not mark_open(path, "DW-1", "by dw-a", OPERATION_ID)
     assert path.read_text(encoding="utf-8") == snapshot
 
 
 def test_mark_open_tolerates_reformatted_resolution_whitespace(tmp_path):
-    path = write_ledger(
-        tmp_path,
-        "### DW-1: closed then reflowed\n\nstatus: done 2026-06-11\n" "resolution:   by dw-a  \n",
+    path = write_ledger(tmp_path, "### DW-1: closed then reflowed\n\nstatus: open\n")
+    close_reopenable(path, "DW-1", "by dw-a")
+    path.write_text(
+        path.read_text(encoding="utf-8").replace("resolution: by dw-a", "resolution:   by dw-a  "),
+        encoding="utf-8",
     )
-    assert mark_open(path, "DW-1", "by dw-a")
+    assert mark_open(path, "DW-1", "by dw-a", OPERATION_ID)
     entry = parse_ledger(path.read_text(encoding="utf-8"))[0]
     assert entry.open and "resolution:" not in entry.body
 
@@ -236,23 +403,23 @@ def test_mark_open_uses_the_same_note_normalization_as_mark_done(tmp_path, note)
     undo accepts the original caller value, not only the rendered ledger line."""
     path = write_ledger(tmp_path)
     before = path.read_text(encoding="utf-8")
-    assert mark_done(path, "DW-1", "2026-06-11", note)
-    assert mark_open(path, "DW-1", note)
+    close_reopenable(path, "DW-1", note)
+    assert mark_open(path, "DW-1", note, OPERATION_ID)
     assert path.read_text(encoding="utf-8") == before
 
 
 def test_mark_open_is_idempotent_after_the_undo(tmp_path):
     path = write_ledger(tmp_path)
-    assert mark_done(path, "DW-1", "2026-06-11", "by dw-a")
-    assert mark_open(path, "DW-1", "by dw-a")
+    close_reopenable(path, "DW-1", "by dw-a")
+    assert mark_open(path, "DW-1", "by dw-a", OPERATION_ID)
     snapshot = path.read_text(encoding="utf-8")
-    assert not mark_open(path, "DW-1", "by dw-a")
+    assert not mark_open(path, "DW-1", "by dw-a", OPERATION_ID)
     assert path.read_text(encoding="utf-8") == snapshot
 
 
 def test_mark_open_write_failure_raises_and_keeps_the_closed_entry(tmp_path, monkeypatch):
     path = write_ledger(tmp_path)
-    assert mark_done(path, "DW-1", "2026-06-11", "by dw-a")
+    close_reopenable(path, "DW-1", "by dw-a")
     closed = path.read_text(encoding="utf-8")
 
     def boom(path, text):
@@ -260,8 +427,21 @@ def test_mark_open_write_failure_raises_and_keeps_the_closed_entry(tmp_path, mon
 
     monkeypatch.setattr(deferredwork, "atomic_write_text", boom)
     with pytest.raises(OSError, match="no space left"):
-        mark_open(path, "DW-1", "by dw-a")
+        mark_open(path, "DW-1", "by dw-a", OPERATION_ID)
     assert path.read_text(encoding="utf-8") == closed
+
+
+def test_reopenable_close_write_failure_raises_and_keeps_the_open_entry(tmp_path, monkeypatch):
+    path = write_ledger(tmp_path)
+    before = path.read_text(encoding="utf-8")
+
+    def boom(path, text):
+        raise OSError("no space left")
+
+    monkeypatch.setattr(deferredwork, "atomic_write_text", boom)
+    with pytest.raises(OSError, match="no space left"):
+        mark_done_many_reopenable(path, ["DW-1", "DW-3"], "2026-06-11", "by dw-a", OPERATION_ID)
+    assert path.read_text(encoding="utf-8") == before
 
 
 def test_append_decision(tmp_path):

--- a/tests/test_deferredwork.py
+++ b/tests/test_deferredwork.py
@@ -181,6 +181,17 @@ def test_mark_open_refuses_a_status_less_entry(tmp_path):
     assert path.read_text(encoding="utf-8") == snapshot
 
 
+@pytest.mark.parametrize("status", ["malformed", "done someday", "done 2026-02-30"])
+def test_mark_open_refuses_a_noncanonical_status(tmp_path, status):
+    path = write_ledger(
+        tmp_path,
+        f"### DW-1: malformed but tolerated\n\nstatus: {status}\nresolution: by dw-a\n",
+    )
+    snapshot = path.read_text(encoding="utf-8")
+    assert not mark_open(path, "DW-1", "by dw-a")
+    assert path.read_text(encoding="utf-8") == snapshot
+
+
 def test_mark_open_refuses_a_closed_entry_without_a_resolution(tmp_path):
     path = write_ledger(tmp_path)
     snapshot = path.read_text(encoding="utf-8")

--- a/tests/test_deferredwork.py
+++ b/tests/test_deferredwork.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+from bmad_loop import deferredwork
 from bmad_loop.deferredwork import (
     _ISO_DATE_RE,
     LINE_BREAK_RE,
@@ -16,6 +17,7 @@ from bmad_loop.deferredwork import (
     has_legacy,
     mark_done,
     mark_done_many,
+    mark_open,
     next_seq,
     open_ids,
     parse_declaration,
@@ -119,6 +121,136 @@ def test_mark_done_missing_entry(tmp_path):
     snapshot = path.read_text(encoding="utf-8")
     assert not mark_done(path, "DW-99", "2026-06-11", "n/a")
     assert path.read_text(encoding="utf-8") == snapshot
+
+
+def test_mark_open_round_trips_one_mark_done_character_for_character(tmp_path):
+    path = write_ledger(tmp_path)
+    before = path.read_text(encoding="utf-8")
+    note = "resolved by sweep bundle dw-fix"
+    assert mark_done(path, "DW-1", "2026-06-11", note)
+    assert mark_open(path, "DW-1", note)
+    assert path.read_text(encoding="utf-8") == before
+
+
+def test_mark_open_touches_only_the_target_entry(tmp_path):
+    path = write_ledger(tmp_path)
+    assert mark_done(path, "DW-1", "2026-06-11", "by dw-a")
+    assert mark_done(path, "DW-3", "2026-06-11", "by dw-a")
+    assert mark_open(path, "DW-1", "by dw-a")
+
+    entries = {e.id: e for e in parse_ledger(path.read_text(encoding="utf-8"))}
+    assert entries["DW-1"].open
+    assert "resolution:" not in entries["DW-1"].body
+    assert entries["DW-2"].status == "done 2026-05-25"
+    assert entries["DW-3"].status == "done 2026-06-11"
+
+
+def test_mark_open_refuses_a_missing_ledger(tmp_path):
+    assert not mark_open(tmp_path / "nope.md", "DW-1", "by dw-a")
+
+
+def test_mark_open_refuses_a_missing_entry(tmp_path):
+    path = write_ledger(tmp_path)
+    snapshot = path.read_text(encoding="utf-8")
+    assert not mark_open(path, "DW-99", "by dw-a")
+    assert path.read_text(encoding="utf-8") == snapshot
+
+
+def test_mark_open_refuses_an_entry_that_is_still_open(tmp_path):
+    """The open guard is independent of note matching: an LLM-written open entry
+    can carry a matching resolution line, but the orchestrator must not delete it."""
+    path = write_ledger(
+        tmp_path,
+        "### DW-1: partially handled\n\nstatus: open\nresolution: by dw-a\n",
+    )
+    snapshot = path.read_text(encoding="utf-8")
+    assert not mark_open(path, "DW-1", "by dw-a")
+    assert path.read_text(encoding="utf-8") == snapshot
+
+
+def test_mark_open_refuses_a_status_less_entry(tmp_path):
+    """parse_ledger tolerates this shape. Without the explicit guard, a future
+    call from _defer raises AttributeError and crashes instead of deferring."""
+    path = write_ledger(
+        tmp_path,
+        "### DW-1: malformed but tolerated\n\norigin: session\nresolution: by dw-a\n",
+    )
+    snapshot = path.read_text(encoding="utf-8")
+    assert parse_ledger(snapshot)[0].status == ""
+    assert not mark_open(path, "DW-1", "by dw-a")
+    assert path.read_text(encoding="utf-8") == snapshot
+
+
+def test_mark_open_refuses_a_closed_entry_without_a_resolution(tmp_path):
+    path = write_ledger(tmp_path)
+    snapshot = path.read_text(encoding="utf-8")
+    assert not mark_open(path, "DW-2", "")
+    assert path.read_text(encoding="utf-8") == snapshot
+
+
+def test_mark_open_refuses_a_close_with_another_callers_note(tmp_path):
+    path = write_ledger(tmp_path)
+    assert mark_done(path, "DW-1", "2026-06-11", "by dw-other")
+    snapshot = path.read_text(encoding="utf-8")
+    assert not mark_open(path, "DW-1", "by dw-mine")
+    assert path.read_text(encoding="utf-8") == snapshot
+
+
+def test_mark_open_requires_the_resolution_directly_below_status(tmp_path):
+    """A later matching resolution belongs to a different annotation. Searching
+    the whole entry would turn this specific undo into a general reopen."""
+    path = write_ledger(
+        tmp_path,
+        "### DW-1: closed elsewhere\n\nstatus: done 2026-06-11\n"
+        "decision: 2026-06-11 keep\nresolution: by dw-a\n",
+    )
+    snapshot = path.read_text(encoding="utf-8")
+    assert not mark_open(path, "DW-1", "by dw-a")
+    assert path.read_text(encoding="utf-8") == snapshot
+
+
+def test_mark_open_tolerates_reformatted_resolution_whitespace(tmp_path):
+    path = write_ledger(
+        tmp_path,
+        "### DW-1: closed then reflowed\n\nstatus: done 2026-06-11\n" "resolution:   by dw-a  \n",
+    )
+    assert mark_open(path, "DW-1", "by dw-a")
+    entry = parse_ledger(path.read_text(encoding="utf-8"))[0]
+    assert entry.open and "resolution:" not in entry.body
+
+
+@pytest.mark.parametrize("note", ["  padded note  ", "line one\nline two"])
+def test_mark_open_uses_the_same_note_normalization_as_mark_done(tmp_path, note):
+    """Main's mark_done flattens line breaks and permits padded clean text. The
+    undo accepts the original caller value, not only the rendered ledger line."""
+    path = write_ledger(tmp_path)
+    before = path.read_text(encoding="utf-8")
+    assert mark_done(path, "DW-1", "2026-06-11", note)
+    assert mark_open(path, "DW-1", note)
+    assert path.read_text(encoding="utf-8") == before
+
+
+def test_mark_open_is_idempotent_after_the_undo(tmp_path):
+    path = write_ledger(tmp_path)
+    assert mark_done(path, "DW-1", "2026-06-11", "by dw-a")
+    assert mark_open(path, "DW-1", "by dw-a")
+    snapshot = path.read_text(encoding="utf-8")
+    assert not mark_open(path, "DW-1", "by dw-a")
+    assert path.read_text(encoding="utf-8") == snapshot
+
+
+def test_mark_open_write_failure_raises_and_keeps_the_closed_entry(tmp_path, monkeypatch):
+    path = write_ledger(tmp_path)
+    assert mark_done(path, "DW-1", "2026-06-11", "by dw-a")
+    closed = path.read_text(encoding="utf-8")
+
+    def boom(path, text):
+        raise OSError("no space left")
+
+    monkeypatch.setattr(deferredwork, "atomic_write_text", boom)
+    with pytest.raises(OSError, match="no space left"):
+        mark_open(path, "DW-1", "by dw-a")
+    assert path.read_text(encoding="utf-8") == closed
 
 
 def test_append_decision(tmp_path):

--- a/tests/test_devcontract.py
+++ b/tests/test_devcontract.py
@@ -1,6 +1,7 @@
 """Tests for the generic bmad-dev-auto -> result.json translation shim."""
 
 import os
+from dataclasses import FrozenInstanceError
 from pathlib import Path
 
 import pytest
@@ -1394,3 +1395,201 @@ def test_auto_run_marker_is_not_read_as_an_operator_confirmation(tmp_path):
     sp = _write(tmp_path, "spec-a.md", _PARKED)
     devcontract.append_auto_run_result(sp, "done")
     assert devcontract.has_operator_confirmation(sp) is False
+
+
+# ---------------------------------------- frontmatter `deferred:` harvest (#2640)
+
+
+def _deferred_spec(path: Path, items) -> dict:
+    """Read the real block-scalar serialization through the production parser."""
+    from conftest import render_deferred
+
+    path.write_text(
+        f"---\nstatus: done\n{render_deferred(items)}---\n\n## Intent\n\ntest\n",
+        encoding="utf-8",
+    )
+    return verify.read_frontmatter(path)
+
+
+def test_parse_deferred_findings_absent_null_and_empty_are_empty(tmp_path):
+    path = tmp_path / "absent.md"
+    path.write_text("---\nstatus: done\n---\n\nbody\n", encoding="utf-8")
+    assert "deferred" not in verify.read_frontmatter(path)
+    assert devcontract.parse_deferred_findings(verify.read_frontmatter(path)) == ([], [])
+    assert devcontract.parse_deferred_findings({"deferred": None}) == ([], [])
+    assert devcontract.parse_deferred_findings(_deferred_spec(tmp_path / "empty.md", [])) == (
+        [],
+        [],
+    )
+
+
+def test_parse_deferred_findings_reads_real_block_scalar_shape(tmp_path):
+    fm = _deferred_spec(
+        tmp_path / "spec.md",
+        [
+            {
+                "summary": "Retry loop can spin: no ceiling # really",
+                "evidence": "first line\nsecond line: still evidence # data",
+                "location": "src/retry.py:88",
+                "severity": "medium",
+            }
+        ],
+    )
+    findings, malformed = devcontract.parse_deferred_findings(fm)
+    assert malformed == []
+    assert findings == [
+        devcontract.DeferredFinding(
+            summary="Retry loop can spin: no ceiling # really",
+            evidence="first line second line: still evidence # data",
+            location="src/retry.py:88",
+            severity="medium",
+            fingerprint=devcontract.harvest_fingerprint(
+                "Retry loop can spin: no ceiling # really", "src/retry.py:88"
+            ),
+        )
+    ]
+
+
+def test_deferred_finding_is_frozen():
+    finding = devcontract.DeferredFinding("summary", "evidence", "location", "high", "abc")
+    with pytest.raises(FrozenInstanceError):
+        setattr(finding, "summary", "changed")
+
+
+def test_parse_deferred_findings_keeps_item_order(tmp_path):
+    fm = _deferred_spec(
+        tmp_path / "spec.md",
+        [
+            {"summary": "first", "evidence": "e1"},
+            {"summary": "second", "evidence": "e2"},
+            {"summary": "third", "evidence": "e3"},
+        ],
+    )
+    findings, malformed = devcontract.parse_deferred_findings(fm)
+    assert malformed == []
+    assert [finding.summary for finding in findings] == ["first", "second", "third"]
+    assert len({finding.fingerprint for finding in findings}) == 3
+
+
+def test_parse_deferred_findings_defaults_optional_fields_and_coerces_scalars():
+    findings, malformed = devcontract.parse_deferred_findings(
+        {"deferred": [{"summary": 42}, {"summary": True, "evidence": False}]}
+    )
+    assert malformed == []
+    assert [(f.summary, f.evidence, f.location, f.severity) for f in findings] == [
+        ("42", "", "", ""),
+        ("True", "False", "", ""),
+    ]
+
+
+def test_parse_deferred_findings_normalizes_known_severity_and_drops_unknown(tmp_path):
+    fm = _deferred_spec(
+        tmp_path / "spec.md",
+        [
+            {"summary": "a", "severity": "blocker"},
+            {"summary": "b", "severity": "Major"},
+            {"summary": "c", "severity": "spicy"},
+        ],
+    )
+    findings, malformed = devcontract.parse_deferred_findings(fm)
+    assert malformed == []
+    assert [finding.severity for finding in findings] == ["critical", "high", ""]
+
+
+def test_parse_deferred_findings_isolates_each_malformed_item(tmp_path):
+    fm = _deferred_spec(
+        tmp_path / "spec.md",
+        [
+            {"summary": "good one", "evidence": "e"},
+            "bare-scalar",
+            {"evidence": "missing summary"},
+            {"summary": "   ", "evidence": "blank summary"},
+            {"summary": "good two", "evidence": "e"},
+        ],
+    )
+    findings, malformed = devcontract.parse_deferred_findings(fm)
+    assert [finding.summary for finding in findings] == ["good one", "good two"]
+    assert malformed == [
+        "item 2: not a mapping (got str)",
+        "item 3: no usable `summary`",
+        "item 4: no usable `summary`",
+    ]
+
+
+@pytest.mark.parametrize("raw", ["one finding", {"summary": "x"}, 3, True])
+def test_parse_deferred_findings_reports_a_non_list_container(raw):
+    findings, malformed = devcontract.parse_deferred_findings({"deferred": raw})
+    assert findings == []
+    assert malformed == [f"`deferred:` is not a list (got {type(raw).__name__})"]
+
+
+def test_parse_deferred_findings_clamps_every_ledger_value(tmp_path):
+    findings, malformed = devcontract.parse_deferred_findings(
+        _deferred_spec(
+            tmp_path / "spec.md",
+            [{"summary": "s" * 500, "evidence": "e" * 4000, "location": "l" * 500}],
+        )
+    )
+    assert malformed == []
+    assert len(findings[0].summary) == 200
+    assert len(findings[0].evidence) == 1000
+    assert len(findings[0].location) == 200
+
+
+def test_flatten_strips_a_join_space_at_the_clamp_boundary(tmp_path):
+    padded = " ".join(["a" * 9] * 30)
+    assert padded[:200].endswith(" ")
+    assert devcontract._flatten(padded, 200) == padded[:200].strip()
+
+    findings, _ = devcontract.parse_deferred_findings(
+        _deferred_spec(tmp_path / "spec.md", [{"summary": "s", "location": padded}])
+    )
+    finding = findings[0]
+    assert not finding.location.endswith(" ")
+    assert finding.fingerprint == devcontract.harvest_fingerprint("s", finding.location)
+
+
+def test_deferred_fingerprint_ignores_evidence_but_tracks_location(tmp_path):
+    def fingerprint(path: Path, evidence: str, location: str) -> str:
+        findings, _ = devcontract.parse_deferred_findings(
+            _deferred_spec(
+                path,
+                [{"summary": "same finding", "evidence": evidence, "location": location}],
+            )
+        )
+        return findings[0].fingerprint
+
+    first = fingerprint(tmp_path / "a.md", "e1", "f.py:1")
+    assert fingerprint(tmp_path / "b.md", "REWORDED", "f.py:1") == first
+    assert fingerprint(tmp_path / "c.md", "e1", "f.py:2") != first
+
+
+def test_deferred_fingerprint_uses_clamped_rendered_values(tmp_path):
+    a, _ = devcontract.parse_deferred_findings(
+        _deferred_spec(tmp_path / "a.md", [{"summary": "x" * 300 + "AAA"}])
+    )
+    b, _ = devcontract.parse_deferred_findings(
+        _deferred_spec(tmp_path / "b.md", [{"summary": "x" * 300 + "BBB"}])
+    )
+    assert a[0].summary == b[0].summary
+    assert a[0].fingerprint == b[0].fingerprint
+
+
+def test_harvest_fingerprint_is_stable_and_nul_separates_parts():
+    # Exact value pins SHA-1, NUL joining, and the 12-character truncation.
+    assert devcontract.harvest_fingerprint("a", "b") == "4a3dec2d1f82"
+    assert devcontract.harvest_fingerprint("ab", "c") != devcontract.harvest_fingerprint("a", "bc")
+    assert len(devcontract.harvest_fingerprint("a", "b")) == 12
+
+
+def test_harvest_fingerprint_marks_sha1_as_non_security_use(monkeypatch):
+    real_sha1 = devcontract.hashlib.sha1
+    seen = []
+
+    def recording_sha1(payload, *, usedforsecurity):
+        seen.append(usedforsecurity)
+        return real_sha1(payload, usedforsecurity=usedforsecurity)
+
+    monkeypatch.setattr(devcontract.hashlib, "sha1", recording_sha1)
+    assert devcontract.harvest_fingerprint("a", "b") == "4a3dec2d1f82"
+    assert seen == [False]

--- a/tests/test_devcontract.py
+++ b/tests/test_devcontract.py
@@ -1498,6 +1498,19 @@ def test_parse_deferred_findings_rejects_collection_valued_text_fields(field, co
     assert malformed == [f"item 1: `{field}` is not a scalar (got {type(collection).__name__})"]
 
 
+@pytest.mark.parametrize("field", ["summary", "evidence", "location"])
+@pytest.mark.parametrize("value", ["before\0after", "x" * 1001 + "\0"])
+def test_parse_deferred_findings_rejects_embedded_nul_in_text_fields(field, value):
+    """Reject before clamping too, so a late NUL cannot evade the stated schema."""
+    malformed_item = {"summary": "bad item", field: value}
+    findings, malformed = devcontract.parse_deferred_findings(
+        {"deferred": [malformed_item, {"summary": "good sibling"}]}
+    )
+
+    assert [finding.summary for finding in findings] == ["good sibling"]
+    assert malformed == [f"item 1: `{field}` contains a NUL character"]
+
+
 def test_parse_deferred_findings_normalizes_known_severity_and_drops_unknown(tmp_path):
     fm = _deferred_spec(
         tmp_path / "spec.md",
@@ -1596,6 +1609,12 @@ def test_harvest_fingerprint_is_stable_and_nul_separates_parts():
     assert devcontract.harvest_fingerprint("a", "b") == "4a3dec2d1f82"
     assert devcontract.harvest_fingerprint("ab", "c") != devcontract.harvest_fingerprint("a", "bc")
     assert len(devcontract.harvest_fingerprint("a", "b")) == 12
+
+
+@pytest.mark.parametrize("parts", [("a\0b", "c"), ("a", "b\0c")])
+def test_harvest_fingerprint_refuses_ambiguous_embedded_nul(parts):
+    with pytest.raises(ValueError, match="must not contain NUL"):
+        devcontract.harvest_fingerprint(*parts)
 
 
 def test_harvest_fingerprint_marks_sha1_as_non_security_use(monkeypatch):

--- a/tests/test_devcontract.py
+++ b/tests/test_devcontract.py
@@ -1482,6 +1482,22 @@ def test_parse_deferred_findings_defaults_optional_fields_and_coerces_scalars():
     ]
 
 
+@pytest.mark.parametrize("field", ["summary", "evidence", "location"])
+@pytest.mark.parametrize("collection", [["nested", "values"], {"nested": "value"}])
+def test_parse_deferred_findings_rejects_collection_valued_text_fields(field, collection):
+    """A malformed optional field costs its whole item too: silently dropping
+    it would harvest only part of an authored finding, while stringifying it
+    would persist Python container repr in the ledger. Scalar siblings remain
+    harvestable, including the numeric/bool normalization pinned above."""
+    malformed_item = {"summary": "bad item", field: collection}
+    findings, malformed = devcontract.parse_deferred_findings(
+        {"deferred": [malformed_item, {"summary": "good sibling"}]}
+    )
+
+    assert [finding.summary for finding in findings] == ["good sibling"]
+    assert malformed == [f"item 1: `{field}` is not a scalar (got {type(collection).__name__})"]
+
+
 def test_parse_deferred_findings_normalizes_known_severity_and_drops_unknown(tmp_path):
     fm = _deferred_spec(
         tmp_path / "spec.md",

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -237,13 +237,18 @@ def test_deferred_work_state_containers_do_not_alias_the_persisted_doc():
     doc = StoryTask(
         story_key="1-1-a",
         epic=1,
-        harvested_deferrals=[{"title": "original"}],
+        harvested_deferrals=[
+            {"title": "original", "metadata": {"labels": ["review"]}},
+        ],
         bundle_closes_intended=["DW-1"],
     ).to_dict()
     restored = StoryTask.from_dict(doc)
     restored.harvested_deferrals[0]["title"] = "mutated"
+    restored.harvested_deferrals[0]["metadata"]["labels"].append("follow-up")
     restored.bundle_closes_intended.append("DW-2")
-    assert doc["harvested_deferrals"] == [{"title": "original"}]
+    assert doc["harvested_deferrals"] == [
+        {"title": "original", "metadata": {"labels": ["review"]}},
+    ]
     assert doc["bundle_closes_intended"] == ["DW-1"]
 
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,5 +1,7 @@
 """RunState serialization + lifecycle-flag tests."""
 
+import json
+
 import pytest
 
 from bmad_loop.model import Phase, RunState, SessionRecord, StoryTask, TokenUsage
@@ -158,6 +160,100 @@ def test_sentinel_kind_defaults_empty_for_legacy_state():
     doc = StoryTask(story_key="1", epic=0).to_dict()
     del doc["sentinel_kind"]  # state.json from before the field existed
     assert StoryTask.from_dict(doc).sentinel_kind == ""
+
+
+_DEFERRED_STATE_KEYS = (
+    "baseline_ledger_digest",
+    "pre_harvest_ledger",
+    "pre_harvest_ledger_captured",
+    "harvest_wrote_ledger",
+    "ledger_changed_before_harvest",
+    "harvested_deferrals",
+    "bundle_closes_intended",
+    "isolated_ledger_carried",
+)
+
+
+def test_deferred_work_state_fields_round_trip_through_json():
+    """All eight fields are hand-enumerated in both serializers. Non-default
+    values make a missing line on either side observable, while the JSON leg pins
+    the on-disk container shape rather than only an in-memory dataclass copy."""
+    task = StoryTask(
+        story_key="1-1-a",
+        epic=1,
+        baseline_ledger_digest="a" * 64,
+        pre_harvest_ledger="",
+        pre_harvest_ledger_captured=True,
+        harvest_wrote_ledger=True,
+        ledger_changed_before_harvest=True,
+        harvested_deferrals=[{"origin": "spec-deferred abc", "title": "finding"}],
+        bundle_closes_intended=["DW-3", "DW-7"],
+        isolated_ledger_carried=True,
+    )
+    restored = StoryTask.from_dict(json.loads(json.dumps(task.to_dict())))
+
+    assert restored.baseline_ledger_digest == "a" * 64
+    assert restored.pre_harvest_ledger == ""
+    assert restored.pre_harvest_ledger is not None
+    assert restored.pre_harvest_ledger_captured is True
+    assert restored.harvest_wrote_ledger is True
+    assert restored.ledger_changed_before_harvest is True
+    assert restored.harvested_deferrals == [{"origin": "spec-deferred abc", "title": "finding"}]
+    assert restored.bundle_closes_intended == ["DW-3", "DW-7"]
+    assert restored.isolated_ledger_carried is True
+
+
+def test_deferred_work_state_fields_default_for_one_old_state_dict():
+    """A state.json written before this package has none of the eight keys.
+    Every load must use ``d.get`` so resume reaches the old behavior instead of
+    raising KeyError; one shared old document prevents testing only a subset."""
+    doc = StoryTask(story_key="1-1-a", epic=1).to_dict()
+    for key in _DEFERRED_STATE_KEYS:
+        del doc[key]
+
+    restored = StoryTask.from_dict(doc)
+    assert restored.baseline_ledger_digest is None
+    assert restored.pre_harvest_ledger is None
+    assert restored.pre_harvest_ledger_captured is False
+    assert restored.harvest_wrote_ledger is False
+    assert restored.ledger_changed_before_harvest is False
+    assert restored.harvested_deferrals == []
+    assert restored.bundle_closes_intended == []
+    assert restored.isolated_ledger_carried is False
+
+
+def test_pre_harvest_ledger_preserves_absent_empty_and_text_states():
+    """Empty text means an existing empty ledger; None means no file. Collapsing
+    them would turn the common empty-ledger restore into an unlink."""
+    for value in (None, "", "# Deferred Work\n"):
+        restored = StoryTask.from_dict(
+            StoryTask(story_key="1-1-a", epic=1, pre_harvest_ledger=value).to_dict()
+        ).pre_harvest_ledger
+        assert restored == value
+        assert (restored is None) is (value is None)
+
+
+def test_deferred_work_state_containers_do_not_alias_the_persisted_doc():
+    doc = StoryTask(
+        story_key="1-1-a",
+        epic=1,
+        harvested_deferrals=[{"title": "original"}],
+        bundle_closes_intended=["DW-1"],
+    ).to_dict()
+    restored = StoryTask.from_dict(doc)
+    restored.harvested_deferrals[0]["title"] = "mutated"
+    restored.bundle_closes_intended.append("DW-2")
+    assert doc["harvested_deferrals"] == [{"title": "original"}]
+    assert doc["bundle_closes_intended"] == ["DW-1"]
+
+
+def test_deferred_work_state_container_defaults_are_not_shared():
+    one = StoryTask(story_key="1-1-a", epic=1)
+    other = StoryTask(story_key="1-2-b", epic=1)
+    one.harvested_deferrals.append({"title": "one"})
+    one.bundle_closes_intended.append("DW-1")
+    assert other.harvested_deferrals == []
+    assert other.bundle_closes_intended == []
 
 
 def test_restore_patch_round_trips():


### PR DESCRIPTION
## Summary

- Add inert persisted deferred-work state to `StoryTask` with backward-compatible rehydration.
- Add pure deferred-finding parsing/fingerprinting and a guarded ledger `mark_open` primitive.
- Add fixtures and regression coverage for YAML shapes, normalization, guard behavior, and atomic writes.

This is pure/inert Phase 6I foundation work. It adds no product readers, engine threading, sweep behavior, verification behavior, or Phase 6J+ behavior.

References #433.

## Validation

- Full suite on Python 3.13 and 3.14: 4,072 passed, 30 skipped (4,102 collected) per lane.
- 11-row ablation matrix on both lanes; every intended assertion reddened.
- `uv run pyright`
- `trunk check --no-fix`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for reopening eligible deferred-work items using matching resolution details.
  * Added deferred-review finding capture with normalized severity, validated details, and stable identification.
  * Deferred-work progress is now preserved across task state saves and restores, including older state files.

* **Bug Fixes**
  * Improved handling of missing, malformed, or mismatched deferred-work entries without altering unrelated records.

* **Tests**
  * Expanded coverage for deferred-work updates, finding validation, fingerprints, and state persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->