### PR TITLE
fix(sweep): gate bundle closure on accepted dev

### DIFF
--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -1058,6 +1058,19 @@ class Engine:
             )
         return None
 
+    def _current_dev_session_index(self, task: StoryTask) -> int | None:
+        """Index of the newest primary dev record for the current attempt."""
+        task_id = _session_task_id(task.story_key, "dev", task.attempt)
+        for index in range(len(task.sessions) - 1, -1, -1):
+            if task.sessions[index].task_id == task_id:
+                return index
+        return None
+
+    def _accepted_dev_session_matches(self, task: StoryTask) -> bool:
+        """Whether the current primary dev record owns the PROCEED receipt."""
+        accepted = task.accepted_dev_session_index
+        return accepted is not None and accepted == self._current_dev_session_index(task)
+
     # ------------------------------------------------------------- per story
 
     def _gate_unit(self, task: StoryTask) -> bool:
@@ -1462,16 +1475,20 @@ class Engine:
                 # the latter, so the fall-through below preserves the worktree.
                 env_fault=bool((outcome is not None and outcome.env_fault) or result.env_fault),
             )
+            if decision.action == Action.PROCEED:
+                # DEV_VERIFY + spec_file is not itself proof of acceptance: this
+                # save also precedes every rejecting decision branch. Persist an
+                # explicit transaction latch so recovery may replay accepted-only
+                # bookkeeping without closing work from a PAUSE/RETRY/DEFER.
+                accepted_index = self._current_dev_session_index(task)
+                if accepted_index is None:
+                    raise RuntimeError(
+                        f"accepted dev decision for {task.story_key} has no session record"
+                    )
+                task.accepted_dev_session_index = accepted_index
             self._save()
             if decision.action == Action.PROCEED:
-                # Every gate that can reject this dev attempt has passed, including
-                # verify commands and CRITICAL-escalation preemption in decide_dev.
-                self._post_dev_accepted_sync(task, result.result_json)
-                # The attempt is accepted; no later path may restore its snapshot.
-                # Persist now because a crash can resume directly into review and
-                # never re-enter this method.
-                self._disarm_ledger_snapshot(task)
-                self._save()
+                self._finish_post_dev_accepted_sync(task, result.result_json)
                 self._emit("post_dev_phase", task)
                 if self._run_workflows("post_dev_phase", task, task.attempt):
                     return False
@@ -2755,6 +2772,27 @@ class Engine:
         """
         return
 
+    def _finish_post_dev_accepted_sync(
+        self, task: StoryTask, result_json: dict | None = None
+    ) -> None:
+        """Finish and durably acknowledge accepted-only bookkeeping.
+
+        ``accepted_dev_session_index`` is persisted only for a PROCEED decision. A
+        crash before or during the mode-owned write therefore replays this
+        transaction without mistaking an arbitrary DEV_VERIFY park for an accepted
+        attempt. The append-only record index prevents a reused attempt number from
+        authorizing a later re-arm. Mode writes must be idempotent; the sweep close
+        uses a stable run/task operation identity for exactly this replay.
+        """
+        if not self._accepted_dev_session_matches(task):
+            return
+        if result_json is None and task.spec_file:
+            result_json = {"spec_file": task.spec_file}
+        self._post_dev_accepted_sync(task, result_json)
+        # The attempt is accepted; no later path may restore its snapshot.
+        self._disarm_ledger_snapshot(task)
+        self._save()
+
     def _harvest_spec_path(self, task: StoryTask, result_json: dict | None) -> Path | None:
         """Resolve the spec whose frontmatter this mode may harvest."""
         spec_file = (result_json or {}).get("spec_file")
@@ -3279,6 +3317,7 @@ class Engine:
         StoriesEngine overrides this to re-drive the implement leg of a
         plan-checkpoint-paused story (leg-2) instead."""
         self.journal.append("resume-review", story_key=task.story_key)
+        self._finish_post_dev_accepted_sync(task)
         self._review_and_commit(task)
 
     def _after_story(self, task: StoryTask) -> None:

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -1394,7 +1394,10 @@ class Engine:
                     self._save()
                 # Snapshot after the session has finished, preserving any ledger
                 # edits it authored, and before reconcile/state-sync/harvest can
-                # write on the engine's behalf. Keep the chain's first snapshot
+                # write on the engine's behalf. The harvest is the engine-side
+                # ledger write this snapshot currently protects; the sweep bundle
+                # close lives below the acceptance gate instead. Keep the chain's
+                # first snapshot
                 # across fixable retries because a later non-fixable reset returns
                 # all the way to the phase baseline. An unarmed replay may safely
                 # arm from disk; an armed replay must retain the dead attempt's
@@ -1417,9 +1420,10 @@ class Engine:
                 # observation faulted, so state sync follows it and sees the
                 # repaired terminal status.
                 harvest_outcome = self._harvest_spec_deferrals(task, result.result_json)
-                # generic-path single-writer for the bookkeeping the decoupled
-                # skill never touches (sprint-status for stories, the deferred-work
-                # ledger for sweep bundles), before verify reads that state.
+                # Generic-path single-writer for the sprint bookkeeping the
+                # decoupled skill never touches, before verify reads that state.
+                # Sweep bundles override this pre-gate seam to a no-op; their
+                # ledger close belongs to the accepted-only seam below.
                 self._post_dev_state_sync(task, result.result_json)
                 # carry the skill's follow-up-review recommendation (PR #2505)
                 # onto the task so _review_and_commit can gate the review loop.
@@ -1460,6 +1464,9 @@ class Engine:
             )
             self._save()
             if decision.action == Action.PROCEED:
+                # Every gate that can reject this dev attempt has passed, including
+                # verify commands and CRITICAL-escalation preemption in decide_dev.
+                self._post_dev_accepted_sync(task, result.result_json)
                 # The attempt is accepted; no later path may restore its snapshot.
                 # Persist now because a crash can resume directly into review and
                 # never re-enter this method.
@@ -2477,8 +2484,8 @@ class Engine:
         frontmatter. ``bmad-dev-auto`` sometimes appends a terminal
         ``## Auto Run Result`` (``Status: done``) yet leaves the frontmatter
         ``status`` at the template default. The orchestrator reads ONLY
