### PR TITLE
fix(sweep): carry an isolated bundle's ledger closes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -260,6 +260,28 @@ story <id>`, the same annotation a sweep bundle writes. Both sprint and stories 
 
 ### Fixed
 
+- **A sweep bundle running in a worktree no longer loses its ledger closures, so later sweeps stop
+  re-driving work that already landed.** With the deferred-work ledger gitignored and named in
+  `scm.worktree_seed`, the orchestrator's closure lands in the unit worktree, `finalize_commit`'s
+  `git add -A` skips the ignored path in silence, and the merge brings nothing back: the entries
+  stay `open`, triage re-bundles them, and every later sweep re-drives resolved work — an unbounded
+  loop rather than a one-time drop. The closure is now re-applied to the main checkout after the
+  unit merges, alongside the harvest carry that already ran there, and journaled
+  `sweep-bundle-close-carried`. The flips are unguarded because losing them is the hazard; the
+  commit is best effort (`git add` refuses an explicitly named ignored path) and records
+  `sweep-bundle-close-carry-uncommitted` instead of costing the run its integration.
+
+- **A host lost in the merge-to-carry window replays a closure-only carry.** The resume pre-pass
+  only replayed units carrying harvested findings, so a bundle whose sole ledger payload was its
+  closures was skipped and the closure stranded. It runs before the sweep's loop reads the open set,
+  so the replayed closure leaves that set before triage can re-bundle it.
+
+- **A deferred bundle's closure is no longer carried by the resume replay.** The deferral path
+  deliberately re-files the harvest and withholds the closure — a defer discarded the code the
+  closure claims to have resolved — but the replay routed through the shared hook, which now also
+  carries closures. Since `open_ids` re-bundles only `open` entries, a wrongly `done` entry is
+  invisible to every later sweep. The replay now mirrors the deferral exactly: harvest only.
+
 - **Refuse `isolation = "worktree"` combined with a `repo_root` override (#414).** The pair
   previously produced a green preflight and then an isolated session with no dev primitive, no
   result, and nothing journaled naming the cause. `validate` now reports it; `run`, `sweep`,

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -837,7 +837,14 @@ class Engine:
         )
 
     def _replay_unlatched_ledger_carries(self) -> None:
