### PR TITLE
feat(engine): harvest spec-frontmatter deferrals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1135,10 +1135,10 @@ that rode the same window. Both skill eras are supported; the rename itself need
   edits outright — on a pre-BMAD-METHOD#2640 skill there is no frontmatter to harvest and the
   session's own append is the finding's only record — and still forbids rewriting existing entries.
 
-- **A transient harvest read cannot silently drop recorded findings (#405).** An unreadable spec
-  at the harvest step now follows the existing bounded retry paths for dev, review, and timeout
-  salvage instead of letting a later successful verifier read accept and commit without the ledger
-  repair.
+- **A transient harvest read cannot silently drop recorded findings (#405).** An unreadable or
+  momentarily missing spec at the harvest step now follows the existing bounded retry paths for
+  dev, review, and timeout salvage instead of letting a later successful verifier read accept and
+  commit without the ledger repair.
 
 - **A harvested deferral is reverted when its attempt rolls back (#405).** The harvest keys on
   the spec's status and runs before the artifact gate, so a session that finalized its spec and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1138,11 +1138,16 @@ that rode the same window. Both skill eras are supported; the rename itself need
 - **A transient harvest read cannot silently drop recorded findings (#405).** An unreadable,
   momentarily missing, undecodable, or temporarily malformed spec at the harvest step now follows
   the existing bounded retry paths for dev, repair, review, and timeout salvage instead of letting
-  a later successful verifier read accept and commit without the ledger repair.
+  a later successful verifier read accept and commit without the ledger repair. A completed review
+  retries that deterministic read against its own result before any later reviewer can replace the
+  source list; a persistent fault defers with the artifacts preserved for recovery, or re-escalates
+  an active human-resolved CRITICAL re-drive.
 
 - **Post-session ledger work keeps its proof attribution across crash replay (#405).** The
   completed-session checkpoint is refreshed after hooks return, so a retained retry cannot hide a
-  hook-authored ledger repair behind an earlier harvest's engine-written exclusion.
+  hook-authored ledger repair behind an earlier harvest's engine-written exclusion. A pre-feature
+  checkpoint with no ledger digest reconstructs path-scoped attribution from its Git baseline, so
+  a legitimate ledger-only session still resumes while the new harvest remains excluded from proof.
 
 - **A harvested deferral is reverted when its attempt rolls back (#405).** The harvest keys on
   the spec's status and runs before the artifact gate, so a session that finalized its spec and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1302,10 +1302,11 @@ that rode the same window. Both skill eras are supported; the rename itself need
   kept worktree.) `_defer` now re-files what the final attempt's harvest intended to file into the
   main checkout's ledger and commits that path alone — leaving it dirty would escalate the next
   story's merge. `append_entry` dedups on `origin:` + `source_spec:`, so an entry already open
-  there is not duplicated. Only the final attempt's record carries: it is cleared at each attempt's
-  start, so an attempt whose session never completed cannot re-file the findings its predecessor's
-  rollback removed. The gap pre-dates this release; the harvest added a systematic producer of
-  such entries.
+  there is not duplicated. The retained retry/review chain carries the stable union of every
+  successful pass: a later pass replacing its frontmatter list no longer erases an earlier
+  finding before an ignored ledger's final carry. A genuinely new attempt still clears the
+  record, so it cannot re-file findings whose code and ledger rows were rolled back. The gap
+  pre-dates this release; the harvest added a systematic producer of such entries.
 
 - **…and so does a unit that LANDS (#405).** A landing unit looked untouched — its ledger edit
   merges with the branch. Not when the ledger is gitignored: `finalize_commit` stages with
@@ -1338,11 +1339,20 @@ that rode the same window. Both skill eras are supported; the rename itself need
   both payloads are already in `state.json`, so only the replay was missing. Resume now re-runs
   an unlatched carry, once, guarded by a persisted latch — the writes are only partly idempotent,
   since `append_entry` dedups against **open** entries and a later close would turn a blind
-  replay into a duplicate. Skipped when the worktree is still mounted (the branch may never have
-  landed, and the human's merge would bring the entry itself), on the in-place path, and on any
-  phase but DONE. The sweep half is the sharper one: a lost close leaves ids open, the
+  replay into a duplicate. Skipped without a matching durable `unit-merged` journal record, on
+  the in-place path, and on any phase but DONE or AWAITING_OPERATOR. Directory disappearance is
+  not evidence: teardown may degrade after a successful merge and leave the directory behind.
+  The sweep half is the sharper one: a lost close leaves ids open, the
   suppression filter does not cover DONE, and every later sweep re-drives already-merged work
   into a non-fixable retry that pauses the run.
+
+- **Tracked ledger carry failures stop and remain replayable (#405).** A rejected `git add`,
+  `status`, or `commit` used to be journaled and swallowed, letting an isolated unit finish with
+  a dirty or staged main ledger. A committable carry now persists its pending commit intent before
+  the first append and raises; resume retries the commit even after provenance dedupes that row.
+  Deferred units remain nonterminal until this repair write succeeds, so resume still records the
+  defer and closes its worktree; post-merge replay likewise completes the after-story continuation.
+  Gitignored and external ledgers keep their advisory degrade behavior.
 
 - **An artifacts dir whose name holds `[` or `]` no longer misdirects the two paths above
   (#405, #423).** Git reads a positional operand as a pathspec, so such a path was a glob that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1135,6 +1135,11 @@ that rode the same window. Both skill eras are supported; the rename itself need
   edits outright — on a pre-BMAD-METHOD#2640 skill there is no frontmatter to harvest and the
   session's own append is the finding's only record — and still forbids rewriting existing entries.
 
+- **A transient harvest read cannot silently drop recorded findings (#405).** An unreadable spec
+  at the harvest step now follows the existing bounded retry paths for dev, review, and timeout
+  salvage instead of letting a later successful verifier read accept and commit without the ledger
+  repair.
+
 - **A harvested deferral is reverted when its attempt rolls back (#405).** The harvest keys on
   the spec's status and runs before the artifact gate, so a session that finalized its spec and
   then failed a non-fixable check (a `baseline_revision` mismatch is the canonical trigger) left

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1135,10 +1135,14 @@ that rode the same window. Both skill eras are supported; the rename itself need
   edits outright — on a pre-BMAD-METHOD#2640 skill there is no frontmatter to harvest and the
   session's own append is the finding's only record — and still forbids rewriting existing entries.
 
-- **A transient harvest read cannot silently drop recorded findings (#405).** An unreadable or
-  momentarily missing spec at the harvest step now follows the existing bounded retry paths for
-  dev, review, and timeout salvage instead of letting a later successful verifier read accept and
-  commit without the ledger repair.
+- **A transient harvest read cannot silently drop recorded findings (#405).** An unreadable,
+  momentarily missing, undecodable, or temporarily malformed spec at the harvest step now follows
+  the existing bounded retry paths for dev, repair, review, and timeout salvage instead of letting
+  a later successful verifier read accept and commit without the ledger repair.
+
+- **Post-session ledger work keeps its proof attribution across crash replay (#405).** The
+  completed-session checkpoint is refreshed after hooks return, so a retained retry cannot hide a
+  hook-authored ledger repair behind an earlier harvest's engine-written exclusion.
 
 - **A harvested deferral is reverted when its attempt rolls back (#405).** The harvest keys on
   the spec's status and runs before the artifact gate, so a session that finalized its spec and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1121,7 +1121,7 @@ that rode the same window. Both skill eras are supported; the rename itself need
 
 - **Deferred review findings are harvested out of the spec's frontmatter (#405).**
   BMAD-METHOD#2640 moved `defer`-triaged findings from `deferred-work.md` into the spec's own
-  `deferred:` list, silently starving the sweep pipeline. A successful dev or review session
+  `deferred:` list, silently starving the sweep pipeline. A successful dev, repair, or review session
   now files each finding into the ledger with its `location` and `severity`, journals
   `spec-deferrals-harvested`, and dedups on a fingerprint of the summary and location so a
   _fixable_ retry, a resume replay or a second review pass never re-files one — including after a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1168,6 +1168,8 @@ that rode the same window. Both skill eras are supported; the rename itself need
   snapshot — except when that retry pauses, which the next bullet covers. A defer still
   keeps its harvested entries: on the in-place path `_stash_deferred_artifacts` has already moved
   the spec out of the artifacts dir, so the ledger entry is the finding's only surviving record.
+  Restoring a non-empty snapshot publishes through the atomic ledger writer, so a second host or
+  filesystem failure during rollback leaves the current ledger intact rather than truncating it.
 
 - **The pre-harvest snapshot is spent by a stop-and-wait pause instead of riding it (#405).**
   `rollback_on_failure = off` is the default and does not roll back: it hands the tree to a human
@@ -1347,6 +1349,10 @@ that rode the same window. Both skill eras are supported; the rename itself need
   replay into a duplicate. Skipped without a matching durable `unit-merged` journal record, on
   the in-place path, and on any phase but DONE or AWAITING_OPERATOR. Directory disappearance is
   not evidence: teardown may degrade after a successful merge and leave the directory behind.
+  The merge itself now writes intent immediately before invoking git. If the host dies after git
+  succeeds but before `unit-merged` lands, resume re-runs that exact merge and carries only after
+  success; merge and ff are naturally idempotent, while squash accepts a clean no-op only on this
+  recovery path. Intent alone is never treated as proof that the branch landed.
   The sweep half is the sharper one: a lost close leaves ids open, the
   suppression filter does not cover DONE, and every later sweep re-drives already-merged work
   into a non-fixable retry that pauses the run.

--- a/src/bmad_loop/data/skills/bmad-loop-sweep/deferred-work-format.md
+++ b/src/bmad_loop/data/skills/bmad-loop-sweep/deferred-work-format.md
@@ -35,6 +35,18 @@ reason: <why this was deferred rather than done now, one or two sentences>
 status: open
 ```
 
+`location:` is always written. Use `n/a` whenever there is nothing to open — a
+deferred goal, but equally a finding whose reporter recorded no place. The field
+says "no location was recorded", not "this item has none": a reader that finds
+`n/a` should fall back to `reason:`, which often names the file even when
+`location:` is empty. Entries written before this rule may omit the line; read
+an absent `location:` as `n/a`, never as "not yet known".
+
+Entries the orchestrator harvests from a spec carry one extra line,
+`source_spec:`, directly after `location:` — the spec the deferral came from. It
+is half the dedupe key (with `origin:`), so never edit or drop it when touching
+an entry; entries written by hand do not need it.
+
 **Every field line is exactly one line, and so is the title.** The format is
 line-oriented: readers find each field by scanning for `<name>:` at the start of
 a line, and an entry ends at whichever comes first — the next `### DW-<n>`

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -3771,7 +3771,16 @@ class Engine:
                 self._escalate(task, f"CRITICAL escalation from fix session: {details}")
             outcome = None
             if result.status == "completed":
-                outcome = verify.verify_commands_outcome(self.policy, self.workspace.root)
+                # A repair is another generic dev-primitive pass: it can leave
+                # terminal prose ahead of frontmatter and record fresh deferred
+                # findings just like the initial dev and review legs. Normalize
+                # and harvest before accepting its verify-green tree, because the
+                # next review pass may replace the frontmatter list.
+                self._reconcile_generic_terminal_status(task, result.result_json)
+                harvest_outcome = self._harvest_spec_deferrals(task, result.result_json)
+                outcome = harvest_outcome or verify.verify_commands_outcome(
+                    self.policy, self.workspace.root
+                )
                 if not outcome.ok:
                     reason = outcome.reason
             ok = outcome is not None and outcome.ok

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -26,6 +26,7 @@ from .adapters.base import CodingCLIAdapter, SessionResult, SessionSpec, SpecSna
 from .bmadconfig import ProjectPaths
 from .escalation import (
     Action,
+    Decision,
     critical_escalations,
     decide_dev,
     decide_review_session,
@@ -71,8 +72,8 @@ if TYPE_CHECKING:
 # the dedup key and must never be reworded; `<prefix>-malformed <fingerprint>`
 # marks the aggregated unparseable-items meta-entry.
 HARVEST_ORIGIN = "spec-deferred"
-# A completed review owns the spec bytes it just wrote. Give a transient repair
-# read one immediate retry, but never dispatch a new reviewer over an unread
+# A completed session owns the spec bytes it just wrote. Give a transient repair
+# read one immediate retry, but never dispatch another session over an unread
 # source: that later pass is allowed to replace the frontmatter list.
 HARVEST_REPAIR_READ_ATTEMPTS = 2
 
@@ -1746,8 +1747,14 @@ class Engine:
                     # re-review of the same tree cannot make them pass. Repair
                     # with the failing output as feedback, then re-review. This
                     # verify-repair round never spends the damping cap.
-                    if not self._fix_phase(task, outcome.reason):
-                        self._defer(task, "verify commands kept failing after clean review")
+                    fix = self._fix_phase(task, outcome.reason)
+                    if fix.action == Action.PAUSE:
+                        self._escalate(task, fix.reason)
+                    if fix.action == Action.DEFER:
+                        self._defer(
+                            task,
+                            fix.reason or "verify commands kept failing after clean review",
+                        )
                         return
                 continue
             if refileable_followup:
@@ -1836,11 +1843,11 @@ class Engine:
     def _salvage_review_timeout(self, task: StoryTask, result: SessionResult) -> bool:
         """``review.on_timeout = "salvage-if-done"`` (#271): try to converge a
         timed-out review by committing the already-finalized dev product instead
-        of burning another review cycle. Returns True when the story committed;
-        False means salvage was not applicable and the caller falls back to the
-        default retry/exhaust routing. The cycle the timed-out session charged is
-        deliberately not refunded — salvage changes what the *next* cycle costs,
-        not what this one did.
+        of burning another review cycle. Returns True when salvage either committed
+        or terminally routed an unreadable harvest; False means salvage was not
+        applicable and the caller falls back to the default retry/exhaust routing.
+        The cycle the timed-out session charged is deliberately not refunded —
+        salvage changes what the *next* cycle costs, not what this one did.
 
         Applicability, all deterministic: not worktree-isolated (a defer there
         already keeps the unit's worktree + diff, and committing into the main
@@ -1877,8 +1884,33 @@ class Engine:
         # A timed-out review can still have recorded new frontmatter findings.
         # Normalize first so the success-status gate sees `done`, then mirror the
         # normal review path before deterministic verification and commit.
-        harvest_outcome = self._harvest_spec_deferrals(task, {"spec_file": str(spec_path)})
-        outcome = harvest_outcome or self._verify_review(task)
+        harvest_outcome = None
+        for harvest_attempt in range(1, HARVEST_REPAIR_READ_ATTEMPTS + 1):
+            harvest_outcome = self._harvest_spec_deferrals(task, {"spec_file": str(spec_path)})
+            if harvest_outcome is None:
+                break
+            self.journal.append(
+                "review-timeout-salvage-failed",
+                story_key=task.story_key,
+                cycle=task.review_cycle,
+                reason=harvest_outcome.reason,
+                env_fault=harvest_outcome.env_fault,
+                harvest_attempt=harvest_attempt,
+            )
+            if not harvest_outcome.retryable:
+                self._escalate(task, harvest_outcome.reason)
+        if harvest_outcome is not None:
+            exhausted = review_exhausted(
+                task,
+                "review timeout deferral harvest remained unreadable after "
+                f"{HARVEST_REPAIR_READ_ATTEMPTS} attempts: {harvest_outcome.reason}",
+            )
+            if exhausted.action == Action.PAUSE:
+                self._escalate(task, exhausted.reason)
+            self._defer(task, exhausted.reason)
+            return True
+
+        outcome = self._verify_review(task)
         if not outcome.ok:
             self.journal.append(
                 "review-timeout-salvage-failed",
@@ -1984,7 +2016,16 @@ class Engine:
         and the journal says which."""
         self.journal.append(kind, story_key=task.story_key)
         outcome = self._verify_review(task)
-        if not outcome.ok and outcome.fixable and self._fix_phase(task, outcome.reason):
+        if not outcome.ok and outcome.fixable:
+            fix = self._fix_phase(task, outcome.reason)
+            if fix.action == Action.PAUSE:
+                self._escalate(task, fix.reason)
+            if fix.action == Action.DEFER:
+                self._defer(
+                    task,
+                    fix.reason or f"verify failed with review disabled: {outcome.reason}",
+                )
+                return
             outcome = self._verify_review(task)
         if not outcome.ok:
             # same event kind as the review-enabled loop so journal consumers
@@ -2749,11 +2790,19 @@ class Engine:
             (str(item.get("origin", "")), str(item.get("source_spec", "")))
             for item in task.harvested_deferrals
         }
+        records_changed = False
         for record in current_records:
             key = (str(record["origin"]), str(record["source_spec"]))
             if key not in known:
                 task.harvested_deferrals.append(record)
                 known.add(key)
+                records_changed = True
+        if records_changed:
+            # The isolation carry reads only persisted records after a hard
+            # loss. Checkpoint every stable-union expansion before a ledger
+            # append, including later passes where harvest_wrote_ledger is
+            # already latched and its separate pre-write save will be skipped.
+            self._save()
 
         ledger = self.workspace.paths.deferred_work
         text = ledger.read_text(encoding="utf-8") if ledger.is_file() else ""
@@ -3895,10 +3944,10 @@ class Engine:
         )
         return path
 
-    def _fix_phase(self, task: StoryTask, reason: str) -> bool:
+    def _fix_phase(self, task: StoryTask, reason: str) -> Decision:
         """Feedback-driven repair after a clean review whose verify commands
-        failed. Consumes the story's dev-attempt budget; returns True once the
-        commands pass so the review loop can re-review the repaired tree."""
+        failed. Consumes the story's dev-attempt budget; returns PROCEED once
+        commands pass, or terminal review routing when repair cannot continue."""
         while task.attempt < self.policy.limits.max_dev_attempts:
             task.attempt += 1
             feedback = self._write_feedback(task, reason)
@@ -3917,6 +3966,7 @@ class Engine:
                 details = "; ".join(str(e.get("detail", e.get("type", "?"))) for e in crits)
                 self._escalate(task, f"CRITICAL escalation from fix session: {details}")
             outcome = None
+            terminal = None
             if result.status == "completed":
                 # A repair is another generic dev-primitive pass: it can leave
                 # terminal prose ahead of frontmatter and record fresh deferred
@@ -3924,7 +3974,31 @@ class Engine:
                 # and harvest before accepting its verify-green tree, because the
                 # next review pass may replace the frontmatter list.
                 self._reconcile_generic_terminal_status(task, result.result_json)
-                harvest_outcome = self._harvest_spec_deferrals(task, result.result_json)
+                harvest_outcome = None
+                for harvest_attempt in range(1, HARVEST_REPAIR_READ_ATTEMPTS + 1):
+                    harvest_outcome = self._harvest_spec_deferrals(task, result.result_json)
+                    if harvest_outcome is None:
+                        break
+                    self.journal.append(
+                        "fix-harvest-failed",
+                        story_key=task.story_key,
+                        attempt=task.attempt,
+                        reason=harvest_outcome.reason,
+                        env_fault=harvest_outcome.env_fault,
+                        harvest_attempt=harvest_attempt,
+                    )
+                    if not harvest_outcome.retryable:
+                        break
+                if harvest_outcome is not None and harvest_outcome.retryable:
+                    outcome = harvest_outcome
+                    terminal = review_exhausted(
+                        task,
+                        "fix-session deferral harvest remained unreadable after "
+                        f"{HARVEST_REPAIR_READ_ATTEMPTS} attempts: "
+                        f"{harvest_outcome.reason}",
+                    )
+                else:
+                    terminal = None
                 outcome = harvest_outcome or verify.verify_commands_outcome(
                     self.policy, self.workspace.root
                 )
@@ -3955,9 +4029,11 @@ class Engine:
                 # dev budget and pause for a human instead
                 self._escalate(task, outcome.reason)
             self._save()
+            if terminal is not None:
+                return terminal
             if ok:
-                return True
-        return False
+                return Decision(Action.PROCEED)
+        return Decision(Action.DEFER)
 
     def _record_review_budget_followup(self, task: StoryTask, damped: bool = False) -> None:
         """A *finalized, verify-green* story that the review pass kept recommending

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -31,6 +31,7 @@ from .escalation import (
     decide_review_session,
     env_fault_pause_reason,
     preference_escalations,
+    review_exhausted,
     review_retry_or_exhaust,
 )
 from .install import dev_primitive_or_default
@@ -70,6 +71,10 @@ if TYPE_CHECKING:
 # the dedup key and must never be reworded; `<prefix>-malformed <fingerprint>`
 # marks the aggregated unparseable-items meta-entry.
 HARVEST_ORIGIN = "spec-deferred"
+# A completed review owns the spec bytes it just wrote. Give a transient repair
+# read one immediate retry, but never dispatch a new reviewer over an unread
+# source: that later pass is allowed to replace the frontmatter list.
+HARVEST_REPAIR_READ_ATTEMPTS = 2
 
 
 def _digest_of(text: str | None) -> str:
@@ -1335,7 +1340,22 @@ class Engine:
                 # and replay must preserve the attribution saved before harvest.
                 if not replayed and feedback is None:
                     task.harvest_wrote_ledger = False
-                if not replayed or not task.harvest_wrote_ledger:
+                if (
+                    replayed
+                    and task.baseline_ledger_digest is None
+                    and not task.harvest_wrote_ledger
+                ):
+                    # A state written before ledger attribution has no digest to
+                    # compare, but it still has the attempt's Git baseline. Use
+                    # the pre-harvest path diff to preserve legitimate ledger-only
+                    # session work without letting the append below become its
+                    # own proof. A later replay with harvest_wrote_ledger already
+                    # latched preserves the attribution saved by this first one.
+                    task.ledger_changed_before_harvest = self._legacy_ledger_changed_before_harvest(
+                        task
+                    )
+                    self._save()
+                elif not replayed or not task.harvest_wrote_ledger:
                     if task.baseline_ledger_digest is not None:
                         task.ledger_changed_before_harvest = (
                             self._ledger_digest() != task.baseline_ledger_digest
@@ -1640,18 +1660,36 @@ class Engine:
             # A follow-up review is another full dev-primitive pass and may add
             # findings to the same frontmatter list. Harvest after reconciliation
             # makes a prose-finalized pass visible; the dev-leg entries dedupe.
-            harvest_outcome = self._harvest_spec_deferrals(task, rj)
-            if harvest_outcome is not None:
+            harvest_outcome = None
+            for harvest_attempt in range(1, HARVEST_REPAIR_READ_ATTEMPTS + 1):
+                harvest_outcome = self._harvest_spec_deferrals(task, rj)
+                if harvest_outcome is None:
+                    break
                 self.journal.append(
                     "review-verify-failed",
                     story_key=task.story_key,
                     reason=harvest_outcome.reason,
                     env_fault=harvest_outcome.env_fault,
                     contradiction=harvest_outcome.contradiction,
+                    harvest_attempt=harvest_attempt,
                 )
                 if not harvest_outcome.retryable:
                     self._escalate(task, harvest_outcome.reason)
-                continue
+            if harvest_outcome is not None:
+                # The bounded deterministic retry could not recover the source.
+                # Do not launch another reviewer: a new pass may replace the
+                # unread `deferred:` list and silently erase a finding. Route as
+                # exhausted without spending a session so a resolved CRITICAL
+                # re-drive re-escalates instead of being downgraded to a defer.
+                exhausted = review_exhausted(
+                    task,
+                    "review deferral harvest remained unreadable after "
+                    f"{HARVEST_REPAIR_READ_ATTEMPTS} attempts: {harvest_outcome.reason}",
+                )
+                if exhausted.action == Action.PAUSE:
+                    self._escalate(task, exhausted.reason)
+                self._defer(task, exhausted.reason)
+                return
             status = str(rj.get("status", "")).strip()
             last_status = status  # remember the last completed pass for the defer reason
             followup = bool(rj.get("followup_review_recommended", False))
@@ -3071,6 +3109,44 @@ class Engine:
         the session's work.
         """
         return _digest_of(self._ledger_text())
+
+    def _legacy_ledger_changed_before_harvest(self, task: StoryTask) -> bool:
+        """Recover pre-feature ledger attribution from the attempt's Git baseline.
+
+        Old resumable state has no ``baseline_ledger_digest``. The completed
+        session can still have authored ledger-only work, and path-granular Git
+        evidence distinguishes that existing diff from the engine harvest about
+        to run. External ledgers cannot satisfy the project proof gate. An
+        attribution probe that raises keeps the path excluded, so uncertainty
+        never credits the engine's own append as session work.
+        """
+        if not task.baseline_commit:
+            return False
+        ledger = self.workspace.paths.deferred_work
+        root = self.workspace.root
+        try:
+            rel = ledger.resolve().relative_to(root.resolve()).as_posix()
+        except (OSError, RuntimeError):
+            try:
+                rel = ledger.relative_to(root).as_posix()
+            except ValueError:
+                return False
+        except ValueError:
+            return False
+        try:
+            return verify.path_changed_since(
+                root,
+                task.baseline_commit,
+                rel,
+                baseline_untracked=task.baseline_untracked,
+            )
+        except (verify.GitError, OSError, RuntimeError) as e:
+            self.journal.append(
+                "legacy-ledger-attribution-failed",
+                story_key=task.story_key,
+                error=str(e),
+            )
+            return False
 
     def _ledger_is_gits_to_restore(self, task: StoryTask) -> bool:
         """Whether git owns the active ledger and reset is responsible for it.

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -63,6 +63,14 @@ if TYPE_CHECKING:
     from .adapters.profile import CLIProfile
 
 
+# `origin:` marker prefix for ledger entries harvested out of a spec's
+# frontmatter `deferred:` list (BMAD-METHOD #2640). The full marker is
+# `<prefix> <fingerprint>` — matched verbatim on every later harvest, so it is
+# the dedup key and must never be reworded; `<prefix>-malformed <fingerprint>`
+# marks the aggregated unparseable-items meta-entry.
+HARVEST_ORIGIN = "spec-deferred"
+
+
 class RunPaused(Exception):
     def __init__(self, reason: str, stage: str, story_key: str | None = None):
         super().__init__(reason)
@@ -1185,8 +1193,15 @@ class Engine:
             # would shift the rollback/squash reference onto the completed
             # session's own tree.
             task.baseline_untracked = sorted(verify.untracked_files(self.workspace.root))
+            # Start the ledger attribution reference under the same fresh-entry
+            # rule. The harvest exclusion compares each attempt's pre-harvest
+            # ledger with this reference so a session-authored ledger edit is
+            # never hidden along with the orchestrator's own append. A fixable
+            # retry rebases it onto the tree that retry deliberately keeps.
+            task.baseline_ledger_digest = self._ledger_digest()
         feedback: Path | None = None
         while True:
+            replayed = resume_result is not None
             if resume_result is None:
                 # a resumed result replays the attempt it was recorded under, so
                 # the counter (and the session task_id derived from it) must not
@@ -1220,6 +1235,20 @@ class Engine:
             advance(task, Phase.DEV_VERIFY)
             outcome = None
             if result.status == "completed":
+                # Everything below this point that appends to the ledger is the
+                # orchestrator, not the session. Reset the write flag only when
+                # this attempt starts from a reset tree. A fixable retry keeps the
+                # prior attempt's tree and harvest, so that provenance must carry
+                # into its repair session. Preserve it on a crash replay too: the
+                # replayed harvest dedupes against the dead attempt's on-disk append.
+                if not replayed:
+                    if feedback is None:
+                        task.harvest_wrote_ledger = False
+                    if task.baseline_ledger_digest is not None:
+                        task.ledger_changed_before_harvest = (
+                            self._ledger_digest() != task.baseline_ledger_digest
+                        )
+                    self._save()
                 # bmad-dev-auto sometimes finalizes the spec in prose (## Auto Run
                 # Result: Status done) but leaves the frontmatter status at the
                 # template default. Repair it BEFORE any frontmatter reader runs —
@@ -1230,6 +1259,11 @@ class Engine:
                 # skill never touches (sprint-status for stories, the deferred-work
                 # ledger for sweep bundles), before verify reads that state.
                 self._post_dev_state_sync(task, result.result_json)
+                # Harvest the session's frontmatter `deferred:` findings into the
+                # ledger before the artifact gate so an accepted attempt carries
+                # them in its story commit. `_harvest_gate_exclude` keeps this
+                # engine-authored append from becoming proof of session work.
+                self._harvest_spec_deferrals(task, result.result_json)
                 # carry the skill's follow-up-review recommendation (PR #2505)
                 # onto the task so _review_and_commit can gate the review loop.
                 # A present key is authoritative (folded from the frontmatter, or
@@ -1278,6 +1312,11 @@ class Engine:
                     # work exists and the failure is concrete: keep the tree,
                     # hand the failing output to a repair session
                     feedback = self._write_feedback(task, decision.reason)
+                    # The repair session is judged against the kept chain. Move
+                    # the ledger reference onto that tree so the retained harvest
+                    # is accounted for, while a new session-authored ledger edit
+                    # still makes `ledger_changed_before_harvest` true.
+                    task.baseline_ledger_digest = self._ledger_digest()
                 else:
                     feedback = None
                     self._rollback_or_pause(task)
@@ -1463,6 +1502,10 @@ class Engine:
             # frontmatter's followup flag into `rj` (only when present), so the
             # convergence/damping gate below sees the finalized state.
             self._reconcile_generic_terminal_status(task, rj)
+            # A follow-up review is another full dev-primitive pass and may add
+            # findings to the same frontmatter list. Harvest after reconciliation
+            # makes a prose-finalized pass visible; the dev-leg entries dedupe.
+            self._harvest_spec_deferrals(task, rj)
             status = str(rj.get("status", "")).strip()
             last_status = status  # remember the last completed pass for the defer reason
             followup = bool(rj.get("followup_review_recommended", False))
@@ -2366,6 +2409,148 @@ class Engine:
         target = "review" if review_enabled else "done"
         sprint_advance(self.workspace.paths.sprint_status, task.story_key, target)
 
+    def _harvest_spec_deferrals(self, task: StoryTask, result_json: dict | None) -> None:
+        """Carry a successful dev primitive's ``deferred:`` findings into the ledger.
+
+        BMAD-METHOD #2640 moved defer-triaged review findings from
+        ``deferred-work.md`` into the spec frontmatter. The orchestrator owns the
+        follow-up policy, so without this bridge the recorded findings are
+        invisible to every sweep reader downstream.
+
+        This is era-agnostic: the gates are the generic-dev seam and the field's
+        presence, never the skill name resolved on disk. A pre-#2640 spec simply
+        takes the no-op path. The spec must also be at the current dev success
+        status, matching the append-on-success behavior of the former writer.
+
+        Replays are idempotent even after an entry is closed. ``append_entry``
+        intentionally dedupes open entries only, so the pre-scan checks the
+        fingerprinted ``origin:`` plus ``source_spec:`` across entries of every
+        status. The spec frontmatter is never mutated; the ledger watermark is
+        sufficient and avoids unsafe YAML block-scalar surgery.
+
+        Ledger writes are unguarded by design: observation may degrade, but a
+        failed repair write must raise rather than silently drop recorded work.
+        Phase 6K will pair this with rollback snapshot/restore; until then a
+        harvested entry can survive a rolled-back attempt.
+        """
+        if not self._generic_dev():
+            return
+        spec_file = (result_json or {}).get("spec_file")
+        if not spec_file:
+            return
+        spec_path = verify.resolve_spec_path(str(spec_file), self.workspace.paths)
+        if not spec_path.is_file():
+            return
+        fm = self._observed_frontmatter(spec_path, task.story_key, "spec-deferrals")
+        if fm is None or devcontract.DEFERRED_FIELD not in fm:
+            return
+        success_status = "in-review" if self._dev_review_enabled() else "done"
+        if verify.status_of(fm) != success_status:
+            return
+        findings, malformed = devcontract.parse_deferred_findings(fm)
+        if not findings and not malformed:
+            return
+
+        spec_name = spec_path.name
+        # (origin, title, reason, location, severity), one row per entry this
+        # harvest may file. The malformed loss is aggregated per spec so a bad
+        # sibling never suppresses a valid finding and never disappears silently.
+        pending: list[tuple[str, str, str, str | None, str | None]] = [
+            (
+                f"{HARVEST_ORIGIN} {finding.fingerprint}",
+                finding.summary,
+                finding.evidence or finding.summary,
+                finding.location or None,
+                finding.severity or None,
+            )
+            for finding in findings
+        ]
+        if malformed:
+            self.journal.append(
+                "spec-deferrals-malformed",
+                story_key=task.story_key,
+                spec=spec_name,
+                items=malformed,
+            )
+            pending.append(
+                (
+                    f"{HARVEST_ORIGIN}-malformed "
+                    f"{devcontract.harvest_fingerprint(spec_name, *malformed)}",
+                    f"Unreadable `deferred:` items in {spec_name}",
+                    "The dev session recorded deferred findings the orchestrator could not "
+                    "parse, so they were NOT filed as entries: "
+                    + "; ".join(malformed)
+                    + f". Read `{spec_name}`'s frontmatter and re-file them by hand.",
+                    None,
+                    "low",
+                )
+            )
+
+        # Persist the full intended set, not only newly-filed rows. A replay can
+        # dedupe every append while a later isolation carry still needs the data.
+        # Assignment (rather than append) also keeps the dev→review double call
+        # from duplicating the dev-leg rows in state.json.
+        task.harvested_deferrals = [
+            {
+                "origin": origin,
+                "title": title,
+                "reason": reason,
+                "location": location,
+                "severity": severity,
+                "source_spec": spec_name,
+            }
+            for origin, title, reason, location, severity in pending
+        ]
+
+        ledger = self.workspace.paths.deferred_work
+        text = ledger.read_text(encoding="utf-8") if ledger.is_file() else ""
+        seen = deferredwork.parse_ledger(text)
+        filed: list[str] = []
+        deduped = 0
+        for origin, title, reason, location, severity in pending:
+            if any(
+                deferredwork.field_line_present(entry.body, "origin", origin)
+                and deferredwork.field_line_present(entry.body, "source_spec", spec_name)
+                for entry in seen
+            ):
+                deduped += 1
+                continue
+            # Persist the provenance before the write. A hard host loss after
+            # append but before the later dev-decision save leaves the ledger on
+            # disk; replay then dedupes and cannot reconstruct authorship from a
+            # newly-filed id. Pre-latching is conservative if the append itself
+            # fails: excluding an unchanged path cannot create proof of work.
+            if not task.harvest_wrote_ledger:
+                task.harvest_wrote_ledger = True
+                self._save()
+            dw_id = deferredwork.append_entry(
+                ledger,
+                title=title,
+                origin=origin,
+                location=location or "n/a",
+                source_spec=spec_name,
+                reason=reason,
+                severity=severity,
+            )
+            # The writer's open-entry guard can catch two frontmatter items with
+            # the same clamped fingerprint inside this one pre-scan snapshot.
+            if dw_id is None:
+                deduped += 1
+            else:
+                filed.append(dw_id)
+        # The flag is set-only within an attempt and was latched durably before
+        # the first append. A crash replay dedupes to an empty `filed` list while
+        # the dead attempt's engine-authored ledger diff is still on disk, so it
+        # must never be cleared from the return values here.
+        self.journal.append(
+            "spec-deferrals-harvested",
+            story_key=task.story_key,
+            spec=spec_name,
+            dw_ids=filed,
+            deduped=deduped,
+            malformed=len(malformed),
+        )
+
     def _manifest_closes_deferred(self, task: StoryTask) -> tuple[str, ...]:
         """Deferred-work ids declared for this story by a *manifest* the
         orchestrator reads, as opposed to the story spec's own frontmatter.
@@ -2657,6 +2842,43 @@ class Engine:
         unit is merged before the run stops."""
         return
 
+    def _ledger_digest(self) -> str:
+        """Digest the current ledger text for proof-of-work attribution.
+
+        An absent ledger and an empty one intentionally hash alike: neither
+        carries an entry, and this comparison never restores or unlinks the file.
+        Reads stay fail-loud because guessing either equality answer can misjudge
+        the session's work.
+        """
+        ledger = self.workspace.paths.deferred_work
+        text = ledger.read_text(encoding="utf-8") if ledger.is_file() else ""
+        return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+    def _harvest_gate_exclude(self, task: StoryTask) -> tuple[str, ...]:
+        """Exclude only this attempt's engine-authored ledger append from proof of work.
+
+        ``_harvest_spec_deferrals`` runs above the artifact gate. Without this
+        exclusion a session that wrote no code can pass because the orchestrator
+        itself changed the ledger. The persisted flag survives crash replay, when
+        the repeated harvest dedupes and reports no newly-filed ids.
+
+        The exclusion is path-granular, so it stands down when the ledger had
+        already changed from the current attribution reference before harvesting. That preserves
+        a session-authored ledger-only change as valid work even when the same
+        attempt also records a frontmatter deferral. Standing down exposes more
+        of the tree to the gate, which is the conservative direction.
+        """
+        if not task.harvest_wrote_ledger or task.ledger_changed_before_harvest:
+            return ()
+        paths = self.workspace.paths
+        try:
+            rel = paths.deferred_work.resolve().relative_to(paths.project.resolve())
+        except ValueError:
+            # The proof-of-work gate only sees the project tree, so an external
+            # ledger cannot satisfy it and needs no exclusion.
+            return ()
+        return (rel.as_posix(),)
+
     def _verify_dev_artifacts(self, task: StoryTask, result_json: dict | None):
         return verify.verify_dev(
             task,
@@ -2664,6 +2886,7 @@ class Engine:
             result_json,
             review_enabled=self._dev_review_enabled(),
             operator_park=self._operator_park_enabled(),
+            engine_written=self._harvest_gate_exclude(task),
         )
 
     def _verify_review(self, task: StoryTask):
@@ -2686,14 +2909,17 @@ class Engine:
         # separate review skill. task.spec_file is set by verify_dev on success.
         # The ledger instruction is the prevention side of the reclose in
         # SweepEngine._verify_review: a review that rewrites deferred-work.md
-        # from a stale snapshot clobbers orchestrator-recorded closures. The
-        # ledger is append-only for sessions — new findings are fine, existing
-        # entries are orchestrator-owned.
+        # from a stale snapshot clobbers orchestrator-recorded closures.
+        # Existing entries are orchestrator-owned; new ones are simply not asked
+        # for. Post-BMAD-METHOD#2640 the primitive records its own `defer`
+        # findings in the spec frontmatter and `_harvest_spec_deferrals` files
+        # them. An affirmative append instruction would therefore file each
+        # finding twice. Keep this neutral for pre-#2640 skills, whose flat append
+        # may still be the only record.
         return (
-            f"/{self._dev_skill('review')} {task.spec_file} — If this review defers new "
-            f"findings, append them to the deferred-work ledger as NEW entries "
-            f"only; do NOT modify, re-open, or rewrite existing ledger entries — "
-            f"the orchestrator owns their status and resolution."
+            f"/{self._dev_skill('review')} {task.spec_file} — do NOT modify, "
+            f"re-open, or rewrite existing deferred-work ledger entries; the "
+            f"orchestrator owns their status and resolution."
         )
 
     def _render_commit_template(self, task: StoryTask) -> str | None:

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -2546,11 +2546,11 @@ class Engine:
         status. The spec frontmatter is never mutated; the ledger watermark is
         sufficient and avoids unsafe YAML block-scalar surgery.
 
-        Reading the finding source is part of this required repair. A transient
-        read failure returns a retry outcome rather than degrading like optional
-        bookkeeping observation: a later verify read must not accept the session
-        while silently dropping its recorded work. Ledger writes remain unguarded
-        so a failed repair write raises.
+        Reading the finding source is part of this required repair. A transiently
+        missing or unreadable source returns a retry outcome rather than degrading
+        like optional bookkeeping observation: a later verify read must not accept
+        the session while silently dropping its recorded work. Ledger writes remain
+        unguarded so a failed repair write raises.
         """
         if not self._generic_dev():
             return
@@ -2558,8 +2558,6 @@ class Engine:
         if not spec_file:
             return
         spec_path = verify.resolve_spec_path(str(spec_file), self.workspace.paths)
-        if not spec_path.is_file():
-            return
         # A session supplies `spec_file`; like reconcile, marker repair, and
         # declared closes, harvesting must not let an arbitrary readable path
         # outside the orchestrator-owned roots steer a ledger write.
@@ -2576,6 +2574,16 @@ class Engine:
                 spec=str(spec_path),
             )
             return
+        try:
+            is_file = spec_path.is_file()
+        except OSError as e:
+            self._journal_spec_read_failed(spec_path, task.story_key, "spec-deferrals", e)
+            return VerifyOutcome.retry(
+                "spec unreadable while harvesting deferrals "
+                f"({e.__class__.__name__}: {e}): {spec_path}"
+            )
+        if not is_file:
+            return VerifyOutcome.retry(f"spec missing while harvesting deferrals: {spec_path}")
         try:
             fm = verify.read_frontmatter(spec_path)
         except OSError as e:

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -819,14 +819,31 @@ class Engine:
 
     def _replay_unlatched_ledger_carries(self) -> None:
         """Replay a successful isolated unit's carry after merge-time host loss."""
+        merged_units = {
+            (
+                str(entry.get("story_key", "")),
+                str(entry.get("branch", "")),
+                str(entry.get("target", "")),
+            )
+            for entry in self.journal.entries()
+            if entry.get("kind") == "unit-merged"
+        }
         for task in list(self.state.tasks.values()):
+            if (
+                task.phase == Phase.DEFERRED
+                and task.worktree_path
+                and task.harvest_carry_commit_pending
+            ):
+                self.journal.append("resume-ledger-carry", story_key=task.story_key)
+                self._carry_isolated_ledger_writes(task)
+                continue
             if task.isolated_ledger_carried or task.phase not in (
                 Phase.DONE,
                 Phase.AWAITING_OPERATOR,
             ):
                 continue
-            wt = task.worktree_path
-            if not wt or Path(wt).is_dir():
+            merged_key = (task.story_key, task.branch, self.state.target_branch)
+            if not task.worktree_path or merged_key not in merged_units:
                 continue
             if not task.harvested_deferrals:
                 continue
@@ -834,6 +851,9 @@ class Engine:
             self._carry_isolated_ledger_writes(task)
             task.isolated_ledger_carried = True
             self._save()
+            # The failed integration unwound before _run_story returned, so the
+            # loop never reached its normal post-integration continuation.
+            self._after_story(task)
 
     def _finish_inflight(self) -> None:
         """Complete or roll back tasks interrupted by a pause or crash."""
@@ -2590,9 +2610,10 @@ class Engine:
 
         # Persist the full intended set, not only newly-filed rows. A replay can
         # dedupe every append while a later isolation carry still needs the data.
-        # Assignment (rather than append) also keeps the dev→review double call
-        # from duplicating the dev-leg rows in state.json.
-        task.harvested_deferrals = [
+        # Keep a stable union across a retained retry/review chain: a later pass
+        # may replace the frontmatter list, but every earlier accepted finding is
+        # still present in an ignored unit ledger and must survive final carry.
+        current_records = [
             {
                 "origin": origin,
                 "title": title,
@@ -2603,6 +2624,15 @@ class Engine:
             }
             for origin, title, reason, location, severity in pending
         ]
+        known = {
+            (str(item.get("origin", "")), str(item.get("source_spec", "")))
+            for item in task.harvested_deferrals
+        }
+        for record in current_records:
+            key = (str(record["origin"]), str(record["source_spec"]))
+            if key not in known:
+                task.harvested_deferrals.append(record)
+                known.add(key)
 
         ledger = self.workspace.paths.deferred_work
         text = ledger.read_text(encoding="utf-8") if ledger.is_file() else ""
@@ -3914,16 +3944,20 @@ class Engine:
 
     def _defer(self, task: StoryTask, reason: str) -> None:
         task.defer_reason = reason
-        advance(task, Phase.DEFERRED)
         if self._isolated:
             # the failed work lives in the unit's worktree; the diff is captured
             # and the worktree kept/dropped by _integrate_unit. Don't touch the
             # tree here (no reset into the main repo — there's nothing to undo).
             # Harvested findings are the exception: re-file them into the main
-            # checkout before the terminal save makes this defer durable.
+            # checkout before the terminal save makes this defer durable. Keep
+            # the pre-terminal phase until that repair write succeeds: if its git
+            # commit fails, ordinary inflight recovery must re-enter this decision
+            # and then finish defer recording + unit teardown/integration.
             self._carry_harvested_deferrals(task)
+            advance(task, Phase.DEFERRED)
             self._record_defer(task, reason)
             return
+        advance(task, Phase.DEFERRED)
         if task.baseline_commit:
             self._stash_deferred_artifacts(task)
             deferred_work = self.workspace.paths.deferred_work
@@ -3964,6 +3998,17 @@ class Engine:
         """Apply Engine-owned ledger writes that an isolated merge may omit."""
         self._carry_harvested_deferrals(task)
 
+    def _harvest_carry_commit_may_degrade(self, ledger: Path) -> bool:
+        """Whether a carry may remain uncommitted because git cannot own its path."""
+        repo = self.paths.repo_root
+        try:
+            rel = ledger.resolve().relative_to(repo.resolve()).as_posix()
+        except (OSError, RuntimeError, ValueError):
+            return True  # external or unresolvable ledgers are advisory artifacts
+        if verify.path_tracked(repo, rel):
+            return False
+        return rel not in verify.untracked_files(repo)
+
     def _carry_harvested_deferrals(self, task: StoryTask) -> None:
         """Re-file an isolated unit's harvested findings into the main ledger."""
         if not task.harvested_deferrals:
@@ -3981,6 +4026,15 @@ class Engine:
                 for entry in seen
             ):
                 continue
+            # Persist the commit obligation before the filesystem write. A host
+            # loss after append_entry writes the row but before it returns must
+            # still make replay commit the now-deduplicated tracked/untracked row.
+            # Latch only once a novel provenance is known: when every row already
+            # arrived through the merge, committing here could sweep unrelated
+            # operator edits to the same ledger into the carry commit.
+            if not task.harvest_carry_commit_pending:
+                task.harvest_carry_commit_pending = True
+                self._save()
             location = item.get("location")
             severity = item.get("severity")
             dw_id = deferredwork.append_entry(
@@ -3996,7 +4050,12 @@ class Engine:
                 carried.append(dw_id)
                 # Keep the same-call dedupe status-agnostic too.
                 seen = deferredwork.parse_ledger(ledger.read_text(encoding="utf-8"))
-        if carried:
+        commit_needed = bool(carried) or task.harvest_carry_commit_pending
+        if commit_needed:
+            # The pre-append latch also covers every git observation/write below.
+            # A failed add/status/commit can leave the row staged or dirty; replay
+            # must retry even when the provenance scan dedupes it to `carried == []`.
+            may_degrade = self._harvest_carry_commit_may_degrade(ledger)
             try:
                 verify.commit_paths(
                     self.paths.repo_root,
@@ -4004,12 +4063,16 @@ class Engine:
                     [ledger],
                 )
             except verify.GitError as e:
+                if not may_degrade:
+                    raise
                 self.journal.append(
                     "harvest-carry-uncommitted",
                     story_key=task.story_key,
                     dw_ids=carried,
                     error=str(e),
                 )
+            task.harvest_carry_commit_pending = False
+            self._save()
         self.journal.append("harvest-carried", story_key=task.story_key, dw_ids=carried)
 
     def _stash_deferred_artifacts(self, task: StoryTask) -> None:

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -2441,6 +2441,22 @@ class Engine:
         spec_path = verify.resolve_spec_path(str(spec_file), self.workspace.paths)
         if not spec_path.is_file():
             return
+        # A session supplies `spec_file`; like reconcile, marker repair, and
+        # declared closes, harvesting must not let an arbitrary readable path
+        # outside the orchestrator-owned roots steer a ledger write.
+        try:
+            within = verify.spec_within_roots(spec_path, self.workspace.paths)
+        except (OSError, RuntimeError):
+            # resolve() faulted (a symlink loop, an unreadable component):
+            # containment can vouch for nothing, so refuse the same way.
+            within = False
+        if not within:
+            self.journal.append(
+                "spec-deferrals-skipped-out-of-tree",
+                story_key=task.story_key,
+                spec=str(spec_path),
+            )
+            return
         fm = self._observed_frontmatter(spec_path, task.story_key, "spec-deferrals")
         if fm is None or devcontract.DEFERRED_FIELD not in fm:
             return
@@ -2877,6 +2893,14 @@ class Engine:
             # The proof-of-work gate only sees the project tree, so an external
             # ledger cannot satisfy it and needs no exclusion.
             return ()
+        except (OSError, RuntimeError):
+            # ProjectPaths are normalized when loaded. If filesystem resolution
+            # nevertheless faults, keep a lexically in-project ledger excluded:
+            # uncertainty must not turn the engine's append into session proof.
+            try:
+                rel = paths.deferred_work.relative_to(paths.project)
+            except ValueError:
+                return ()
         return (rel.as_posix(),)
 
     def _verify_dev_artifacts(self, task: StoryTask, result_json: dict | None):

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -2626,6 +2626,25 @@ class Engine:
                 "spec unreadable while harvesting deferrals "
                 f"({e.__class__.__name__}: {e}): {spec_path}"
             )
+        # The shared observation reader deliberately collapses a second missing-
+        # file probe, invalid UTF-8, malformed YAML, and a non-mapping document to
+        # `{}`. That is safe for status observation, whose verifier re-reads and
+        # retries, but not for this required repair input: a later clean verifier
+        # read could otherwise accept the session after the harvest silently
+        # skipped every recorded finding. A successful spec always has at least a
+        # status mapping, so this does not reject the valid pre-`deferred:` era.
+        if not fm:
+            self.journal.append(
+                "spec-read-failed",
+                story_key=task.story_key,
+                spec=str(spec_path),
+                site="spec-deferrals",
+                error="empty or invalid frontmatter",
+            )
+            return VerifyOutcome.retry(
+                "spec unreadable while harvesting deferrals "
+                f"(empty or invalid frontmatter): {spec_path}"
+            )
         if devcontract.DEFERRED_FIELD not in fm:
             return
         status = verify.status_of(fm)
@@ -3551,6 +3570,24 @@ class Engine:
             session_status=result.status,  # pyright: ignore[reportOptionalMemberAccess]
             result_json=result.result_json,  # pyright: ignore[reportOptionalMemberAccess]
         )
+        # A post-session hook may be the session's last writer. The completed
+        # result was checkpointed before hooks so it is replayable, but a retained
+        # retry can already carry `harvest_wrote_ledger=True`; replay then
+        # deliberately preserves the saved attribution instead of comparing an
+        # engine-modified ledger again. Close that crash window immediately after
+        # hooks finish. Save only when the comparison changed, keeping the
+        # zero-plugin/no-ledger-change path free of a redundant state rewrite.
+        if (
+            resumable
+            and role == "dev"
+            and result.status == "completed"  # pyright: ignore[reportOptionalMemberAccess]
+            and result.result_json is not None  # pyright: ignore[reportOptionalMemberAccess]
+            and task.baseline_ledger_digest is not None
+        ):
+            ledger_changed = self._ledger_digest() != task.baseline_ledger_digest
+            if ledger_changed != task.ledger_changed_before_harvest:
+                task.ledger_changed_before_harvest = ledger_changed
+                self._save()
         return result  # pyright: ignore[reportReturnType]
 
     def _note_story_token_budget(self, task: StoryTask) -> None:

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -71,6 +71,11 @@ if TYPE_CHECKING:
 HARVEST_ORIGIN = "spec-deferred"
 
 
+def _digest_of(text: str | None) -> str:
+    """Hash ledger text for attribution; absent and empty are equivalent."""
+    return hashlib.sha256((text or "").encode("utf-8")).hexdigest()
+
+
 class RunPaused(Exception):
     def __init__(self, reason: str, stage: str, story_key: str | None = None):
         super().__init__(reason)
@@ -304,6 +309,7 @@ class Engine:
             emit=lambda *a, **k: self._emit(*a, **k),
             save=self._save,
             gate_unit=self._gate_unit,
+            carry_isolated_ledger_writes=lambda task: self._carry_isolated_ledger_writes(task),
             escalation_pause=self._escalation_pause,
             workspace_get=lambda: self.workspace,
             workspace_set=lambda ws: setattr(self, "workspace", ws),
@@ -390,6 +396,7 @@ class Engine:
                 self._emit_run_boundary("pre_run")
                 self._ensure_target_branch()
                 self._prune_preserve_refs()
+                self._replay_unlatched_ledger_carries()
                 self._loop()
                 self.state.finished = True
                 self._gc_run_worktrees()
@@ -810,6 +817,24 @@ class Engine:
             snapshot_failed=snapshot_failed,
         )
 
+    def _replay_unlatched_ledger_carries(self) -> None:
+        """Replay a successful isolated unit's carry after merge-time host loss."""
+        for task in list(self.state.tasks.values()):
+            if task.isolated_ledger_carried or task.phase not in (
+                Phase.DONE,
+                Phase.AWAITING_OPERATOR,
+            ):
+                continue
+            wt = task.worktree_path
+            if not wt or Path(wt).is_dir():
+                continue
+            if not task.harvested_deferrals:
+                continue
+            self.journal.append("resume-ledger-carry", story_key=task.story_key)
+            self._carry_isolated_ledger_writes(task)
+            task.isolated_ledger_carried = True
+            self._save()
+
     def _finish_inflight(self) -> None:
         """Complete or roll back tasks interrupted by a pause or crash."""
         for task in list(self.state.tasks.values()):
@@ -1183,6 +1208,10 @@ class Engine:
         self._review_and_commit(task)
 
     def _dev_phase(self, task: StoryTask, resume_result: SessionResult | None = None) -> bool:
+        if resume_result is None:
+            # A fresh invocation cannot consume a snapshot armed by an earlier,
+            # non-replayable invocation. Keep crash replay's snapshot intact.
+            self._disarm_ledger_snapshot(task)
         if self._vetoed(self._emit("pre_dev_phase", task), task):
             return False
         if resume_result is None:
@@ -1199,11 +1228,6 @@ class Engine:
             # never hidden along with the orchestrator's own append. A fixable
             # retry rebases it onto the tree that retry deliberately keeps.
             task.baseline_ledger_digest = self._ledger_digest()
-            # A new phase invocation owns no prior harvest. Retries stay inside
-            # this invocation and preserve the flag while their ledger writes
-            # remain on disk; a crash replay enters with `resume_result` and must
-            # preserve the dead attempt's persisted authorship too.
-            task.harvest_wrote_ledger = False
         feedback: Path | None = None
         while True:
             replayed = resume_result is not None
@@ -1213,6 +1237,12 @@ class Engine:
                 # advance; a second host death then still finds the record and
                 # re-enters this continuation instead of falling back to restart.
                 task.attempt += 1
+                # A genuinely new attempt starts from a rolled-back tree and owes
+                # nothing to the rejected attempt's harvest. A fixable retry keeps
+                # that tree and ledger intentionally, so preserve its payload for a
+                # later isolated carry. Crash replay never enters this branch.
+                if feedback is None:
+                    task.harvested_deferrals = []
             advance(task, Phase.DEV_RUNNING)
             self._save()
             if resume_result is not None:
@@ -1241,20 +1271,31 @@ class Engine:
             outcome = None
             if result.status == "completed":
                 # Everything below this point that appends to the ledger is the
-                # orchestrator, not the session. Retry-chain provenance carries
-                # across both a fixable retry's kept tree and, until Phase 6K, a
-                # non-fixable retry's protected ledger. Preserve it on a crash
-                # replay too: the replayed harvest dedupes against the dead
-                # attempt's on-disk append.
+                # orchestrator, not the session. Preserve attribution on crash
+                # replay: the replayed harvest dedupes against the dead attempt's
+                # on-disk append.
                 # Before the first harvest write, a replay can still reconstruct
                 # session authorship from the persisted baseline digest. Once an
                 # engine write is latched, the current ledger includes that write
                 # and replay must preserve the attribution saved before harvest.
+                if not replayed and feedback is None:
+                    task.harvest_wrote_ledger = False
                 if not replayed or not task.harvest_wrote_ledger:
                     if task.baseline_ledger_digest is not None:
                         task.ledger_changed_before_harvest = (
                             self._ledger_digest() != task.baseline_ledger_digest
                         )
+                    self._save()
+                # Snapshot after the session has finished, preserving any ledger
+                # edits it authored, and before reconcile/state-sync/harvest can
+                # write on the engine's behalf. Keep the chain's first snapshot
+                # across fixable retries because a later non-fixable reset returns
+                # all the way to the phase baseline. An unarmed replay may safely
+                # arm from disk; an armed replay must retain the dead attempt's
+                # pre-harvest bytes.
+                if (not replayed and feedback is None) or not task.pre_harvest_ledger_captured:
+                    task.pre_harvest_ledger = self._ledger_text()
+                    task.pre_harvest_ledger_captured = True
                     self._save()
                 # bmad-dev-auto sometimes finalizes the spec in prose (## Auto Run
                 # Result: Status done) but leaves the frontmatter status at the
@@ -1310,6 +1351,11 @@ class Engine:
             )
             self._save()
             if decision.action == Action.PROCEED:
+                # The attempt is accepted; no later path may restore its snapshot.
+                # Persist now because a crash can resume directly into review and
+                # never re-enter this method.
+                self._disarm_ledger_snapshot(task)
+                self._save()
                 self._emit("post_dev_phase", task)
                 if self._run_workflows("post_dev_phase", task, task.attempt):
                     return False
@@ -1326,13 +1372,35 @@ class Engine:
                     task.baseline_ledger_digest = self._ledger_digest()
                 else:
                     feedback = None
-                    self._rollback_or_pause(task)
-                    # The rollback resets code/spec bookkeeping but the artifact
-                    # shield preserves today's harvested ledger (Phase 6K will
-                    # restore it). Rebase onto that accounted-for engine state so
-                    # it cannot masquerade as the next session's ledger edit.
-                    task.baseline_ledger_digest = self._ledger_digest()
+                    paused = False
+                    try:
+                        self._rollback_or_pause(task)
+                    except RunPaused:
+                        paused = True
+                        raise
+                    finally:
+                        # Recovery resets code/spec state but protects artifact
+                        # directories, so an untracked or ignored harvest-created
+                        # ledger survives unless restored explicitly. Run this for
+                        # stop-and-wait too: the operator's eventual reset would not
+                        # remove such a file either.
+                        self._restore_persisted_ledger(task, replayed=replayed)
+                        # Rebase from the snapshot already in hand so a filesystem
+                        # fault cannot replace a RunPaused while unwinding.
+                        if task.pre_harvest_ledger_captured:
+                            task.baseline_ledger_digest = _digest_of(task.pre_harvest_ledger)
+                        if paused:
+                            # Do not carry the snapshot across a human-scale pause;
+                            # resume re-arms from the operator's then-current ledger.
+                            self._disarm_ledger_snapshot(task)
+                            self._save()
+                    # The completed rollback spent the chain snapshot. The next
+                    # genuinely new attempt will arm its own after its session.
+                    self._disarm_ledger_snapshot(task)
                 continue
+            # DEFER and escalation preserve their current tree/knowledge rather
+            # than rejecting the attempt, so neither may later consume this arm.
+            self._disarm_ledger_snapshot(task)
             if decision.action == Action.DEFER:
                 self._record_dev_spec(task, result.result_json)
                 self._defer(task, decision.reason)
@@ -2876,6 +2944,11 @@ class Engine:
         unit is merged before the run stops."""
         return
 
+    def _ledger_text(self) -> str | None:
+        """Return the active workspace ledger text, preserving absence."""
+        ledger = self.workspace.paths.deferred_work
+        return ledger.read_text(encoding="utf-8") if ledger.is_file() else None
+
     def _ledger_digest(self) -> str:
         """Digest the current ledger text for proof-of-work attribution.
 
@@ -2884,9 +2957,70 @@ class Engine:
         Reads stay fail-loud because guessing either equality answer can misjudge
         the session's work.
         """
+        return _digest_of(self._ledger_text())
+
+    def _ledger_is_gits_to_restore(self, task: StoryTask) -> bool:
+        """Whether git owns the active ledger and reset is responsible for it.
+
+        Probe failures degrade toward keeping the file: uncertainty must never
+        authorize deleting a tracked ledger that ``reset --hard`` restored.
+        """
         ledger = self.workspace.paths.deferred_work
-        text = ledger.read_text(encoding="utf-8") if ledger.is_file() else ""
-        return hashlib.sha256(text.encode("utf-8")).hexdigest()
+        root = self.workspace.root
+        try:
+            rel = ledger.relative_to(root).as_posix()
+        except ValueError:
+            try:
+                rel = ledger.resolve().relative_to(root.resolve()).as_posix()
+            except (OSError, RuntimeError) as e:
+                self.journal.append(
+                    "ledger-scope-probe-failed",
+                    story_key=task.story_key,
+                    error=str(e),
+                )
+                return True
+            except ValueError:
+                # An external ledger was outside the reset's reach. A None
+                # snapshot means this harvest created it, so it remains ours to
+                # unlink.
+                return False
+        try:
+            return verify.path_tracked(root, rel)
+        except (verify.GitError, OSError, RuntimeError) as e:
+            self.journal.append(
+                "ledger-tracked-probe-failed",
+                story_key=task.story_key,
+                error=str(e),
+            )
+            return True
+
+    def _restore_ledger(self, task: StoryTask, snapshot: str | None) -> None:
+        """Restore the active ledger to a pre-harvest filesystem snapshot."""
+        ledger = self.workspace.paths.deferred_work
+        if self._ledger_text() == snapshot:
+            return
+        if snapshot is None:
+            # The harvest created an untracked/ignored ledger. A tracked ledger
+            # absent at snapshot time is different: reset restored its committed
+            # bytes, which must never be deleted here.
+            if not self._ledger_is_gits_to_restore(task):
+                ledger.unlink(missing_ok=True)
+            return
+        ledger.parent.mkdir(parents=True, exist_ok=True)
+        ledger.write_text(snapshot, encoding="utf-8")
+
+    def _restore_persisted_ledger(self, task: StoryTask, *, replayed: bool) -> None:
+        """Restore the snapshot durably armed before this attempt's engine writes."""
+        if not task.pre_harvest_ledger_captured:
+            if replayed:
+                self.journal.append("ledger-snapshot-missing", story_key=task.story_key)
+            return
+        self._restore_ledger(task, task.pre_harvest_ledger)
+
+    def _disarm_ledger_snapshot(self, task: StoryTask) -> None:
+        """Drop the chain-scoped pre-harvest ledger snapshot."""
+        task.pre_harvest_ledger = None
+        task.pre_harvest_ledger_captured = False
 
     def _harvest_gate_exclude(self, task: StoryTask) -> tuple[str, ...]:
         """Exclude only this attempt's engine-authored ledger append from proof of work.
@@ -3785,6 +3919,9 @@ class Engine:
             # the failed work lives in the unit's worktree; the diff is captured
             # and the worktree kept/dropped by _integrate_unit. Don't touch the
             # tree here (no reset into the main repo — there's nothing to undo).
+            # Harvested findings are the exception: re-file them into the main
+            # checkout before the terminal save makes this defer durable.
+            self._carry_harvested_deferrals(task)
             self._record_defer(task, reason)
             return
         if task.baseline_commit:
@@ -3822,6 +3959,58 @@ class Engine:
                     deferred_work.parent.mkdir(parents=True, exist_ok=True)
                     deferred_work.write_text(snapshot, encoding="utf-8")
         self._record_defer(task, reason)
+
+    def _carry_isolated_ledger_writes(self, task: StoryTask) -> None:
+        """Apply Engine-owned ledger writes that an isolated merge may omit."""
+        self._carry_harvested_deferrals(task)
+
+    def _carry_harvested_deferrals(self, task: StoryTask) -> None:
+        """Re-file an isolated unit's harvested findings into the main ledger."""
+        if not task.harvested_deferrals:
+            return
+        ledger = self.paths.deferred_work
+        text = ledger.read_text(encoding="utf-8") if ledger.is_file() else ""
+        seen = deferredwork.parse_ledger(text)
+        carried: list[str] = []
+        for item in task.harvested_deferrals:
+            origin = str(item["origin"])
+            source_spec = str(item["source_spec"])
+            if any(
+                deferredwork.field_line_present(entry.body, "origin", origin)
+                and deferredwork.field_line_present(entry.body, "source_spec", source_spec)
+                for entry in seen
+            ):
+                continue
+            location = item.get("location")
+            severity = item.get("severity")
+            dw_id = deferredwork.append_entry(
+                ledger,
+                title=str(item["title"]),
+                origin=origin,
+                location=str(location) if location else "n/a",
+                source_spec=source_spec,
+                reason=str(item["reason"]),
+                severity=str(severity) if severity else None,
+            )
+            if dw_id:
+                carried.append(dw_id)
+                # Keep the same-call dedupe status-agnostic too.
+                seen = deferredwork.parse_ledger(ledger.read_text(encoding="utf-8"))
+        if carried:
+            try:
+                verify.commit_paths(
+                    self.paths.repo_root,
+                    f"chore(deferred-work): carry harvested findings from {task.story_key}",
+                    [ledger],
+                )
+            except verify.GitError as e:
+                self.journal.append(
+                    "harvest-carry-uncommitted",
+                    story_key=task.story_key,
+                    dw_ids=carried,
+                    error=str(e),
+                )
+        self.journal.append("harvest-carried", story_key=task.story_key, dw_ids=carried)
 
     def _stash_deferred_artifacts(self, task: StoryTask) -> None:
         """Move the deferred story's spec out of the artifacts dir into the run

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -632,8 +632,20 @@ class Engine:
     def _integrate_unit(self, task: StoryTask, unit: UnitWorkspace) -> None:
         self._worktree_flow.integrate_unit(task, unit)
 
-    def _merge_local(self, task: StoryTask, unit: UnitWorkspace, *, replay: bool = False) -> None:
-        self._worktree_flow.merge_local(task, unit, replay=replay)
+    def _merge_local(
+        self,
+        task: StoryTask,
+        unit: UnitWorkspace,
+        *,
+        replay: bool = False,
+        replay_strategy: str | None = None,
+    ) -> None:
+        self._worktree_flow.merge_local(
+            task,
+            unit,
+            replay=replay,
+            replay_strategy=replay_strategy,
+        )
 
     def _keep_branch_and_escalate(self, task: StoryTask, unit: UnitWorkspace, reason: str) -> None:
         self._worktree_flow.keep_branch_and_escalate(task, unit, reason)
@@ -841,9 +853,8 @@ class Engine:
                 str(entry.get("story_key", "")),
                 str(entry.get("branch", "")),
                 str(entry.get("target", "")),
-                str(entry.get("strategy", "")),
                 str(entry.get("source", "")),
-            )
+            ): str(entry.get("strategy", ""))
             for entry in entries
             if entry.get("kind") == "unit-merge-started"
         }
@@ -866,12 +877,9 @@ class Engine:
                 continue
             if merged_key not in merged_units:
                 source = task.commit_sha or ""
-                started_key = (
-                    *merged_key,
-                    self.policy.scm.merge_strategy,
-                    source,
-                )
-                if not source or started_key not in started_units:
+                started_key = (*merged_key, source)
+                replay_strategy = started_units.get(started_key)
+                if not source or replay_strategy is None:
                     continue
                 # The write-ahead record is intent, never merge proof. Re-run the
                 # exact merge and latch completion only after git confirms it;
@@ -882,11 +890,16 @@ class Engine:
                     story_key=task.story_key,
                     branch=task.branch,
                     target=self.state.target_branch,
-                    strategy=self.policy.scm.merge_strategy,
+                    strategy=replay_strategy,
                     source=source,
                 )
                 unit = self._reopen_unit(task)
-                self._merge_local(task, unit, replay=True)
+                self._merge_local(
+                    task,
+                    unit,
+                    replay=True,
+                    replay_strategy=replay_strategy,
+                )
                 merged_units.add(merged_key)
             self.journal.append("resume-ledger-carry", story_key=task.story_key)
             self._carry_isolated_ledger_writes(task)

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -915,7 +915,23 @@ class Engine:
             if task.terminal:
                 continue
             isolated = self._isolated and task.worktree_path
-            if task.phase == Phase.DEV_VERIFY and task.spec_file:
+            if isolated and task.defer_reason is not None:
+                # _defer records its reason before carrying harvested findings.
+                # A read/commit fault (or host loss before the terminal advance)
+                # can therefore leave a rejected result in the same DEV_VERIFY +
+                # spec_file shape as a verified spec-approval pause. A persisted
+                # defer reason on a nonterminal isolated task is that interrupted
+                # decision's intent; finish it before any session-replay arm.
+                self.journal.append("resume-defer", story_key=task.story_key)
+                unit = self._reopen_unit(task)
+                prev = self.workspace
+                self.workspace = unit.workspace
+                try:
+                    self._defer(task, task.defer_reason)
+                finally:
+                    self.workspace = prev
+                self._integrate_unit(task, unit)
+            elif task.phase == Phase.DEV_VERIFY and task.spec_file:
                 # paused at the spec-approval gate (or, in stories mode, a
                 # plan-checkpoint awaiting implementation — _resume_after_dev_verify
                 # dispatches the right leg): dev verified on disk.
@@ -1017,9 +1033,10 @@ class Engine:
         returns None and the caller falls through to resume-restart (#100: that
         restart used to discard a completed-``done`` attempt's commits).
 
-        DEV_VERIFY reaches this matcher only when ``task.spec_file`` is empty
-        (verify did not fully pass before the death): _finish_inflight checks
-        the spec-approval-gate arm first, so a DEV_VERIFY task WITH a verified
+        DEV_VERIFY reaches this matcher only when no persisted defer identifies
+        an interrupted decision and ``task.spec_file`` is empty (verify did not
+        fully pass before the death): _finish_inflight checks the defer-replay
+        and spec-approval-gate arms first, so a DEV_VERIFY task WITH a verified
         spec keeps its _resume_after_dev_verify recovery."""
         if task.phase in (Phase.DEV_RUNNING, Phase.DEV_VERIFY):
             role, seq = "dev", task.attempt

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -43,6 +43,7 @@ from .model import (
     RunState,
     SessionRecord,
     StoryTask,
+    VerifyOutcome,
 )
 from .platform_util import atomic_replace, atomic_write_text, retrying_unlink, safe_segment
 from .plugins import HookBus, HookContext, PluginRegistry
@@ -1331,7 +1332,7 @@ class Engine:
                 # ledger before the artifact gate so an accepted attempt carries
                 # them in its story commit. `_harvest_gate_exclude` keeps this
                 # engine-authored append from becoming proof of session work.
-                self._harvest_spec_deferrals(task, result.result_json)
+                harvest_outcome = self._harvest_spec_deferrals(task, result.result_json)
                 # carry the skill's follow-up-review recommendation (PR #2505)
                 # onto the task so _review_and_commit can gate the review loop.
                 # A present key is authoritative (folded from the frontmatter, or
@@ -1344,7 +1345,7 @@ class Engine:
                     task.followup_review_recommended = bool(rj["followup_review_recommended"])
                 else:
                     task.followup_review_recommended = self._followup_from_spec(task, rj)
-                outcome = self._verify_dev_artifacts(task, result.result_json)
+                outcome = harvest_outcome or self._verify_dev_artifacts(task, result.result_json)
                 if outcome.ok and self._run_verify_commands_after_dev(task, result.result_json):
                     # deterministic gates run here too: a broken build must not
                     # reach the (far more expensive) review loop
@@ -1605,7 +1606,18 @@ class Engine:
             # A follow-up review is another full dev-primitive pass and may add
             # findings to the same frontmatter list. Harvest after reconciliation
             # makes a prose-finalized pass visible; the dev-leg entries dedupe.
-            self._harvest_spec_deferrals(task, rj)
+            harvest_outcome = self._harvest_spec_deferrals(task, rj)
+            if harvest_outcome is not None:
+                self.journal.append(
+                    "review-verify-failed",
+                    story_key=task.story_key,
+                    reason=harvest_outcome.reason,
+                    env_fault=harvest_outcome.env_fault,
+                    contradiction=harvest_outcome.contradiction,
+                )
+                if not harvest_outcome.retryable:
+                    self._escalate(task, harvest_outcome.reason)
+                continue
             status = str(rj.get("status", "")).strip()
             last_status = status  # remember the last completed pass for the defer reason
             followup = bool(rj.get("followup_review_recommended", False))
@@ -1793,8 +1805,8 @@ class Engine:
         # A timed-out review can still have recorded new frontmatter findings.
         # Normalize first so the success-status gate sees `done`, then mirror the
         # normal review path before deterministic verification and commit.
-        self._harvest_spec_deferrals(task, {"spec_file": str(spec_path)})
-        outcome = self._verify_review(task)
+        harvest_outcome = self._harvest_spec_deferrals(task, {"spec_file": str(spec_path)})
+        outcome = harvest_outcome or self._verify_review(task)
         if not outcome.ok:
             self.journal.append(
                 "review-timeout-salvage-failed",
@@ -2513,7 +2525,9 @@ class Engine:
         target = "review" if review_enabled else "done"
         sprint_advance(self.workspace.paths.sprint_status, task.story_key, target)
 
-    def _harvest_spec_deferrals(self, task: StoryTask, result_json: dict | None) -> None:
+    def _harvest_spec_deferrals(
+        self, task: StoryTask, result_json: dict | None
+    ) -> VerifyOutcome | None:
         """Carry a successful dev primitive's ``deferred:`` findings into the ledger.
 
         BMAD-METHOD #2640 moved defer-triaged review findings from
@@ -2532,10 +2546,11 @@ class Engine:
         status. The spec frontmatter is never mutated; the ledger watermark is
         sufficient and avoids unsafe YAML block-scalar surgery.
 
-        Ledger writes are unguarded by design: observation may degrade, but a
-        failed repair write must raise rather than silently drop recorded work.
-        Phase 6K will pair this with rollback snapshot/restore; until then a
-        harvested entry can survive a rolled-back attempt.
+        Reading the finding source is part of this required repair. A transient
+        read failure returns a retry outcome rather than degrading like optional
+        bookkeeping observation: a later verify read must not accept the session
+        while silently dropping its recorded work. Ledger writes remain unguarded
+        so a failed repair write raises.
         """
         if not self._generic_dev():
             return
@@ -2561,8 +2576,15 @@ class Engine:
                 spec=str(spec_path),
             )
             return
-        fm = self._observed_frontmatter(spec_path, task.story_key, "spec-deferrals")
-        if fm is None or devcontract.DEFERRED_FIELD not in fm:
+        try:
+            fm = verify.read_frontmatter(spec_path)
+        except OSError as e:
+            self._journal_spec_read_failed(spec_path, task.story_key, "spec-deferrals", e)
+            return VerifyOutcome.retry(
+                "spec unreadable while harvesting deferrals "
+                f"({e.__class__.__name__}: {e}): {spec_path}"
+            )
+        if devcontract.DEFERRED_FIELD not in fm:
             return
         status = verify.status_of(fm)
         success_status = "in-review" if self._dev_review_enabled() else "done"

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -626,8 +626,8 @@ class Engine:
     def _integrate_unit(self, task: StoryTask, unit: UnitWorkspace) -> None:
         self._worktree_flow.integrate_unit(task, unit)
 
-    def _merge_local(self, task: StoryTask, unit: UnitWorkspace) -> None:
-        self._worktree_flow.merge_local(task, unit)
+    def _merge_local(self, task: StoryTask, unit: UnitWorkspace, *, replay: bool = False) -> None:
+        self._worktree_flow.merge_local(task, unit, replay=replay)
 
     def _keep_branch_and_escalate(self, task: StoryTask, unit: UnitWorkspace, reason: str) -> None:
         self._worktree_flow.keep_branch_and_escalate(task, unit, reason)
@@ -820,14 +820,26 @@ class Engine:
 
     def _replay_unlatched_ledger_carries(self) -> None:
         """Replay a successful isolated unit's carry after merge-time host loss."""
+        entries = self.journal.entries()
         merged_units = {
             (
                 str(entry.get("story_key", "")),
                 str(entry.get("branch", "")),
                 str(entry.get("target", "")),
             )
-            for entry in self.journal.entries()
+            for entry in entries
             if entry.get("kind") == "unit-merged"
+        }
+        started_units = {
+            (
+                str(entry.get("story_key", "")),
+                str(entry.get("branch", "")),
+                str(entry.get("target", "")),
+                str(entry.get("strategy", "")),
+                str(entry.get("source", "")),
+            )
+            for entry in entries
+            if entry.get("kind") == "unit-merge-started"
         }
         for task in list(self.state.tasks.values()):
             if (
@@ -844,10 +856,32 @@ class Engine:
             ):
                 continue
             merged_key = (task.story_key, task.branch, self.state.target_branch)
-            if not task.worktree_path or merged_key not in merged_units:
+            if not task.worktree_path or not task.harvested_deferrals:
                 continue
-            if not task.harvested_deferrals:
-                continue
+            if merged_key not in merged_units:
+                source = task.commit_sha or ""
+                started_key = (
+                    *merged_key,
+                    self.policy.scm.merge_strategy,
+                    source,
+                )
+                if not source or started_key not in started_units:
+                    continue
+                # The write-ahead record is intent, never merge proof. Re-run the
+                # exact merge and latch completion only after git confirms it;
+                # merge/ff are naturally idempotent, while squash enables its
+                # recovery-only clean-tree success arm.
+                self.journal.append(
+                    "resume-unit-merge",
+                    story_key=task.story_key,
+                    branch=task.branch,
+                    target=self.state.target_branch,
+                    strategy=self.policy.scm.merge_strategy,
+                    source=source,
+                )
+                unit = self._reopen_unit(task)
+                self._merge_local(task, unit, replay=True)
+                merged_units.add(merged_key)
             self.journal.append("resume-ledger-carry", story_key=task.story_key)
             self._carry_isolated_ledger_writes(task)
             task.isolated_ledger_carried = True
@@ -3067,7 +3101,7 @@ class Engine:
                 ledger.unlink(missing_ok=True)
             return
         ledger.parent.mkdir(parents=True, exist_ok=True)
-        ledger.write_text(snapshot, encoding="utf-8")
+        atomic_write_text(ledger, snapshot)
 
     def _restore_persisted_ledger(self, task: StoryTask, *, replayed: bool) -> None:
         """Restore the snapshot durably armed before this attempt's engine writes."""

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -1246,7 +1246,11 @@ class Engine:
                 # non-fixable retry's protected ledger. Preserve it on a crash
                 # replay too: the replayed harvest dedupes against the dead
                 # attempt's on-disk append.
-                if not replayed:
+                # Before the first harvest write, a replay can still reconstruct
+                # session authorship from the persisted baseline digest. Once an
+                # engine write is latched, the current ledger includes that write
+                # and replay must preserve the attribution saved before harvest.
+                if not replayed or not task.harvest_wrote_ledger:
                     if task.baseline_ledger_digest is not None:
                         task.ledger_changed_before_harvest = (
                             self._ledger_digest() != task.baseline_ledger_digest
@@ -3218,6 +3222,22 @@ class Engine:
             # returned rather than aliasing a later, half-mutated dict. Shallow is
             # enough — reconcile only touches top-level keys.
             resumable = label is None and role in ("dev", "review")
+            # Make a completed dev result and its proof-of-work attribution
+            # durable in the same state save. A host death after this save makes
+            # the result replayable, so leaving the comparison until _dev_phase
+            # resumes would lose attempt identity when a prior retry already
+            # latched harvest_wrote_ledger. The ordinary-path comparison remains
+            # after post_session so later hook-side changes are still observed.
+            if (
+                resumable
+                and role == "dev"
+                and result.status == "completed"
+                and result.result_json is not None
+                and task.baseline_ledger_digest is not None
+            ):
+                task.ledger_changed_before_harvest = (
+                    self._ledger_digest() != task.baseline_ledger_digest
+                )
             task.record_session(
                 SessionRecord(
                     task_id=task_id,

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -1199,6 +1199,11 @@ class Engine:
             # never hidden along with the orchestrator's own append. A fixable
             # retry rebases it onto the tree that retry deliberately keeps.
             task.baseline_ledger_digest = self._ledger_digest()
+            # A new phase invocation owns no prior harvest. Retries stay inside
+            # this invocation and preserve the flag while their ledger writes
+            # remain on disk; a crash replay enters with `resume_result` and must
+            # preserve the dead attempt's persisted authorship too.
+            task.harvest_wrote_ledger = False
         feedback: Path | None = None
         while True:
             replayed = resume_result is not None
@@ -1236,14 +1241,12 @@ class Engine:
             outcome = None
             if result.status == "completed":
                 # Everything below this point that appends to the ledger is the
-                # orchestrator, not the session. Reset the write flag only when
-                # this attempt starts from a reset tree. A fixable retry keeps the
-                # prior attempt's tree and harvest, so that provenance must carry
-                # into its repair session. Preserve it on a crash replay too: the
-                # replayed harvest dedupes against the dead attempt's on-disk append.
+                # orchestrator, not the session. Retry-chain provenance carries
+                # across both a fixable retry's kept tree and, until Phase 6K, a
+                # non-fixable retry's protected ledger. Preserve it on a crash
+                # replay too: the replayed harvest dedupes against the dead
+                # attempt's on-disk append.
                 if not replayed:
-                    if feedback is None:
-                        task.harvest_wrote_ledger = False
                     if task.baseline_ledger_digest is not None:
                         task.ledger_changed_before_harvest = (
                             self._ledger_digest() != task.baseline_ledger_digest
@@ -1320,6 +1323,11 @@ class Engine:
                 else:
                     feedback = None
                     self._rollback_or_pause(task)
+                    # The rollback resets code/spec bookkeeping but the artifact
+                    # shield preserves today's harvested ledger (Phase 6K will
+                    # restore it). Rebase onto that accounted-for engine state so
+                    # it cannot masquerade as the next session's ledger edit.
+                    task.baseline_ledger_digest = self._ledger_digest()
                 continue
             if decision.action == Action.DEFER:
                 self._record_dev_spec(task, result.result_json)
@@ -1690,6 +1698,10 @@ class Engine:
             reset_from = fm_status
             devcontract.reset_spec_status(spec_path, "done")
             devcontract.strip_auto_run_result(spec_path)
+        # A timed-out review can still have recorded new frontmatter findings.
+        # Normalize first so the success-status gate sees `done`, then mirror the
+        # normal review path before deterministic verification and commit.
+        self._harvest_spec_deferrals(task, {"spec_file": str(spec_path)})
         outcome = self._verify_review(task)
         if not outcome.ok:
             self.journal.append(
@@ -2460,8 +2472,10 @@ class Engine:
         fm = self._observed_frontmatter(spec_path, task.story_key, "spec-deferrals")
         if fm is None or devcontract.DEFERRED_FIELD not in fm:
             return
+        status = verify.status_of(fm)
         success_status = "in-review" if self._dev_review_enabled() else "done"
-        if verify.status_of(fm) != success_status:
+        parked = self._operator_park_enabled() and status == verify.AWAITING_OPERATOR
+        if status != success_status and not parked:
             return
         findings, malformed = devcontract.parse_deferred_findings(fm)
         if not findings and not malformed:

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -1392,15 +1392,18 @@ class Engine:
                 # the sync below, verify_dev, and the review-verify gate all key
                 # off the on-disk frontmatter status.
                 self._reconcile_generic_terminal_status(task, result.result_json)
+                # Harvest the session's frontmatter `deferred:` findings into the
+                # ledger before the artifact gate so an accepted attempt carries
+                # them in its story commit. `_harvest_gate_exclude` keeps this
+                # engine-authored append from becoming proof of session work. This
+                # strict read can also finish a reconciliation whose preceding
+                # observation faulted, so state sync follows it and sees the
+                # repaired terminal status.
+                harvest_outcome = self._harvest_spec_deferrals(task, result.result_json)
                 # generic-path single-writer for the bookkeeping the decoupled
                 # skill never touches (sprint-status for stories, the deferred-work
                 # ledger for sweep bundles), before verify reads that state.
                 self._post_dev_state_sync(task, result.result_json)
-                # Harvest the session's frontmatter `deferred:` findings into the
-                # ledger before the artifact gate so an accepted attempt carries
-                # them in its story commit. `_harvest_gate_exclude` keeps this
-                # engine-authored append from becoming proof of session work.
-                harvest_outcome = self._harvest_spec_deferrals(task, result.result_json)
                 # carry the skill's follow-up-review recommendation (PR #2505)
                 # onto the task so _review_and_commit can gate the review loop.
                 # A present key is authoritative (folded from the frontmatter, or
@@ -2452,10 +2455,27 @@ class Engine:
                 spec=str(spec_path),
             )
             return
-        success_status = "in-review" if self._dev_review_enabled() else "done"
         fm = self._observed_frontmatter(spec_path, task.story_key, "reconcile")
         if fm is None:
             return
+        self._reconcile_generic_terminal_frontmatter(task, result_json, spec_path, fm)
+
+    def _reconcile_generic_terminal_frontmatter(
+        self,
+        task: StoryTask,
+        result_json: dict | None,
+        spec_path: Path,
+        fm: dict,
+    ) -> str:
+        """Apply generic terminal reconciliation from an already-read mapping.
+
+        The bookkeeping path supplies an observed mapping; required deferral
+        harvesting supplies a strict one. Sharing the decision/write step lets a
+        recovered harvest read finish a reconciliation whose earlier observation
+        faulted, without trusting result JSON or launching a replacement session
+        over the first session's findings. Returns the effective status.
+        """
+        success_status = "in-review" if self._dev_review_enabled() else "done"
         # A blank `status:` reads "" here (status_of normalizes YAML-null), so the
         # blank-status template shape reconciles like a missing key does.
         fm_status = verify.status_of(fm)
@@ -2478,22 +2498,22 @@ class Engine:
                     result_json["followup_review_recommended"] = bool(
                         fm.get("followup_review_recommended")
                     )
-            return
+            return success_status
         if fm_status not in devcontract.RECONCILABLE_FROM:
-            return  # blocked / unknown custom status: never override a deliberate one
+            return fm_status  # blocked / unknown custom status: never override a deliberate one
         try:
             text = spec_path.read_text(encoding="utf-8")
         except OSError as e:
             self._journal_spec_read_failed(spec_path, task.story_key, "reconcile-prose", e)
-            return
+            return fm_status
         arr = devcontract.parse_auto_run_result(text)
         if not arr.present or arr.status != devcontract.DONE:
-            return  # no terminal prose, or a blocked outcome: leave for the escalation path
+            return fm_status  # no terminal prose, or blocked: leave for escalation
         # Repair-write doctrine: the False arm is "nothing to change" only. A status
         # the reader can see but no line edit can move raises instead, and that raise
         # is deliberately left uncaught (see _reset_spec_for_repair).
         if not devcontract.reset_spec_status(spec_path, success_status):
-            return
+            return fm_status
         # Keep the in-place result_json the rest of _dev_phase reads consistent with
         # the now-reconciled spec (the followup flag is only carried on a done exit).
         # `reset_spec_status` rewrites only the status line, so `fm` (read above)
@@ -2512,6 +2532,7 @@ class Engine:
             frm=fm_status,
             to=success_status,
         )
+        return success_status
 
     def _repair_spec_marker(self, task: StoryTask, rj: dict) -> None:
         """Append the ``## Auto Run Result`` marker a missing-marker synthesis
@@ -2743,7 +2764,28 @@ class Engine:
         success_status = "in-review" if self._dev_review_enabled() else "done"
         parked = self._operator_park_enabled() and status == verify.AWAITING_OPERATOR
         if status != success_status and not parked:
-            return
+            # Stories mode's explicit plan checkpoint is a verified terminal for
+            # that leg, not a half-finalized implementation. Its deferred notes
+            # remain in the spec until the post-checkpoint implementation pass.
+            if (
+                status == devcontract.PLAN_HALT_STATUS
+                and (result_json or {}).get("plan_halt") is True
+            ):
+                return
+            if status not in devcontract.RECONCILABLE_FROM:
+                return
+            # Reconcile's preceding bookkeeping observation may have faulted even
+            # though this required read recovered. Reuse the strict mapping to
+            # finish the same session's terminal-prose repair before any later
+            # session can replace its `deferred:` list.
+            status = self._reconcile_generic_terminal_frontmatter(task, result_json, spec_path, fm)
+            parked = self._operator_park_enabled() and status == verify.AWAITING_OPERATOR
+            if status != success_status and not parked:
+                shown_status = status or "<blank>"
+                return VerifyOutcome.retry(
+                    "spec remained at reconcilable nonterminal status "
+                    f"{shown_status!r} while harvesting deferrals: {spec_path}"
+                )
         findings, malformed = devcontract.parse_deferred_findings(fm)
         if not findings and not malformed:
             return

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -2689,6 +2689,13 @@ class Engine:
         target = "review" if review_enabled else "done"
         sprint_advance(self.workspace.paths.sprint_status, task.story_key, target)
 
+    def _harvest_spec_path(self, task: StoryTask, result_json: dict | None) -> Path | None:
+        """Resolve the spec whose frontmatter this mode may harvest."""
+        spec_file = (result_json or {}).get("spec_file")
+        if not spec_file:
+            return None
+        return verify.resolve_spec_path(str(spec_file), self.workspace.paths)
+
     def _harvest_spec_deferrals(
         self, task: StoryTask, result_json: dict | None
     ) -> VerifyOutcome | None:
@@ -2718,13 +2725,13 @@ class Engine:
         """
         if not self._generic_dev():
             return
-        spec_file = (result_json or {}).get("spec_file")
-        if not spec_file:
+        spec_path = self._harvest_spec_path(task, result_json)
+        if spec_path is None:
             return
-        spec_path = verify.resolve_spec_path(str(spec_file), self.workspace.paths)
-        # A session supplies `spec_file`; like reconcile, marker repair, and
-        # declared closes, harvesting must not let an arbitrary readable path
-        # outside the orchestrator-owned roots steer a ledger write.
+        # A session supplies `spec_file`; a mode may replace its untrusted value
+        # with a deterministic artifact path. Like reconcile, marker repair, and
+        # declared closes, harvesting must not let any readable path outside the
+        # orchestrator-owned roots steer a ledger write.
         try:
             within = verify.spec_within_roots(spec_path, self.workspace.paths)
         except (OSError, RuntimeError):

--- a/src/bmad_loop/escalation.py
+++ b/src/bmad_loop/escalation.py
@@ -158,6 +158,16 @@ def review_retry_or_exhaust(task: StoryTask, policy: Policy, reason: str) -> Dec
     not to be applicable (#271)."""
     if task.review_cycle < policy.limits.max_review_cycles:
         return Decision(Action.RETRY, reason)
+    return review_exhausted(task, reason)
+
+
+def review_exhausted(task: StoryTask, reason: str) -> Decision:
+    """Terminal review-side failure routing without spending another session.
+
+    Used when a deterministic post-review repair has exhausted its own local
+    retry bound and launching another reviewer would be unsafe. It preserves the
+    same resolved-CRITICAL re-drive rule as ordinary review-budget exhaustion.
+    """
     return Decision(_exhausted_action(task), _exhaust_reason(task, reason))
 
 

--- a/src/bmad_loop/model.py
+++ b/src/bmad_loop/model.py
@@ -195,6 +195,7 @@ class StoryTask:
     # JSON-native containers only; callers persist these through state.json.
     harvested_deferrals: list[dict[str, Any]] = field(default_factory=list)
     bundle_closes_intended: list[str] = field(default_factory=list)
+    harvest_carry_commit_pending: bool = False
     isolated_ledger_carried: bool = False
     spec_file: str | None = None
     commit_sha: str | None = None
@@ -343,6 +344,7 @@ class StoryTask:
             "ledger_changed_before_harvest": self.ledger_changed_before_harvest,
             "harvested_deferrals": self.harvested_deferrals,
             "bundle_closes_intended": self.bundle_closes_intended,
+            "harvest_carry_commit_pending": self.harvest_carry_commit_pending,
             "isolated_ledger_carried": self.isolated_ledger_carried,
             "spec_file": self._serialized_spec_file(),
             "commit_sha": self.commit_sha,
@@ -410,6 +412,7 @@ class StoryTask:
             ledger_changed_before_harvest=bool(d.get("ledger_changed_before_harvest", False)),
             harvested_deferrals=[deepcopy(dict(item)) for item in d.get("harvested_deferrals", [])],
             bundle_closes_intended=[str(i) for i in d.get("bundle_closes_intended", [])],
+            harvest_carry_commit_pending=bool(d.get("harvest_carry_commit_pending", False)),
             isolated_ledger_carried=bool(d.get("isolated_ledger_carried", False)),
             spec_file=d.get("spec_file"),
             commit_sha=d.get("commit_sha"),

--- a/src/bmad_loop/stories_engine.py
+++ b/src/bmad_loop/stories_engine.py
@@ -11,7 +11,8 @@ mtime-scan, no shared mutable board.
 Like ``SweepEngine``, this is a thin override layer over the mature story
 pipeline: only the story source (``_pick_next``), the dispatch prompt
 (``_dev_prompt``), the (absent) bookkeeping sync (``_post_dev_state_sync``), the
-artifact verification (``_verify_dev_artifacts``), the session env
+deferral-harvest source (``_harvest_spec_path``), artifact verification
+(``_verify_dev_artifacts``), the session env
 (``_extra_session_env``), and the HITL checkpoints differ. Everything else —
 dev/verify/review/commit, crash resume, worktree isolation, gates — is inherited
 unchanged.
@@ -415,6 +416,13 @@ class StoriesEngine(Engine):
         return stories.is_plan_halt_leg(entry.spec_checkpoint, state)
 
     # ---------------------------------------------------------- sync + verify
+
+    def _harvest_spec_path(self, task: StoryTask, result_json: dict | None) -> Path | None:
+        """Resolve the same id-keyed story spec that verification will accept."""
+        if not (result_json or {}).get("spec_file"):
+            return None
+        state = stories.resolve_story_spec(self._stories_folder(), task.story_key)
+        return state.path if state.kind == stories.KIND_PRESENT else None
 
     def _post_dev_state_sync(self, task: StoryTask, result_json: dict | None) -> None:
         """No-op: stories mode has no sprint board. Honors the contract's "the

--- a/src/bmad_loop/stories_engine.py
+++ b/src/bmad_loop/stories_engine.py
@@ -482,6 +482,7 @@ class StoriesEngine(Engine):
             spec_folder=folder,
             review_enabled=self._dev_review_enabled(),
             plan_halt=plan_halt,
+            engine_written=self._harvest_gate_exclude(task),
         )
 
     def _run_verify_commands_after_dev(self, task: StoryTask, result_json: dict | None) -> bool:

--- a/src/bmad_loop/sweep.py
+++ b/src/bmad_loop/sweep.py
@@ -1276,7 +1276,11 @@ class SweepEngine(Engine):
 
     def _verify_dev_artifacts(self, task: StoryTask, result_json: dict | None):
         return verify.verify_dev_bundle(
-            task, self.workspace.paths, result_json, review_enabled=self._dev_review_enabled()
+            task,
+            self.workspace.paths,
+            result_json,
+            review_enabled=self._dev_review_enabled(),
+            engine_written=self._harvest_gate_exclude(task),
         )
 
     def _verify_review(self, task: StoryTask):

--- a/src/bmad_loop/verify.py
+++ b/src/bmad_loop/verify.py
@@ -308,6 +308,36 @@ def has_changes_since(
     return bool(created)
 
 
+def path_changed_since(
+    repo: Path,
+    baseline: str,
+    rel: str,
+    *,
+    baseline_untracked: list[str] | None = None,
+) -> bool:
+    """Whether one literal repo-relative path changed since ``baseline``.
+
+    This is the single-path form of :func:`has_changes_since`: tracked content
+    is compared to the recorded commit, while an ordinary untracked path counts
+    only when the attempt's baseline snapshot did not already contain it.
+    ``baseline_untracked=None`` keeps the proof gate's legacy behavior of
+    counting every ordinary untracked path. Ignored paths are absent from
+    :func:`untracked_files` and therefore cannot become proof of work here.
+
+    Any non-zero diff result fails open toward "changed", matching the
+    authoritative :func:`has_changes_since` gate. The literal pathspec is
+    required for operator-configured ledger paths containing Git wildmatch
+    characters.
+    """
+    rc, _ = _git(repo, "diff", "--quiet", baseline, "--", f":(literal){rel}")
+    if rc != 0:
+        return True
+    untracked = untracked_files(repo)
+    if rel not in untracked:
+        return False
+    return baseline_untracked is None or rel not in set(baseline_untracked)
+
+
 def attempt_dirty(
     repo: Path,
     baseline: str,

--- a/src/bmad_loop/verify.py
+++ b/src/bmad_loop/verify.py
@@ -1048,7 +1048,12 @@ def _tree_dirty_vs_head(repo: Path) -> bool:
 
 
 def merge_branch(
-    repo: Path, branch: str, *, strategy: str = "merge", message: str | None = None
+    repo: Path,
+    branch: str,
+    *,
+    strategy: str = "merge",
+    message: str | None = None,
+    allow_empty_squash: bool = False,
 ) -> None:
     """Merge `branch` into the branch currently checked out in `repo`.
 
@@ -1059,6 +1064,11 @@ def merge_branch(
     Editor-induced dirt first via `clean_incoming_collisions`. When git refuses
     a merge at pre-flight (no MERGE_HEAD created) the tree was never touched, so
     no abort/reset is attempted and the raw git error is raised verbatim.
+
+    ``allow_empty_squash`` is recovery-only: re-running a squash that committed
+    before a host loss stages nothing because the target already has the merged
+    tree. That clean result confirms the replay without manufacturing an empty
+    commit; ordinary squash calls keep commit failures strict.
     """
     if strategy == "ff":
         rc, out = _git(repo, "merge", "--ff-only", branch)
@@ -1087,6 +1097,8 @@ def merge_branch(
                 if reset_rc != 0:
                     detail += f"; AND git reset --hard HEAD failed (tree not restored): {reset_out}"
             raise GitError(detail)
+        if allow_empty_squash and not _tree_dirty_vs_head(repo):
+            return
         msg = message or f"Squash-merge branch '{branch}'"
         rc, out = _git(repo, "commit", "-m", msg)
         if rc != 0:

--- a/src/bmad_loop/verify.py
+++ b/src/bmad_loop/verify.py
@@ -1436,6 +1436,7 @@ def verify_dev(
     review_enabled: bool = True,
     *,
     operator_park: bool = False,
+    engine_written: tuple[str, ...] = (),
 ) -> VerifyOutcome:
     """Verify a dev session's on-disk artifacts against its result.json claims.
 
@@ -1454,6 +1455,11 @@ def verify_dev(
     state and to a non-empty action list. Off by policy, the token is simply not
     a terminal the gate knows, so it fails the ordinary status check and the
     session is retried with that mismatch as feedback.
+
+    ``engine_written`` names project-relative paths the orchestrator itself
+    wrote above this gate during the attempt. They compose with the mode's normal
+    proof-of-work exclusions so engine bookkeeping cannot masquerade as session
+    work; see :meth:`Engine._harvest_gate_exclude`.
     """
     rj = result_json or {}
     spec_file = rj.get("spec_file")
@@ -1483,7 +1489,7 @@ def verify_dev(
         expected_status=(
             AWAITING_OPERATOR if parked else ("in-review" if review_enabled else "done")
         ),
-        extra_exclude=(),
+        extra_exclude=engine_written,
         fm=fm,
     )
     if gate is not None:
@@ -1505,13 +1511,17 @@ def verify_dev_bundle(
     paths: ProjectPaths,
     result_json: dict[str, Any] | None,
     review_enabled: bool = True,
+    *,
+    engine_written: tuple[str, ...] = (),
 ) -> VerifyOutcome:
     """verify_dev for a deferred-work bundle: bundles have no sprint-status
     entry. The orchestrator owns the bundle→dw-id binding (``task.dw_ids``,
     marked done by ``SweepEngine``'s ledger sync); the generic ``bmad-dev-auto``
     primitive never authors dw ids. So the dw_ids cross-check is enforced only
     when the session actually claims them — an empty/absent claim is the normal
-    generic path and passes."""
+    generic path and passes.
+
+    ``engine_written`` has the same contract as :func:`verify_dev`."""
     rj = result_json or {}
     spec_file = rj.get("spec_file")
     if not spec_file:
@@ -1529,7 +1539,7 @@ def verify_dev_bundle(
         task,
         paths,
         expected_status="in-review" if review_enabled else "done",
-        extra_exclude=(),
+        extra_exclude=engine_written,
         allow_ancestor_baseline=True,
     )
     if gate is not None:
@@ -1561,6 +1571,7 @@ def verify_dev_stories(
     spec_folder: Path,
     review_enabled: bool = True,
     plan_halt: bool = False,
+    engine_written: tuple[str, ...] = (),
 ) -> VerifyOutcome:
     """verify_dev for stories mode: the story spec lives at the id-keyed path
     ``<spec-folder>/stories/<id>-<slug>.md`` and there is no sprint-status entry.
@@ -1632,14 +1643,18 @@ def verify_dev_stories(
     # Otherwise stories mode adds the spec folder's stories/ subdir + stories.yaml
     # on top of the gate's own file-granular exclude — NOT the whole-folder
     # artifact_relpaths, so a story whose entire authorized scope is ledger/spec
-    # reconciliation doesn't register as a false "no changes".
+    # reconciliation doesn't register as a false "no changes". Engine-written
+    # paths compose only on that live-gate leg; ``None`` must remain ``None`` for
+    # plan halt rather than being combined with a tuple.
     gate = _verify_shared_gates(
         spec_path,
         rj,
         task,
         paths,
         expected_status=expected,
-        extra_exclude=(None if plan_halt else _stories_relpaths(paths.project, spec_folder)),
+        extra_exclude=(
+            None if plan_halt else _stories_relpaths(paths.project, spec_folder) + engine_written
+        ),
     )
     if gate is not None:
         return gate

--- a/src/bmad_loop/worktree_flow.py
+++ b/src/bmad_loop/worktree_flow.py
@@ -1008,9 +1008,10 @@ class WorktreeFlow:
                 patch=str(patch) if patch else None,
             )
 
-    def merge_local(self, task: StoryTask, unit: UnitWorkspace) -> None:
+    def merge_local(self, task: StoryTask, unit: UnitWorkspace, *, replay: bool = False) -> None:
         """Merge a DONE unit's branch into the target branch from the main repo."""
-        self._emit("pre_merge", task)
+        if not replay:
+            self._emit("pre_merge", task)
         scm = self.policy.scm
         repo = self.paths.repo_root
         target = self.state.target_branch
@@ -1051,12 +1052,27 @@ class WorktreeFlow:
                 branch=unit.branch,
                 paths=cleaned,
             )
+        source = task.commit_sha or verify.rev_parse_head(unit.path)
+        if not replay:
+            # The task is already terminal and durable here. Record integration
+            # intent immediately before git so a host loss after merge success but
+            # before `unit-merged` can safely re-run the merge instead of losing a
+            # gitignored ledger when the stale worktree is reclaimed.
+            self.journal.append(
+                "unit-merge-started",
+                story_key=task.story_key,
+                branch=unit.branch,
+                target=target,
+                strategy=scm.merge_strategy,
+                source=source,
+            )
         try:
             verify.merge_branch(
                 repo,
                 unit.branch,
                 strategy=scm.merge_strategy,
                 message=self.merge_message(task),
+                allow_empty_squash=replay,
             )
         except verify.GitError as e:
             # genuine content conflict against the target: keep the branch for
@@ -1073,6 +1089,8 @@ class WorktreeFlow:
             story_key=task.story_key,
             branch=unit.branch,
             target=self.state.target_branch,
+            strategy=scm.merge_strategy,
+            source=source,
         )
         self._emit("post_merge", task)
         close_unit_workspace(

--- a/src/bmad_loop/worktree_flow.py
+++ b/src/bmad_loop/worktree_flow.py
@@ -5,7 +5,8 @@ Extracted from :class:`bmad_loop.engine.Engine` (issue #244, findings F-3/F-9a):
 state machine. It lives here as a collaborator built from narrow dependencies
 (repo paths, the policy, run state, journal, plugin registry, loaded adapters)
 plus a handful of engine callbacks (emit a plugin hook, save state, run the
-per-unit ready gate, escalate-pause, and get/set the engine's active workspace).
+per-unit ready gate, carry isolated ledger writes, escalate-pause, and get/set
+the engine's active workspace).
 The collaborator never receives the whole ``Engine`` — it cannot reach engine
 internals beyond those callables.
 
@@ -633,10 +634,11 @@ class WorktreeFlow:
     only structural changes are that engine-owned effects go through injected
     callables: ``emit`` fires a plugin hook (late-bound so a monkeypatched
     ``Engine._emit`` still wins), ``save`` persists run state, ``gate_unit`` runs
-    the per-unit ready gate, ``workspace_get``/``workspace_set`` read and swap the
-    engine's active workspace, and ``escalation_pause`` raises the engine's
-    ``RunPaused`` (injected so this module need not import ``engine`` — that would
-    reintroduce a runtime<->engine import cycle)."""
+    the per-unit ready gate, ``carry_isolated_ledger_writes`` applies Engine-owned
+    ledger bookkeeping after a successful merge, ``workspace_get``/``workspace_set``
+    read and swap the engine's active workspace, and ``escalation_pause`` raises the
+    engine's ``RunPaused`` (injected so this module need not import ``engine`` — that
+    would reintroduce a runtime<->engine import cycle)."""
 
     def __init__(
         self,
@@ -652,6 +654,7 @@ class WorktreeFlow:
         emit: Callable[..., object],
         save: Callable[[], None],
         gate_unit: Callable[[StoryTask], bool],
+        carry_isolated_ledger_writes: Callable[[StoryTask], None],
         escalation_pause: Callable[..., NoReturn],
         workspace_get: Callable[[], Workspace],
         workspace_set: Callable[[Workspace], None],
@@ -671,6 +674,7 @@ class WorktreeFlow:
         self._emit = emit
         self._save = save
         self._gate_unit = gate_unit
+        self._carry_isolated_ledger_writes = carry_isolated_ledger_writes
         self._pause = escalation_pause
         self._workspace_get = workspace_get
         self._workspace_set = workspace_set
@@ -971,6 +975,17 @@ class WorktreeFlow:
             # ourselves by hand once the branch has landed; the orchestrator only
             # commits the worktree onto the selected target.
             self.merge_local(task, unit)
+            # Engine-authored ledger writes normally ride the unit commit, but a
+            # gitignored ledger is omitted by finalize_commit's `git add -A` and
+            # would otherwise disappear with successful teardown. Carry only after
+            # merge: a tracked ledger reaches the target through the merge first,
+            # where Engine's all-status provenance scan can deduplicate it.
+            self._carry_isolated_ledger_writes(task)
+            # Phase is already terminal and persisted before integration, so make
+            # the carry completion durable here. Engine replays an unlatched carry
+            # after a crash in the merge-to-carry window.
+            task.isolated_ledger_carried = True
+            self._save()
         else:  # DEFERRED — capture the diff, keep or drop per keep_failed
             patch = close_unit_workspace(
                 unit,

--- a/src/bmad_loop/worktree_flow.py
+++ b/src/bmad_loop/worktree_flow.py
@@ -1008,11 +1008,19 @@ class WorktreeFlow:
                 patch=str(patch) if patch else None,
             )
 
-    def merge_local(self, task: StoryTask, unit: UnitWorkspace, *, replay: bool = False) -> None:
+    def merge_local(
+        self,
+        task: StoryTask,
+        unit: UnitWorkspace,
+        *,
+        replay: bool = False,
+        replay_strategy: str | None = None,
+    ) -> None:
         """Merge a DONE unit's branch into the target branch from the main repo."""
         if not replay:
             self._emit("pre_merge", task)
         scm = self.policy.scm
+        merge_strategy = scm.merge_strategy if replay_strategy is None else replay_strategy
         repo = self.paths.repo_root
         target = self.state.target_branch
         source = task.commit_sha or verify.rev_parse_head(unit.path)
@@ -1079,14 +1087,14 @@ class WorktreeFlow:
                 story_key=task.story_key,
                 branch=unit.branch,
                 target=target,
-                strategy=scm.merge_strategy,
+                strategy=merge_strategy,
                 source=source,
             )
         try:
             verify.merge_branch(
                 repo,
                 merge_ref,
-                strategy=scm.merge_strategy,
+                strategy=merge_strategy,
                 message=self.merge_message(task),
                 allow_empty_squash=replay,
             )
@@ -1105,7 +1113,7 @@ class WorktreeFlow:
             story_key=task.story_key,
             branch=unit.branch,
             target=self.state.target_branch,
-            strategy=scm.merge_strategy,
+            strategy=merge_strategy,
             source=source,
         )
         self._emit("post_merge", task)

--- a/src/bmad_loop/worktree_flow.py
+++ b/src/bmad_loop/worktree_flow.py
@@ -1015,13 +1015,30 @@ class WorktreeFlow:
         scm = self.policy.scm
         repo = self.paths.repo_root
         target = self.state.target_branch
+        source = task.commit_sha or verify.rev_parse_head(unit.path)
+        merge_ref = unit.branch
+        if replay:
+            current_source = verify.rev_parse_head(unit.path)
+            if current_source != source:
+                reason = (
+                    f"merge replay of {unit.branch} into {target} blocked: the unit "
+                    f"branch advanced from recorded source {source} to {current_source}; "
+                    "the later commits were not produced or verified by the completed "
+                    "session and the branch was preserved for manual recovery"
+                )
+                self.keep_branch_and_escalate(task, unit, reason)  # always raises RunPaused
+                return
+            # Pin both the collision allowlist and the merge operand to the
+            # write-ahead SHA. The branch can move after the check; replay must
+            # integrate only the commit the completed session actually proved.
+            merge_ref = source
         # A per_worktree Unity Editor can leak asset writes into the *main*
         # checkout (see the unity plugin's worktree setup), dirtying the target with the very
         # files this branch already committed. Reconcile that first: clean only
         # the leaked copies of incoming files; refuse (escalate) if anything dirty
         # falls outside this branch's path set — that may be real operator work.
         try:
-            cleaned = verify.clean_incoming_collisions(repo, target, unit.branch)
+            cleaned = verify.clean_incoming_collisions(repo, target, merge_ref)
         except (verify.GitError, OSError) as e:
             # OSError joins GitError because clean_incoming_collisions mutates the
             # checkout directly (unlink/iterdir/rmdir) — a non-spawn FS fault the
@@ -1052,7 +1069,6 @@ class WorktreeFlow:
                 branch=unit.branch,
                 paths=cleaned,
             )
-        source = task.commit_sha or verify.rev_parse_head(unit.path)
         if not replay:
             # The task is already terminal and durable here. Record integration
             # intent immediately before git so a host loss after merge success but
@@ -1069,7 +1085,7 @@ class WorktreeFlow:
         try:
             verify.merge_branch(
                 repo,
-                unit.branch,
+                merge_ref,
                 strategy=scm.merge_strategy,
                 message=self.merge_message(task),
                 allow_empty_squash=replay,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -515,6 +515,7 @@ def write_spec(
     prose_status: str | None = None,
     closes_deferred: object = None,
     operator_actions: object = None,
+    deferred=None,
 ) -> None:
     """Write a spec the way the real bmad-dev-auto skill does. The skill's step-03
     stamps `baseline_revision` and NEVER `baseline_commit` (that name exists only
@@ -532,7 +533,13 @@ def write_spec(
     reads back — so the reading under test is the one production sees. A non-list
     renders as a scalar, which is the wrong-container mistake for this field
     too (a bare string is iterable, so a lenient reader would turn one
-    instruction into a list of characters)."""
+    instruction into a list of characters).
+
+    ``deferred`` adds the post-#2640 frontmatter list using
+    :func:`render_deferred`. ``None`` omits the field entirely (the pre-#2640
+    shape); ``[]`` emits an explicit empty list. It is rendered last so adding
+    this fixture capability does not reorder either pre-existing declaration.
+    """
     declare = ""
     if isinstance(closes_deferred, list):
         declare = f"closes_deferred: [{', '.join(closes_deferred)}]\n"
@@ -543,6 +550,8 @@ def write_spec(
         declare += f"operator_actions:\n{rendered}" if rendered else "operator_actions: []\n"
     elif operator_actions is not None:
         declare += f"operator_actions: {operator_actions}\n"
+    if deferred is not None:
+        declare += render_deferred(deferred)
     body = (
         f"---\ntitle: 'test'\ntype: 'feature'\nstatus: '{status}'\n"
         f"baseline_revision: '{baseline}'\n{declare}---\n\n## Intent\n\ntest spec\n"
@@ -628,6 +637,7 @@ def dev_effect(
     write_src: bool = True,
     closes_deferred: object = None,
     operator_actions: object = None,
+    deferred=None,
 ):
     """Simulate a successful bmad-dev-auto session: it self-finalizes the spec
     (no in-review handoff — always straight to ``done``) but never touches the
@@ -650,7 +660,10 @@ def dev_effect(
     patch-restore tests assert the re-driven session ran against the RESTORED diff.
     ``write_src=False`` then keeps the session from appending its own line, so what
     lands in the tree is exactly what the restore laid down (the applied patch is
-    the session's proof of work; a second edit would muddy the assertion)."""
+    the session's proof of work; a second edit would muddy the assertion).
+
+    ``deferred`` records post-#2640 review findings in the spec frontmatter; the
+    simulated session still never writes the deferred-work ledger itself."""
 
     def effect(spec: SessionSpec) -> SessionResult:
         baseline = rev_parse_head(paths.project)
@@ -667,6 +680,7 @@ def dev_effect(
             prose_status=prose_status,
             closes_deferred=closes_deferred,
             operator_actions=operator_actions,
+            deferred=deferred,
         )
         # deliberately NO set_sprint: the dev skill does not write sprint-status
         return SessionResult(
@@ -828,6 +842,8 @@ def bundle_dev_effect(
     followup_review: bool = True,
     final_status: str = "done",
     prose_status: str | None = None,
+    deferred=None,
+    write_src: bool = True,
 ):
     """Simulate a bmad-dev-auto bundle dev session: edits code and self-finalizes
     the bundle spec to ``done`` (no in-review handoff). On the decoupled path the
@@ -835,16 +851,19 @@ def bundle_dev_effect(
     ``mark_ledger=True`` is kept only for the legacy-marking path in older tests.
     ``followup_review`` mirrors `followup_review_recommended` — defaults True so
     the bundle review runs under the default trigger = "recommended". ``final_status``
-    / ``prose_status`` mirror ``dev_effect``: pair a non-terminal ``final_status``
-    with ``prose_status="done"`` to reproduce the skill finalizing in prose only."""
+    / ``prose_status`` / ``deferred`` / ``write_src`` mirror ``dev_effect``: pair
+    a non-terminal ``final_status`` with ``prose_status="done"`` to reproduce the
+    skill finalizing in prose only; ``write_src=False`` expresses a session whose
+    only post-baseline diff comes from orchestrator ledger bookkeeping."""
 
     def effect(spec: SessionSpec) -> SessionResult:
         baseline = rev_parse_head(paths.project)
         source = paths.project / "src.txt"
-        source.write_text(source.read_text() + f"change for dw-{name}\n")
+        if write_src:
+            source.write_text(source.read_text() + f"change for dw-{name}\n")
         sp = bundle_spec_path(paths, name)
         # mirror the skill: always self-finalize the bundle spec straight to done
-        write_spec(sp, final_status, baseline, prose_status=prose_status)
+        write_spec(sp, final_status, baseline, prose_status=prose_status, deferred=deferred)
         if mark_ledger:
             mark_ledger_done(paths, dw_ids)
         return SessionResult(

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -8038,6 +8038,48 @@ def test_spec_deferrals_absent_field_writes_no_ledger(project):
     assert not [e for e in engine.journal.entries() if e["kind"] == "spec-deferrals-harvested"]
 
 
+def test_spec_deferrals_skip_out_of_tree_session_spec(project, tmp_path):
+    engine, _ = make_engine(project, [], policy=_harvest_policy())
+    task = StoryTask(story_key="1-1-a", epic=1)
+    outside = tmp_path / "outside-spec.md"
+    write_spec(outside, "done", "abc123", deferred=[HARVEST_A])
+
+    engine._harvest_spec_deferrals(task, {"spec_file": str(outside)})
+
+    assert not project.deferred_work.exists()
+    assert task.harvested_deferrals == []
+    assert task.harvest_wrote_ledger is False
+    skipped = [
+        e for e in engine.journal.entries() if e["kind"] == "spec-deferrals-skipped-out-of-tree"
+    ]
+    assert len(skipped) == 1
+    assert skipped[0]["story_key"] == task.story_key
+    assert skipped[0]["spec"] == str(outside)
+
+
+@pytest.mark.parametrize("error_type", [OSError, RuntimeError])
+def test_spec_deferrals_skip_when_containment_probe_faults(project, monkeypatch, error_type):
+    engine, _ = make_engine(project, [], policy=_harvest_policy())
+    task = StoryTask(story_key="1-1-a", epic=1)
+    sp = spec_path(project, task.story_key)
+    sp.parent.mkdir(parents=True, exist_ok=True)
+    write_spec(sp, "done", "abc123", deferred=[HARVEST_A])
+
+    def containment_fault(*args, **kwargs):
+        raise error_type("injected containment fault")
+
+    monkeypatch.setattr(verify, "spec_within_roots", containment_fault)
+    engine._harvest_spec_deferrals(task, {"spec_file": str(sp)})
+
+    assert not project.deferred_work.exists()
+    assert task.harvested_deferrals == []
+    assert task.harvest_wrote_ledger is False
+    skipped = [
+        e for e in engine.journal.entries() if e["kind"] == "spec-deferrals-skipped-out-of-tree"
+    ]
+    assert len(skipped) == 1 and skipped[0]["spec"] == str(sp)
+
+
 def test_spec_deferrals_harvest_across_the_disk_resolved_skill_rename(project):
     from conftest import attach_profile, install_build_auto_skill
 
@@ -8275,6 +8317,49 @@ def test_harvest_alone_is_not_proof_of_work(project):
     assert "no changes" in decisions[0]["reason"]
     assert [s.role for s in adapter.sessions] == ["dev", "dev"]
     assert summary.done == 1
+
+
+@pytest.mark.parametrize("error_type", [OSError, RuntimeError])
+def test_harvest_gate_resolve_fault_fails_proof_conservatively_without_crashing(
+    project, monkeypatch, error_type
+):
+    write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
+    engine, adapter = make_engine(
+        project,
+        [
+            dev_effect(
+                project,
+                "1-1-a",
+                followup_review=False,
+                write_src=False,
+                deferred=[HARVEST_A],
+            ),
+            dev_effect(project, "1-1-a", followup_review=False),
+        ],
+        policy=_harvest_policy(attempts=2),
+    )
+    real_gate = engine._harvest_gate_exclude
+    real_resolve = Path.resolve
+
+    def resolve_fault(self, *args, **kwargs):
+        if self == project.deferred_work:
+            raise error_type("injected ledger resolve fault")
+        return real_resolve(self, *args, **kwargs)
+
+    def gate_with_fault(task):
+        with monkeypatch.context() as m:
+            m.setattr(Path, "resolve", resolve_fault)
+            return real_gate(task)
+
+    monkeypatch.setattr(engine, "_harvest_gate_exclude", gate_with_fault)
+
+    summary = engine.run()
+
+    decisions = [e for e in engine.journal.entries() if e["kind"] == "dev-decision"]
+    assert [decision["action"] for decision in decisions] == ["retry", "proceed"]
+    assert "no changes" in decisions[0]["reason"]
+    assert len(adapter.sessions) == 2
+    assert summary.done == 1 and not summary.crashed and not summary.paused
 
 
 def test_real_work_plus_a_harvest_still_proceeds(project):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -8221,6 +8221,43 @@ def test_spec_deferral_provenance_is_durable_before_append_for_crash_replay(proj
     assert resumed._harvest_gate_exclude(saved_task) == (rel,)
 
 
+def test_expanded_harvest_records_are_durable_before_a_later_append(project, monkeypatch):
+    """A prior ledger-write latch cannot suppress the stable-union checkpoint."""
+    engine, _ = make_engine(project, [], policy=_harvest_policy())
+    task = StoryTask(story_key="1-1-a", epic=1, phase=Phase.DEV_VERIFY)
+    engine.state.tasks[task.story_key] = task
+    sp = spec_path(project, task.story_key)
+    sp.parent.mkdir(parents=True, exist_ok=True)
+    result_json = {"spec_file": str(sp)}
+    write_spec(sp, "done", "abc123", deferred=[HARVEST_A])
+    engine._harvest_spec_deferrals(task, result_json)
+    assert task.harvest_wrote_ledger is True
+
+    write_spec(sp, "done", "abc123", deferred=[HARVEST_A, HARVEST_B])
+    real_append = deferredwork.append_entry
+
+    class PowerLoss(BaseException):
+        pass
+
+    def append_then_die(*args, **kwargs):
+        real_append(*args, **kwargs)
+        raise PowerLoss
+
+    monkeypatch.setattr(deferredwork, "append_entry", append_then_die)
+    with pytest.raises(PowerLoss):
+        engine._harvest_spec_deferrals(task, result_json)
+
+    assert [entry.title for entry in _harvest_entries(project)] == [
+        HARVEST_A["summary"],
+        HARVEST_B["summary"],
+    ]
+    saved_task = load_state(engine.run_dir).tasks[task.story_key]
+    assert [record["title"] for record in saved_task.harvested_deferrals] == [
+        HARVEST_A["summary"],
+        HARVEST_B["summary"],
+    ]
+
+
 def test_spec_deferrals_dedup_sees_already_done_entries(project):
     write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
     engine, _ = make_engine(
@@ -8482,7 +8519,7 @@ def test_fix_harvest_read_failure_retries_before_rereview(project, monkeypatch):
 
     def fix_with_deferral(spec):
         marker.write_text("ok\n", encoding="utf-8")
-        return dev_effect(project, "1-1-a", deferred=[HARVEST_A])(spec)
+        return dev_effect(project, "1-1-a", deferred=[HARVEST_A, HARVEST_B])(spec)
 
     write_sprint(project, {"1-1-a": "ready-for-dev"})
     policy = dataclasses.replace(
@@ -8495,7 +8532,6 @@ def test_fix_harvest_read_failure_retries_before_rereview(project, monkeypatch):
             dev_with_marker,
             breaking_review,
             fix_with_deferral,
-            fix_with_deferral,
             review_effect(project, "1-1-a", clean=True),
         ],
         policy=policy,
@@ -8505,16 +8541,75 @@ def test_fix_harvest_read_failure_retries_before_rereview(project, monkeypatch):
     summary = engine.run()
 
     assert summary.done == 1 and not summary.crashed and not summary.paused
-    assert [session.role for session in adapter.sessions] == [
-        "dev",
-        "review",
-        "dev",
-        "dev",
-        "review",
-    ]
+    assert [session.role for session in adapter.sessions] == ["dev", "review", "dev", "review"]
     decisions = [e for e in engine.journal.entries() if e["kind"] == "fix-decision"]
-    assert [decision["ok"] for decision in decisions] == [False, True]
-    assert [entry.title for entry in _harvest_entries(project)] == [HARVEST_A["summary"]]
+    assert [decision["ok"] for decision in decisions] == [True]
+    failures = [e for e in engine.journal.entries() if e["kind"] == "fix-harvest-failed"]
+    assert [event["harvest_attempt"] for event in failures] == [1]
+    assert [entry.title for entry in _harvest_entries(project)] == [
+        HARVEST_A["summary"],
+        HARVEST_B["summary"],
+    ]
+
+
+def test_persistent_fix_harvest_failure_defers_without_replacement_session(project, monkeypatch):
+    marker = project.project / "fixed.marker"
+
+    def dev_with_marker(spec):
+        marker.write_text("ok\n", encoding="utf-8")
+        return dev_effect(project, "1-1-a")(spec)
+
+    def breaking_review(spec):
+        marker.unlink()
+        return review_effect(project, "1-1-a", clean=True)(spec)
+
+    def fix_with_findings(spec):
+        marker.write_text("ok\n", encoding="utf-8")
+        return dev_effect(project, "1-1-a", deferred=[HARVEST_A, HARVEST_B])(spec)
+
+    def replacement_fix(spec):
+        marker.write_text("ok\n", encoding="utf-8")
+        return dev_effect(project, "1-1-a", deferred=[HARVEST_A])(spec)
+
+    write_sprint(project, {"1-1-a": "ready-for-dev"})
+    policy = dataclasses.replace(
+        _harvest_policy(review=True),
+        verify=VerifyPolicy(commands=(_file_exists_cmd(marker),)),
+    )
+    engine, adapter = make_engine(
+        project,
+        [
+            dev_with_marker,
+            breaking_review,
+            fix_with_findings,
+            replacement_fix,
+            review_effect(project, "1-1-a", clean=True),
+        ],
+        policy=policy,
+    )
+    real_harvest = engine._harvest_spec_deferrals
+    calls = 0
+
+    def fail_fix_pair(task, result_json):
+        nonlocal calls
+        calls += 1
+        if calls in (3, 4):
+            return VerifyOutcome.retry(
+                "spec unreadable while harvesting deferrals (PermissionError: persistent)"
+            )
+        return real_harvest(task, result_json)
+
+    monkeypatch.setattr(engine, "_harvest_spec_deferrals", fail_fix_pair)
+
+    summary = engine.run()
+
+    assert summary.deferred == 1 and not summary.done and not summary.crashed
+    assert [session.role for session in adapter.sessions] == ["dev", "review", "dev"]
+    assert calls == 4
+    failures = [e for e in engine.journal.entries() if e["kind"] == "fix-harvest-failed"]
+    assert [event["harvest_attempt"] for event in failures] == [1, 2]
+    task = engine.state.tasks["1-1-a"]
+    assert "harvest remained unreadable after 2 attempts" in task.defer_reason
 
 
 def test_spec_deferrals_malformed_siblings_file_valid_and_one_aggregated_entry(project):
@@ -8811,13 +8906,13 @@ def test_timeout_salvage_harvest_read_failure_falls_back_before_commit(project, 
         return SessionResult(status="timeout")
 
     write_sprint(project, {"1-1-a": "ready-for-dev"})
-    review_with_findings = _review_with_deferrals(project, [HARVEST_A, HARVEST_B])
+    replacement_review = _review_with_deferrals(project, [HARVEST_A])
     engine, adapter = make_engine(
         project,
         [
             dev_effect(project, "1-1-a", deferred=[HARVEST_A]),
             timeout_with_findings,
-            review_with_findings,
+            replacement_review,
         ],
         policy=_salvage_policy(),
     )
@@ -8828,12 +8923,59 @@ def test_timeout_salvage_harvest_read_failure_falls_back_before_commit(project, 
     failures = [e for e in engine.journal.entries() if e["kind"] == "review-timeout-salvage-failed"]
     assert len(failures) == 1
     assert "spec unreadable while harvesting deferrals" in failures[0]["reason"]
-    assert [session.role for session in adapter.sessions] == ["dev", "review", "review"]
-    assert [entry.title for entry in _harvest_entries(project)] == [
+    assert failures[0]["harvest_attempt"] == 1
+    assert [session.role for session in adapter.sessions] == ["dev", "review"]
+    harvested = [
+        entry
+        for entry in _harvest_entries(project)
+        if re.search(r"^origin: spec-deferred [0-9a-f]{12}$", entry.body, re.M)
+    ]
+    assert [entry.title for entry in harvested] == [
         HARVEST_A["summary"],
         HARVEST_B["summary"],
     ]
     assert summary.done == 1 and not summary.crashed and not summary.paused
+
+
+def test_persistent_timeout_salvage_harvest_failure_defers_without_reviewer(project, monkeypatch):
+    def timeout_with_findings(_spec):
+        sp = spec_path(project, "1-1-a")
+        write_spec(sp, "in-review", _spec_baseline(sp), deferred=[HARVEST_A, HARVEST_B])
+        return SessionResult(status="timeout")
+
+    write_sprint(project, {"1-1-a": "ready-for-dev"})
+    engine, adapter = make_engine(
+        project,
+        [
+            dev_effect(project, "1-1-a", deferred=[HARVEST_A]),
+            timeout_with_findings,
+            _review_with_deferrals(project, [HARVEST_A]),
+        ],
+        policy=_salvage_policy(),
+    )
+    real_harvest = engine._harvest_spec_deferrals
+    calls = 0
+
+    def fail_salvage_pair(task, result_json):
+        nonlocal calls
+        calls += 1
+        if calls in (2, 3):
+            return VerifyOutcome.retry(
+                "spec unreadable while harvesting deferrals (PermissionError: persistent)"
+            )
+        return real_harvest(task, result_json)
+
+    monkeypatch.setattr(engine, "_harvest_spec_deferrals", fail_salvage_pair)
+
+    summary = engine.run()
+
+    assert summary.deferred == 1 and not summary.done and not summary.crashed
+    assert [session.role for session in adapter.sessions] == ["dev", "review"]
+    assert calls == 3
+    failures = [e for e in engine.journal.entries() if e["kind"] == "review-timeout-salvage-failed"]
+    assert [event["harvest_attempt"] for event in failures] == [1, 2]
+    task = engine.state.tasks["1-1-a"]
+    assert "harvest remained unreadable after 2 attempts" in task.defer_reason
 
 
 def test_harvest_alone_is_not_proof_of_work(project):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -8447,6 +8447,59 @@ def test_spec_deferrals_unreadable_spec_returns_retry_without_harvest(project, m
     assert len(failures) == 1 and failures[0]["site"] == "spec-deferrals"
 
 
+def test_spec_deferrals_transient_missing_probe_returns_retry_without_harvest(project, monkeypatch):
+    engine, _ = make_engine(project, [], policy=_harvest_policy())
+    sp = spec_path(project, "1-1-a")
+    sp.parent.mkdir(parents=True, exist_ok=True)
+    write_spec(sp, "done", "abc123", deferred=[HARVEST_A])
+    real_is_file = Path.is_file
+    first_probe = True
+
+    def transient_missing(path, *args, **kwargs):
+        nonlocal first_probe
+        if path == sp and first_probe:
+            first_probe = False
+            return False
+        return real_is_file(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "is_file", transient_missing)
+    task = StoryTask(story_key="1-1-a", epic=1)
+
+    outcome = engine._harvest_spec_deferrals(task, {"spec_file": str(sp)})
+
+    assert not project.deferred_work.exists()
+    assert outcome is not None and outcome.retryable and not outcome.fixable
+    assert "spec missing while harvesting deferrals" in outcome.reason
+
+    assert engine._harvest_spec_deferrals(task, {"spec_file": str(sp)}) is None
+    assert [entry.title for entry in _harvest_entries(project)] == [HARVEST_A["summary"]]
+
+
+def test_spec_deferrals_stat_failure_returns_retry_without_harvest(project, monkeypatch):
+    engine, _ = make_engine(project, [], policy=_harvest_policy())
+    sp = spec_path(project, "1-1-a")
+    sp.parent.mkdir(parents=True, exist_ok=True)
+    write_spec(sp, "done", "abc123", deferred=[HARVEST_A])
+    real_is_file = Path.is_file
+
+    def fault_is_file(path, *args, **kwargs):
+        if path == sp:
+            raise PermissionError("transient stat fault")
+        return real_is_file(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "is_file", fault_is_file)
+
+    outcome = engine._harvest_spec_deferrals(
+        StoryTask(story_key="1-1-a", epic=1), {"spec_file": str(sp)}
+    )
+
+    assert not project.deferred_work.exists()
+    assert outcome is not None and outcome.retryable and not outcome.fixable
+    assert "spec unreadable while harvesting deferrals" in outcome.reason
+    failures = [e for e in engine.journal.entries() if e["kind"] == "spec-read-failed"]
+    assert len(failures) == 1 and failures[0]["site"] == "spec-deferrals"
+
+
 def test_dev_harvest_read_failure_retries_before_accepting(project, monkeypatch):
     write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
     engine, adapter = make_engine(

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -8697,7 +8697,10 @@ def test_dev_harvest_read_failure_retries_before_accepting(project, monkeypatch)
     assert summary.done == 1 and not summary.crashed and not summary.paused
 
 
-def test_review_harvest_read_failure_retries_before_commit(project, monkeypatch):
+def test_review_harvest_read_failure_retries_same_result_before_another_session(
+    project, monkeypatch
+):
+    """A deterministic read retry must not let another reviewer replace the source."""
     review_with_findings = _review_with_deferrals(project, [HARVEST_A, HARVEST_B])
 
     write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
@@ -8706,7 +8709,7 @@ def test_review_harvest_read_failure_retries_before_commit(project, monkeypatch)
         [
             dev_effect(project, "1-1-a", deferred=[HARVEST_A]),
             review_with_findings,
-            review_with_findings,
+            _review_with_deferrals(project, [HARVEST_A]),
         ],
         policy=_harvest_policy(review=True),
     )
@@ -8717,12 +8720,88 @@ def test_review_harvest_read_failure_retries_before_commit(project, monkeypatch)
     failures = [e for e in engine.journal.entries() if e["kind"] == "review-verify-failed"]
     assert len(failures) == 1
     assert "spec unreadable while harvesting deferrals" in failures[0]["reason"]
-    assert [session.role for session in adapter.sessions] == ["dev", "review", "review"]
+    assert [session.role for session in adapter.sessions] == ["dev", "review"]
     assert [entry.title for entry in _harvest_entries(project)] == [
         HARVEST_A["summary"],
         HARVEST_B["summary"],
     ]
     assert summary.done == 1 and not summary.crashed and not summary.paused
+
+
+def test_persistent_review_harvest_read_failure_defers_without_another_session(
+    project, monkeypatch
+):
+    """Persistent repair-input failure terminates without overwriting its spec."""
+    write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
+    engine, adapter = make_engine(
+        project,
+        [
+            dev_effect(project, "1-1-a", deferred=[HARVEST_A]),
+            _review_with_deferrals(project, [HARVEST_A, HARVEST_B]),
+        ],
+        policy=_harvest_policy(review=True),
+    )
+    real_harvest = engine._harvest_spec_deferrals
+    calls = 0
+
+    def fail_review_harvest(task, result_json):
+        nonlocal calls
+        calls += 1
+        if calls > 1:
+            return VerifyOutcome.retry(
+                "spec unreadable while harvesting deferrals (PermissionError: persistent)"
+            )
+        return real_harvest(task, result_json)
+
+    monkeypatch.setattr(engine, "_harvest_spec_deferrals", fail_review_harvest)
+
+    summary = engine.run()
+
+    assert summary.deferred == 1 and not summary.done and not summary.crashed
+    assert [session.role for session in adapter.sessions] == ["dev", "review"]
+    assert calls == 3  # dev harvest, then the bounded pair of review reads
+    failures = [e for e in engine.journal.entries() if e["kind"] == "review-verify-failed"]
+    assert len(failures) == 2
+
+
+def test_persistent_review_harvest_failure_reescalates_resolved_redrive(project, monkeypatch):
+    """A resolved CRITICAL re-drive may never be downgraded to a defer."""
+    write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
+
+    def resolved_review(spec):
+        engine.state.tasks["1-1-a"].resolved_redrive = True
+        return _review_with_deferrals(project, [HARVEST_A, HARVEST_B])(spec)
+
+    engine, adapter = make_engine(
+        project,
+        [
+            dev_effect(project, "1-1-a", deferred=[HARVEST_A]),
+            resolved_review,
+        ],
+        policy=_harvest_policy(review=True),
+    )
+    real_harvest = engine._harvest_spec_deferrals
+    calls = 0
+
+    def fail_review_harvest(task, result_json):
+        nonlocal calls
+        calls += 1
+        if calls > 1:
+            return VerifyOutcome.retry(
+                "spec unreadable while harvesting deferrals (PermissionError: persistent)"
+            )
+        return real_harvest(task, result_json)
+
+    monkeypatch.setattr(engine, "_harvest_spec_deferrals", fail_review_harvest)
+
+    summary = engine.run()
+
+    assert summary.paused and summary.escalated == 1 and summary.deferred == 0
+    assert [session.role for session in adapter.sessions] == ["dev", "review"]
+    assert calls == 3
+    saved = load_state(engine.run_dir)
+    assert saved.tasks["1-1-a"].phase == Phase.ESCALATED
+    assert "re-escalating instead of deferring" in saved.paused_reason
 
 
 def test_timeout_salvage_harvest_read_failure_falls_back_before_commit(project, monkeypatch):
@@ -8945,6 +9024,104 @@ def test_replay_before_harvest_recovers_session_ledger_attribution(project):
         "Session's own ledger work",
         HARVEST_A["summary"],
     ]
+
+
+def _downgrade_harvest_state_to_legacy(engine):
+    """Remove every harvest field as an older state.json loader would."""
+    legacy = engine.state.tasks["1-1-a"]
+    legacy.baseline_ledger_digest = None
+    legacy.pre_harvest_ledger = None
+    legacy.pre_harvest_ledger_captured = False
+    legacy.harvest_wrote_ledger = False
+    legacy.ledger_changed_before_harvest = False
+    legacy.harvested_deferrals = []
+    legacy.bundle_closes_intended = []
+    legacy.harvest_carry_commit_pending = False
+    legacy.isolated_ledger_carried = False
+    engine._save()
+
+
+def test_legacy_replay_derives_session_ledger_attribution_before_harvest(project):
+    """A pre-harvest checkpoint from before the attribution fields still resumes.
+
+    Git still carries the attempt baseline, so recovery can distinguish the
+    session's existing ledger diff from the engine append it is about to make.
+    """
+    write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(
+        project,
+        [_session_authored_ledger_effect(project, deferred=[HARVEST_A])],
+        policy=_harvest_policy(attempts=1),
+    )
+
+    original_emit = engine._emit
+
+    def crash_after_session_save(stage, *args, **kwargs):
+        if stage == "post_session":
+            raise RuntimeError("host died before the legacy engine could verify")
+        return original_emit(stage, *args, **kwargs)
+
+    engine._emit = crash_after_session_save
+    assert engine.run().crashed
+
+    # Exact defaults loaded from a state.json written before the harvest fields
+    # existed. The completed SessionRecord and baseline_commit predate them and
+    # remain sufficient to resume the result without launching another session.
+    _downgrade_harvest_state_to_legacy(engine)
+
+    resumed, adapter = resume_engine(project, engine, [])
+    summary = resumed.run()
+
+    assert summary.done == 1 and not summary.crashed and not summary.deferred
+    assert adapter.sessions == []
+    final = load_state(resumed.run_dir).tasks["1-1-a"]
+    assert final.ledger_changed_before_harvest is True
+    decisions = [e for e in resumed.journal.entries() if e["kind"] == "dev-decision"]
+    assert [decision["action"] for decision in decisions] == ["proceed"]
+    assert [entry.title for entry in _harvest_entries(project)] == [
+        "Session's own ledger work",
+        HARVEST_A["summary"],
+    ]
+
+
+def test_legacy_replay_does_not_credit_its_new_harvest_as_session_work(project):
+    """Missing attribution must not let the upgrade's own append satisfy proof."""
+    write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(
+        project,
+        [
+            dev_effect(
+                project,
+                "1-1-a",
+                followup_review=False,
+                write_src=False,
+                deferred=[HARVEST_A],
+            )
+        ],
+        policy=_harvest_policy(attempts=1),
+    )
+
+    original_emit = engine._emit
+
+    def crash_after_session_save(stage, *args, **kwargs):
+        if stage == "post_session":
+            raise RuntimeError("host died before the legacy engine could verify")
+        return original_emit(stage, *args, **kwargs)
+
+    engine._emit = crash_after_session_save
+    assert engine.run().crashed
+    _downgrade_harvest_state_to_legacy(engine)
+
+    resumed, adapter = resume_engine(project, engine, [])
+    summary = resumed.run()
+
+    assert summary.deferred == 1 and not summary.done and not summary.crashed
+    assert adapter.sessions == []
+    final = load_state(resumed.run_dir).tasks["1-1-a"]
+    assert final.ledger_changed_before_harvest is False
+    decisions = [e for e in resumed.journal.entries() if e["kind"] == "dev-decision"]
+    assert [decision["action"] for decision in decisions] == ["defer"]
+    assert "no changes in worktree" in decisions[0]["reason"]
 
 
 def test_retry_replay_recovers_session_ledger_attribution_after_prior_harvest(project):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -7941,6 +7941,473 @@ def test_review_prompt_resolves_through_the_review_adapters_own_tree(project):
     }
 
 
+# ------------------------- frontmatter `deferred:` harvest (BMAD-METHOD #2640)
+
+HARVEST_A = {
+    "summary": "Retry loop has no ceiling",
+    "evidence": "the backoff doubles forever: no cap",
+    "location": "src/retry.py:88",
+    "severity": "medium",
+}
+HARVEST_B = {
+    "summary": "Timeout is not configurable",
+    "evidence": "hardcoded 30s",
+    "location": "src/net.py:12",
+    "severity": "low",
+}
+
+
+def _harvest_policy(*, review: bool = False, attempts: int = 3) -> Policy:
+    return Policy(
+        gates=GatesPolicy(mode="none"),
+        notify=QUIET,
+        review=ReviewPolicy(enabled=review, trigger="always"),
+        dev=DevPolicy(skill="bmad-dev-auto"),
+        limits=LimitsPolicy(max_dev_attempts=attempts),
+        scm=ScmPolicy(rollback_on_failure=True),
+    )
+
+
+def _harvest_entries(project):
+    text = (
+        project.deferred_work.read_text(encoding="utf-8") if project.deferred_work.is_file() else ""
+    )
+    return deferredwork.parse_ledger(text)
+
+
+def test_review_prompt_does_not_ask_the_session_to_double_file_deferrals(project):
+    engine, _ = make_engine(project, [])
+    spec = str(project.implementation_artifacts / "spec-1-1-a.md")
+
+    prompt = engine._review_prompt(_prompt_task(spec_file=spec))
+
+    assert prompt.startswith(f"/bmad-dev-auto {spec} —")
+    assert "append" not in prompt.lower()
+    assert "do NOT modify, re-open, or rewrite existing deferred-work ledger" in prompt
+    assert "the orchestrator owns their status and resolution" in prompt
+
+
+def test_spec_frontmatter_deferrals_harvested_into_ledger(project):
+    write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(
+        project,
+        [dev_effect(project, "1-1-a", followup_review=False, deferred=[HARVEST_A])],
+        policy=_harvest_policy(),
+    )
+
+    summary = engine.run()
+
+    assert summary.done == 1 and summary.deferred == 0
+    (entry,) = _harvest_entries(project)
+    assert entry.title == HARVEST_A["summary"] and entry.open
+    assert re.search(r"^origin: spec-deferred [0-9a-f]{12}$", entry.body, re.M)
+    assert "location: src/retry.py:88\nsource_spec: `spec-1-1-a.md`" in entry.body
+    assert "severity: medium" in entry.body
+    assert "reason: the backoff doubles forever: no cap" in entry.body
+    events = [e for e in engine.journal.entries() if e["kind"] == "spec-deferrals-harvested"]
+    assert len(events) == 1
+    assert events[0]["dw_ids"] == [entry.id]
+    assert events[0]["deduped"] == 0 and events[0]["malformed"] == 0
+
+
+def test_spec_deferrals_use_na_when_no_location_was_recorded(project):
+    finding = {"summary": "No location", "evidence": "the report omitted it"}
+    write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(
+        project,
+        [dev_effect(project, "1-1-a", followup_review=False, deferred=[finding])],
+        policy=_harvest_policy(),
+    )
+
+    assert engine.run().done == 1
+
+    (entry,) = _harvest_entries(project)
+    assert "location: n/a\nsource_spec: `spec-1-1-a.md`" in entry.body
+
+
+def test_spec_deferrals_absent_field_writes_no_ledger(project):
+    write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(
+        project,
+        [dev_effect(project, "1-1-a", followup_review=False)],
+        policy=_harvest_policy(),
+    )
+
+    assert engine.run().done == 1
+    assert not project.deferred_work.exists()
+    assert not [e for e in engine.journal.entries() if e["kind"] == "spec-deferrals-harvested"]
+
+
+def test_spec_deferrals_harvest_across_the_disk_resolved_skill_rename(project):
+    from conftest import attach_profile, install_build_auto_skill
+
+    install_build_auto_skill(project.project, ".claude/skills")
+    write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
+    engine, adapter = make_engine(
+        project,
+        [dev_effect(project, "1-1-a", followup_review=False, deferred=[HARVEST_A])],
+        policy=_harvest_policy(),
+    )
+    attach_profile(adapter, "claude")
+
+    assert engine.run().done == 1
+
+    assert adapter.sessions[0].prompt.startswith("/bmad-build-auto 1-1-a")
+    assert [entry.title for entry in _harvest_entries(project)] == [HARVEST_A["summary"]]
+
+
+def test_spec_deferrals_require_the_generic_dev_seam(project, monkeypatch):
+    engine, _ = make_engine(project, [], policy=_harvest_policy())
+    monkeypatch.setattr(engine, "_generic_dev", lambda: False)
+    sp = spec_path(project, "1-1-a")
+    sp.parent.mkdir(parents=True, exist_ok=True)
+    write_spec(sp, "done", "abc123", deferred=[HARVEST_A])
+
+    engine._harvest_spec_deferrals(StoryTask(story_key="1-1-a", epic=1), {"spec_file": str(sp)})
+
+    assert not project.deferred_work.exists()
+
+
+def test_spec_deferrals_plain_replay_does_not_double_append_or_mutate_frontmatter(project):
+    write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(
+        project,
+        [dev_effect(project, "1-1-a", followup_review=False, deferred=[HARVEST_A])],
+        policy=_harvest_policy(),
+    )
+    assert engine.run().done == 1
+    task = engine.state.tasks["1-1-a"]
+    sp = Path(task.spec_file)
+    before = sp.read_bytes()
+
+    engine._harvest_spec_deferrals(task, task.sessions[0].result_json)
+
+    assert sp.read_bytes() == before
+    assert len(_harvest_entries(project)) == 1
+    events = [e for e in engine.journal.entries() if e["kind"] == "spec-deferrals-harvested"]
+    assert [e["deduped"] for e in events] == [0, 1]
+    assert events[-1]["dw_ids"] == []
+    assert len(task.harvested_deferrals) == 1
+    record = task.harvested_deferrals[0]
+    assert re.fullmatch(r"spec-deferred [0-9a-f]{12}", record["origin"])
+    assert {key: value for key, value in record.items() if key != "origin"} == {
+        "title": HARVEST_A["summary"],
+        "reason": HARVEST_A["evidence"],
+        "location": HARVEST_A["location"],
+        "severity": HARVEST_A["severity"],
+        "source_spec": "spec-1-1-a.md",
+    }
+
+
+def test_spec_deferral_provenance_is_durable_before_append_for_crash_replay(project, monkeypatch):
+    """A host loss after append must not persist an authorless engine write."""
+    engine, _ = make_engine(project, [], policy=_harvest_policy())
+    task = StoryTask(story_key="1-1-a", epic=1, phase=Phase.DEV_VERIFY)
+    engine.state.tasks[task.story_key] = task
+    sp = spec_path(project, task.story_key)
+    sp.parent.mkdir(parents=True, exist_ok=True)
+    write_spec(sp, "done", "abc123", deferred=[HARVEST_A])
+    result_json = {"spec_file": str(sp)}
+    real_append = deferredwork.append_entry
+
+    class PowerLoss(BaseException):
+        pass
+
+    def append_then_die(*args, **kwargs):
+        real_append(*args, **kwargs)
+        raise PowerLoss
+
+    monkeypatch.setattr(deferredwork, "append_entry", append_then_die)
+    with pytest.raises(PowerLoss):
+        engine._harvest_spec_deferrals(task, result_json)
+
+    assert project.deferred_work.is_file()
+    saved = load_state(engine.run_dir)
+    saved_task = saved.tasks[task.story_key]
+    assert saved_task.harvest_wrote_ledger is True
+
+    monkeypatch.setattr(deferredwork, "append_entry", real_append)
+    resumed = Engine(
+        paths=project,
+        policy=engine.policy,
+        adapter=MockAdapter([]),
+        run_dir=engine.run_dir,
+        journal=engine.journal,
+        state=saved,
+    )
+    resumed._harvest_spec_deferrals(saved_task, result_json)
+
+    assert len(_harvest_entries(project)) == 1
+    rel = project.deferred_work.relative_to(project.project).as_posix()
+    assert resumed._harvest_gate_exclude(saved_task) == (rel,)
+
+
+def test_spec_deferrals_dedup_sees_already_done_entries(project):
+    write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(
+        project,
+        [dev_effect(project, "1-1-a", followup_review=False, deferred=[HARVEST_A])],
+        policy=_harvest_policy(),
+    )
+    assert engine.run().done == 1
+    task = engine.state.tasks["1-1-a"]
+    (entry,) = _harvest_entries(project)
+    assert deferredwork.mark_done(project.deferred_work, entry.id, "2026-08-03", "fixed")
+
+    engine._harvest_spec_deferrals(task, task.sessions[0].result_json)
+
+    entries = _harvest_entries(project)
+    assert len(entries) == 1
+    assert entries[0].status.startswith("done")
+
+
+def test_spec_deferrals_not_harvested_when_spec_is_short_of_success(project):
+    engine, _ = make_engine(project, [], policy=_harvest_policy())
+    sp = spec_path(project, "1-1-a")
+    sp.parent.mkdir(parents=True, exist_ok=True)
+    write_spec(sp, "in-progress", "abc123", deferred=[HARVEST_A])
+
+    engine._harvest_spec_deferrals(StoryTask(story_key="1-1-a", epic=1), {"spec_file": str(sp)})
+
+    assert not project.deferred_work.exists()
+    assert not [e for e in engine.journal.entries() if e["kind"] == "spec-deferrals-harvested"]
+
+
+def test_review_pass_deferrals_harvested_and_deduped_across_both_sites(project):
+    def review_with_b(_spec):
+        sp = spec_path(project, "1-1-a")
+        write_spec(sp, "done", _spec_baseline(sp), deferred=[HARVEST_A, HARVEST_B])
+        return SessionResult(
+            status="completed",
+            result_json={
+                "workflow": "auto-dev",
+                "story_key": "1-1-a",
+                "spec_file": str(sp),
+                "status": "done",
+                "followup_review_recommended": False,
+                "escalations": [],
+            },
+        )
+
+    write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
+    engine, adapter = make_engine(
+        project,
+        [dev_effect(project, "1-1-a", deferred=[HARVEST_A]), review_with_b],
+        policy=_harvest_policy(review=True),
+    )
+
+    assert engine.run().done == 1
+
+    assert [session.role for session in adapter.sessions] == ["dev", "review"]
+    assert [entry.title for entry in _harvest_entries(project)] == [
+        HARVEST_A["summary"],
+        HARVEST_B["summary"],
+    ]
+    events = [e for e in engine.journal.entries() if e["kind"] == "spec-deferrals-harvested"]
+    assert [e["dw_ids"] for e in events] == [["DW-1"], ["DW-2"]]
+    assert events[-1]["deduped"] == 1
+
+
+def test_spec_deferrals_malformed_siblings_file_valid_and_one_aggregated_entry(project):
+    write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(
+        project,
+        [
+            dev_effect(
+                project,
+                "1-1-a",
+                followup_review=False,
+                deferred=[HARVEST_A, "a bare string", {"evidence": "no summary"}],
+            )
+        ],
+        policy=_harvest_policy(),
+    )
+
+    assert engine.run().done == 1
+
+    entries = _harvest_entries(project)
+    assert len(entries) == 2
+    assert entries[0].title == HARVEST_A["summary"]
+    meta = entries[1]
+    assert meta.title == "Unreadable `deferred:` items in spec-1-1-a.md"
+    assert re.search(r"^origin: spec-deferred-malformed [0-9a-f]{12}$", meta.body, re.M)
+    assert "location: n/a" in meta.body
+    assert "item 2" in meta.body and "item 3" in meta.body
+    malformed = [e for e in engine.journal.entries() if e["kind"] == "spec-deferrals-malformed"]
+    assert len(malformed) == 1 and len(malformed[0]["items"]) == 2
+
+
+def test_spec_deferrals_unreadable_spec_degrades_without_harvest(project, monkeypatch):
+    engine, _ = make_engine(project, [], policy=_harvest_policy())
+    sp = spec_path(project, "1-1-a")
+    sp.parent.mkdir(parents=True, exist_ok=True)
+    write_spec(sp, "done", "abc123", deferred=[HARVEST_A])
+    fault_read_text(monkeypatch, sp)
+
+    engine._harvest_spec_deferrals(StoryTask(story_key="1-1-a", epic=1), {"spec_file": str(sp)})
+
+    assert not project.deferred_work.exists()
+    failures = [e for e in engine.journal.entries() if e["kind"] == "spec-read-failed"]
+    assert len(failures) == 1 and failures[0]["site"] == "spec-deferrals"
+
+
+def test_harvest_alone_is_not_proof_of_work(project):
+    write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
+    engine, adapter = make_engine(
+        project,
+        [
+            dev_effect(
+                project,
+                "1-1-a",
+                followup_review=False,
+                write_src=False,
+                deferred=[HARVEST_A],
+            ),
+            dev_effect(project, "1-1-a", followup_review=False),
+        ],
+        policy=_harvest_policy(attempts=2),
+    )
+
+    summary = engine.run()
+
+    decisions = [e for e in engine.journal.entries() if e["kind"] == "dev-decision"]
+    assert [d["action"] for d in decisions] == ["retry", "proceed"]
+    assert "no changes" in decisions[0]["reason"]
+    assert [s.role for s in adapter.sessions] == ["dev", "dev"]
+    assert summary.done == 1
+
+
+def test_real_work_plus_a_harvest_still_proceeds(project):
+    write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
+    engine, adapter = make_engine(
+        project,
+        [dev_effect(project, "1-1-a", followup_review=False, deferred=[HARVEST_A])],
+        policy=_harvest_policy(),
+    )
+
+    summary = engine.run()
+
+    decisions = [e for e in engine.journal.entries() if e["kind"] == "dev-decision"]
+    assert [d["action"] for d in decisions] == ["proceed"]
+    assert [s.role for s in adapter.sessions] == ["dev"]
+    assert summary.done == 1
+
+
+def _session_authored_ledger_effect(project, *, deferred=None):
+    inner = dev_effect(
+        project,
+        "1-1-a",
+        followup_review=False,
+        write_src=False,
+        deferred=deferred,
+    )
+
+    def effect(spec):
+        deferredwork.append_entry(
+            project.deferred_work,
+            title="Session's own ledger work",
+            origin="the session itself",
+            source_spec="specs/older.md",
+            reason="filed by the session, not by the harvest",
+        )
+        return inner(spec)
+
+    return effect
+
+
+def _fixable_harvest_policy(marker):
+    """Fail attempt 1 after artifact verification, then pass once repaired."""
+    return dataclasses.replace(
+        _harvest_policy(),
+        scm=ScmPolicy(rollback_on_failure=False),
+        verify=VerifyPolicy(commands=(_file_exists_cmd(marker),)),
+    )
+
+
+def _repairing_effect(project, marker, inner):
+    """Fix the command gate while reverting attempt 1's source change."""
+
+    def effect(spec):
+        marker.write_text("ok\n", encoding="utf-8")
+        (project.project / "src.txt").write_text("original\n", encoding="utf-8")
+        return inner(spec)
+
+    return effect
+
+
+def test_session_ledger_edit_is_proof_of_work_even_when_the_attempt_harvests(project):
+    write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
+    engine, adapter = make_engine(
+        project,
+        [_session_authored_ledger_effect(project, deferred=[HARVEST_A])],
+        policy=_harvest_policy(),
+    )
+
+    summary = engine.run()
+
+    decisions = [e for e in engine.journal.entries() if e["kind"] == "dev-decision"]
+    assert [d["action"] for d in decisions] == ["proceed"]
+    assert [s.role for s in adapter.sessions] == ["dev"]
+    assert summary.done == 1
+    assert [entry.title for entry in _harvest_entries(project)] == [
+        "Session's own ledger work",
+        HARVEST_A["summary"],
+    ]
+
+
+def test_fixable_retry_kept_harvest_is_not_the_repair_sessions_work(project, tmp_path):
+    """A fixable retry keeps attempt 1's tree, including its harvest.
+
+    Attempt 2 reverts the source change and writes nothing. The retained ledger
+    entry is still engine-authored, so it must not let the empty repair proceed.
+    """
+    write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
+    marker = tmp_path / "repair-complete"
+    engine, _ = make_engine(
+        project,
+        [
+            dev_effect(project, "1-1-a", followup_review=False, deferred=[HARVEST_A]),
+            _repairing_effect(
+                project,
+                marker,
+                dev_effect(project, "1-1-a", followup_review=False, write_src=False),
+            ),
+        ],
+        policy=_fixable_harvest_policy(marker),
+    )
+
+    summary = engine.run()
+
+    decisions = [e for e in engine.journal.entries() if e["kind"] == "dev-decision"]
+    assert [decision["action"] for decision in decisions] == ["retry", "retry"]
+    assert "no changes" in decisions[-1]["reason"]
+    assert summary.paused and summary.done == 0
+
+
+def test_fixable_retry_recomputes_attribution_for_repairs_own_ledger_work(project, tmp_path):
+    """The repair's own ledger edit must stand down the path-wide exclusion."""
+    write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
+    marker = tmp_path / "repair-complete"
+    engine, _ = make_engine(
+        project,
+        [
+            dev_effect(project, "1-1-a", followup_review=False, deferred=[HARVEST_A]),
+            _repairing_effect(project, marker, _session_authored_ledger_effect(project)),
+        ],
+        policy=_fixable_harvest_policy(marker),
+    )
+
+    summary = engine.run()
+
+    decisions = [e for e in engine.journal.entries() if e["kind"] == "dev-decision"]
+    assert [decision["action"] for decision in decisions] == ["retry", "proceed"]
+    assert summary.done == 1 and not summary.paused
+    assert [entry.title for entry in _harvest_entries(project)] == [
+        HARVEST_A["summary"],
+        "Session's own ledger work",
+    ]
+
+
 def test_workflow_marker_is_named_for_the_workflows_own_role_tree(project):
     """The completion-marker filename (WORKFLOW_COMPLETION_CONTRACT) is PRODUCED
     from ``_dev_skill(role)`` — the injected workflow's OWN role, not the dev

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -8292,6 +8292,37 @@ def test_nonfixable_retry_reverts_harvest_before_the_next_attempt(project):
     assert summary.done == 1 and not summary.crashed and not summary.paused
 
 
+def test_nonfixable_retry_resets_harvest_records_to_the_fresh_attempt(project):
+    """A rolled-back finding cannot survive in the next attempt's carry set."""
+    write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(
+        project,
+        [
+            dev_effect(
+                project,
+                "1-1-a",
+                followup_review=False,
+                write_src=False,
+                deferred=[HARVEST_A],
+            ),
+            dev_effect(
+                project,
+                "1-1-a",
+                followup_review=False,
+                deferred=[HARVEST_B],
+            ),
+        ],
+        policy=_harvest_policy(attempts=2),
+    )
+
+    summary = engine.run()
+
+    task = engine.state.tasks["1-1-a"]
+    assert summary.done == 1 and not summary.crashed and not summary.paused
+    assert [item["title"] for item in task.harvested_deferrals] == [HARVEST_B["summary"]]
+    assert [entry.title for entry in _harvest_entries(project)] == [HARVEST_B["summary"]]
+
+
 def test_awaiting_operator_spec_deferrals_are_harvested_before_park(project):
     write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
     engine, _ = make_engine(
@@ -8662,6 +8693,37 @@ def test_fixable_retry_kept_harvest_is_not_the_repair_sessions_work(project, tmp
     assert [decision["action"] for decision in decisions] == ["retry", "retry"]
     assert "no changes" in decisions[-1]["reason"]
     assert summary.paused and summary.done == 0
+
+
+def test_fixable_retry_unions_harvest_records_across_the_retained_chain(project, tmp_path):
+    """A repair pass adds to, rather than replaces, its kept predecessor's records."""
+    write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
+    marker = tmp_path / "repair-complete"
+    engine, _ = make_engine(
+        project,
+        [
+            dev_effect(project, "1-1-a", followup_review=False, deferred=[HARVEST_A]),
+            _repairing_effect(
+                project,
+                marker,
+                dev_effect(
+                    project,
+                    "1-1-a",
+                    followup_review=False,
+                    deferred=[HARVEST_B],
+                ),
+            ),
+        ],
+        policy=_fixable_harvest_policy(marker),
+    )
+
+    summary = engine.run()
+
+    task = engine.state.tasks["1-1-a"]
+    expected = [HARVEST_A["summary"], HARVEST_B["summary"]]
+    assert summary.done == 1 and not summary.crashed and not summary.paused
+    assert [item["title"] for item in task.harvested_deferrals] == expected
+    assert [entry.title for entry in _harvest_entries(project)] == expected
 
 
 def test_fixable_retry_recomputes_attribution_for_repairs_own_ledger_work(project, tmp_path):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -8400,6 +8400,103 @@ def test_review_timeout_salvage_harvests_new_frontmatter_deferrals(project):
     assert events[-1]["dw_ids"] == [harvested[-1].id]
 
 
+def test_fix_phase_harvests_findings_before_followup_review_replaces_them(project):
+    marker = project.project / "fixed.marker"
+
+    def dev_with_marker(spec):
+        marker.write_text("ok\n", encoding="utf-8")
+        return dev_effect(project, "1-1-a", deferred=[HARVEST_A])(spec)
+
+    def breaking_review(spec):
+        marker.unlink()
+        return review_effect(project, "1-1-a", clean=True)(spec)
+
+    def fix_with_new_deferral(spec):
+        marker.write_text("ok\n", encoding="utf-8")
+        return dev_effect(
+            project,
+            "1-1-a",
+            final_status="in-progress",
+            prose_status="done",
+            deferred=[HARVEST_B],
+        )(spec)
+
+    write_sprint(project, {"1-1-a": "ready-for-dev"})
+    policy = dataclasses.replace(
+        _harvest_policy(review=True),
+        verify=VerifyPolicy(commands=(_file_exists_cmd(marker),)),
+    )
+    engine, adapter = make_engine(
+        project,
+        [
+            dev_with_marker,
+            breaking_review,
+            fix_with_new_deferral,
+            review_effect(project, "1-1-a", clean=True),
+        ],
+        policy=policy,
+    )
+
+    summary = engine.run()
+
+    assert summary.done == 1 and not summary.crashed and not summary.paused
+    assert [session.role for session in adapter.sessions] == ["dev", "review", "dev", "review"]
+    assert [entry.title for entry in _harvest_entries(project)] == [
+        HARVEST_A["summary"],
+        HARVEST_B["summary"],
+    ]
+    events = [e for e in engine.journal.entries() if e["kind"] == "spec-deferrals-harvested"]
+    assert [event["dw_ids"] for event in events] == [["DW-1"], ["DW-2"]]
+
+
+def test_fix_harvest_read_failure_retries_before_rereview(project, monkeypatch):
+    marker = project.project / "fixed.marker"
+
+    def dev_with_marker(spec):
+        marker.write_text("ok\n", encoding="utf-8")
+        return dev_effect(project, "1-1-a")(spec)
+
+    def breaking_review(spec):
+        marker.unlink()
+        return review_effect(project, "1-1-a", clean=True)(spec)
+
+    def fix_with_deferral(spec):
+        marker.write_text("ok\n", encoding="utf-8")
+        return dev_effect(project, "1-1-a", deferred=[HARVEST_A])(spec)
+
+    write_sprint(project, {"1-1-a": "ready-for-dev"})
+    policy = dataclasses.replace(
+        _harvest_policy(review=True),
+        verify=VerifyPolicy(commands=(_file_exists_cmd(marker),)),
+    )
+    engine, adapter = make_engine(
+        project,
+        [
+            dev_with_marker,
+            breaking_review,
+            fix_with_deferral,
+            fix_with_deferral,
+            review_effect(project, "1-1-a", clean=True),
+        ],
+        policy=policy,
+    )
+    _fail_nth_harvest(engine, monkeypatch, 3)
+
+    summary = engine.run()
+
+    assert summary.done == 1 and not summary.crashed and not summary.paused
+    assert [session.role for session in adapter.sessions] == [
+        "dev",
+        "review",
+        "dev",
+        "dev",
+        "review",
+    ]
+    decisions = [e for e in engine.journal.entries() if e["kind"] == "fix-decision"]
+    assert [decision["ok"] for decision in decisions] == [False, True]
+    assert [entry.title for entry in _harvest_entries(project)] == [HARVEST_A["summary"]]
+
+
 def test_spec_deferrals_malformed_siblings_file_valid_and_one_aggregated_entry(project):
     write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
     engine, _ = make_engine(

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -8250,6 +8250,91 @@ def test_review_pass_deferrals_harvested_and_deduped_across_both_sites(project):
     assert events[-1]["deduped"] == 1
 
 
+def test_nonfixable_retry_kept_harvest_is_not_the_next_sessions_work(project):
+    """Until 6K, rollback preserves a harvest under the artifact shield.
+
+    The retained engine write remains excluded on the next attempt; only the
+    third session's source edit is proof of work.
+    """
+    write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
+    engine, adapter = make_engine(
+        project,
+        [
+            dev_effect(
+                project,
+                "1-1-a",
+                followup_review=False,
+                write_src=False,
+                deferred=[HARVEST_A],
+            ),
+            dev_effect(project, "1-1-a", followup_review=False, write_src=False),
+            dev_effect(project, "1-1-a", followup_review=False),
+        ],
+        policy=_harvest_policy(attempts=3),
+    )
+
+    summary = engine.run()
+
+    decisions = [e for e in engine.journal.entries() if e["kind"] == "dev-decision"]
+    assert [decision["action"] for decision in decisions] == ["retry", "retry", "proceed"]
+    assert "no changes" in decisions[1]["reason"]
+    assert len(adapter.sessions) == 3
+    assert summary.done == 1 and not summary.crashed and not summary.paused
+
+
+def test_awaiting_operator_spec_deferrals_are_harvested_before_park(project):
+    write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(
+        project,
+        [
+            generic_dev_effect(
+                project,
+                "1-1-a",
+                final_status="awaiting-operator",
+                operator_actions=ACTIONS,
+                deferred=[HARVEST_A],
+            )
+        ],
+        policy=_park_policy(),
+    )
+
+    summary = engine.run()
+
+    assert summary.awaiting_operator == 1 and summary.done == 0
+    assert [entry.title for entry in _harvest_entries(project)] == [HARVEST_A["summary"]]
+    assert engine.state.tasks["1-1-a"].phase == Phase.AWAITING_OPERATOR
+
+
+def test_review_timeout_salvage_harvests_new_frontmatter_deferrals(project):
+    def timeout_with_new_deferral(_spec):
+        sp = spec_path(project, "1-1-a")
+        write_spec(sp, "in-review", _spec_baseline(sp), deferred=[HARVEST_A, HARVEST_B])
+        return SessionResult(status="timeout")
+
+    write_sprint(project, {"1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(
+        project,
+        [
+            dev_effect(project, "1-1-a", deferred=[HARVEST_A]),
+            timeout_with_new_deferral,
+        ],
+        policy=_salvage_policy(),
+    )
+
+    summary = engine.run()
+
+    assert summary.done == 1 and summary.deferred == 0
+    harvested = [
+        entry
+        for entry in _harvest_entries(project)
+        if re.search(r"^origin: spec-deferred [0-9a-f]{12}$", entry.body, re.M)
+    ]
+    assert [entry.title for entry in harvested] == [HARVEST_A["summary"], HARVEST_B["summary"]]
+    events = [e for e in engine.journal.entries() if e["kind"] == "spec-deferrals-harvested"]
+    assert [event["deduped"] for event in events] == [0, 1]
+    assert events[-1]["dw_ids"] == [harvested[-1].id]
+
+
 def test_spec_deferrals_malformed_siblings_file_valid_and_one_aggregated_entry(project):
     write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
     engine, _ = make_engine(

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -8289,6 +8289,70 @@ def test_spec_deferrals_not_harvested_when_spec_is_short_of_success(project):
     assert not [e for e in engine.journal.entries() if e["kind"] == "spec-deferrals-harvested"]
 
 
+def test_spec_deferrals_reconcile_same_result_after_observation_fault(project, monkeypatch):
+    """A recovered strict harvest read finishes the same session's reconcile.
+
+    Otherwise a transient failure in the preceding observation leaves the spec at
+    ``in-progress``; harvest mistakes that for a legitimate no-op, and a later
+    attempt can replace the completed session's unfiled findings.
+    """
+    write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
+    engine, adapter = make_engine(
+        project,
+        [
+            dev_effect(
+                project,
+                "1-1-a",
+                final_status="in-progress",
+                followup_review=False,
+                prose_status="done",
+                deferred=[HARVEST_A],
+            )
+        ],
+        policy=_harvest_policy(attempts=2),
+    )
+    observed = engine._observed_frontmatter
+    failed = False
+
+    def fail_first_reconcile(path, story_key, site):
+        nonlocal failed
+        if site == "reconcile" and not failed:
+            failed = True
+            engine._journal_spec_read_failed(
+                path, story_key, site, PermissionError(13, "transient")
+            )
+            return None
+        return observed(path, story_key, site)
+
+    monkeypatch.setattr(engine, "_observed_frontmatter", fail_first_reconcile)
+
+    summary = engine.run()
+
+    sp = spec_path(project, "1-1-a")
+    assert failed and summary.done == 1 and not summary.deferred and not summary.crashed
+    assert [session.role for session in adapter.sessions] == ["dev"]
+    assert verify.status_of(verify.read_frontmatter(sp)) == "done"
+    assert [entry.title for entry in _harvest_entries(project)] == [HARVEST_A["summary"]]
+    failures = [event for event in engine.journal.entries() if event["kind"] == "spec-read-failed"]
+    assert len(failures) == 1 and failures[0]["site"] == "reconcile"
+
+
+def test_spec_deferrals_retry_unproven_reconcilable_status(project):
+    """A nonterminal spec with findings is never a successful harvest no-op."""
+    engine, _ = make_engine(project, [], policy=_harvest_policy())
+    task = StoryTask(story_key="1-1-a", epic=1)
+    sp = spec_path(project, task.story_key)
+    sp.parent.mkdir(parents=True, exist_ok=True)
+    write_spec(sp, "in-review", "abc123", deferred=[HARVEST_A])
+
+    outcome = engine._harvest_spec_deferrals(task, {"spec_file": str(sp)})
+
+    assert outcome is not None and outcome.retryable and not outcome.fixable
+    assert "reconcilable nonterminal status 'in-review'" in outcome.reason
+    assert not project.deferred_work.exists()
+    assert task.harvested_deferrals == []
+
+
 def test_review_pass_deferrals_harvested_and_deduped_across_both_sites(project):
     review_with_b = _review_with_deferrals(project, [HARVEST_A, HARVEST_B])
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -45,6 +45,7 @@ from bmad_loop.model import (
     SessionRecord,
     StoryTask,
     TokenUsage,
+    VerifyOutcome,
 )
 from bmad_loop.policy import (
     AdapterPolicy,
@@ -7975,6 +7976,42 @@ def _harvest_entries(project):
     return deferredwork.parse_ledger(text)
 
 
+def _fail_nth_harvest(engine, monkeypatch, nth: int) -> None:
+    """Inject the retry outcome produced by a one-shot harvest read fault."""
+    real_harvest = engine._harvest_spec_deferrals
+    calls = 0
+
+    def fail_once(task, result_json):
+        nonlocal calls
+        calls += 1
+        if calls == nth:
+            return VerifyOutcome.retry(
+                "spec unreadable while harvesting deferrals (PermissionError: transient)"
+            )
+        return real_harvest(task, result_json)
+
+    monkeypatch.setattr(engine, "_harvest_spec_deferrals", fail_once)
+
+
+def _review_with_deferrals(project, findings):
+    def effect(_spec):
+        sp = spec_path(project, "1-1-a")
+        write_spec(sp, "done", _spec_baseline(sp), deferred=findings)
+        return SessionResult(
+            status="completed",
+            result_json={
+                "workflow": "auto-dev",
+                "story_key": "1-1-a",
+                "spec_file": str(sp),
+                "status": "done",
+                "followup_review_recommended": False,
+                "escalations": [],
+            },
+        )
+
+    return effect
+
+
 def test_review_prompt_does_not_ask_the_session_to_double_file_deferrals(project):
     engine, _ = make_engine(project, [])
     spec = str(project.implementation_artifacts / "spec-1-1-a.md")
@@ -8216,20 +8253,7 @@ def test_spec_deferrals_not_harvested_when_spec_is_short_of_success(project):
 
 
 def test_review_pass_deferrals_harvested_and_deduped_across_both_sites(project):
-    def review_with_b(_spec):
-        sp = spec_path(project, "1-1-a")
-        write_spec(sp, "done", _spec_baseline(sp), deferred=[HARVEST_A, HARVEST_B])
-        return SessionResult(
-            status="completed",
-            result_json={
-                "workflow": "auto-dev",
-                "story_key": "1-1-a",
-                "spec_file": str(sp),
-                "status": "done",
-                "followup_review_recommended": False,
-                "escalations": [],
-            },
-        )
+    review_with_b = _review_with_deferrals(project, [HARVEST_A, HARVEST_B])
 
     write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
     engine, adapter = make_engine(
@@ -8405,18 +8429,104 @@ def test_spec_deferrals_malformed_siblings_file_valid_and_one_aggregated_entry(p
     assert len(malformed) == 1 and len(malformed[0]["items"]) == 2
 
 
-def test_spec_deferrals_unreadable_spec_degrades_without_harvest(project, monkeypatch):
+def test_spec_deferrals_unreadable_spec_returns_retry_without_harvest(project, monkeypatch):
     engine, _ = make_engine(project, [], policy=_harvest_policy())
     sp = spec_path(project, "1-1-a")
     sp.parent.mkdir(parents=True, exist_ok=True)
     write_spec(sp, "done", "abc123", deferred=[HARVEST_A])
     fault_read_text(monkeypatch, sp)
 
-    engine._harvest_spec_deferrals(StoryTask(story_key="1-1-a", epic=1), {"spec_file": str(sp)})
+    outcome = engine._harvest_spec_deferrals(
+        StoryTask(story_key="1-1-a", epic=1), {"spec_file": str(sp)}
+    )
 
     assert not project.deferred_work.exists()
+    assert outcome is not None and outcome.retryable and not outcome.fixable
+    assert "spec unreadable while harvesting deferrals" in outcome.reason
     failures = [e for e in engine.journal.entries() if e["kind"] == "spec-read-failed"]
     assert len(failures) == 1 and failures[0]["site"] == "spec-deferrals"
+
+
+def test_dev_harvest_read_failure_retries_before_accepting(project, monkeypatch):
+    write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
+    engine, adapter = make_engine(
+        project,
+        [
+            dev_effect(project, "1-1-a", followup_review=False, deferred=[HARVEST_A]),
+            dev_effect(project, "1-1-a", followup_review=False, deferred=[HARVEST_A]),
+        ],
+        policy=_harvest_policy(attempts=2),
+    )
+    _fail_nth_harvest(engine, monkeypatch, 1)
+
+    summary = engine.run()
+
+    decisions = [e for e in engine.journal.entries() if e["kind"] == "dev-decision"]
+    assert [decision["action"] for decision in decisions] == ["retry", "proceed"]
+    assert "spec unreadable while harvesting deferrals" in decisions[0]["reason"]
+    assert [session.role for session in adapter.sessions] == ["dev", "dev"]
+    assert [entry.title for entry in _harvest_entries(project)] == [HARVEST_A["summary"]]
+    assert summary.done == 1 and not summary.crashed and not summary.paused
+
+
+def test_review_harvest_read_failure_retries_before_commit(project, monkeypatch):
+    review_with_findings = _review_with_deferrals(project, [HARVEST_A, HARVEST_B])
+
+    write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
+    engine, adapter = make_engine(
+        project,
+        [
+            dev_effect(project, "1-1-a", deferred=[HARVEST_A]),
+            review_with_findings,
+            review_with_findings,
+        ],
+        policy=_harvest_policy(review=True),
+    )
+    _fail_nth_harvest(engine, monkeypatch, 2)
+
+    summary = engine.run()
+
+    failures = [e for e in engine.journal.entries() if e["kind"] == "review-verify-failed"]
+    assert len(failures) == 1
+    assert "spec unreadable while harvesting deferrals" in failures[0]["reason"]
+    assert [session.role for session in adapter.sessions] == ["dev", "review", "review"]
+    assert [entry.title for entry in _harvest_entries(project)] == [
+        HARVEST_A["summary"],
+        HARVEST_B["summary"],
+    ]
+    assert summary.done == 1 and not summary.crashed and not summary.paused
+
+
+def test_timeout_salvage_harvest_read_failure_falls_back_before_commit(project, monkeypatch):
+    def timeout_with_findings(_spec):
+        sp = spec_path(project, "1-1-a")
+        write_spec(sp, "in-review", _spec_baseline(sp), deferred=[HARVEST_A, HARVEST_B])
+        return SessionResult(status="timeout")
+
+    write_sprint(project, {"1-1-a": "ready-for-dev"})
+    review_with_findings = _review_with_deferrals(project, [HARVEST_A, HARVEST_B])
+    engine, adapter = make_engine(
+        project,
+        [
+            dev_effect(project, "1-1-a", deferred=[HARVEST_A]),
+            timeout_with_findings,
+            review_with_findings,
+        ],
+        policy=_salvage_policy(),
+    )
+    _fail_nth_harvest(engine, monkeypatch, 2)
+
+    summary = engine.run()
+
+    failures = [e for e in engine.journal.entries() if e["kind"] == "review-timeout-salvage-failed"]
+    assert len(failures) == 1
+    assert "spec unreadable while harvesting deferrals" in failures[0]["reason"]
+    assert [session.role for session in adapter.sessions] == ["dev", "review", "review"]
+    assert [entry.title for entry in _harvest_entries(project)] == [
+        HARVEST_A["summary"],
+        HARVEST_B["summary"],
+    ]
+    assert summary.done == 1 and not summary.crashed and not summary.paused
 
 
 def test_harvest_alone_is_not_proof_of_work(project):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -8592,6 +8592,64 @@ def test_spec_deferrals_transient_missing_probe_returns_retry_without_harvest(pr
     assert [entry.title for entry in _harvest_entries(project)] == [HARVEST_A["summary"]]
 
 
+def test_spec_deferrals_transient_inner_missing_probe_returns_retry(project, monkeypatch):
+    """The reader's own file probe must not collapse a race to a clean no-op."""
+    engine, _ = make_engine(project, [], policy=_harvest_policy())
+    sp = spec_path(project, "1-1-a")
+    sp.parent.mkdir(parents=True, exist_ok=True)
+    write_spec(sp, "done", "abc123", deferred=[HARVEST_A])
+    real_is_file = Path.is_file
+    probes = 0
+
+    def transient_inner_missing(path, *args, **kwargs):
+        nonlocal probes
+        if path == sp:
+            probes += 1
+            if probes == 2:
+                return False
+        return real_is_file(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "is_file", transient_inner_missing)
+    task = StoryTask(story_key="1-1-a", epic=1)
+
+    outcome = engine._harvest_spec_deferrals(task, {"spec_file": str(sp)})
+
+    assert outcome is not None and outcome.retryable and not outcome.fixable
+    assert "empty or invalid frontmatter" in outcome.reason
+    assert not project.deferred_work.exists()
+
+    assert engine._harvest_spec_deferrals(task, {"spec_file": str(sp)}) is None
+    assert [entry.title for entry in _harvest_entries(project)] == [HARVEST_A["summary"]]
+
+
+@pytest.mark.parametrize(
+    "broken_frontmatter",
+    [
+        b"\xff\xfe\x00\x00",
+        b"---\nstatus: done\ndeferred: [unterminated\n---\nbody\n",
+    ],
+    ids=["invalid-utf8", "invalid-yaml"],
+)
+def test_spec_deferrals_degraded_frontmatter_returns_retry_then_recovers(
+    project, broken_frontmatter
+):
+    engine, _ = make_engine(project, [], policy=_harvest_policy())
+    sp = spec_path(project, "1-1-a")
+    sp.parent.mkdir(parents=True, exist_ok=True)
+    sp.write_bytes(broken_frontmatter)
+    task = StoryTask(story_key="1-1-a", epic=1)
+
+    outcome = engine._harvest_spec_deferrals(task, {"spec_file": str(sp)})
+
+    assert outcome is not None and outcome.retryable and not outcome.fixable
+    assert "empty or invalid frontmatter" in outcome.reason
+    assert not project.deferred_work.exists()
+
+    write_spec(sp, "done", "abc123", deferred=[HARVEST_A])
+    assert engine._harvest_spec_deferrals(task, {"spec_file": str(sp)}) is None
+    assert [entry.title for entry in _harvest_entries(project)] == [HARVEST_A["summary"]]
+
+
 def test_spec_deferrals_stat_failure_returns_retry_without_harvest(project, monkeypatch):
     engine, _ = make_engine(project, [], policy=_harvest_policy())
     sp = spec_path(project, "1-1-a")
@@ -8943,6 +9001,72 @@ def test_retry_replay_recovers_session_ledger_attribution_after_prior_harvest(pr
     assert [entry.title for entry in _harvest_entries(project)] == [
         "Session's own ledger work",
         HARVEST_B["summary"],
+    ]
+
+
+def test_retry_replay_persists_post_session_hook_ledger_attribution(project, tmp_path):
+    """A hook-only repair remains visible across the post-session crash window."""
+    write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
+    marker = tmp_path / "repair-complete"
+    engine, _ = make_engine(
+        project,
+        [
+            dev_effect(project, "1-1-a", followup_review=False, deferred=[HARVEST_A]),
+            _repairing_effect(
+                project,
+                marker,
+                dev_effect(project, "1-1-a", followup_review=False, write_src=False),
+            ),
+        ],
+        policy=_fixable_harvest_policy(marker),
+    )
+    original_emit = engine._emit
+    post_sessions = 0
+
+    def append_from_second_post_session(stage, *args, **kwargs):
+        nonlocal post_sessions
+        if stage == "post_session":
+            post_sessions += 1
+            if post_sessions == 2:
+                deferredwork.append_entry(
+                    project.deferred_work,
+                    title="Repair hook's ledger work",
+                    origin="post-session repair hook",
+                    source_spec="spec-1-1-a.md",
+                    reason="the retained repair recorded its only work here",
+                )
+        return original_emit(stage, *args, **kwargs)
+
+    engine._emit = append_from_second_post_session
+    original_run_session = engine._run_session
+
+    def crash_after_second_session_checkpoint(*args, **kwargs):
+        result = original_run_session(*args, **kwargs)
+        if kwargs.get("seq") == 2:
+            raise RuntimeError("host died after post-session hooks")
+        return result
+
+    engine._run_session = crash_after_second_session_checkpoint
+
+    assert engine.run().crashed
+
+    crashed_task = load_state(engine.run_dir).tasks["1-1-a"]
+    assert crashed_task.phase == Phase.DEV_RUNNING
+    assert crashed_task.attempt == 2
+    assert crashed_task.sessions[-1].status == "completed"
+    assert crashed_task.harvest_wrote_ledger is True
+    assert crashed_task.ledger_changed_before_harvest is True
+
+    resumed, adapter = resume_engine(project, engine, [])
+    summary = resumed.run()
+
+    assert summary.done == 1 and not summary.crashed and not summary.paused
+    assert adapter.sessions == []
+    decisions = [e for e in resumed.journal.entries() if e["kind"] == "dev-decision"]
+    assert [decision["action"] for decision in decisions] == ["retry", "proceed"]
+    assert [entry.title for entry in _harvest_entries(project)] == [
+        HARVEST_A["summary"],
+        "Repair hook's ledger work",
     ]
 
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -8250,12 +8250,19 @@ def test_review_pass_deferrals_harvested_and_deduped_across_both_sites(project):
     assert events[-1]["deduped"] == 1
 
 
-def test_nonfixable_retry_kept_harvest_is_not_the_next_sessions_work(project):
-    """Until 6K, rollback preserves a harvest under the artifact shield.
+def test_nonfixable_retry_reverts_harvest_before_the_next_attempt(project):
+    """A rejected attempt's finding is removed and the retry files it afresh."""
+    ledger_present_at_retry: list[bool] = []
 
-    The retained engine write remains excluded on the next attempt; only the
-    third session's source edit is proof of work.
-    """
+    def retry_with_the_same_finding(spec):
+        ledger_present_at_retry.append(project.deferred_work.exists())
+        return dev_effect(
+            project,
+            "1-1-a",
+            followup_review=False,
+            deferred=[HARVEST_A],
+        )(spec)
+
     write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
     engine, adapter = make_engine(
         project,
@@ -8267,19 +8274,21 @@ def test_nonfixable_retry_kept_harvest_is_not_the_next_sessions_work(project):
                 write_src=False,
                 deferred=[HARVEST_A],
             ),
-            dev_effect(project, "1-1-a", followup_review=False, write_src=False),
-            dev_effect(project, "1-1-a", followup_review=False),
+            retry_with_the_same_finding,
         ],
-        policy=_harvest_policy(attempts=3),
+        policy=_harvest_policy(attempts=2),
     )
 
     summary = engine.run()
 
     decisions = [e for e in engine.journal.entries() if e["kind"] == "dev-decision"]
-    assert [decision["action"] for decision in decisions] == ["retry", "retry", "proceed"]
+    assert [decision["action"] for decision in decisions] == ["retry", "proceed"]
     assert "no changes" in decisions[0]["reason"]
-    assert "no changes" in decisions[1]["reason"]
-    assert len(adapter.sessions) == 3
+    harvests = [e for e in engine.journal.entries() if e["kind"] == "spec-deferrals-harvested"]
+    assert [event["dw_ids"] for event in harvests] == [["DW-1"], ["DW-1"]]
+    assert ledger_present_at_retry == [False]
+    assert [entry.title for entry in _harvest_entries(project)] == [HARVEST_A["summary"]]
+    assert len(adapter.sessions) == 2
     assert summary.done == 1 and not summary.crashed and not summary.paused
 
 
@@ -8570,9 +8579,11 @@ def test_replay_before_harvest_recovers_session_ledger_attribution(project):
 
 
 def test_retry_replay_recovers_session_ledger_attribution_after_prior_harvest(project):
-    """A prior attempt's harvest latch survives rollback. Attempt 2's completed
-    result must persist its own attribution before replay can consume it, rather
-    than mistaking the old latch for proof that attempt 2 already harvested.
+    """A rejected harvest is reverted but its stale latch survives until attempt 2.
+
+    Attempt 2's completed result must persist its own attribution before replay
+    can consume it, rather than mistaking the old latch for proof that attempt 2
+    already harvested.
     """
     write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
     engine, _ = make_engine(
@@ -8619,7 +8630,6 @@ def test_retry_replay_recovers_session_ledger_attribution_after_prior_harvest(pr
     decisions = [e for e in resumed.journal.entries() if e["kind"] == "dev-decision"]
     assert [decision["action"] for decision in decisions] == ["retry", "proceed"]
     assert [entry.title for entry in _harvest_entries(project)] == [
-        HARVEST_A["summary"],
         "Session's own ledger work",
         HARVEST_B["summary"],
     ]

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -8274,6 +8274,26 @@ def test_review_pass_deferrals_harvested_and_deduped_across_both_sites(project):
     assert events[-1]["deduped"] == 1
 
 
+def test_pre_harvest_ledger_restore_is_atomic_on_publication_failure(project, monkeypatch):
+    """A failed rollback publish leaves the current ledger byte-intact."""
+    engine, _ = make_engine(project, [], policy=_harvest_policy())
+    task = StoryTask(story_key="1-1-a", epic=1)
+    project.deferred_work.parent.mkdir(parents=True, exist_ok=True)
+    current = "# Deferred Work\n\ncurrent harvested row\n"
+    project.deferred_work.write_text(current, encoding="utf-8")
+
+    def publication_fails(*args, **kwargs):
+        raise OSError("atomic replace blocked")
+
+    monkeypatch.setattr(platform_util, "atomic_replace", publication_fails)
+
+    with pytest.raises(OSError, match="atomic replace blocked"):
+        engine._restore_ledger(task, "# Deferred Work\n\npre-harvest snapshot\n")
+
+    assert project.deferred_work.read_text(encoding="utf-8") == current
+    assert list(project.deferred_work.parent.glob("deferred-work.md.*.tmp")) == []
+
+
 def test_nonfixable_retry_reverts_harvest_before_the_next_attempt(project):
     """A rejected attempt's finding is removed and the retry files it afresh."""
     ledger_present_at_retry: list[bool] = []

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -8277,6 +8277,7 @@ def test_nonfixable_retry_kept_harvest_is_not_the_next_sessions_work(project):
 
     decisions = [e for e in engine.journal.entries() if e["kind"] == "dev-decision"]
     assert [decision["action"] for decision in decisions] == ["retry", "retry", "proceed"]
+    assert "no changes" in decisions[0]["reason"]
     assert "no changes" in decisions[1]["reason"]
     assert len(adapter.sessions) == 3
     assert summary.done == 1 and not summary.crashed and not summary.paused
@@ -8522,6 +8523,105 @@ def test_session_ledger_edit_is_proof_of_work_even_when_the_attempt_harvests(pro
     assert [entry.title for entry in _harvest_entries(project)] == [
         "Session's own ledger work",
         HARVEST_A["summary"],
+    ]
+
+
+def test_replay_before_harvest_recovers_session_ledger_attribution(project):
+    """A crash after session persistence but before harvest has no latched
+    engine write. Its session-authored ledger attribution must already be
+    durable so replay harvesting cannot hide the attempt's only work.
+    """
+    write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(
+        project,
+        [_session_authored_ledger_effect(project, deferred=[HARVEST_A])],
+        policy=_harvest_policy(),
+    )
+
+    original_emit = engine._emit
+
+    def crash_after_session_save(stage, *args, **kwargs):
+        if stage == "post_session":
+            raise RuntimeError("host died before ledger attribution")
+        return original_emit(stage, *args, **kwargs)
+
+    engine._emit = crash_after_session_save
+    assert engine.run().crashed
+
+    crashed_task = load_state(engine.run_dir).tasks["1-1-a"]
+    assert crashed_task.phase == Phase.DEV_RUNNING
+    assert crashed_task.sessions[0].status == "completed"
+    assert crashed_task.harvest_wrote_ledger is False
+    assert crashed_task.ledger_changed_before_harvest is True
+
+    resumed, adapter = resume_engine(project, engine, [])
+    summary = resumed.run()
+
+    assert summary.done == 1 and not summary.crashed
+    final = load_state(resumed.run_dir).tasks["1-1-a"]
+    assert final.ledger_changed_before_harvest is True
+    assert adapter.sessions == []
+    decisions = [e for e in resumed.journal.entries() if e["kind"] == "dev-decision"]
+    assert [decision["action"] for decision in decisions] == ["proceed"]
+    assert [entry.title for entry in _harvest_entries(project)] == [
+        "Session's own ledger work",
+        HARVEST_A["summary"],
+    ]
+
+
+def test_retry_replay_recovers_session_ledger_attribution_after_prior_harvest(project):
+    """A prior attempt's harvest latch survives rollback. Attempt 2's completed
+    result must persist its own attribution before replay can consume it, rather
+    than mistaking the old latch for proof that attempt 2 already harvested.
+    """
+    write_sprint(project, {"epic-1": "backlog", "1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(
+        project,
+        [
+            dev_effect(
+                project,
+                "1-1-a",
+                followup_review=False,
+                write_src=False,
+                deferred=[HARVEST_A],
+            ),
+            _session_authored_ledger_effect(project, deferred=[HARVEST_B]),
+        ],
+        policy=_harvest_policy(),
+    )
+
+    original_emit = engine._emit
+    post_sessions = 0
+
+    def crash_after_retry_session_save(stage, *args, **kwargs):
+        nonlocal post_sessions
+        if stage == "post_session":
+            post_sessions += 1
+            if post_sessions == 2:
+                raise RuntimeError("host died before retry ledger attribution")
+        return original_emit(stage, *args, **kwargs)
+
+    engine._emit = crash_after_retry_session_save
+    assert engine.run().crashed
+
+    crashed_task = load_state(engine.run_dir).tasks["1-1-a"]
+    assert crashed_task.phase == Phase.DEV_RUNNING
+    assert crashed_task.attempt == 2
+    assert crashed_task.sessions[-1].status == "completed"
+    assert crashed_task.harvest_wrote_ledger is True
+    assert crashed_task.ledger_changed_before_harvest is True
+
+    resumed, adapter = resume_engine(project, engine, [])
+    summary = resumed.run()
+
+    assert summary.done == 1 and not summary.crashed
+    assert adapter.sessions == []
+    decisions = [e for e in resumed.journal.entries() if e["kind"] == "dev-decision"]
+    assert [decision["action"] for decision in decisions] == ["retry", "proceed"]
+    assert [entry.title for entry in _harvest_entries(project)] == [
+        HARVEST_A["summary"],
+        "Session's own ledger work",
+        HARVEST_B["summary"],
     ]
 
 

--- a/tests/test_engine_worktree.py
+++ b/tests/test_engine_worktree.py
@@ -30,6 +30,7 @@ from conftest import (
 from bmad_loop import verify, worktree_flow
 from bmad_loop.adapters.base import SessionResult
 from bmad_loop.adapters.mock import MockAdapter
+from bmad_loop.bmadconfig import ProjectPaths
 from bmad_loop.engine import Engine
 from bmad_loop.install import (
     BMAD_SCRIPTS_SEED_REL,
@@ -146,7 +147,7 @@ def wt_bad_dev(project, story_key):
     return effect
 
 
-def wt_review_effect(project, story_key, clean: bool, patched: int = 0):
+def wt_review_effect(project, story_key, clean: bool, patched: int = 0, deferred=None):
     """Follow-up review pass in a worktree — a bmad-dev-auto re-invocation on the
     done spec. ``clean=True`` converges; ``clean=False`` keeps recommending."""
 
@@ -155,7 +156,7 @@ def wt_review_effect(project, story_key, clean: bool, patched: int = 0):
         wt = project.rebased(cwd)
         sp = wt.implementation_artifacts / f"spec-{story_key}.md"
         baseline = _spec_baseline(sp)
-        write_spec(sp, "done", baseline)
+        write_spec(sp, "done", baseline, deferred=deferred)
         set_sprint(wt, story_key, "done")
         return SessionResult(
             status="completed",
@@ -622,6 +623,25 @@ _HARVEST_CARRY = {
     "severity": "medium",
 }
 
+_HARVEST_CARRY_LATER = {
+    "summary": "Timeout path drops the cancellation reason",
+    "evidence": "the timeout handler replaces the original exception",
+    "location": "src/timeout.py:41",
+    "severity": "high",
+}
+
+
+def _harvest_record(finding=None):
+    finding = finding or _HARVEST_CARRY
+    return {
+        "origin": "spec-deferred abc123",
+        "title": finding["summary"],
+        "reason": finding["evidence"],
+        "location": finding["location"],
+        "severity": finding["severity"],
+        "source_spec": "spec-1-1-a.md",
+    }
+
 
 def _main_harvest_entries(project):
     from bmad_loop import deferredwork
@@ -666,6 +686,66 @@ def test_deferred_isolated_unit_carries_harvest_before_terminal_save(project):
     assert not branch_exists(project.project, "bmad-loop/test-run/1-1-a")
 
 
+def test_deferred_carry_commit_failure_resumes_before_terminal_integration(project, monkeypatch):
+    """A carry fault cannot strand a terminal task before defer teardown."""
+    commit_sprint(project, {"1-1-a": "ready-for-dev"})
+    script = [wt_dev_effect(project, "1-1-a", deferred=[_HARVEST_CARRY])] + [
+        wt_review_effect(project, "1-1-a", clean=False, patched=1) for _ in range(3)
+    ]
+    engine, _ = make_engine(
+        project,
+        script,
+        policy=wt_policy(keep_failed=False, limits=_NO_DAMP),
+    )
+    real_commit = verify.commit_paths
+    failures = 0
+
+    def commit_fails_once(*args, **kwargs):
+        nonlocal failures
+        failures += 1
+        if failures == 1:
+            raise verify.GitError("commit hook rejects deferred carry")
+        return real_commit(*args, **kwargs)
+
+    monkeypatch.setattr(verify, "commit_paths", commit_fails_once)
+
+    assert engine.run().crashed
+
+    failed = load_state(engine.run_dir).tasks["1-1-a"]
+    assert failed.phase == Phase.REVIEW_VERIFY
+    assert failed.harvest_carry_commit_pending is True
+    assert Path(failed.worktree_path).is_dir()
+    assert "story-deferred" not in journal_kinds(engine)
+    assert "unit-closed" not in journal_kinds(engine)
+
+    state = load_state(engine.run_dir)
+    state.clear_pause()
+    adapter = MockAdapter([])
+    resumed = Engine(
+        paths=project,
+        policy=engine.policy,
+        adapter=adapter,
+        run_dir=engine.run_dir,
+        journal=engine.journal,
+        state=state,
+    )
+    summary = resumed.run()
+
+    restored = load_state(resumed.run_dir).tasks["1-1-a"]
+    assert summary.deferred == 1 and not summary.crashed and not summary.paused
+    assert restored.phase == Phase.DEFERRED
+    assert restored.harvest_carry_commit_pending is False
+    assert adapter.sessions == []
+    assert "story-deferred" in journal_kinds(resumed)
+    assert "unit-closed" in journal_kinds(resumed)
+    assert [entry.title for entry in _main_harvest_entries(project)] == [_HARVEST_CARRY["summary"]]
+    assert [path.resolve() for path in worktree_list(project.project)] == [
+        project.project.resolve()
+    ]
+    assert not branch_exists(project.project, failed.branch)
+    assert worktree_clean(project.project)
+
+
 def test_done_isolated_unit_carries_a_gitignored_harvest_after_merge(project):
     ignore_before_commit(project, "deferred-work.md")
     commit_sprint(project, {"1-1-a": "ready-for-dev"})
@@ -696,6 +776,306 @@ def test_done_isolated_unit_carries_a_gitignored_harvest_after_merge(project):
     assert [path.resolve() for path in worktree_list(project.project)] == [
         project.project.resolve()
     ]
+
+
+def test_done_isolated_unit_carries_gitignored_harvests_from_every_successful_pass(project):
+    """A later review payload cannot erase a retained dev finding before carry."""
+    ignore_before_commit(project, "deferred-work.md")
+    commit_sprint(project, {"1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(
+        project,
+        [
+            wt_dev_effect(project, "1-1-a", deferred=[_HARVEST_CARRY]),
+            wt_review_effect(
+                project,
+                "1-1-a",
+                clean=True,
+                deferred=[_HARVEST_CARRY_LATER],
+            ),
+        ],
+    )
+
+    summary = engine.run()
+
+    task = engine.state.tasks["1-1-a"]
+    expected = [_HARVEST_CARRY["summary"], _HARVEST_CARRY_LATER["summary"]]
+    assert summary.done == 1 and not summary.crashed and not summary.paused
+    assert [item["title"] for item in task.harvested_deferrals] == expected
+    assert [entry.title for entry in _main_harvest_entries(project)] == expected
+    assert [event["dw_ids"] for event in _harvest_carry_events(engine)] == [["DW-1", "DW-2"]]
+
+
+def test_tracked_harvest_carry_commit_failure_propagates(project, monkeypatch):
+    """A tracked ledger persistence fault cannot be reported as a completed carry."""
+    project.deferred_work.parent.mkdir(parents=True, exist_ok=True)
+    project.deferred_work.write_text("# Deferred Work\n", encoding="utf-8")
+    commit_sprint(project, {"1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(project, [])
+    task = StoryTask(
+        story_key="1-1-a",
+        epic=1,
+        harvested_deferrals=[_harvest_record()],
+    )
+    engine.state.tasks[task.story_key] = task
+
+    def commit_fails(*args, **kwargs):
+        raise verify.GitError("index lock blocks tracked ledger carry")
+
+    monkeypatch.setattr(verify, "commit_paths", commit_fails)
+
+    with pytest.raises(verify.GitError, match="index lock"):
+        engine._carry_harvested_deferrals(task)
+
+    assert "harvest-carried" not in journal_kinds(engine)
+    assert "harvest-carry-uncommitted" not in journal_kinds(engine)
+    assert load_state(engine.run_dir).tasks[task.story_key].harvest_carry_commit_pending
+
+
+def test_untracked_nonignored_harvest_carry_commit_failure_propagates(project, monkeypatch):
+    """An ordinary new ledger is committable, so its git failure is fatal too."""
+    engine, _ = make_engine(project, [])
+    task = StoryTask(
+        story_key="1-1-a",
+        epic=1,
+        harvested_deferrals=[_harvest_record()],
+    )
+    engine.state.tasks[task.story_key] = task
+
+    def commit_fails(*args, **kwargs):
+        raise verify.GitError("status fails for untracked ledger carry")
+
+    monkeypatch.setattr(verify, "commit_paths", commit_fails)
+
+    with pytest.raises(verify.GitError, match="untracked ledger"):
+        engine._carry_harvested_deferrals(task)
+
+    rel = project.deferred_work.relative_to(project.project).as_posix()
+    assert rel in verify.untracked_files(project.project)
+    assert load_state(engine.run_dir).tasks[task.story_key].harvest_carry_commit_pending
+    assert "harvest-carry-uncommitted" not in journal_kinds(engine)
+
+
+def test_external_harvest_carry_commit_failure_degrades(project, tmp_path, monkeypatch):
+    """A configured external ledger remains an advisory, non-git artifact."""
+    external_paths = ProjectPaths(
+        project=project.project,
+        implementation_artifacts=tmp_path / "external-artifacts",
+        planning_artifacts=project.planning_artifacts,
+        output_folder=project.output_folder,
+        repo_root=project.repo_root,
+    )
+    engine, _ = make_engine(external_paths, [])
+    task = StoryTask(
+        story_key="1-1-a",
+        epic=1,
+        harvested_deferrals=[_harvest_record()],
+    )
+    engine.state.tasks[task.story_key] = task
+
+    def commit_fails(*args, **kwargs):
+        raise verify.GitError("external ledger cannot be committed")
+
+    monkeypatch.setattr(verify, "commit_paths", commit_fails)
+
+    engine._carry_harvested_deferrals(task)
+
+    restored = load_state(engine.run_dir).tasks[task.story_key]
+    assert restored.harvest_carry_commit_pending is False
+    assert [entry.title for entry in _main_harvest_entries(external_paths)] == [
+        _HARVEST_CARRY["summary"]
+    ]
+    uncommitted = [
+        event for event in engine.journal.entries() if event["kind"] == "harvest-carry-uncommitted"
+    ]
+    assert len(uncommitted) == 1 and uncommitted[0]["dw_ids"] == ["DW-1"]
+
+
+def test_host_loss_after_harvest_append_replays_the_pending_commit(project, monkeypatch):
+    """The commit intent is durable before append_entry can mutate the ledger."""
+    from bmad_loop import deferredwork
+
+    commit_sprint(project, {"1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(project, [])
+    engine.state.target_branch = "main"
+    worktree = engine.run_dir / "worktrees" / "1-1-a"
+    worktree.mkdir(parents=True)
+    task = StoryTask(
+        story_key="1-1-a",
+        epic=1,
+        phase=Phase.DONE,
+        worktree_path=str(worktree),
+        branch="bmad-loop/test-run/1-1-a",
+        harvested_deferrals=[_harvest_record()],
+    )
+    engine.state.tasks[task.story_key] = task
+    engine.journal.append(
+        "unit-merged",
+        story_key=task.story_key,
+        branch=task.branch,
+        target="main",
+    )
+    real_append = deferredwork.append_entry
+
+    def append_then_host_dies(*args, **kwargs):
+        real_append(*args, **kwargs)
+        raise SystemExit("host died after ledger append")
+
+    monkeypatch.setattr(deferredwork, "append_entry", append_then_host_dies)
+    with pytest.raises(SystemExit, match="host died"):
+        engine._carry_harvested_deferrals(task)
+
+    failed = load_state(engine.run_dir).tasks[task.story_key]
+    assert failed.harvest_carry_commit_pending is True
+    assert [entry.title for entry in _main_harvest_entries(project)] == [_HARVEST_CARRY["summary"]]
+
+    monkeypatch.setattr(deferredwork, "append_entry", real_append)
+    failed_state = load_state(engine.run_dir)
+    resumed = Engine(
+        paths=project,
+        policy=engine.policy,
+        adapter=MockAdapter([]),
+        run_dir=engine.run_dir,
+        journal=engine.journal,
+        state=failed_state,
+    )
+    after_story: list[str] = []
+    monkeypatch.setattr(
+        resumed,
+        "_after_story",
+        lambda restored_task: after_story.append(restored_task.story_key),
+    )
+    resumed._replay_unlatched_ledger_carries()
+
+    restored = load_state(resumed.run_dir).tasks[task.story_key]
+    assert failed_state.tasks[task.story_key].isolated_ledger_carried is True
+    assert restored.harvest_carry_commit_pending is False
+    assert restored.isolated_ledger_carried is True
+    assert after_story == [task.story_key]
+    assert worktree_clean(project.project)
+    assert "carry harvested findings from 1-1-a" in git(project.project, "log", "-1", "--format=%s")
+
+
+@pytest.mark.parametrize("phase", [Phase.DONE, Phase.AWAITING_OPERATOR, Phase.DEFERRED])
+def test_tracked_harvest_carry_commit_failure_retries_its_pending_commit(
+    project, monkeypatch, phase
+):
+    """A failed commit remains replayable after provenance dedupes its append."""
+    project.deferred_work.parent.mkdir(parents=True, exist_ok=True)
+    project.deferred_work.write_text("# Deferred Work\n", encoding="utf-8")
+    commit_sprint(project, {"1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(project, [])
+    engine.state.target_branch = "main"
+    worktree = engine.run_dir / "worktrees" / "1-1-a"
+    worktree.mkdir(parents=True)
+    task = StoryTask(
+        story_key="1-1-a",
+        epic=1,
+        phase=phase,
+        worktree_path=str(worktree),
+        branch="bmad-loop/test-run/1-1-a",
+        harvested_deferrals=[_harvest_record()],
+    )
+    engine.state.tasks[task.story_key] = task
+    if phase in (Phase.DONE, Phase.AWAITING_OPERATOR):
+        engine.journal.append(
+            "unit-merged",
+            story_key=task.story_key,
+            branch=task.branch,
+            target="main",
+        )
+    real_commit = verify.commit_paths
+
+    def commit_fails(*args, **kwargs):
+        raise verify.GitError("commit hook rejects tracked carry")
+
+    monkeypatch.setattr(verify, "commit_paths", commit_fails)
+    with pytest.raises(verify.GitError, match="commit hook"):
+        engine._carry_harvested_deferrals(task)
+
+    failed = load_state(engine.run_dir).tasks[task.story_key]
+    assert failed.harvest_carry_commit_pending is True
+    assert failed.isolated_ledger_carried is False
+
+    monkeypatch.setattr(verify, "commit_paths", real_commit)
+    resumed = Engine(
+        paths=project,
+        policy=engine.policy,
+        adapter=MockAdapter([]),
+        run_dir=engine.run_dir,
+        journal=engine.journal,
+        state=load_state(engine.run_dir),
+    )
+    resumed._replay_unlatched_ledger_carries()
+
+    restored = load_state(resumed.run_dir).tasks[task.story_key]
+    assert restored.harvest_carry_commit_pending is False
+    assert restored.isolated_ledger_carried is (phase != Phase.DEFERRED)
+    assert "resume-ledger-carry" in journal_kinds(resumed)
+    assert [entry.title for entry in _main_harvest_entries(project)] == [_HARVEST_CARRY["summary"]]
+    assert "carry harvested findings from 1-1-a" in git(project.project, "log", "-1", "--format=%s")
+
+
+def test_unmerged_terminal_unit_does_not_replay_harvest_carry(project):
+    """A terminal phase and live directory alone are not durable merge evidence."""
+    commit_sprint(project, {"1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(project, [])
+    engine.state.target_branch = "main"
+    worktree = engine.run_dir / "worktrees" / "1-1-a"
+    worktree.mkdir(parents=True)
+    task = StoryTask(
+        story_key="1-1-a",
+        epic=1,
+        phase=Phase.DONE,
+        worktree_path=str(worktree),
+        branch="bmad-loop/test-run/1-1-a",
+        harvested_deferrals=[_harvest_record()],
+    )
+    engine.state.tasks[task.story_key] = task
+
+    engine._replay_unlatched_ledger_carries()
+
+    assert not project.deferred_work.exists()
+    assert task.isolated_ledger_carried is False
+    assert "resume-ledger-carry" not in journal_kinds(engine)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("story_key", "1-2-other"),
+        ("branch", "bmad-loop/test-run/other-branch"),
+        ("target", "release"),
+    ],
+)
+def test_mismatched_unit_merge_evidence_does_not_replay_harvest_carry(project, field, value):
+    """Replay requires the merged story, unit branch, and target to all match."""
+    commit_sprint(project, {"1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(project, [])
+    engine.state.target_branch = "main"
+    worktree = engine.run_dir / "worktrees" / "1-1-a"
+    worktree.mkdir(parents=True)
+    task = StoryTask(
+        story_key="1-1-a",
+        epic=1,
+        phase=Phase.DONE,
+        worktree_path=str(worktree),
+        branch="bmad-loop/test-run/1-1-a",
+        harvested_deferrals=[_harvest_record()],
+    )
+    engine.state.tasks[task.story_key] = task
+    evidence = {
+        "story_key": task.story_key,
+        "branch": task.branch,
+        "target": "main",
+    }
+    evidence[field] = value
+    engine.journal.append("unit-merged", **evidence)
+
+    engine._replay_unlatched_ledger_carries()
+
+    assert not project.deferred_work.exists()
+    assert task.isolated_ledger_carried is False
+    assert "resume-ledger-carry" not in journal_kinds(engine)
 
 
 def test_done_isolated_unit_dedupes_a_tracked_closed_harvest_after_merge(project):
@@ -793,6 +1173,71 @@ def test_crashed_post_merge_harvest_carry_replays_and_persists_its_latch(project
     assert not Path(crashed.worktree_path).exists()
     assert not project.deferred_work.exists()
 
+    state = load_state(engine.run_dir)
+    state.clear_pause()
+    adapter = MockAdapter([])
+    resumed = Engine(
+        paths=project,
+        policy=engine.policy,
+        adapter=adapter,
+        run_dir=engine.run_dir,
+        journal=engine.journal,
+        state=state,
+    )
+    summary = resumed.run()
+
+    assert summary.done == 1 and not summary.crashed and not summary.paused
+    assert adapter.sessions == []
+    assert "resume-ledger-carry" in journal_kinds(resumed)
+    assert [entry.title for entry in _main_harvest_entries(project)] == [_HARVEST_CARRY["summary"]]
+    assert load_state(resumed.run_dir).tasks["1-1-a"].isolated_ledger_carried
+
+
+def test_crashed_post_merge_harvest_carry_replays_when_teardown_leaves_directory(
+    project, monkeypatch
+):
+    """A stale teardown directory is not evidence that the merge never landed."""
+    import bmad_loop.workspace as workspace_mod
+
+    ignore_before_commit(project, "deferred-work.md")
+    commit_sprint(project, {"1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(
+        project,
+        [
+            wt_dev_effect(
+                project,
+                "1-1-a",
+                followup_review=False,
+                deferred=[_HARVEST_CARRY],
+            )
+        ],
+    )
+    real_remove = verify.worktree_remove
+    real_rmtree = workspace_mod._rmtree_confined
+
+    def teardown_fails(*args, **kwargs):
+        raise verify.GitError("worktree teardown blocked")
+
+    def leave_directory(*args, **kwargs):
+        return True
+
+    def crash_before_carry(_task) -> None:
+        raise RuntimeError("host died after degraded teardown")
+
+    monkeypatch.setattr(verify, "worktree_remove", teardown_fails)
+    monkeypatch.setattr(workspace_mod, "_rmtree_confined", leave_directory)
+    engine._carry_isolated_ledger_writes = crash_before_carry
+    assert engine.run().crashed
+
+    crashed = load_state(engine.run_dir).tasks["1-1-a"]
+    assert crashed.phase == Phase.DONE and not crashed.isolated_ledger_carried
+    assert Path(crashed.worktree_path).is_dir()
+    assert "unit-merged" in journal_kinds(engine)
+    assert "worktree-teardown-degraded" in journal_kinds(engine)
+    assert not project.deferred_work.exists()
+
+    monkeypatch.setattr(verify, "worktree_remove", real_remove)
+    monkeypatch.setattr(workspace_mod, "_rmtree_confined", real_rmtree)
     state = load_state(engine.run_dir)
     state.clear_pause()
     adapter = MockAdapter([])

--- a/tests/test_engine_worktree.py
+++ b/tests/test_engine_worktree.py
@@ -1185,11 +1185,14 @@ def test_awaiting_operator_isolated_unit_carries_a_gitignored_harvest(project):
     assert [event["dw_ids"] for event in _harvest_carry_events(engine)] == [["DW-1"]]
 
 
-@pytest.mark.parametrize("merge_strategy", ["merge", "ff", "squash"])
+@pytest.mark.parametrize(
+    ("merge_strategy", "resumed_strategy"),
+    [("merge", "ff"), ("ff", "squash"), ("squash", "merge")],
+)
 def test_host_loss_after_merge_before_evidence_replays_gitignored_harvest(
-    project, monkeypatch, merge_strategy
+    project, monkeypatch, merge_strategy, resumed_strategy
 ):
-    """A landed branch remains recoverable before `unit-merged` is journaled."""
+    """Replay uses durable merge intent even when the live policy changed."""
     ignore_before_commit(project, "deferred-work.md")
     commit_sprint(project, {"1-1-a": "ready-for-dev"})
     engine, _ = make_engine(
@@ -1226,6 +1229,7 @@ def test_host_loss_after_merge_before_evidence_replays_gitignored_harvest(
     monkeypatch.setattr(engine.journal, "append", real_append)
     replay_collision_refs: list[str] = []
     replay_merge_refs: list[str] = []
+    replay_strategies: list[str] = []
     real_clean = verify.clean_incoming_collisions
     real_merge = verify.merge_branch
 
@@ -1235,13 +1239,14 @@ def test_host_loss_after_merge_before_evidence_replays_gitignored_harvest(
 
     def record_merge_ref(repo, merge_ref, **kwargs):
         replay_merge_refs.append(merge_ref)
+        replay_strategies.append(kwargs["strategy"])
         return real_merge(repo, merge_ref, **kwargs)
 
     monkeypatch.setattr(verify, "clean_incoming_collisions", record_collision_ref)
     monkeypatch.setattr(verify, "merge_branch", record_merge_ref)
     resumed = Engine(
         paths=project,
-        policy=engine.policy,
+        policy=wt_policy(merge_strategy=resumed_strategy),
         adapter=MockAdapter([]),
         run_dir=engine.run_dir,
         journal=engine.journal,
@@ -1253,8 +1258,19 @@ def test_host_loss_after_merge_before_evidence_replays_gitignored_harvest(
     assert rev_parse_head(project.project) == landed_head
     assert replay_collision_refs == [crashed.commit_sha]
     assert replay_merge_refs == [crashed.commit_sha]
+    assert replay_strategies == [merge_strategy]
     assert "unit-merge-started" in journal_kinds(resumed)
     assert "unit-merged" in journal_kinds(resumed)
+    assert [
+        (entry["strategy"], entry["source"])
+        for entry in resumed.journal.entries()
+        if entry["kind"] == "resume-unit-merge"
+    ] == [(merge_strategy, crashed.commit_sha)]
+    assert [
+        (entry["strategy"], entry["source"])
+        for entry in resumed.journal.entries()
+        if entry["kind"] == "unit-merged"
+    ] == [(merge_strategy, crashed.commit_sha)]
     assert [entry.title for entry in _main_harvest_entries(project)] == [_HARVEST_CARRY["summary"]]
     assert load_state(resumed.run_dir).tasks["1-1-a"].isolated_ledger_carried
 

--- a/tests/test_engine_worktree.py
+++ b/tests/test_engine_worktree.py
@@ -1224,6 +1224,21 @@ def test_host_loss_after_merge_before_evidence_replays_gitignored_harvest(
     assert "unit-merged" not in journal_kinds(engine)
 
     monkeypatch.setattr(engine.journal, "append", real_append)
+    replay_collision_refs: list[str] = []
+    replay_merge_refs: list[str] = []
+    real_clean = verify.clean_incoming_collisions
+    real_merge = verify.merge_branch
+
+    def record_collision_ref(repo, target, merge_ref):
+        replay_collision_refs.append(merge_ref)
+        return real_clean(repo, target, merge_ref)
+
+    def record_merge_ref(repo, merge_ref, **kwargs):
+        replay_merge_refs.append(merge_ref)
+        return real_merge(repo, merge_ref, **kwargs)
+
+    monkeypatch.setattr(verify, "clean_incoming_collisions", record_collision_ref)
+    monkeypatch.setattr(verify, "merge_branch", record_merge_ref)
     resumed = Engine(
         paths=project,
         policy=engine.policy,
@@ -1236,10 +1251,75 @@ def test_host_loss_after_merge_before_evidence_replays_gitignored_harvest(
 
     assert summary.done == 1 and not summary.crashed and not summary.paused
     assert rev_parse_head(project.project) == landed_head
+    assert replay_collision_refs == [crashed.commit_sha]
+    assert replay_merge_refs == [crashed.commit_sha]
     assert "unit-merge-started" in journal_kinds(resumed)
     assert "unit-merged" in journal_kinds(resumed)
     assert [entry.title for entry in _main_harvest_entries(project)] == [_HARVEST_CARRY["summary"]]
     assert load_state(resumed.run_dir).tasks["1-1-a"].isolated_ledger_carried
+
+
+@pytest.mark.parametrize("merge_strategy", ["merge", "ff", "squash"])
+def test_merge_replay_rejects_a_unit_branch_advanced_after_recorded_source(
+    project, monkeypatch, merge_strategy
+):
+    """Recovery preserves and refuses commits outside the completed session."""
+    ignore_before_commit(project, "deferred-work.md")
+    commit_sprint(project, {"1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(
+        project,
+        [
+            wt_dev_effect(
+                project,
+                "1-1-a",
+                followup_review=False,
+                deferred=[_HARVEST_CARRY],
+            )
+        ],
+        policy=wt_policy(merge_strategy=merge_strategy),
+    )
+    real_append = engine.journal.append
+
+    def host_dies_before_merge_evidence(kind, **fields):
+        if kind == "unit-merged":
+            raise SystemExit("host died before merge evidence")
+        return real_append(kind, **fields)
+
+    monkeypatch.setattr(engine.journal, "append", host_dies_before_merge_evidence)
+    with pytest.raises(SystemExit, match="host died before merge evidence"):
+        engine.run()
+
+    crashed = load_state(engine.run_dir).tasks["1-1-a"]
+    landed_head = rev_parse_head(project.project)
+    unit_path = Path(crashed.worktree_path)
+    (unit_path / "late.txt").write_text("not part of the completed session\n", encoding="utf-8")
+    git(unit_path, "add", "late.txt")
+    git(unit_path, "commit", "-q", "-m", "late unverified commit")
+    advanced_head = rev_parse_head(unit_path)
+    assert advanced_head != crashed.commit_sha
+
+    monkeypatch.setattr(engine.journal, "append", real_append)
+    resumed = Engine(
+        paths=project,
+        policy=engine.policy,
+        adapter=MockAdapter([]),
+        run_dir=engine.run_dir,
+        journal=engine.journal,
+        state=load_state(engine.run_dir),
+    )
+    summary = resumed.run()
+
+    assert summary.paused and summary.escalated == 1 and not summary.crashed
+    assert rev_parse_head(project.project) == landed_head
+    assert not (project.project / "late.txt").exists()
+    assert unit_path.is_dir()
+    assert branch_exists(project.project, crashed.branch)
+    assert rev_parse_head(unit_path) == advanced_head
+    assert "unit-merged" not in journal_kinds(resumed)
+    assert not project.deferred_work.exists()
+    restored = load_state(resumed.run_dir).tasks["1-1-a"]
+    assert restored.phase == Phase.ESCALATED
+    assert not restored.isolated_ledger_carried
 
 
 def test_crashed_post_merge_harvest_carry_replays_and_persists_its_latch(project):

--- a/tests/test_engine_worktree.py
+++ b/tests/test_engine_worktree.py
@@ -1039,6 +1039,47 @@ def test_unmerged_terminal_unit_does_not_replay_harvest_carry(project):
     assert "resume-ledger-carry" not in journal_kinds(engine)
 
 
+def test_started_merge_replay_failure_does_not_carry_harvest(project, monkeypatch):
+    """Write-ahead merge intent cannot stand in for successful merge proof."""
+    commit_sprint(project, {"1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(project, [])
+    engine.state.target_branch = "main"
+    worktree = engine.run_dir / "worktrees" / "1-1-a"
+    worktree.mkdir(parents=True)
+    source = rev_parse_head(project.project)
+    task = StoryTask(
+        story_key="1-1-a",
+        epic=1,
+        phase=Phase.DONE,
+        worktree_path=str(worktree),
+        branch="bmad-loop/test-run/1-1-a",
+        commit_sha=source,
+        harvested_deferrals=[_harvest_record()],
+    )
+    engine.state.tasks[task.story_key] = task
+    engine.journal.append(
+        "unit-merge-started",
+        story_key=task.story_key,
+        branch=task.branch,
+        target="main",
+        strategy="merge",
+        source=source,
+    )
+
+    def replay_fails(*args, **kwargs):
+        raise verify.GitError("replayed merge still conflicts")
+
+    monkeypatch.setattr(engine, "_merge_local", replay_fails)
+
+    with pytest.raises(verify.GitError, match="still conflicts"):
+        engine._replay_unlatched_ledger_carries()
+
+    assert not project.deferred_work.exists()
+    assert task.isolated_ledger_carried is False
+    assert "resume-unit-merge" in journal_kinds(engine)
+    assert "resume-ledger-carry" not in journal_kinds(engine)
+
+
 @pytest.mark.parametrize(
     ("field", "value"),
     [
@@ -1142,6 +1183,63 @@ def test_awaiting_operator_isolated_unit_carries_a_gitignored_harvest(project):
     assert task.isolated_ledger_carried
     assert [entry.title for entry in _main_harvest_entries(project)] == [_HARVEST_CARRY["summary"]]
     assert [event["dw_ids"] for event in _harvest_carry_events(engine)] == [["DW-1"]]
+
+
+@pytest.mark.parametrize("merge_strategy", ["merge", "ff", "squash"])
+def test_host_loss_after_merge_before_evidence_replays_gitignored_harvest(
+    project, monkeypatch, merge_strategy
+):
+    """A landed branch remains recoverable before `unit-merged` is journaled."""
+    ignore_before_commit(project, "deferred-work.md")
+    commit_sprint(project, {"1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(
+        project,
+        [
+            wt_dev_effect(
+                project,
+                "1-1-a",
+                followup_review=False,
+                deferred=[_HARVEST_CARRY],
+            )
+        ],
+        policy=wt_policy(merge_strategy=merge_strategy),
+    )
+    real_append = engine.journal.append
+
+    def host_dies_before_merge_evidence(kind, **fields):
+        if kind == "unit-merged":
+            raise SystemExit("host died before merge evidence")
+        return real_append(kind, **fields)
+
+    monkeypatch.setattr(engine.journal, "append", host_dies_before_merge_evidence)
+    with pytest.raises(SystemExit, match="host died before merge evidence"):
+        engine.run()
+
+    crashed = load_state(engine.run_dir).tasks["1-1-a"]
+    landed_head = rev_parse_head(project.project)
+    assert crashed.phase == Phase.DONE and not crashed.isolated_ledger_carried
+    assert "change for 1-1-a" in (project.project / "src.txt").read_text()
+    assert Path(crashed.worktree_path).is_dir()
+    assert not project.deferred_work.exists()
+    assert "unit-merged" not in journal_kinds(engine)
+
+    monkeypatch.setattr(engine.journal, "append", real_append)
+    resumed = Engine(
+        paths=project,
+        policy=engine.policy,
+        adapter=MockAdapter([]),
+        run_dir=engine.run_dir,
+        journal=engine.journal,
+        state=load_state(engine.run_dir),
+    )
+    summary = resumed.run()
+
+    assert summary.done == 1 and not summary.crashed and not summary.paused
+    assert rev_parse_head(project.project) == landed_head
+    assert "unit-merge-started" in journal_kinds(resumed)
+    assert "unit-merged" in journal_kinds(resumed)
+    assert [entry.title for entry in _main_harvest_entries(project)] == [_HARVEST_CARRY["summary"]]
+    assert load_state(resumed.run_dir).tasks["1-1-a"].isolated_ledger_carried
 
 
 def test_crashed_post_merge_harvest_carry_replays_and_persists_its_latch(project):

--- a/tests/test_engine_worktree.py
+++ b/tests/test_engine_worktree.py
@@ -75,6 +75,7 @@ def wt_dev_effect(
     followup_review=True,
     closes_deferred=None,
     operator_actions=None,
+    deferred=None,
 ):
     """Dev session running inside the unit worktree (spec.cwd). Mirrors the
     bmad-dev-auto skill: self-finalizes the spec to done, never writes the sprint
@@ -95,6 +96,7 @@ def wt_dev_effect(
             baseline,
             closes_deferred=closes_deferred,
             operator_actions=operator_actions,
+            deferred=deferred,
         )
         # NO set_sprint: the orchestrator is the single sprint-status writer
         return SessionResult(
@@ -611,6 +613,204 @@ def test_worktree_defer_without_keep_drops_worktree_but_saves_patch(project):
     # in the run dir is the only surviving artifact.
     attention = (engine.run_dir / "ATTENTION").read_text()
     assert "story deferred: 1-1-a" in attention and "kept on branch" not in attention
+
+
+_HARVEST_CARRY = {
+    "summary": "Retry loop has no ceiling",
+    "evidence": "the backoff doubles forever with no cap",
+    "location": "src/retry.py:88",
+    "severity": "medium",
+}
+
+
+def _main_harvest_entries(project):
+    from bmad_loop import deferredwork
+
+    text = project.deferred_work.read_text(encoding="utf-8")
+    return deferredwork.parse_ledger(text)
+
+
+def _harvest_carry_events(engine):
+    return [entry for entry in engine.journal.entries() if entry["kind"] == "harvest-carried"]
+
+
+def test_deferred_isolated_unit_carries_harvest_before_terminal_save(project):
+    """A dropped failed worktree cannot be the only durable home of its finding."""
+    commit_sprint(project, {"1-1-a": "ready-for-dev"})
+    script = [wt_dev_effect(project, "1-1-a", deferred=[_HARVEST_CARRY])] + [
+        wt_review_effect(project, "1-1-a", clean=False, patched=1) for _ in range(3)
+    ]
+    engine, _ = make_engine(
+        project,
+        script,
+        policy=wt_policy(keep_failed=False, limits=_NO_DAMP),
+    )
+    terminal_saves: list[bool] = []
+    real_save = engine._save
+
+    def observe_terminal_save() -> None:
+        task = engine.state.tasks.get("1-1-a")
+        if task is not None and task.phase == Phase.DEFERRED:
+            terminal_saves.append(project.deferred_work.is_file())
+        real_save()
+
+    engine._save = observe_terminal_save
+    summary = engine.run()
+
+    assert summary.deferred == 1 and not summary.paused and not summary.crashed
+    assert terminal_saves and terminal_saves[0] is True
+    assert [entry.title for entry in _main_harvest_entries(project)] == [_HARVEST_CARRY["summary"]]
+    assert [path.resolve() for path in worktree_list(project.project)] == [
+        project.project.resolve()
+    ]
+    assert not branch_exists(project.project, "bmad-loop/test-run/1-1-a")
+
+
+def test_done_isolated_unit_carries_a_gitignored_harvest_after_merge(project):
+    ignore_before_commit(project, "deferred-work.md")
+    commit_sprint(project, {"1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(
+        project,
+        [
+            wt_dev_effect(
+                project,
+                "1-1-a",
+                followup_review=False,
+                deferred=[_HARVEST_CARRY],
+            )
+        ],
+    )
+
+    summary = engine.run()
+
+    task = engine.state.tasks["1-1-a"]
+    assert summary.done == 1 and task.phase == Phase.DONE
+    assert task.isolated_ledger_carried
+    assert "change for 1-1-a" in (project.project / "src.txt").read_text()
+    assert [entry.title for entry in _main_harvest_entries(project)] == [_HARVEST_CARRY["summary"]]
+    assert [event["dw_ids"] for event in _harvest_carry_events(engine)] == [["DW-1"]]
+    uncommitted = [
+        entry for entry in engine.journal.entries() if entry["kind"] == "harvest-carry-uncommitted"
+    ]
+    assert len(uncommitted) == 1 and uncommitted[0]["dw_ids"] == ["DW-1"]
+    assert [path.resolve() for path in worktree_list(project.project)] == [
+        project.project.resolve()
+    ]
+
+
+def test_done_isolated_unit_dedupes_a_tracked_closed_harvest_after_merge(project):
+    from bmad_loop import deferredwork
+
+    project.deferred_work.parent.mkdir(parents=True, exist_ok=True)
+    project.deferred_work.write_text("# Deferred Work\n", encoding="utf-8")
+    commit_sprint(project, {"1-1-a": "ready-for-dev"})
+    head_before = rev_parse_head(project.project)
+
+    def close_harvest_then_review(spec):
+        wt = project.rebased(spec.cwd)
+        assert deferredwork.mark_done(
+            wt.deferred_work,
+            "DW-1",
+            "2026-08-03",
+            "fixed before the unit merged",
+        )
+        return wt_review_effect(project, "1-1-a", clean=True)(spec)
+
+    engine, _ = make_engine(
+        project,
+        [
+            wt_dev_effect(project, "1-1-a", deferred=[_HARVEST_CARRY]),
+            close_harvest_then_review,
+        ],
+    )
+    summary = engine.run()
+
+    assert summary.done == 1 and not summary.paused and not summary.crashed
+    entries = _main_harvest_entries(project)
+    assert len(entries) == 1 and entries[0].title == _HARVEST_CARRY["summary"]
+    assert not entries[0].open
+    assert [event["dw_ids"] for event in _harvest_carry_events(engine)] == [[]]
+    subjects = git(project.project, "log", "--format=%s", f"{head_before}..HEAD").splitlines()
+    assert not [
+        subject
+        for subject in subjects
+        if subject.startswith("chore(deferred-work): carry harvested findings")
+    ]
+
+
+def test_awaiting_operator_isolated_unit_carries_a_gitignored_harvest(project):
+    ignore_before_commit(project, "deferred-work.md")
+    commit_sprint(project, {"1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(
+        project,
+        [
+            wt_dev_effect(
+                project,
+                "1-1-a",
+                final_status="awaiting-operator",
+                followup_review=False,
+                operator_actions=["publish the DNS record"],
+                deferred=[_HARVEST_CARRY],
+            )
+        ],
+    )
+
+    summary = engine.run()
+
+    task = engine.state.tasks["1-1-a"]
+    assert summary.awaiting_operator == 1 and task.phase == Phase.AWAITING_OPERATOR
+    assert task.isolated_ledger_carried
+    assert [entry.title for entry in _main_harvest_entries(project)] == [_HARVEST_CARRY["summary"]]
+    assert [event["dw_ids"] for event in _harvest_carry_events(engine)] == [["DW-1"]]
+
+
+def test_crashed_post_merge_harvest_carry_replays_and_persists_its_latch(project):
+    ignore_before_commit(project, "deferred-work.md")
+    commit_sprint(project, {"1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(
+        project,
+        [
+            wt_dev_effect(
+                project,
+                "1-1-a",
+                followup_review=False,
+                deferred=[_HARVEST_CARRY],
+            )
+        ],
+    )
+
+    def crash_before_carry(_task) -> None:
+        raise RuntimeError("host died after merge and teardown")
+
+    # The WorktreeFlow callback must look this method up when invoked, not capture
+    # the original bound method at Engine construction time.
+    engine._carry_isolated_ledger_writes = crash_before_carry
+    assert engine.run().crashed
+
+    crashed = load_state(engine.run_dir).tasks["1-1-a"]
+    assert crashed.phase == Phase.DONE and not crashed.isolated_ledger_carried
+    assert crashed.harvested_deferrals
+    assert not Path(crashed.worktree_path).exists()
+    assert not project.deferred_work.exists()
+
+    state = load_state(engine.run_dir)
+    state.clear_pause()
+    adapter = MockAdapter([])
+    resumed = Engine(
+        paths=project,
+        policy=engine.policy,
+        adapter=adapter,
+        run_dir=engine.run_dir,
+        journal=engine.journal,
+        state=state,
+    )
+    summary = resumed.run()
+
+    assert summary.done == 1 and not summary.crashed and not summary.paused
+    assert adapter.sessions == []
+    assert "resume-ledger-carry" in journal_kinds(resumed)
+    assert [entry.title for entry in _main_harvest_entries(project)] == [_HARVEST_CARRY["summary"]]
+    assert load_state(resumed.run_dir).tasks["1-1-a"].isolated_ledger_carried
 
 
 def test_worktree_defer_then_next_story_succeeds(project):

--- a/tests/test_engine_worktree.py
+++ b/tests/test_engine_worktree.py
@@ -27,7 +27,7 @@ from conftest import (
     write_sprint,
 )
 
-from bmad_loop import verify, worktree_flow
+from bmad_loop import sprintstatus, verify, worktree_flow
 from bmad_loop.adapters.base import SessionResult
 from bmad_loop.adapters.mock import MockAdapter
 from bmad_loop.bmadconfig import ProjectPaths
@@ -74,6 +74,7 @@ def wt_dev_effect(
     *,
     final_status="done",
     followup_review=True,
+    write_src=True,
     closes_deferred=None,
     operator_actions=None,
     deferred=None,
@@ -88,8 +89,9 @@ def wt_dev_effect(
         cwd = spec.cwd
         wt = project.rebased(cwd)
         baseline = rev_parse_head(cwd)
-        src = cwd / "src.txt"
-        src.write_text(src.read_text() + f"change for {story_key}\n")
+        if write_src:
+            src = cwd / "src.txt"
+            src.write_text(src.read_text() + f"change for {story_key}\n")
         sp = wt.implementation_artifacts / f"spec-{story_key}.md"
         write_spec(
             sp,
@@ -738,6 +740,82 @@ def test_deferred_carry_commit_failure_resumes_before_terminal_integration(proje
     assert adapter.sessions == []
     assert "story-deferred" in journal_kinds(resumed)
     assert "unit-closed" in journal_kinds(resumed)
+    assert [entry.title for entry in _main_harvest_entries(project)] == [_HARVEST_CARRY["summary"]]
+    assert [path.resolve() for path in worktree_list(project.project)] == [
+        project.project.resolve()
+    ]
+    assert not branch_exists(project.project, failed.branch)
+    assert worktree_clean(project.project)
+
+
+def test_dev_defer_carry_failure_resumes_the_rejected_decision(project, monkeypatch):
+    """A carry fault cannot turn a rejected dev result into a verified spec."""
+    project.deferred_work.parent.mkdir(parents=True, exist_ok=True)
+    project.deferred_work.write_text("# Deferred Work\n", encoding="utf-8")
+    commit_sprint(project, {"1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(
+        project,
+        [
+            wt_dev_effect(
+                project,
+                "1-1-a",
+                followup_review=False,
+                write_src=False,
+                deferred=[_HARVEST_CARRY],
+            )
+        ],
+        policy=wt_policy(keep_failed=False, limits=LimitsPolicy(max_dev_attempts=1)),
+    )
+    real_commit = verify.commit_paths
+    failures = 0
+
+    def commit_fails_once(*args, **kwargs):
+        nonlocal failures
+        message = str(args[1]) if len(args) > 1 else str(kwargs.get("message", ""))
+        if message.startswith("chore(deferred-work): carry harvested findings") and failures == 0:
+            failures += 1
+            raise verify.GitError("commit hook rejects deferred carry")
+        return real_commit(*args, **kwargs)
+
+    monkeypatch.setattr(verify, "commit_paths", commit_fails_once)
+
+    assert engine.run().crashed
+
+    failed = load_state(engine.run_dir).tasks["1-1-a"]
+    assert failed.phase == Phase.DEV_VERIFY
+    assert failed.spec_file
+    assert failed.harvest_carry_commit_pending is True
+    assert "no changes" in (failed.defer_reason or "")
+    assert Path(failed.worktree_path).is_dir()
+    assert "story-deferred" not in journal_kinds(engine)
+    assert "unit-closed" not in journal_kinds(engine)
+
+    state = load_state(engine.run_dir)
+    state.clear_pause()
+    adapter = MockAdapter([])
+    resumed = Engine(
+        paths=project,
+        policy=engine.policy,
+        adapter=adapter,
+        run_dir=engine.run_dir,
+        journal=engine.journal,
+        state=state,
+    )
+    summary = resumed.run()
+
+    restored = load_state(resumed.run_dir).tasks["1-1-a"]
+    assert summary.deferred == 1 and not summary.done
+    assert not summary.crashed and not summary.paused
+    assert restored.phase == Phase.DEFERRED
+    assert restored.harvest_carry_commit_pending is False
+    assert adapter.sessions == []
+    decisions = [event for event in resumed.journal.entries() if event["kind"] == "dev-decision"]
+    assert len(decisions) == 1 and decisions[0]["action"] == "defer"
+    assert "resume-defer" in journal_kinds(resumed)
+    assert "resume-review" not in journal_kinds(resumed)
+    assert "story-deferred" in journal_kinds(resumed)
+    assert "unit-closed" in journal_kinds(resumed)
+    assert sprintstatus.story_status(project.sprint_status, "1-1-a") == "ready-for-dev"
     assert [entry.title for entry in _main_harvest_entries(project)] == [_HARVEST_CARRY["summary"]]
     assert [path.resolve() for path in worktree_list(project.project)] == [
         project.project.resolve()

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -170,12 +170,13 @@ _DEFERRED_STATE_KEYS = (
     "ledger_changed_before_harvest",
     "harvested_deferrals",
     "bundle_closes_intended",
+    "harvest_carry_commit_pending",
     "isolated_ledger_carried",
 )
 
 
 def test_deferred_work_state_fields_round_trip_through_json():
-    """All eight fields are hand-enumerated in both serializers. Non-default
+    """All nine fields are hand-enumerated in both serializers. Non-default
     values make a missing line on either side observable, while the JSON leg pins
     the on-disk container shape rather than only an in-memory dataclass copy."""
     task = StoryTask(
@@ -188,6 +189,7 @@ def test_deferred_work_state_fields_round_trip_through_json():
         ledger_changed_before_harvest=True,
         harvested_deferrals=[{"origin": "spec-deferred abc", "title": "finding"}],
         bundle_closes_intended=["DW-3", "DW-7"],
+        harvest_carry_commit_pending=True,
         isolated_ledger_carried=True,
     )
     restored = StoryTask.from_dict(json.loads(json.dumps(task.to_dict())))
@@ -200,11 +202,12 @@ def test_deferred_work_state_fields_round_trip_through_json():
     assert restored.ledger_changed_before_harvest is True
     assert restored.harvested_deferrals == [{"origin": "spec-deferred abc", "title": "finding"}]
     assert restored.bundle_closes_intended == ["DW-3", "DW-7"]
+    assert restored.harvest_carry_commit_pending is True
     assert restored.isolated_ledger_carried is True
 
 
 def test_deferred_work_state_fields_default_for_one_old_state_dict():
-    """A state.json written before this package has none of the eight keys.
+    """A state.json written before this package has none of the nine keys.
     Every load must use ``d.get`` so resume reaches the old behavior instead of
     raising KeyError; one shared old document prevents testing only a subset."""
     doc = StoryTask(story_key="1-1-a", epic=1).to_dict()
@@ -219,6 +222,7 @@ def test_deferred_work_state_fields_default_for_one_old_state_dict():
     assert restored.ledger_changed_before_harvest is False
     assert restored.harvested_deferrals == []
     assert restored.bundle_closes_intended == []
+    assert restored.harvest_carry_commit_pending is False
     assert restored.isolated_ledger_carried is False
 
 

--- a/tests/test_stories_engine.py
+++ b/tests/test_stories_engine.py
@@ -76,6 +76,7 @@ def stories_dev_effect(
     prose_status: str | None = None,
     closes_deferred: object = None,
     write_src: bool = True,
+    deferred=None,
 ):
     """Simulate a bmad-dev-auto folder+id dispatch: read the story id + spec
     folder from the session env (as the real adapter does), write the id-keyed
@@ -83,7 +84,8 @@ def stories_dev_effect(
 
     ``write_src=False`` skips the code change, so the proof-of-work gate fails and
     the story defers with its spec still finalized — the shape a story-declared
-    ledger closure must survive without claiming anything resolved."""
+    ledger closure must survive without claiming anything resolved. ``deferred``
+    writes the post-#2640 finding list into that spec."""
 
     def effect(spec) -> SessionResult:
         story_id = spec.env["BMAD_LOOP_STORY_KEY"]
@@ -96,7 +98,12 @@ def stories_dev_effect(
         if write_src:
             src.write_text(src.read_text() + f"work for {story_id}\n")
         write_spec(
-            sp, final_status, baseline, prose_status=prose_status, closes_deferred=closes_deferred
+            sp,
+            final_status,
+            baseline,
+            prose_status=prose_status,
+            closes_deferred=closes_deferred,
+            deferred=deferred,
         )
         return SessionResult(
             status="completed",
@@ -116,7 +123,7 @@ def stories_dev_effect(
     return effect
 
 
-def stories_checkpoint_effect():
+def stories_checkpoint_effect(*, deferred=None):
     """Simulate bmad-dev-auto honoring `Halt after planning.`: on a plan-halt leg
     (BMAD_LOOP_PLAN_HALT set by the engine) write the id-keyed spec at
     ready-for-dev with NO code change — the plan is just the spec — and mark the
@@ -139,14 +146,14 @@ def stories_checkpoint_effect():
             "escalations": [],
         }
         if spec.env.get("BMAD_LOOP_PLAN_HALT"):
-            write_spec(sp, "ready-for-dev", baseline)
+            write_spec(sp, "ready-for-dev", baseline, deferred=deferred)
             return SessionResult(
                 status="completed",
                 result_json={**common, "status": "ready-for-dev", "plan_halt": True},
             )
         src = Path(spec.cwd) / "src.txt"
         src.write_text(src.read_text() + f"work for {story_id}\n")
-        write_spec(sp, "done", baseline)
+        write_spec(sp, "done", baseline, deferred=deferred)
         return SessionResult(
             status="completed",
             result_json={**common, "status": "done", "followup_review_recommended": False},
@@ -1539,3 +1546,73 @@ def test_stories_mode_unknown_id_is_journaled_not_fatal(project):
     assert project.deferred_work.read_bytes() == before
     unmatched = _kinds(engine.journal, "deferred-close-unmatched")
     assert len(unmatched) == 1 and unmatched[0]["dw_ids"] == ["DW-99"]
+
+
+# ---------------- frontmatter `deferred:` harvest parity (BMAD-METHOD #2640)
+
+STORY_FINDING = {
+    "summary": "The id-keyed spec loader rescans on every call",
+    "evidence": "resolve_story_spec globs the folder each time",
+    "location": "src/bmad_loop/stories.py:120",
+    "severity": "low",
+}
+
+
+def test_stories_mode_harvests_spec_deferrals_into_the_ledger(project):
+    from bmad_loop import deferredwork
+
+    setup_stories(project, [entry("1")])
+    engine, _ = make_engine(project, [stories_dev_effect(deferred=[STORY_FINDING])])
+
+    summary = engine.run()
+
+    assert summary.done == 1 and not summary.paused
+    entries = deferredwork.parse_ledger(project.deferred_work.read_text(encoding="utf-8"))
+    assert len(entries) == 1 and entries[0].open
+    assert entries[0].title == STORY_FINDING["summary"]
+    assert "location: src/bmad_loop/stories.py:120" in entries[0].body
+    assert "source_spec: `1-slug.md`" in entries[0].body
+    assert _kinds(engine.journal, "spec-deferrals-harvested")[0]["dw_ids"] == ["DW-1"]
+
+
+def test_plan_halt_leg_does_not_harvest_then_implement_leg_does(project):
+    from bmad_loop import deferredwork
+
+    setup_stories(project, [entry("1", spec_checkpoint=True)])
+    engine, _ = make_engine(project, [stories_checkpoint_effect(deferred=[STORY_FINDING])])
+
+    summary = engine.run()
+
+    assert summary.paused and summary.done == 0
+    assert status_of(read_frontmatter(story_spec(project, "1"))) == "ready-for-dev"
+    assert not project.deferred_work.exists()
+    assert not _kinds(engine.journal, "spec-deferrals-harvested")
+
+    resumed, _ = resume_engine(
+        project, engine, [stories_checkpoint_effect(deferred=[STORY_FINDING])]
+    )
+    resumed_summary = resumed.run()
+
+    assert resumed_summary.done == 1
+    entries = deferredwork.parse_ledger(project.deferred_work.read_text(encoding="utf-8"))
+    assert len(entries) == 1 and entries[0].open
+    assert _kinds(resumed.journal, "spec-deferrals-harvested")[0]["dw_ids"] == ["DW-1"]
+
+
+def test_stories_harvest_alone_is_not_proof_of_work(project):
+    setup_stories(project, [entry("1")])
+    engine, _ = make_engine(
+        project,
+        [
+            stories_dev_effect(write_src=False, deferred=[STORY_FINDING]),
+            stories_dev_effect(),
+        ],
+    )
+
+    summary = engine.run()
+
+    decisions = _kinds(engine.journal, "dev-decision")
+    assert [decision["action"] for decision in decisions] == ["retry", "proceed"]
+    assert "no changes" in decisions[0]["reason"]
+    assert _kinds(engine.journal, "spec-deferrals-harvested")[0]["dw_ids"] == ["DW-1"]
+    assert summary.done == 1

--- a/tests/test_stories_engine.py
+++ b/tests/test_stories_engine.py
@@ -1575,6 +1575,47 @@ def test_stories_mode_harvests_spec_deferrals_into_the_ledger(project):
     assert _kinds(engine.journal, "spec-deferrals-harvested")[0]["dw_ids"] == ["DW-1"]
 
 
+def test_stories_mode_harvests_id_resolved_spec_not_reported_sibling(project):
+    """The harvest and verifier must consume the same story-id-keyed artifact.
+
+    A session-reported sibling is untrusted in stories mode: harvesting it before
+    ``verify_dev_stories`` resolves the real spec can file another story's finding
+    even though only the id-keyed spec is subsequently accepted and committed.
+    """
+    from bmad_loop import deferredwork
+
+    sibling_finding = {
+        "summary": "A stale sibling must not drive the harvest",
+        "evidence": "The session reported an unrelated spec path",
+        "location": "src/unrelated.py:1",
+        "severity": "high",
+    }
+    write_id_spec = stories_dev_effect(deferred=[STORY_FINDING])
+
+    def report_sibling(spec):
+        result = write_id_spec(spec)
+        result_json = dict(result.result_json or {})
+        sibling = Path(spec.cwd) / SPEC_FOLDER / "stories" / "stale-sibling.md"
+        write_spec(
+            sibling,
+            "done",
+            result_json["baseline_commit"],
+            deferred=[sibling_finding],
+        )
+        result_json["spec_file"] = str(sibling)
+        return SessionResult(status="completed", result_json=result_json)
+
+    setup_stories(project, [entry("1")])
+    engine, _ = make_engine(project, [report_sibling])
+
+    summary = engine.run()
+
+    assert summary.done == 1 and not summary.paused
+    entries = deferredwork.parse_ledger(project.deferred_work.read_text(encoding="utf-8"))
+    assert [item.title for item in entries] == [STORY_FINDING["summary"]]
+    assert "source_spec: `1-slug.md`" in entries[0].body
+
+
 def test_plan_halt_leg_does_not_harvest_then_implement_leg_does(project):
     from bmad_loop import deferredwork
 

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -2583,3 +2583,98 @@ def test_bundle_dispatch_does_not_pin_expected_spec(project, tmp_path):
     assert str(intent) in prompt and task.spec_file not in prompt
     engine._run_session(task, role="dev", prompt=prompt, seq=1)
     assert adapter.sessions[-1].expected_spec is None
+
+
+# ---------------- frontmatter `deferred:` harvest parity (BMAD-METHOD #2640)
+
+SWEEP_FINDING = {
+    "summary": "The retry cap should be configurable",
+    "evidence": "hardcoded while fixing DW-1",
+    "location": "src/retry.py:88",
+    "severity": "low",
+}
+
+
+def _harvest_bundle_policy(*, attempts: int = 3) -> Policy:
+    return Policy(
+        gates=GatesPolicy(mode="none"),
+        notify=QUIET,
+        review=ReviewPolicy(enabled=False),
+        dev=DevPolicy(skill="bmad-dev-auto"),
+        limits=LimitsPolicy(max_dev_attempts=attempts),
+        scm=ScmPolicy(rollback_on_failure=True),
+    )
+
+
+def test_generic_bundle_harvests_new_spec_deferrals_alongside_its_ids(project):
+    write_ledger(project, {"DW-1": "open", "DW-2": "open"})
+    plan = triage_result(
+        ["DW-1", "DW-2"],
+        bundles=[{"name": "fix-things", "dw_ids": ["DW-1", "DW-2"], "intent": "fix both"}],
+    )
+    engine, _ = make_sweep(
+        project,
+        [
+            triage_effect(plan),
+            bundle_dev_effect(
+                project,
+                "fix-things",
+                ["DW-1", "DW-2"],
+                mark_ledger=False,
+                followup_review=False,
+                deferred=[SWEEP_FINDING],
+            ),
+        ],
+        policy=_harvest_bundle_policy(),
+    )
+
+    summary = engine.run()
+
+    assert not summary.paused
+    assert engine.state.tasks["dw-fix-things"].phase == Phase.DONE
+    entries = ledger_entries(project)
+    assert entries["DW-1"].status.startswith("done")
+    assert entries["DW-2"].status.startswith("done")
+    assert entries["DW-3"].open
+    assert entries["DW-3"].title == SWEEP_FINDING["summary"]
+    assert "origin: spec-deferred " in entries["DW-3"].body
+    assert "location: src/retry.py:88" in entries["DW-3"].body
+    assert "source_spec: `spec-dw-fix-things.md`" in entries["DW-3"].body
+    assert engine.state.tasks["dw-fix-things"].dw_ids == ["DW-1", "DW-2"]
+    harvested = [e for e in engine.journal.entries() if e["kind"] == "spec-deferrals-harvested"]
+    assert len(harvested) == 1 and harvested[0]["dw_ids"] == ["DW-3"]
+
+
+def test_bundle_harvest_alone_is_not_proof_of_work(project):
+    """Scope this 6J witness to the gate action; 6L moves bundle close timing."""
+    write_ledger(project, {"DW-1": "open"})
+    plan = triage_result(
+        ["DW-1"],
+        bundles=[{"name": "fix-things", "dw_ids": ["DW-1"], "intent": "fix it"}],
+    )
+    engine, _ = make_sweep(
+        project,
+        [
+            triage_effect(plan),
+            bundle_dev_effect(
+                project,
+                "fix-things",
+                ["DW-1"],
+                mark_ledger=False,
+                followup_review=False,
+                deferred=[SWEEP_FINDING],
+                write_src=False,
+            ),
+        ],
+        policy=_harvest_bundle_policy(attempts=1),
+    )
+
+    summary = engine.run()
+
+    decisions = [e for e in engine.journal.entries() if e["kind"] == "dev-decision"]
+    assert [decision["action"] for decision in decisions] == ["defer"]
+    assert "no changes" in decisions[0]["reason"]
+    assert summary.deferred == 1
+    assert engine.state.tasks["dw-fix-things"].phase == Phase.DEFERRED
+    harvested = [e for e in engine.journal.entries() if e["kind"] == "spec-deferrals-harvested"]
+    assert len(harvested) == 1 and harvested[0]["dw_ids"] == ["DW-2"]

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -102,6 +102,33 @@ def test_attempt_dirty_none_snapshot_ignores_untracked(project):
     assert verify.attempt_dirty(project.project, baseline, None) is True
 
 
+def test_path_changed_since_detects_one_tracked_path(project):
+    baseline = verify.rev_parse_head(project.project)
+
+    assert verify.path_changed_since(project.project, baseline, "src.txt") is False
+
+    (project.project / "src.txt").write_text("changed\n", encoding="utf-8")
+    assert verify.path_changed_since(project.project, baseline, "src.txt") is True
+
+
+def test_path_changed_since_respects_the_untracked_baseline(project):
+    baseline = verify.rev_parse_head(project.project)
+    (project.project / "ledger[1].md").write_text("finding\n", encoding="utf-8")
+
+    assert verify.path_changed_since(
+        project.project,
+        baseline,
+        "ledger[1].md",
+        baseline_untracked=[],
+    )
+    assert not verify.path_changed_since(
+        project.project,
+        baseline,
+        "ledger[1].md",
+        baseline_untracked=["ledger[1].md"],
+    )
+
+
 def test_attempt_dirty_excludes_untracked_artifact(project):
     """A new untracked spec under an orchestrator-owned artifact folder is not the
     dev attempt's dirtiness when that folder is excluded — but counts otherwise."""

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -3190,3 +3190,13 @@ def test_snapshot_worktree_unknown_baseline_skips_untracked(project):
     tree = git(repo, "ls-tree", "-r", "--name-only", ref)
     assert "src.txt" in tree  # tracked edit captured
     assert "user_untracked.txt" not in tree  # unknown-baseline untracked left untouched
+
+
+def test_engine_written_is_keyword_only_on_all_dev_verifiers():
+    """The three mode gates share one call contract; stories was positional in 0.9.x."""
+    import inspect
+
+    for fn in (verify.verify_dev, verify.verify_dev_bundle, verify.verify_dev_stories):
+        parameter = inspect.signature(fn).parameters["engine_written"]
+        assert parameter.kind is inspect.Parameter.KEYWORD_ONLY
+    assert "operator_park" in inspect.signature(verify.verify_dev).parameters

--- a/tests/test_worktree_flow.py
+++ b/tests/test_worktree_flow.py
@@ -86,7 +86,14 @@ def _make_flow(
 ):
     """Build a WorktreeFlow wired to recording stubs. The returned flow carries a
     ``.calls`` namespace tallying the injected callbacks for assertions."""
-    calls = SimpleNamespace(saves=0, emits=[], gates=[], pauses=[], workspaces=[workspace])
+    calls = SimpleNamespace(
+        saves=0,
+        emits=[],
+        gates=[],
+        carries=[],
+        pauses=[],
+        workspaces=[workspace],
+    )
 
     def _save() -> None:
         calls.saves += 1
@@ -98,6 +105,9 @@ def _make_flow(
     def _gate_unit(task) -> bool:
         calls.gates.append(task)
         return True
+
+    def _carry(task) -> None:
+        calls.carries.append(task)
 
     def _pause(reason, story_key="", *, cause=None):
         calls.pauses.append((reason, story_key))
@@ -129,6 +139,7 @@ def _make_flow(
         emit=_emit,
         save=_save,
         gate_unit=_gate_unit,
+        carry_isolated_ledger_writes=_carry,
         escalation_pause=_pause,
         workspace_get=lambda: calls.workspaces[-1],
         workspace_set=lambda ws: calls.workspaces.append(ws),


### PR DESCRIPTION
## Summary

- harvest successful generic-dev `deferred:` findings into the canonical deferred-work ledger without mutating spec frontmatter
- deduplicate across all ledger statuses, isolate malformed siblings, and persist harvest provenance before the append for crash replay
- exclude orchestrator-authored ledger writes from sprint, stories, and sweep proof-of-work gates while preserving session-authored ledger work and `operator_park`
- keep stories plan-halt proof gating disabled and make the follow-up review prompt neutral

## Validation

- focused Phase 6J set: 32 passed
- touched test modules: 639 passed, 23 skipped
- clean temporary clone full suite: 4141 passed, 30 skipped
- `uv run pyright`
- `trunk check --no-fix`
- `git diff --check`
- required source ablations on Python 3.13.13 and 3.14.6, with matched collection totals and each witness failing in the predicted direction

## Known Phase 6J gap

Until Phase 6K, a harvested deferral can survive a rolled-back attempt, so an open ledger entry may name work that no longer exists. This is strictly better than today’s lost findings and follows _close_declared_deferred’s doctrine that ledger consumers re-verify entries against the codebase. Phase 6K closes this gap.

References #433.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Automatically records deferred findings from completed specifications in the deferred-work ledger.
  - Preserves locations and specification provenance for tracking and deduplication, while supporting legacy entries.
  - Supports harvesting across development, review, repair, retry, recovery, and isolated-worktree workflows.
  - Safely replays and carries harvested updates without duplicates.

- **Bug Fixes**
  - Prevents harvested updates from counting as proof of work.
  - Restores harvested changes during rollback.
  - Preserves pending updates for reliable recovery after interruptions.
  - Improves handling of malformed, unreadable, and previously recorded entries.
  - Adds bounded retries for transient harvesting failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->