-        frontmatter, so without this the sprint/ledger sync no-ops and the verify
-        gate falsely defers completed, tested work.
+        frontmatter, so without this the sprint sync and accepted bundle close
+        no-op and the verify gate falsely defers completed, tested work.
 
         When (and only when) the prose terminal Status is ``done`` AND the
         frontmatter sits at a reconcilable non-terminal status, advance the
@@ -2489,8 +2496,9 @@ class Engine:
         an already-``done`` or unknown frontmatter status. Idempotent and
         never-regress: every deterministic verify gate still runs afterward against
         real on-disk/git state, so this repairs bookkeeping only — it cannot pass
-        uncompleted work. Runs ahead of ``_post_dev_state_sync`` so both the story
-        (sprint) and bundle (ledger) sync, then verify, read the reconciled spec."""
+        uncompleted work. Runs ahead of ``_post_dev_state_sync`` and the later
+        ``_post_dev_accepted_sync`` so the story board, bundle ledger, and verify
+        all read the reconciled spec."""
         if not self._generic_dev():
             return
         spec_file = (result_json or {}).get("spec_file")
@@ -2689,9 +2697,12 @@ class Engine:
         before ``verify_dev`` checks the sprint stage. Mirrors ``verify_dev``:
         advance the story to the sprint stage matching the spec status the skill
         actually reached, so a failed or blocked session (spec not at the success
-        status) never advances the sprint. No-op for the legacy path; SweepEngine
-        overrides this to flip the deferred-work ledger instead (bundles carry no
-        sprint-status entry)."""
+        status) never advances the sprint. No-op for the legacy path.
+
+        This runs above the artifact gate because ``verify_dev`` reads the board it
+        writes. That ordering does not generalize to bookkeeping a gate does not
+        consume: ``SweepEngine`` makes this a no-op and closes bundle ledger entries
+        from ``_post_dev_accepted_sync`` instead."""
         if not self._generic_dev():
             return
         spec_file = (result_json or {}).get("spec_file")
@@ -2724,6 +2735,25 @@ class Engine:
             return
         target = "review" if review_enabled else "done"
         sprint_advance(self.workspace.paths.sprint_status, task.story_key, target)
+
+    def _post_dev_accepted_sync(self, task: StoryTask, result_json: dict | None) -> None:
+        """Write bookkeeping that is valid only after a dev attempt is accepted.
+
+        This is the accepted-only counterpart to ``_post_dev_state_sync``. It is
+        called only after ``decide_dev`` returns PROCEED, not merely when
+        ``outcome.ok`` is true: CRITICAL escalations preempt a passing outcome, and
+        a failing verify command can replace the artifact outcome before the
+        decision. The base path has nothing to write; ``SweepEngine`` closes bundle
+        ledger entries here so a rejected attempt cannot leave resolved work hidden
+        from later sweeps.
+
+        Do not combine this seam with ``_close_declared_deferred``. That regular-
+        story mechanism already runs at the commit boundary and its caller takes a
+        snapshot and restores it on commit failure, so it already has the acceptance
+        property this seam supplies for sweep bundles through a different, correct
+        transaction boundary.
+        """
+        return
 
     def _harvest_spec_path(self, task: StoryTask, result_json: dict | None) -> Path | None:
         """Resolve the spec whose frontmatter this mode may harvest."""
@@ -4369,7 +4399,22 @@ class Engine:
                 if current != snapshot:
                     deferred_work.parent.mkdir(parents=True, exist_ok=True)
                     deferred_work.write_text(snapshot, encoding="utf-8")
+            # The restore deliberately keeps review-found ledger knowledge, but
+            # it also replays this bundle's accepted close after the code was
+            # discarded. Let the mode undo only the close it can identify as its
+            # own; the base path has no bundle close and is a no-op.
+            self._reopen_ledger_after_defer(task)
         self._record_defer(task, reason)
+
+    def _reopen_ledger_after_defer(self, task: StoryTask) -> None:
+        """Undo mode-owned ledger closes after a defer discarded their code.
+
+        No-op on the base path; only ``SweepEngine`` writes reopenable bundle
+        closes. This is reached on the in-place branch after a reset was attempted
+        and the ledger was restored. An isolated defer returns earlier because the
+        unit worktree, including its close, is discarded without merging.
+        """
+        return
 
     def _carry_isolated_ledger_writes(self, task: StoryTask) -> None:
         """Apply Engine-owned ledger writes that an isolated merge may omit."""

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -1066,6 +1066,13 @@ class Engine:
                 return index
         return None
 
+    def _accept_current_dev_session(self, task: StoryTask) -> None:
+        """Latch the current dev or repair record as the accepted tree owner."""
+        accepted_index = self._current_dev_session_index(task)
+        if accepted_index is None:
+            raise RuntimeError(f"accepted dev decision for {task.story_key} has no session record")
+        task.accepted_dev_session_index = accepted_index
+
     def _accepted_dev_session_matches(self, task: StoryTask) -> bool:
         """Whether the current primary dev record owns the PROCEED receipt."""
         accepted = task.accepted_dev_session_index
@@ -1480,12 +1487,7 @@ class Engine:
                 # save also precedes every rejecting decision branch. Persist an
                 # explicit transaction latch so recovery may replay accepted-only
                 # bookkeeping without closing work from a PAUSE/RETRY/DEFER.
-                accepted_index = self._current_dev_session_index(task)
-                if accepted_index is None:
-                    raise RuntimeError(
-                        f"accepted dev decision for {task.story_key} has no session record"
-                    )
-                task.accepted_dev_session_index = accepted_index
+                self._accept_current_dev_session(task)
             self._save()
             if decision.action == Action.PROCEED:
                 self._finish_post_dev_accepted_sync(task, result.result_json)
@@ -4212,6 +4214,12 @@ class Engine:
                 # session cannot fix the run environment — stop spending the
                 # dev budget and pause for a human instead
                 self._escalate(task, outcome.reason)
+            if ok:
+                # A verify-green repair supersedes the original accepted dev
+                # record as the owner of the tree now parked at DEV_VERIFY. Make
+                # that receipt durable in the same save as the fix decision so a
+                # sweep crash resumes the repaired tree instead of restarting it.
+                self._accept_current_dev_session(task)
             self._save()
             if terminal is not None:
                 return terminal