-        """Replay a successful isolated unit's carry after merge-time host loss."""
+        """Replay a successful isolated unit's carry after merge-time host loss.
+
+        Called from ``run()`` and required to PRECEDE ``_loop``. ``SweepEngine``
+        replaces ``_loop`` wholesale and does not override ``run()``, so this frame
+        is the only one both engines share — and a replayed bundle close has to
+        leave the open set before ``_loop`` reads ``deferredwork.open_ids``, or the
+        resumed sweep re-triages and re-drives work that already landed.
+        """
         entries = self.journal.entries()
         merged_units = {
             (
@@ -865,7 +872,13 @@ class Engine:
                 and task.harvest_carry_commit_pending
             ):
                 self.journal.append("resume-ledger-carry", story_key=task.story_key)
-                self._carry_isolated_ledger_writes(task)
+                # The HARVEST alone, exactly as `_defer`'s isolated arm calls it.
+                # Replaying a defer through the composite hook would let a mode
+                # override carry writes the defer deliberately withheld — a sweep
+                # bundle's close names work whose code this defer discarded, and
+                # `open_ids` re-bundles only `open` entries, so a wrong `done` is
+                # invisible to every later sweep.
+                self._carry_harvested_deferrals(task)
                 continue
             if task.isolated_ledger_carried or task.phase not in (
                 Phase.DONE,
@@ -873,7 +886,17 @@ class Engine:
             ):
                 continue
             merged_key = (task.story_key, task.branch, self.state.target_branch)
-            if not task.worktree_path or not task.harvested_deferrals:
+            # `not task.worktree_path` is the in-place guard, and a truthiness test
+            # is the whole of it: an in-place task carries "", and `Path("")` is
+            # `PosixPath(".")` whose `is_dir()` is True, so any probe placed ahead of
+            # this one absorbs the in-place case and leaves it unfalsifiable. Merge
+            # evidence comes from the journal below, never from a mounted worktree.
+            # A close-only payload replays too: a sweep bundle whose ledger writes
+            # are all closures has an empty `harvested_deferrals`, and skipping it
+            # here would strand the close and re-triage resolved work for ever.
+            if not task.worktree_path or not (
+                task.harvested_deferrals or task.bundle_closes_intended
+            ):
                 continue
             if merged_key not in merged_units:
                 source = task.commit_sha or ""

--- a/src/bmad_loop/sweep.py
+++ b/src/bmad_loop/sweep.py
@@ -1332,6 +1332,94 @@ class SweepEngine(Engine):
         if reopened:
             self.journal.append("sweep-bundle-reopened", story_key=task.story_key, dw_ids=reopened)
 
+    def _carry_isolated_ledger_writes(self, task: StoryTask) -> None:
+        """The base hook's sweep half: re-apply this bundle's ledger CLOSES to the
+        MAIN checkout after an isolated unit lands, the base having first carried
+        the harvest.
+
+        ``super()`` runs FIRST, and that is a contract rather than a style choice.
+        ``deferredwork.append_entry``'s idempotence scan is OPEN-ONLY, so a close
+        applied ahead of the harvest hides an already-filed row from it and mints a
+        duplicate under a fresh id. ``_carry_harvested_deferrals`` defends the same
+        hazard a second time with its own status-agnostic pre-scan, which is exactly
+        why the order is pinned by a test: with that second line of defence in place
+        a reversal is silent today and would only surface if the pre-scan were ever
+        narrowed back to the writer's semantics.
+
+        ``_close_bundle_ledger_when_spec_status`` writes
+        ``self.workspace.paths.deferred_work`` — under ``scm.isolation = "worktree"``
+        that is the unit worktree's copy. The shape this rescues is a GITIGNORED
+        ledger named in ``scm.worktree_seed``: the flip lands in the worktree, then
+        ``finalize_commit``'s ``git add -A`` skips the ignored path in silence, so it
+        never rides the unit branch and the merge brings nothing over. The bundle's
+        entries stay ``open``, ``deferredwork.open_ids`` re-bundles them, and every
+        later sweep re-triages work that is already done — an unbounded loop rather
+        than a one-time drop, which is what makes this worth a carry.
+
+        An UNSEEDED gitignored ledger is a different, still-open hole this cannot
+        reach: a worktree checks out tracked files only, so the ledger is absent
+        there entirely, ``verify_review_bundle`` (which reads the WORKTREE's copy)
+        never sees the ids ``done``, and the unit DEFERS on a fixable retry instead
+        of landing. That shape is loud where this one is silent, and no DONE-leg
+        carry helps a unit that never reaches DONE (#426).
+
+        DONE leg only, deliberately: ``Engine._defer``'s isolated arm calls
+        ``_carry_harvested_deferrals`` directly and never this hook, and
+        ``_replay_unlatched_ledger_carries``'s DEFERRED leg matches it for the same
+        reason. A defer discarded the code the close claims to have RESOLVED, and a
+        close is the most expensive engine-side write to leave behind — ``open_ids``
+        re-bundles only ``open`` entries, so a wrong ``done`` is invisible to every
+        future sweep.
+
+        Keyed on ``task.bundle_closes_intended``, never on the ids the in-worktree
+        close managed to flip: those are exactly empty in the broken case above.
+        The close is written reopenable, with the same note and operation id as the
+        in-worktree close, so a carried row is indistinguishable from one that
+        arrived through the merge instead of a second row shape for one event.
+
+        No ``_generic_dev()`` guard, unlike the two ledger WRITERS: the record is
+        the guard. ``bundle_closes_intended`` is assigned only by
+        ``_close_bundle_ledger_when_spec_status``, which ``_post_dev_accepted_sync``
+        reaches on the generic path alone, so on the legacy path — where the session
+        owns the ledger — it is empty and this returns before touching anything. A
+        second predicate saying the same thing would be a branch no test can redden.
+
+        The commit is best effort, where ``_carry_harvested_deferrals`` re-raises on
+        a ledger git can own. The asymmetry is deliberate: that method's raise is
+        backed by ``harvest_carry_commit_pending``, so a replay still owes the commit
+        after dedup empties its carried list. This carry has no such latch and its
+        flips are idempotent, so a replay finds nothing left to commit — raising here
+        would cost the run its ``integrate_unit`` over bookkeeping whose real work is
+        already done. The flips themselves are unguarded: losing them is the hazard
+        this exists to prevent.
+        """
+        super()._carry_isolated_ledger_writes(task)
+        if not task.bundle_closes_intended:
+            return
+        ledger = self.paths.deferred_work
+        carried = deferredwork.mark_done_many_reopenable(
+            ledger,
+            task.bundle_closes_intended,
+            self._today(),
+            self._bundle_close_note(task),
+            self._bundle_close_operation_id(task),
+        )
+        if carried:
+            try:
+                verify.commit_paths(
+                    self.paths.repo_root,
+                    f"chore(deferred-work): close {task.story_key}'s bundle ids",
+                    [ledger],
+                )
+            except verify.GitError as e:
+                self.journal.append(
+                    "sweep-bundle-close-carry-uncommitted",
+                    story_key=task.story_key,
+                    dw_ids=carried,
+                    error=str(e),
+                )
+        self.journal.append("sweep-bundle-close-carried", story_key=task.story_key, dw_ids=carried)
+
     def _verify_dev_artifacts(self, task: StoryTask, result_json: dict | None):
         return verify.verify_dev_bundle(
             task,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -770,6 +770,62 @@ def _spec_baseline(path: Path) -> str:
     return ""
 
 
+def ignore_before_commit(project: ProjectPaths, *patterns: str) -> None:
+    """Append gitignore patterns, leaving the file staged for a later commit.
+
+    Appends rather than rewrites: the sandbox template ships `.bmad-loop/runs/`,
+    and clobbering it leaves the run dir tracked, so `worktree_clean()` then fails
+    for a reason that has nothing to do with the test. Leaving the change
+    UNCOMMITTED is what lets a following `write_ledger(..., commit=True)` succeed —
+    once the rule is committed, `git add -A` stages nothing for the now-ignored
+    ledger and the commit fails on an empty index.
+    """
+    gitignore = project.project / ".gitignore"
+    existing = gitignore.read_text(encoding="utf-8")
+    prefix = existing if not existing or existing.endswith("\n") else existing + "\n"
+    gitignore.write_text(prefix + "".join(f"{pattern}\n" for pattern in patterns), encoding="utf-8")
+
+
+def crash_at_merge_back(engine, *, after: str = "merge") -> None:
+    """Kill the host inside the isolated DONE arm, in one of its two windows.
+
+    `WorktreeFlow.integrate_unit`'s DONE arm runs merge -> carry -> latch, and each
+    gap has its own recovery contract:
+
+    - ``"merge"``: after `merge_local`, before `_carry_isolated_ledger_writes`. The
+      branch landed and the worktree is gone; no ledger write happened.
+    - ``"carry"``: after the whole carry, before `isolated_ledger_carried` is set
+      and saved. This is the window that pins call-site latching — a latch moved
+      inside the base hook is already durable here, so the resume finds the task
+      latched and never replays.
+
+    `_emit("post_merge")` cannot stand in for either: it fires above the teardown,
+    so the crash would land outside the window under test.
+
+    Replaces a method on the engine INSTANCE rather than monkeypatching the class.
+    `WorktreeFlow` is handed `carry_isolated_ledger_writes=lambda task:
+    self._carry_isolated_ledger_writes(task)`, a late-binding lambda, so instance
+    assignment is what the callback sees.
+    """
+    if after not in ("merge", "carry"):
+        raise ValueError(f"unknown crash window: {after!r}")
+    if after == "merge":
+
+        def crash_before_carry(_task) -> None:
+            raise RuntimeError("host died after merge, before the ledger carry")
+
+        engine._carry_isolated_ledger_writes = crash_before_carry
+        return
+
+    original = engine._carry_isolated_ledger_writes
+
+    def crash_after_carry(task) -> None:
+        original(task)
+        raise RuntimeError("host died after the ledger carry, before its latch")
+
+    engine._carry_isolated_ledger_writes = crash_after_carry
+
+
 # ----------------------------------------------------------- sweep helpers
 
 

--- a/tests/test_engine_worktree.py
+++ b/tests/test_engine_worktree.py
@@ -21,6 +21,7 @@ from conftest import (
     _touch_run,
     attach_profile,
     git,
+    ignore_before_commit,
     install_build_auto_skill,
     set_sprint,
     write_spec,
@@ -194,13 +195,6 @@ def make_engine(project, script, policy=None, run_id="test-run", **kwargs):
 
 def journal_kinds(engine):
     return [e["kind"] for e in engine.journal.entries()]
-
-
-def ignore_before_commit(project, *patterns):
-    gitignore = project.project / ".gitignore"
-    existing = gitignore.read_text(encoding="utf-8")
-    prefix = existing if not existing or existing.endswith("\n") else existing + "\n"
-    gitignore.write_text(prefix + "".join(f"{pattern}\n" for pattern in patterns), encoding="utf-8")
 
 
 # ----------------------------------------------------------------- happy path

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -11,8 +11,10 @@ from conftest import (
     bundle_dev_effect,
     bundle_dev_escalates,
     bundle_review_effect,
+    crash_at_merge_back,
     fault_read_text,
     git,
+    ignore_before_commit,
     install_build_auto_skill,
     migrate_effect,
     passes_once,
@@ -517,6 +519,323 @@ def test_sweep_worktree_bundle_merges_to_target(project):
     assert [p.resolve() for p in worktree_list(project.project)] == [project.project.resolve()]
     assert not branch_exists(project.project, "bmad_loop/sweep-run/dw-fix")
     assert worktree_clean(project.project)
+
+
+# ------------------------------------- isolated bundle ledger carry + replay
+#
+# The shape every test below shares: the ledger is GITIGNORED and named in
+# `scm.worktree_seed`, so the unit worktree carries a copy the orchestrator
+# closes, `finalize_commit`'s `git add -A` skips it, and the merge brings
+# nothing back. Without `SweepEngine._carry_isolated_ledger_writes` the main
+# checkout's entries stay `open` and every later sweep re-triages resolved work.
+
+_BUNDLE_HARVEST = {
+    "summary": "Bundle left the retry ceiling unbounded",
+    "evidence": "the backoff still doubles forever",
+    "location": "src/retry.py:88",
+    "severity": "medium",
+}
+
+
+def journal_kinds(engine):
+    return [entry["kind"] for entry in engine.journal.entries()]
+
+
+def ledger_rel(project) -> str:
+    return project.deferred_work.relative_to(project.project).as_posix()
+
+
+def ignored_ledger(project, statuses: dict[str, str]) -> str:
+    """Gitignore the ledger, then write and commit it in that order.
+
+    Order matters both ways: committing the rule first leaves `write_ledger`'s
+    `git add -A` with nothing to stage (empty-index commit failure), and writing
+    the ledger first would track it, which is the shape that needs no carry at
+    all. `check-ignore` is the oracle — a pattern that is present is not
+    necessarily effective."""
+    ignore_before_commit(project, "deferred-work.md")
+    write_ledger(project, statuses)
+    rel = ledger_rel(project)
+    assert git(project.project, "check-ignore", rel).strip() == rel
+    assert not verify.path_tracked(project.project, rel)
+    return rel
+
+
+def isolated_seeded_policy(project, **scm) -> Policy:
+    return Policy(
+        gates=GatesPolicy(mode="none"),
+        notify=QUIET,
+        scm=ScmPolicy(isolation="worktree", worktree_seed=(ledger_rel(project),), **scm),
+    )
+
+
+def wt_bundle_dev(project, name="fix", dw_ids=("DW-1",), deferred=None):
+    """Bundle dev session running inside the unit worktree (spec.cwd)."""
+
+    def effect(spec):
+        cwd = spec.cwd
+        wt = project.rebased(cwd)
+        baseline = verify.rev_parse_head(cwd)
+        src = cwd / "src.txt"
+        src.write_text(src.read_text() + f"change for dw-{name}\n")
+        sp = wt.implementation_artifacts / f"spec-dw-{name}.md"
+        # mirror bmad-dev-auto: self-finalize the spec, leave the ledger to the
+        # orchestrator (single writer, marking inside the worktree)
+        write_spec(sp, "done", baseline, deferred=deferred)
+        return SessionResult(
+            status="completed",
+            result_json={
+                "workflow": "auto-dev",
+                "story_key": f"dw-{name}",
+                "spec_file": str(sp),
+                "baseline_commit": baseline,
+                "tasks_total": 1,
+                "tasks_done": 1,
+                "verification": [],
+                "escalations": [],
+                "dw_ids": list(dw_ids),
+                "followup_review_recommended": False,
+            },
+        )
+
+    return effect
+
+
+def bundle_plan(dw_ids=("DW-1",), name="fix"):
+    return triage_result(
+        list(dw_ids),
+        bundles=[{"name": name, "dw_ids": list(dw_ids), "intent": "fix it"}],
+    )
+
+
+def test_isolated_bundle_carries_its_gitignored_ledger_close_to_the_main_checkout(project):
+    ignored_ledger(project, {"DW-1": "open", "DW-2": "open"})
+    plan = triage_result(
+        ["DW-1", "DW-2"],
+        bundles=[{"name": "fix", "dw_ids": ["DW-1"], "intent": "fix it"}],
+        skip=[{"id": "DW-2", "reason": "moot"}],
+    )
+    engine, _ = make_sweep(
+        project,
+        [triage_effect(plan), wt_bundle_dev(project)],
+        policy=isolated_seeded_policy(project),
+    )
+
+    summary = engine.run()
+
+    task = engine.state.tasks["dw-fix"]
+    assert not summary.paused and not summary.crashed
+    assert task.phase == Phase.DONE and task.isolated_ledger_carried
+    assert task.bundle_closes_intended == ["DW-1"]
+    entries = ledger_entries(project)
+    assert entries["DW-1"].status.startswith("done")
+    assert entries["DW-2"].open  # an untouched id is never swept up by the carry
+    carried = [e for e in engine.journal.entries() if e["kind"] == "sweep-bundle-close-carried"]
+    assert [e["dw_ids"] for e in carried] == [["DW-1"]]
+    # `git add -- <ignored path>` refuses with rc 1, so the flips land but the
+    # commit cannot: best effort, and recorded rather than raised.
+    uncommitted = [
+        e for e in engine.journal.entries() if e["kind"] == "sweep-bundle-close-carry-uncommitted"
+    ]
+    assert len(uncommitted) == 1 and uncommitted[0]["dw_ids"] == ["DW-1"]
+    assert [p.resolve() for p in verify.worktree_list(project.project)] == [
+        project.project.resolve()
+    ]
+    assert worktree_clean(project.project)
+
+
+def test_isolated_bundle_carry_files_the_harvest_before_closing_the_bundle(project):
+    """`super()` first: `append_entry`'s idempotence scan is open-only, so a close
+    applied ahead of the harvest would hide an already-filed row from it.
+
+    Pinned on the observable sequence rather than on a reproduced duplicate:
+    `_carry_harvested_deferrals` re-scans status-agnostically, which defends the
+    same hazard a second time, so reversing the two halves is silent on the ledger
+    today. A reviewer reasoning from "no duplicate appears" would ship the bug."""
+    ignored_ledger(project, {"DW-1": "open"})
+    engine, _ = make_sweep(
+        project,
+        [
+            triage_effect(bundle_plan(["DW-1"])),
+            wt_bundle_dev(project, deferred=[_BUNDLE_HARVEST]),
+        ],
+        policy=isolated_seeded_policy(project),
+    )
+
+    summary = engine.run()
+
+    assert not summary.paused and not summary.crashed
+    kinds = journal_kinds(engine)
+    assert kinds.index("harvest-carried") < kinds.index("sweep-bundle-close-carried")
+    entries = ledger_entries(project)
+    assert entries["DW-1"].status.startswith("done")
+    # the harvest reached the MAIN checkout too, exactly once
+    titles = [e.title for e in deferredwork.parse_ledger(project.deferred_work.read_text())]
+    assert titles.count(_BUNDLE_HARVEST["summary"]) == 1
+
+
+def test_isolated_bundle_close_replays_after_a_crash_between_the_carry_and_its_latch(project):
+    """`isolated_ledger_carried` is latched by the CALL SITE, never by the base
+    hook. A hook-side latch would be durable the moment the base half returned, so
+    a subclass half that had not run yet would look carried and never replay."""
+    ignored_ledger(project, {"DW-1": "open"})
+    engine, _ = make_sweep(
+        project,
+        [triage_effect(bundle_plan(["DW-1"])), wt_bundle_dev(project)],
+        policy=isolated_seeded_policy(project),
+    )
+    crash_at_merge_back(engine, after="carry")
+
+    assert engine.run().crashed
+
+    crashed = load_state(engine.run_dir).tasks["dw-fix"]
+    assert crashed.phase == Phase.DONE
+    assert not crashed.isolated_ledger_carried
+    assert crashed.bundle_closes_intended == ["DW-1"]
+
+    resumed, adapter = resume_sweep(project, engine, [])
+    summary = resumed.run()
+
+    assert not summary.crashed and not summary.paused
+    assert adapter.sessions == []  # no re-triage: the close left the open set first
+    assert "resume-ledger-carry" in journal_kinds(resumed)
+    assert ledger_entries(project)["DW-1"].status.startswith("done")
+    assert load_state(resumed.run_dir).tasks["dw-fix"].isolated_ledger_carried
+    # the replay re-ran an already-applied carry: idempotent, no second row
+    assert len(ledger_entries(project)) == 1
+
+
+def test_resumed_sweep_replays_a_close_only_carry_before_it_re_triages(project):
+    """A bundle whose only ledger payload is closures still replays.
+
+    Two things fail together if either half regresses: gating the replay on
+    `harvested_deferrals` alone strands the close, and running the replay after
+    `_loop` lets `deferredwork.open_ids` re-bundle an id that already landed."""
+    ignored_ledger(project, {"DW-1": "open"})
+    engine, _ = make_sweep(
+        project,
+        [triage_effect(bundle_plan(["DW-1"])), wt_bundle_dev(project)],
+        policy=isolated_seeded_policy(project),
+    )
+    crash_at_merge_back(engine, after="merge")
+
+    assert engine.run().crashed
+
+    crashed = load_state(engine.run_dir).tasks["dw-fix"]
+    assert crashed.phase == Phase.DONE and not crashed.isolated_ledger_carried
+    assert not crashed.harvested_deferrals  # close-only payload
+    assert crashed.bundle_closes_intended == ["DW-1"]
+    assert ledger_entries(project)["DW-1"].open  # the merge brought nothing over
+
+    resumed, adapter = resume_sweep(project, engine, [])
+    summary = resumed.run()
+
+    assert not summary.crashed and not summary.paused
+    assert adapter.sessions == []
+    kinds = journal_kinds(resumed)
+    assert "resume-ledger-carry" in kinds and "sweep-bundle-close-carried" in kinds
+    assert ledger_entries(project)["DW-1"].status.startswith("done")
+    assert load_state(resumed.run_dir).tasks["dw-fix"].isolated_ledger_carried
+
+
+def test_replayed_bundle_close_leaves_the_open_set_before_the_sweep_loop_reads_it(project):
+    """The replay pre-pass sits in `run()`, above `_loop`, and must stay there.
+
+    `SweepEngine` replaces `_loop` wholesale and does not override `run()`, and
+    `_loop` reads `deferredwork.open_ids` at the head of every cycle — so a close
+    replayed after it re-enters triage as open work. Pinned on the invariant (the
+    ledger state `_loop` is handed) rather than on a reproduced re-triage: a
+    resumed sweep finishes its persisted cycle's bundles and returns without
+    opening a fresh triage, so the consequence is latent on main today. Moving the
+    call below `_loop` reddens this and nothing else in the suite."""
+    ignored_ledger(project, {"DW-1": "open", "DW-2": "open"})
+    plan = triage_result(
+        ["DW-1", "DW-2"],
+        bundles=[
+            {"name": "one", "dw_ids": ["DW-1"], "intent": "fix one"},
+            {"name": "two", "dw_ids": ["DW-2"], "intent": "fix two"},
+        ],
+    )
+    engine, _ = make_sweep(
+        project,
+        [triage_effect(plan), wt_bundle_dev(project, name="one", dw_ids=["DW-1"])],
+        policy=isolated_seeded_policy(project),
+    )
+    crash_at_merge_back(engine, after="merge")
+    assert engine.run().crashed
+    assert ledger_entries(project)["DW-1"].open  # the close never rode the merge
+
+    resumed, _ = resume_sweep(
+        project, engine, [wt_bundle_dev(project, name="two", dw_ids=["DW-2"])]
+    )
+    at_loop_entry: list[list[str]] = []
+    real_loop = resumed._loop
+
+    def recording_loop() -> None:
+        text = project.deferred_work.read_text(encoding="utf-8")
+        at_loop_entry.append(sorted(deferredwork.open_ids(text)))
+        real_loop()
+
+    resumed._loop = recording_loop
+    summary = resumed.run()
+
+    assert not summary.crashed and not summary.paused
+    assert at_loop_entry == [["DW-2"]], "the landed bundle's id must already be closed"
+    assert ledger_entries(project)["DW-1"].status.startswith("done")
+
+
+def test_bundle_close_carry_is_a_no_op_when_no_close_was_recorded(project):
+    """`bundle_closes_intended` IS the guard, and it is keyed on the record rather
+    than on `task.dw_ids`: only `_close_bundle_ledger_when_spec_status` writes it,
+    so an empty record means this bundle closed nothing and the carry must leave no
+    trace — including no journal line claiming a carry happened, which would read as
+    "the carry ran" when diagnosing a run."""
+    write_ledger(project, {"DW-1": "open"})
+    before = project.deferred_work.read_text(encoding="utf-8")
+    engine, _ = make_sweep(project, [], policy=isolated_seeded_policy(project))
+    task = StoryTask(story_key="dw-fix", epic="deferred-work")
+    task.dw_ids = ["DW-1"]  # ids the bundle owns, but no close was ever recorded
+
+    engine._carry_isolated_ledger_writes(task)
+
+    assert project.deferred_work.read_text(encoding="utf-8") == before
+    assert "sweep-bundle-close-carried" not in journal_kinds(engine)
+
+
+def test_deferred_bundle_replay_carries_the_harvest_without_closing_its_ids(project):
+    """The DEFERRED replay leg mirrors `_defer`: harvest only, never the hook.
+
+    A defer discarded the code the close claims to have resolved, and `open_ids`
+    re-bundles only `open` entries — so a close carried here would hide real work
+    from every later sweep."""
+    write_ledger(project, {"DW-1": "open"})
+    engine, _ = make_sweep(project, [], policy=isolated_seeded_policy(project))
+    task = StoryTask(story_key="dw-fix", epic="deferred-work")
+    task.phase = Phase.DEFERRED
+    task.worktree_path = str(project.project / ".bmad-loop" / "worktrees" / "dw-fix")
+    task.dw_ids = ["DW-1"]
+    task.bundle_closes_intended = ["DW-1"]
+    task.harvest_carry_commit_pending = True
+    task.harvested_deferrals = [
+        {
+            "origin": "spec-deferred abc123",
+            "title": _BUNDLE_HARVEST["summary"],
+            "reason": _BUNDLE_HARVEST["evidence"],
+            "location": _BUNDLE_HARVEST["location"],
+            "severity": _BUNDLE_HARVEST["severity"],
+            "source_spec": "spec-dw-fix.md",
+        }
+    ]
+    engine.state.tasks["dw-fix"] = task
+
+    engine._replay_unlatched_ledger_carries()
+
+    entries = ledger_entries(project)
+    assert entries["DW-1"].open, "a discarded bundle's close must not be carried"
+    assert [e.title for e in entries.values()] == ["item DW-1", _BUNDLE_HARVEST["summary"]]
+    kinds = journal_kinds(engine)
+    assert "resume-ledger-carry" in kinds and "harvest-carried" in kinds
+    assert "sweep-bundle-close-carried" not in kinds
 
 
 def test_sweep_happy_path(project):

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -793,7 +793,7 @@ def test_bundle_close_carry_is_a_no_op_when_no_close_was_recorded(project):
     write_ledger(project, {"DW-1": "open"})
     before = project.deferred_work.read_text(encoding="utf-8")
     engine, _ = make_sweep(project, [], policy=isolated_seeded_policy(project))
-    task = StoryTask(story_key="dw-fix", epic="deferred-work")
+    task = StoryTask(story_key="dw-fix", epic=0)
     task.dw_ids = ["DW-1"]  # ids the bundle owns, but no close was ever recorded
 
     engine._carry_isolated_ledger_writes(task)
@@ -810,7 +810,7 @@ def test_deferred_bundle_replay_carries_the_harvest_without_closing_its_ids(proj
     from every later sweep."""
     write_ledger(project, {"DW-1": "open"})
     engine, _ = make_sweep(project, [], policy=isolated_seeded_policy(project))
-    task = StoryTask(story_key="dw-fix", epic="deferred-work")
+    task = StoryTask(story_key="dw-fix", epic=0)
     task.phase = Phase.DEFERRED
     task.worktree_path = str(project.project / ".bmad-loop" / "worktrees" / "dw-fix")
     task.dw_ids = ["DW-1"]


### PR DESCRIPTION
Phase 6M of the #433 forward-port program. Refs #433.

## The bug

A sweep bundle running under `scm.isolation = "worktree"`, with the deferred-work
ledger gitignored and named in `scm.worktree_seed`, closes its dw ids in the **unit
worktree**. `finalize_commit`'s `git add -A` skips the ignored path in silence, so the
close never rides the unit branch and the merge brings nothing over. The entries stay
`open`, `deferredwork.open_ids` re-bundles them, and every later sweep re-triages and
re-drives work that already landed — an unbounded loop rather than a one-time drop.

`SweepEngine._carry_isolated_ledger_writes` re-applies the close to the main checkout
after the unit merges, alongside the harvest carry that already ran there.

## Scope: main already carried the engine half

`_carry_harvested_deferrals`, the base `_carry_isolated_ledger_writes`,
`_replay_unlatched_ledger_carries`, the `integrate_unit` DONE-arm latch and every
persisted model field landed on main in **6I/6J** (`8f55af5`, `0e17232`) — in versions
*ahead* of 0.9.x. This PR is therefore the **sweep half** plus **two engine fixes that
the override makes load-bearing**:

1. **`_replay_unlatched_ledger_carries`'s DONE gate widened to a close-only payload.**
   It gated on `task.harvested_deferrals` alone, so a bundle whose entire ledger payload
   is its closes (empty harvest) was skipped and the close stranded across a crash.
2. **The DEFERRED replay leg switched from the composite hook to
   `_carry_harvested_deferrals`.** That leg (`harvest_carry_commit_pending`, added in 6J,
   no 0.9.x counterpart) called `_carry_isolated_ledger_writes`. Once `SweepEngine`
   overrides that hook, replaying a defer would carry a bundle **close** naming work whose
   code the defer discarded — and `open_ids` re-bundles only `open` entries, so a wrong
   `done` is invisible to every future sweep. It now mirrors `_defer`'s isolated arm
   exactly: harvest only.

`bundle_closes_intended` was **write-only dead state** on main before this PR
(`sweep.py` assigned it; nothing read it). This is what reads it.

## #426 stays open — this PR cannot reach it

Stating it explicitly, because a reviewer will reasonably assume otherwise (and the
phrasing here deliberately keeps GitHub's closing keywords away from the number): the hole
repaired here is a **seeded** gitignored ledger, where the close lands in the worktree and
is lost on the way back. #426 is the **unseeded** shape — `worktree_seed` defaults to `()`, a
worktree checks out tracked files only, so the ledger is absent from the worktree
entirely, `verify_review_bundle` (which reads the *worktree's* copy) never sees the ids
`done`, and the unit **DEFERS** on a fixable retry instead of landing. **No DONE-leg carry
can help a unit that never reaches DONE.** That shape is loud where this one is silent,
and it stays open for 6N.

## Three things a reviewer should know before judging the tests

**`super()`-first is pinned on JOURNAL SEQUENCE, not on a reproduced duplicate id.**
The stated hazard is real — `deferredwork.append_entry`'s idempotence scan is open-only,
so a close applied ahead of the harvest hides an already-filed row and mints a duplicate
under a fresh id. But main's `_carry_harvested_deferrals` defends the same hazard a second
time with its **own status-agnostic pre-scan**, so on today's code a reversal is **silent
on the ledger**: no duplicate appears. The ordering test therefore asserts
`harvest-carried` precedes `sweep-bundle-close-carried` in the journal. A reviewer
reasoning from "no duplicate appears, so the order doesn't matter" would ship the bug the
day that pre-scan is narrowed back to the writer's semantics.

**The `replay-after-loop` ablation reddens only an invariant test, and that is honest.**
Moving the replay pre-pass below `_loop` reddens no consequence test, because a resumed
sweep finishes its **persisted cycle's** bundles and returns without opening a fresh
triage — so the re-triage consequence is **latent on main**, not reachable today. The test
pins the **invariant** instead: it records `open_ids` at `_loop` entry and asserts the
landed bundle's id is already closed. It does not claim to reproduce the re-triage.

**`may_degrade` is deliberately NOT mirrored from `_carry_harvested_deferrals`.**
That method re-raises on a ledger git can own; this carry commits best effort. The
asymmetry is not an oversight: that method's raise is backed by
`harvest_carry_commit_pending`, so after dedup empties `carried` a replay still owes the
commit and the raise buys a real retry. This carry has **no such latch** and its flips are
idempotent, so raising would cost the run its `integrate_unit` in exchange for a replay
that can only no-op. The flips themselves stay unguarded — losing them is the hazard this
exists to prevent — and a refused commit journals `sweep-bundle-close-carry-uncommitted`
(`git add` returns rc 1 on an explicitly named ignored path).

## Verification

- `uv run pytest -q -n auto`: **4248 passed / 24 skipped (4272 collected)** on **both** the
  3.13 and 3.14 lanes, identical collected totals.
- `uv run pyright`: 0 errors (main baseline is also 0).
- `trunk check --no-fix`: clean.
- **11-row ablation matrix on both lanes**, every row reddening only its intended test.
  Two rows were predicted 0-red and **both were resolved by writing a test, not by deleting
  code**: `replay-after-loop` (above) and `no-record-guard` (the guard's only effect is
  journal honesty — an empty `sweep-bundle-close-carried` line reads as "the carry ran" —
  so a unit test asserts no journal line and no ledger byte change). A twelfth
  `add-generic-dev-guard` row was run to test the opposite direction: adding a
  `_generic_dev()` guard to the override reddens **0** on both lanes, proving that guard
  would be redundant here (the record *is* the guard — `bundle_closes_intended` is assigned
  only on the generic path).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ledger closures so completed deferred work is consistently reflected in the main checkout.
  * Improved recovery after crashes and resumed runs, including closure-only updates.
  * Prevented deferred bundles from incorrectly carrying closure records during replay.
  * Preserved safe, repeatable behavior when ledger updates are retried.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->