--- a/src/bmad_loop/model.py
+++ b/src/bmad_loop/model.py
@@ -195,6 +195,10 @@ class StoryTask:
     # JSON-native containers only; callers persist these through state.json.
     harvested_deferrals: list[dict[str, Any]] = field(default_factory=list)
     bundle_closes_intended: list[str] = field(default_factory=list)
+    # Index of the append-only primary dev SessionRecord whose decision durably
+    # returned PROCEED. Attempt numbers can be reused after a human re-arm, so the
+    # exact record occurrence is the acceptance identity; None is legacy/unarmed.
+    accepted_dev_session_index: int | None = None
     harvest_carry_commit_pending: bool = False
     isolated_ledger_carried: bool = False
     spec_file: str | None = None
@@ -344,6 +348,7 @@ class StoryTask:
             "ledger_changed_before_harvest": self.ledger_changed_before_harvest,
             "harvested_deferrals": self.harvested_deferrals,
             "bundle_closes_intended": self.bundle_closes_intended,
+            "accepted_dev_session_index": self.accepted_dev_session_index,
             "harvest_carry_commit_pending": self.harvest_carry_commit_pending,
             "isolated_ledger_carried": self.isolated_ledger_carried,
             "spec_file": self._serialized_spec_file(),
@@ -412,6 +417,11 @@ class StoryTask:
             ledger_changed_before_harvest=bool(d.get("ledger_changed_before_harvest", False)),
             harvested_deferrals=[deepcopy(dict(item)) for item in d.get("harvested_deferrals", [])],
             bundle_closes_intended=[str(i) for i in d.get("bundle_closes_intended", [])],
+            accepted_dev_session_index=(
+                int(d["accepted_dev_session_index"])
+                if d.get("accepted_dev_session_index") is not None
+                else None
+            ),
             harvest_carry_commit_pending=bool(d.get("harvest_carry_commit_pending", False)),
             isolated_ledger_carried=bool(d.get("isolated_ledger_carried", False)),
             spec_file=d.get("spec_file"),

--- a/src/bmad_loop/model.py
+++ b/src/bmad_loop/model.py
@@ -195,9 +195,10 @@ class StoryTask:
     # JSON-native containers only; callers persist these through state.json.
     harvested_deferrals: list[dict[str, Any]] = field(default_factory=list)
     bundle_closes_intended: list[str] = field(default_factory=list)
-    # Index of the append-only primary dev SessionRecord whose decision durably
-    # returned PROCEED. Attempt numbers can be reused after a human re-arm, so the
-    # exact record occurrence is the acceptance identity; None is legacy/unarmed.
+    # Index of the append-only primary dev SessionRecord whose initial decision or
+    # later verify-repair result durably returned PROCEED. Attempt numbers can be
+    # reused after a human re-arm, so the exact record occurrence is the acceptance
+    # identity; None is legacy/unarmed.
     accepted_dev_session_index: int | None = None
     harvest_carry_commit_pending: bool = False
     isolated_ledger_carried: bool = False

--- a/src/bmad_loop/sweep.py
+++ b/src/bmad_loop/sweep.py
@@ -488,8 +488,10 @@ class SweepEngine(Engine):
         Runs before the ledger is read, so a bundle it closes leaves the open set
         and no fresh triage can re-bundle those ids (validate_triage rejects a plan
         whose open_ids disagree with the ledger). A recovered bundle that defers or
-        escalates keeps its ids open, where the existing failed_ids filter drops the
-        fresh plan's overlapping bundle."""
+        escalates keeps its ids open. A dev-leg discard never closes them; an
+        in-place post-acceptance defer reopens this run's close, while an isolated
+        unit's close dies with its unmerged worktree. The existing failed_ids filter
+        then drops the fresh plan's overlapping bundle."""
         recovered = 0
         for task in list(self.state.tasks.values()):
             if task.terminal or not BUNDLE_KEY_RE.match(task.story_key):
@@ -1192,7 +1194,7 @@ class SweepEngine(Engine):
         ``Engine._dev_skill``): the self-contained
         intent.md (intent + verbatim ledger entries) is handed over as freeform
         intent. The orchestrator owns the deferred-work ledger — the skill is told
-        not to edit it — and records resolution itself in `_post_dev_state_sync`.
+        not to edit it — and records resolution itself in `_post_dev_accepted_sync`.
         On a repair the bundle spec is re-opened first (B6) so step-01 resumes.
 
         A patch-restore re-drive (#2564, #75) must point at the bundle spec
@@ -1230,11 +1232,26 @@ class SweepEngine(Engine):
         )
 
     def _post_dev_state_sync(self, task: StoryTask, result_json: dict | None) -> None:
+        """No-op: bundles have no sprint-status row for the pre-gate sync.
+
+        This override and the accepted-only override below are one behavior
+        change. Leaving the former close here as well would run bundle closure
+        twice at two different gate positions.
+        """
+        return
+
+    def _post_dev_accepted_sync(self, task: StoryTask, result_json: dict | None) -> None:
         """Generic-path ledger single-writer for bundles. The decoupled
         bmad-dev-auto skill does not touch the ledger, so the orchestrator marks
         each dw id the bundle owns ``done`` once the bundle's spec reaches the
-        terminal status for the current stage. Mirrors the story sprint sync;
-        no-op on the legacy path."""
+        terminal status for the current stage. No-op on the legacy path.
+
+        This runs only after the artifact gate, verify commands, and ``decide_dev``
+        have accepted the attempt. In particular, ``outcome.ok`` is insufficient:
+        a CRITICAL escalation in the session result preempts that outcome. The
+        review gate later requires these entries closed; ``_verify_review`` retains
+        its separate reclose because a review session can rewrite the ledger.
+        """
         if not self._generic_dev():
             return
         spec_file = (result_json or {}).get("spec_file")
@@ -1243,14 +1260,18 @@ class SweepEngine(Engine):
         success_status = "in-review" if self._dev_review_enabled() else "done"
         self._close_bundle_ledger_when_spec_status(task, str(spec_file), success_status)
 
+    def _bundle_close_operation_id(self, task: StoryTask) -> str:
+        """Stable identity for a close and its possible defer-time undo."""
+        return f"{self.state.run_id}/{task.story_key}"
+
     def _close_declared_deferred(
         self, task: StoryTask, snapshot: list[tuple[Path, str]] | None = None
     ) -> None:
         """No-op: a bundle's ledger closure is owned by
-        ``_close_bundle_ledger_when_spec_status``, which runs at dev-sync time
-        because ``verify_review_bundle`` *requires* those entries closed before it
-        will pass. Letting the base class's commit-boundary hook (#234) also fire
-        here would re-derive closure for a task whose ids come from
+        ``_close_bundle_ledger_when_spec_status``, which runs after accepted dev
+        because ``verify_review_bundle`` *requires* those entries closed before the
+        later commit boundary. Letting the base class's commit-boundary hook (#234)
+        also fire here would re-derive closure for a task whose ids come from
         ``task.dw_ids``, not from a ``closes_deferred:`` declaration."""
 
     def _close_bundle_ledger_when_spec_status(
@@ -1270,9 +1291,36 @@ class SweepEngine(Engine):
             return
         ledger = self.workspace.paths.deferred_work
         note = f"resolved by sweep bundle {task.story_key}"
-        marked = [i for i in task.dw_ids if deferredwork.mark_done(ledger, i, self._today(), note)]
+        # Record the intended ids, never only `marked`. This method is called once
+        # after accepted dev and again by the review-leg reclose. The second call
+        # normally finds every entry already done, so `marked` is empty; deriving
+        # the record from it would erase exactly the state a landing bundle needs.
+        task.bundle_closes_intended = list(task.dw_ids)
+        marked = deferredwork.mark_done_many_reopenable(
+            ledger,
+            task.dw_ids,
+            self._today(),
+            note,
+            self._bundle_close_operation_id(task),
+        )
         if marked:
             self.journal.append(kind, story_key=task.story_key, dw_ids=marked)
+
+    def _reopen_ledger_after_defer(self, task: StoryTask) -> None:
+        """Reopen only this run's bundle closes after its code was discarded.
+
+        ``Engine._defer`` deliberately restores the whole post-review ledger after
+        rollback so harvested findings survive. That restore can also replay a
+        bundle close whose code no longer exists. The operation-specific undo marker
+        makes this "undo my close", not "open these ids": human, legacy, and earlier
+        run closures remain untouched. Replaying this method is idempotent.
+        """
+        ledger = self.workspace.paths.deferred_work
+        note = f"resolved by sweep bundle {task.story_key}"
+        operation_id = self._bundle_close_operation_id(task)
+        reopened = [i for i in task.dw_ids if deferredwork.mark_open(ledger, i, note, operation_id)]
+        if reopened:
+            self.journal.append("sweep-bundle-reopened", story_key=task.story_key, dw_ids=reopened)
 
     def _verify_dev_artifacts(self, task: StoryTask, result_json: dict | None):
         return verify.verify_dev_bundle(

--- a/src/bmad_loop/sweep.py
+++ b/src/bmad_loop/sweep.py
@@ -1264,6 +1264,10 @@ class SweepEngine(Engine):
         """Stable identity for a close and its possible defer-time undo."""
         return f"{self.state.run_id}/{task.story_key}"
 
+    def _bundle_close_note(self, task: StoryTask) -> str:
+        """Resolution note shared by a bundle close and its possible undo."""
+        return f"resolved by sweep bundle {task.story_key}"
+
     def _close_declared_deferred(
         self, task: StoryTask, snapshot: list[tuple[Path, str]] | None = None
     ) -> None:
@@ -1290,7 +1294,7 @@ class SweepEngine(Engine):
         if verify.status_of(fm) != success_status:
             return
         ledger = self.workspace.paths.deferred_work
-        note = f"resolved by sweep bundle {task.story_key}"
+        note = self._bundle_close_note(task)
         # Record the intended ids, never only `marked`. This method is called once
         # after accepted dev and again by the review-leg reclose. The second call
         # normally finds every entry already done, so `marked` is empty; deriving
@@ -1316,7 +1320,7 @@ class SweepEngine(Engine):
         run closures remain untouched. Replaying this method is idempotent.
         """
         ledger = self.workspace.paths.deferred_work
-        note = f"resolved by sweep bundle {task.story_key}"
+        note = self._bundle_close_note(task)
         operation_id = self._bundle_close_operation_id(task)
         reopened = [i for i in task.dw_ids if deferredwork.mark_open(ledger, i, note, operation_id)]
         if reopened:

--- a/src/bmad_loop/sweep.py
+++ b/src/bmad_loop/sweep.py
@@ -619,9 +619,11 @@ class SweepEngine(Engine):
         human-resolved escalation is protected through every reset (mirrors
         engine.py:1163-1169).
 
-        Returns True when the dev-verified arm carried the bundle all the way
-        through review and commit — the caller is done. Returns False once the
-        task has been reset to PENDING, leaving the caller to dispatch it.
+        Returns True when the persisted PROCEED receipt carried the bundle all
+        the way through accepted sync, review, and commit — the caller is done.
+        Returns False once the task has been reset to PENDING, leaving the caller
+        to dispatch it. A bare DEV_VERIFY + spec_file shape is insufficient: the
+        pre-action decision save has the same shape for rejected decisions.
 
         Deliberately narrower than the base _finish_inflight: no
         `_resumable_session` arm, so a bundle whose host died in the
@@ -648,19 +650,23 @@ class SweepEngine(Engine):
                 self._finalize_commit_phase(task)
             return True
         self.journal.append("resume-restart", story_key=task.story_key, phase=str(task.phase))
-        if task.phase == Phase.DEV_VERIFY and task.spec_file:
+        if (
+            task.phase == Phase.DEV_VERIFY
+            and task.spec_file
+            and self._accepted_dev_session_matches(task)
+        ):
             self._save()
             if isolated:
                 unit = self._reopen_unit(task)
                 prev = self.workspace
                 self.workspace = unit.workspace
                 try:
-                    self._review_and_commit(task)
+                    self._resume_after_dev_verify(task)
                 finally:
                     self.workspace = prev
                 self._integrate_unit(task, unit)
             else:
-                self._review_and_commit(task)
+                self._resume_after_dev_verify(task)
             return True
         if isolated:
             # drop the half-built worktree; _run_story mounts a fresh one

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -170,13 +170,14 @@ _DEFERRED_STATE_KEYS = (
     "ledger_changed_before_harvest",
     "harvested_deferrals",
     "bundle_closes_intended",
+    "accepted_dev_session_index",
     "harvest_carry_commit_pending",
     "isolated_ledger_carried",
 )
 
 
 def test_deferred_work_state_fields_round_trip_through_json():
-    """All nine fields are hand-enumerated in both serializers. Non-default
+    """All ten fields are hand-enumerated in both serializers. Non-default
     values make a missing line on either side observable, while the JSON leg pins
     the on-disk container shape rather than only an in-memory dataclass copy."""
     task = StoryTask(
@@ -189,6 +190,7 @@ def test_deferred_work_state_fields_round_trip_through_json():
         ledger_changed_before_harvest=True,
         harvested_deferrals=[{"origin": "spec-deferred abc", "title": "finding"}],
         bundle_closes_intended=["DW-3", "DW-7"],
+        accepted_dev_session_index=3,
         harvest_carry_commit_pending=True,
         isolated_ledger_carried=True,
     )
@@ -202,12 +204,13 @@ def test_deferred_work_state_fields_round_trip_through_json():
     assert restored.ledger_changed_before_harvest is True
     assert restored.harvested_deferrals == [{"origin": "spec-deferred abc", "title": "finding"}]
     assert restored.bundle_closes_intended == ["DW-3", "DW-7"]
+    assert restored.accepted_dev_session_index == 3
     assert restored.harvest_carry_commit_pending is True
     assert restored.isolated_ledger_carried is True
 
 
 def test_deferred_work_state_fields_default_for_one_old_state_dict():
-    """A state.json written before this package has none of the nine keys.
+    """A state.json written before this package has none of the ten keys.
     Every load must use ``d.get`` so resume reaches the old behavior instead of
     raising KeyError; one shared old document prevents testing only a subset."""
     doc = StoryTask(story_key="1-1-a", epic=1).to_dict()
@@ -222,6 +225,7 @@ def test_deferred_work_state_fields_default_for_one_old_state_dict():
     assert restored.ledger_changed_before_harvest is False
     assert restored.harvested_deferrals == []
     assert restored.bundle_closes_intended == []
+    assert restored.accepted_dev_session_index is None
     assert restored.harvest_carry_commit_pending is False
     assert restored.isolated_ledger_carried is False
 

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 from conftest import (
+    _file_exists_cmd,
     attach_profile,
     bundle_dev_effect,
     bundle_dev_escalates,
@@ -666,6 +667,92 @@ def test_resume_dev_verify_bundle_replays_accepted_sync_before_review(project, m
     accepted = saved.accepted_dev_session_index
     assert accepted is not None and saved.sessions[accepted].role == "dev"
     assert saved.pre_harvest_ledger_captured is False
+
+
+def test_resume_dev_verify_bundle_after_repair_preserves_acceptance(project, monkeypatch):
+    """A verify-green repair remains accepted across a DEV_VERIFY crash."""
+    write_ledger(project, {"DW-1": "open"})
+    plan = triage_result(
+        ["DW-1"], bundles=[{"name": "fix", "dw_ids": ["DW-1"], "intent": "resolve DW-1"}]
+    )
+    marker = project.project / "verify-green"
+    dev = bundle_dev_effect(project, "fix", ["DW-1"], mark_ledger=False)
+    review = bundle_review_effect(project, "fix")
+
+    def dev_with_marker(spec):
+        result = dev(spec)
+        marker.write_text("ok\n", encoding="utf-8")
+        return result
+
+    def breaking_review(spec):
+        marker.unlink()
+        return review(spec)
+
+    def repair(spec):
+        marker.write_text("repaired\n", encoding="utf-8")
+        return SessionResult(
+            status="completed", result_json={"workflow": "auto-dev", "escalations": []}
+        )
+
+    pol = Policy(
+        gates=GatesPolicy(mode="none"),
+        notify=QUIET,
+        review=ReviewPolicy(enabled=True, trigger="always"),
+        dev=DevPolicy(skill="bmad-dev-auto"),
+        scm=ScmPolicy(rollback_on_failure=True),
+        verify=VerifyPolicy(commands=(_file_exists_cmd(marker),)),
+    )
+    engine, _ = make_sweep(
+        project,
+        [triage_effect(plan), dev_with_marker, breaking_review, repair],
+        policy=pol,
+    )
+    original_save = engine._save
+    crashed = False
+
+    def crash_after_repair_dev_verify_save():
+        nonlocal crashed
+        original_save()
+        task = engine.state.tasks.get("dw-fix")
+        if (
+            not crashed
+            and task is not None
+            and task.phase == Phase.DEV_VERIFY
+            and task.attempt == 2
+            and task.sessions[-1].role == "dev"
+        ):
+            crashed = True
+            raise RuntimeError("host died after repair DEV_VERIFY save")
+
+    monkeypatch.setattr(engine, "_save", crash_after_repair_dev_verify_save)
+    assert engine.run().crashed
+
+    persisted = load_state(engine.run_dir).tasks["dw-fix"]
+    assert persisted.phase == Phase.DEV_VERIFY
+    assert persisted.attempt == 2 and persisted.review_cycle == 1
+    assert [session.role for session in persisted.sessions] == ["dev", "review", "dev"]
+    assert persisted.accepted_dev_session_index == len(persisted.sessions) - 1
+    assert persisted.sessions[-1].task_id.endswith("-dev-2")
+    assert ledger_entries(project)["DW-1"].status.startswith("done")
+    fix_decisions = [e for e in engine.journal.entries() if e["kind"] == "fix-decision"]
+    assert fix_decisions[-1]["ok"] is True
+
+    seen_at_review = []
+    final_review = bundle_review_effect(project, "fix")
+
+    def review_repaired_tree(spec):
+        seen_at_review.append(marker.read_text(encoding="utf-8"))
+        return final_review(spec)
+
+    resumed, adapter = resume_sweep(project, engine, [review_repaired_tree])
+    summary = resumed.run()
+
+    assert not summary.crashed and not summary.paused
+    assert [session.role for session in adapter.sessions] == ["review"]
+    assert seen_at_review == ["repaired\n"]
+    saved = load_state(engine.run_dir).tasks["dw-fix"]
+    assert saved.phase == Phase.DONE
+    assert saved.accepted_dev_session_index == len(persisted.sessions) - 1
 
 
 def test_bundle_ledger_close_withheld_on_a_non_fixable_retry(project):

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -14,6 +14,7 @@ from conftest import (
     git,
     install_build_auto_skill,
     migrate_effect,
+    passes_once,
     triage_effect,
     write_ledger,
     write_legacy_ledger,
@@ -36,6 +37,7 @@ from bmad_loop.policy import (
     ScmPolicy,
     StageAdapterPolicy,
     SweepPolicy,
+    VerifyPolicy,
 )
 from bmad_loop.sweep import (
     Decision,
@@ -560,8 +562,9 @@ def test_sweep_happy_path(project):
 
 def test_generic_skill_bundle_orchestrator_closes_ledger(project):
     """B4: on the generic bmad-dev-auto path the bundle session never edits the
-    ledger; the orchestrator marks each owned dw id done (in _post_dev_state_sync)
-    and verify_review_bundle confirms its own write. The invocation is freeform."""
+    ledger; the orchestrator marks each owned dw id done only after the dev attempt
+    is accepted, and verify_review_bundle confirms its own write. The invocation is
+    freeform."""
     write_ledger(project, {"DW-1": "open", "DW-2": "open"})
     plan = triage_result(
         ["DW-1", "DW-2"],
@@ -595,8 +598,228 @@ def test_generic_skill_bundle_orchestrator_closes_ledger(project):
     dev_prompt = adapter.sessions[1].prompt
     assert dev_prompt.startswith("/bmad-dev-auto Implement the deferred-work bundle")
     assert "--dw-bundle" not in dev_prompt
+    events = engine.journal.entries()
+    close_at = next(i for i, e in enumerate(events) if e["kind"] == "sweep-bundle-closed")
+    decision_at = next(
+        i for i, e in enumerate(events) if e["kind"] == "dev-decision" and e["action"] == "proceed"
+    )
+    assert decision_at < close_at
+    # Review-disabled still calls `_verify_review`, so this flow invokes the close
+    # twice. The second call marks nothing and must not erase the durable carry
+    # receipt recorded from task.dw_ids.
+    assert "sweep-bundle-reclosed" not in {e["kind"] for e in events}
+    saved = load_state(engine.run_dir).tasks["dw-fix-things"]
+    assert saved.bundle_closes_intended == ["DW-1", "DW-2"]
+
+
+def test_bundle_ledger_close_withheld_on_a_non_fixable_retry(project):
+    """A rejected attempt must not close the ids whose code it rolls back."""
+    write_ledger(project, {"DW-1": "open"})
+    plan = triage_result(
+        ["DW-1"], bundles=[{"name": "fix", "dw_ids": ["DW-1"], "intent": "resolve DW-1"}]
+    )
+    seen = []
+
+    def capture_then_die(spec):
+        seen.append(project.deferred_work.read_text(encoding="utf-8"))
+        return SessionResult(status="died")
+
+    pol = Policy(
+        gates=GatesPolicy(mode="none"),
+        notify=QUIET,
+        review=ReviewPolicy(enabled=False),
+        dev=DevPolicy(skill="bmad-dev-auto"),
+        scm=ScmPolicy(rollback_on_failure=True),
+        limits=LimitsPolicy(max_dev_attempts=2),
+    )
+    engine, _ = make_sweep(
+        project,
+        [
+            triage_effect(plan),
+            bundle_dev_effect(project, "fix", ["DW-99"], mark_ledger=False, followup_review=False),
+            capture_then_die,
+        ],
+        policy=pol,
+    )
+
+    summary = engine.run()
+
+    decisions = [e for e in engine.journal.entries() if e["kind"] == "dev-decision"]
+    assert decisions[0]["action"] == "retry" and "do not match" in decisions[0]["reason"]
+    assert "rollback-auto" in journal_text(engine)
+    assert "sweep-bundle-closed" not in {e["kind"] for e in engine.journal.entries()}
+    assert "status: open" in seen[0]
+    assert "resolved by sweep bundle dw-fix" not in seen[0]
+    assert summary.deferred == 1 and not summary.paused
+    assert ledger_entries(project)["DW-1"].open
+
+
+def test_bundle_ledger_close_withheld_when_a_completed_attempt_defers(project):
+    """A completed but rejected final attempt reaches DEFER with the ids still open."""
+    write_ledger(project, {"DW-1": "open"})
+    plan = triage_result(
+        ["DW-1"], bundles=[{"name": "fix", "dw_ids": ["DW-1"], "intent": "resolve DW-1"}]
+    )
+
+    def mismatching_attempt():
+        return bundle_dev_effect(
+            project, "fix", ["DW-99"], mark_ledger=False, followup_review=False
+        )
+
+    pol = Policy(
+        gates=GatesPolicy(mode="none"),
+        notify=QUIET,
+        review=ReviewPolicy(enabled=False),
+        dev=DevPolicy(skill="bmad-dev-auto"),
+        scm=ScmPolicy(rollback_on_failure=True),
+        limits=LimitsPolicy(max_dev_attempts=2),
+    )
+    engine, _ = make_sweep(
+        project,
+        [triage_effect(plan), mismatching_attempt(), mismatching_attempt()],
+        policy=pol,
+    )
+
+    summary = engine.run()
+
+    actions = [e["action"] for e in engine.journal.entries() if e["kind"] == "dev-decision"]
+    assert actions == ["retry", "defer"]
+    assert summary.deferred == 1 and not summary.paused
+    text = project.deferred_work.read_text(encoding="utf-8")
+    assert "resolved by sweep bundle dw-fix" not in text
+    assert deferredwork.open_ids(text) == {"DW-1"}
+    assert "change for dw-fix" not in (project.project / "src.txt").read_text()
     kinds = {e["kind"] for e in engine.journal.entries()}
+    assert "sweep-bundle-closed" not in kinds
+    assert "sweep-bundle-reopened" not in kinds
+
+
+def test_bundle_ledger_close_withheld_when_critical_preempts_a_passing_gate(project):
+    """PROCEED, not outcome.ok, authorizes the close."""
+    write_ledger(project, {"DW-1": "open"})
+    plan = triage_result(
+        ["DW-1"], bundles=[{"name": "fix", "dw_ids": ["DW-1"], "intent": "resolve DW-1"}]
+    )
+    clean = bundle_dev_effect(project, "fix", ["DW-1"], mark_ledger=False, followup_review=False)
+
+    def clean_but_critical(spec):
+        result = clean(spec)
+        assert result.result_json is not None
+        result.result_json["escalations"] = [
+            {"type": "bundle-item-blocked", "severity": "CRITICAL", "detail": "intent gap"}
+        ]
+        return result
+
+    pol = Policy(
+        gates=GatesPolicy(mode="none"),
+        notify=QUIET,
+        review=ReviewPolicy(enabled=False),
+        dev=DevPolicy(skill="bmad-dev-auto"),
+        scm=ScmPolicy(rollback_on_failure=True),
+    )
+    engine, _ = make_sweep(project, [triage_effect(plan), clean_but_critical], policy=pol)
+
+    summary = engine.run()
+
+    decisions = [e for e in engine.journal.entries() if e["kind"] == "dev-decision"]
+    assert len(decisions) == 1
+    assert decisions[0]["action"] == "pause" and "CRITICAL" in decisions[0]["reason"]
+    assert summary.paused
+    assert ledger_entries(project)["DW-1"].open
+    assert "sweep-bundle-closed" not in {e["kind"] for e in engine.journal.entries()}
+
+
+def test_bundle_ledger_close_reopened_when_the_review_leg_defers(project):
+    """A later review failure undoes the accepted close after rollback."""
+    write_ledger(project, {"DW-1": "open"})
+    plan = triage_result(
+        ["DW-1"], bundles=[{"name": "fix", "dw_ids": ["DW-1"], "intent": "resolve DW-1"}]
+    )
+    pol = Policy(
+        gates=GatesPolicy(mode="none"),
+        notify=QUIET,
+        review=ReviewPolicy(enabled=True, trigger="always"),
+        dev=DevPolicy(skill="bmad-dev-auto"),
+        scm=ScmPolicy(rollback_on_failure=True),
+        limits=LimitsPolicy(max_review_cycles=1),
+    )
+    engine, _ = make_sweep(
+        project,
+        [
+            triage_effect(plan),
+            bundle_dev_effect(project, "fix", ["DW-1"], mark_ledger=False),
+            lambda spec: SessionResult(status="died"),
+        ],
+        policy=pol,
+    )
+
+    summary = engine.run()
+
+    kinds = [e["kind"] for e in engine.journal.entries()]
     assert "sweep-bundle-closed" in kinds
+    assert summary.deferred == 1 and not summary.paused
+    assert "change for dw-fix" not in (project.project / "src.txt").read_text()
+    text = project.deferred_work.read_text(encoding="utf-8")
+    assert deferredwork.open_ids(text) == {"DW-1"}
+    assert "resolved by sweep bundle dw-fix" not in text
+    reopened = [e for e in engine.journal.entries() if e["kind"] == "sweep-bundle-reopened"]
+    assert len(reopened) == 1 and reopened[0]["dw_ids"] == ["DW-1"]
+    assert worktree_clean(project.project)
+
+
+def test_bundle_ledger_close_reopened_when_review_disabled_defers_at_gate(project, tmp_path):
+    """The no-review path also reopens when its post-accept verify gate defers."""
+    write_ledger(project, {"DW-1": "open"})
+    plan = triage_result(
+        ["DW-1"], bundles=[{"name": "fix", "dw_ids": ["DW-1"], "intent": "resolve DW-1"}]
+    )
+    pol = Policy(
+        gates=GatesPolicy(mode="none"),
+        notify=QUIET,
+        review=ReviewPolicy(enabled=False),
+        dev=DevPolicy(skill="bmad-dev-auto"),
+        scm=ScmPolicy(rollback_on_failure=True),
+        verify=VerifyPolicy(commands=(passes_once(tmp_path / "verify-ran"),)),
+        limits=LimitsPolicy(max_dev_attempts=1),
+    )
+    engine, _ = make_sweep(
+        project,
+        [
+            triage_effect(plan),
+            bundle_dev_effect(project, "fix", ["DW-1"], mark_ledger=False, followup_review=False),
+        ],
+        policy=pol,
+    )
+
+    summary = engine.run()
+
+    kinds = [e["kind"] for e in engine.journal.entries()]
+    assert "sweep-bundle-closed" in kinds
+    assert summary.deferred == 1 and not summary.paused
+    assert "change for dw-fix" not in (project.project / "src.txt").read_text()
+    assert deferredwork.open_ids(project.deferred_work.read_text(encoding="utf-8")) == {"DW-1"}
+    assert "sweep-bundle-reopened" in kinds
+
+
+def test_bundle_pre_gate_state_sync_is_a_noop(project):
+    """The sweep override must not retain the old pre-gate close."""
+    write_ledger(project, {"DW-1": "open"})
+    pol = Policy(
+        gates=GatesPolicy(mode="none"),
+        notify=QUIET,
+        review=ReviewPolicy(enabled=False),
+        dev=DevPolicy(skill="bmad-dev-auto"),
+    )
+    engine, _ = make_sweep(project, [], policy=pol)
+    spec = project.implementation_artifacts / "spec-dw-fix.md"
+    write_spec(spec, "done", git(project.project, "rev-parse", "HEAD"))
+    task = StoryTask(story_key="dw-fix", epic=0, dw_ids=["DW-1"])
+
+    engine._post_dev_state_sync(task, {"spec_file": str(spec)})
+
+    assert ledger_entries(project)["DW-1"].open
+    assert task.bundle_closes_intended == []
+    assert "sweep-bundle-closed" not in {e["kind"] for e in engine.journal.entries()}
 
 
 def test_bundle_ledger_close_skips_on_unreadable_spec(project, monkeypatch):
@@ -618,7 +841,7 @@ def test_bundle_ledger_close_skips_on_unreadable_spec(project, monkeypatch):
     task = StoryTask(story_key="dw-fix-things", epic=0, dw_ids=["DW-1", "DW-2"])
     fault_read_text(monkeypatch, sp)
 
-    engine._post_dev_state_sync(task, {"spec_file": str(sp)})
+    engine._post_dev_accepted_sync(task, {"spec_file": str(sp)})
 
     entries = ledger_entries(project)
     assert entries["DW-1"].status == "open" and entries["DW-2"].status == "open"
@@ -667,7 +890,7 @@ def test_generic_bundle_reconcile_closes_ledger_on_stale_frontmatter(project):
     """Regression for the DW-159/160/162 false-defer: the bundle session finalized
     in prose (## Auto Run Result: Status done) but left the bundle spec frontmatter
     at the template default `draft`. The orchestrator reconciles the frontmatter
-    before the ledger sync, so the bundle CLOSES — its dw ids are marked done and
+    before accepted bookkeeping, so the bundle CLOSES — its dw ids are marked done and
     not stranded in failed_ids — instead of falsely deferring completed work."""
     write_ledger(project, {"DW-1": "open", "DW-2": "open"})
     plan = triage_result(
@@ -715,7 +938,7 @@ def test_generic_bundle_reconcile_closes_ledger_on_in_review_frontmatter(project
     prose (## Auto Run Result: Status done) but left the bundle spec frontmatter at
     the transient `in-review` marker. in-review is never a deliberate terminal on
     the generic path (the legacy review-handoff fork is retired), so the
-    orchestrator reconciles it to done before the ledger sync — the bundle CLOSES
+    orchestrator reconciles it to done before accepted bookkeeping — the bundle CLOSES
     instead of false-deferring + rolling back into an endless re-sweep loop."""
     write_ledger(project, {"DW-1": "open", "DW-2": "open"})
     plan = triage_result(

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -612,6 +612,62 @@ def test_generic_skill_bundle_orchestrator_closes_ledger(project):
     assert saved.bundle_closes_intended == ["DW-1", "DW-2"]
 
 
+def test_resume_dev_verify_bundle_replays_accepted_sync_before_review(project, monkeypatch):
+    """A persisted PROCEED decision must finish accepted bookkeeping before review."""
+    write_ledger(project, {"DW-1": "open"})
+    plan = triage_result(
+        ["DW-1"], bundles=[{"name": "fix", "dw_ids": ["DW-1"], "intent": "resolve DW-1"}]
+    )
+    pol = Policy(
+        gates=GatesPolicy(mode="none"),
+        notify=QUIET,
+        review=ReviewPolicy(enabled=True, trigger="always"),
+        dev=DevPolicy(skill="bmad-dev-auto"),
+        scm=ScmPolicy(rollback_on_failure=True),
+    )
+    engine, _ = make_sweep(
+        project,
+        [
+            triage_effect(plan),
+            bundle_dev_effect(project, "fix", ["DW-1"], mark_ledger=False),
+        ],
+        policy=pol,
+    )
+
+    def crash_before_accepted_sync(task, result_json):
+        persisted = load_state(engine.run_dir).tasks[task.story_key]
+        assert persisted.accepted_dev_session_index == len(task.sessions) - 1
+        raise RuntimeError("host died before accepted sync")
+
+    monkeypatch.setattr(engine, "_post_dev_accepted_sync", crash_before_accepted_sync)
+    assert engine.run().crashed
+
+    crashed = load_state(engine.run_dir).tasks["dw-fix"]
+    assert crashed.phase == Phase.DEV_VERIFY and crashed.spec_file
+    assert crashed.accepted_dev_session_index == len(crashed.sessions) - 1
+    assert crashed.pre_harvest_ledger_captured is True
+    assert ledger_entries(project)["DW-1"].open
+
+    seen_at_review = []
+    review = bundle_review_effect(project, "fix")
+
+    def review_after_sync(spec):
+        seen_at_review.append(ledger_entries(project)["DW-1"].status)
+        return review(spec)
+
+    resumed, adapter = resume_sweep(project, engine, [review_after_sync])
+    summary = resumed.run()
+
+    assert not summary.crashed and not summary.paused
+    assert [s.role for s in adapter.sessions] == ["review"]
+    assert seen_at_review[0].startswith("done")
+    saved = load_state(engine.run_dir).tasks["dw-fix"]
+    assert saved.bundle_closes_intended == ["DW-1"]
+    accepted = saved.accepted_dev_session_index
+    assert accepted is not None and saved.sessions[accepted].role == "dev"
+    assert saved.pre_harvest_ledger_captured is False
+
+
 def test_bundle_ledger_close_withheld_on_a_non_fixable_retry(project):
     """A rejected attempt must not close the ids whose code it rolls back."""
     write_ledger(project, {"DW-1": "open"})


### PR DESCRIPTION
## Summary

- Move generic sweep bundle closure from pre-gate dev state sync to an accepted-dev seam that runs only after `decide_dev` returns `PROCEED`.
- Record reopenable bundle closures with a stable run/task operation identity, then reopen only this run's closures when an in-place post-accept defer discards the code.
- Preserve the two-call intended-close receipt and the review-leg reclose.

## Transaction boundaries

Bundle closure uses the accepted-dev seam because `verify_review_bundle` needs the ledger entries closed before review verification. `_verify_review`'s reclose remains because a review session can rewrite the ledger.

Regular story `_close_declared_deferred` remains at its existing commit boundary with its existing snapshot/undo path. These are two distinct retained mechanisms and are intentionally not unified.

Scope note: #426 remains open. No DONE-leg carry helps an isolated unit that never reaches DONE. Phase 6M carry/replay is outside this PR.

Tracking context: #433.

## Verification

- `uv run pytest tests/test_sweep.py -q`: 89 passed
- `uv run pyright`: 0 errors, warnings, or information
- `trunk fmt`: clean
- `trunk check --no-fix`: clean
- Full suite: 4235 passed, 24 skipped, plus the 4 documented pre-existing local failures from drifted gitignored `.claude/skills` and `.agents/skills` copies
- Python 3.13 and 3.14 isolated sweep baselines: 89 passed in each lane
- All five Phase 6L mutation checks reddened their intended tests on both Python lanes, with every temporary copy restored byte-identically afterward
- Two independent read-only final-diff reviews found no scope or control-flow defects

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sweep recovery and deferred-work handling.
  * Ledger entries now close only after development work is accepted and verified.
  * Prevented premature closures during retries, deferrals, escalations, verification failures, or unreadable specifications.
  * Automatically reopens entries when deferred work is discarded or later verification fails.
  * Improved crash recovery and reconciliation of stale draft or in-review statuses.
  * Added safeguards for consistent, repeatable synchronization without duplicate ledger updates.
* **Data Updates**
  * Accepted development session details are now preserved when work is saved and restored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->