### PR TITLE
fix(isolation): seed the unseeded ledger and carry the damped review follow-up

### DIFF
--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -4646,10 +4646,25 @@ class Engine:
         dedupe empties its list. This carry has no such latch, so a raise would buy
         a replay that can only find its row already filed — at the cost of the
         run's ``integrate_unit``. The row on disk is the value; the commit is
-        bookkeeping. Do NOT read that as "the commit cannot fail on a git-ownable
-        ledger": an untracked-but-not-ignored ledger reaches it and succeeds, and a
-        seeded one is shielded from the unit's ``git add -A`` regardless of what
-        the main checkout ignores.
+        bookkeeping.
+
+        It is best effort because it can only ever FAIL here, not because failure
+        is rare. Measured over all three shapes the main ledger can take:
+
+        * TRACKED -- an exclude never masks a tracked file's MODIFICATION, so the
+          unit's write always rides the merge and ``append_entry`` dedupes it
+          here. ``carried`` is empty and no commit is attempted.
+        * UNTRACKED, NOT IGNORED -- this frame is never reached at all.
+          ``_merge_local`` runs ``verify.clean_incoming_collisions`` before every
+          unit merge, and it refuses a target checkout dirtied outside the
+          branch's incoming set, so the unit escalates and the DONE leg with it.
+        * GITIGNORED -- the only shape that appends here, and ``git add`` refuses
+          an ignored path with rc 1 every time.
+
+        So a commit-pending latch would only retry a ``git add`` that refuses
+        identically, which is why this carry does not carry one (asked for in
+        #457's review). It also cannot leave the tree dirty for a later run to
+        trip on: the one shape it writes is the one git does not see.
         """
         if not task.refiled_followups:
             return

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -894,8 +894,11 @@ class Engine:
             # A close-only payload replays too: a sweep bundle whose ledger writes
             # are all closures has an empty `harvested_deferrals`, and skipping it
             # here would strand the close and re-triage resolved work for ever.
+            # Every payload the hook carries has to be named here — a story whose
+            # only ledger write was a damped review-budget follow-up has both other
+            # lists empty, and omitting it strands that row in a deleted worktree.
             if not task.worktree_path or not (
-                task.harvested_deferrals or task.bundle_closes_intended
+                task.harvested_deferrals or task.bundle_closes_intended or task.refiled_followups
             ):
                 continue
             if merged_key not in merged_units:
@@ -4309,14 +4312,23 @@ class Engine:
         if not re_review:
             tail = "the damping cap was spent" if damped else "the review budget was exhausted"
             title = f"Follow-up review still recommended for {task.story_key} after {tail}"
-            refiled = deferredwork.append_entry(
-                ledger,
-                title=title,
-                origin="review-budget-followup",  # verbatim: re-review cap + replay dedupe key on it
-                source_spec=spec,
-                reason=reason,
-                severity="low",
-            )
+            entry = {
+                "title": title,
+                "origin": "review-budget-followup",  # verbatim: re-review cap + replay dedupe key
+                "source_spec": spec,
+                "reason": reason,
+                "severity": "low",
+            }
+            refiled = deferredwork.append_entry(ledger, **entry)
+            if refiled:
+                # This wrote the ACTIVE workspace's ledger, so under isolation the
+                # row is inside a unit worktree that `close_unit_workspace` deletes,
+                # and a gitignored one is skipped by `finalize_commit`'s `git add -A`
+                # in silence — the run journals `refiled: DW-n` having filed nothing
+                # a later sweep can reach (#425). Record the intent for the DONE-leg
+                # carry; `append_entry`'s open-entry dedupe makes replaying it into a
+                # ledger that DID merge normally a no-op.
+                task.refiled_followups.append(entry)
         if damped:
             self.journal.append(
                 "review-followup-damped",
@@ -4487,8 +4499,15 @@ class Engine:
         return
 
     def _carry_isolated_ledger_writes(self, task: StoryTask) -> None:
-        """Apply Engine-owned ledger writes that an isolated merge may omit."""
+        """Apply Engine-owned ledger writes that an isolated merge may omit.
+
+        Both members APPEND, and that is what lets ``SweepEngine``'s override run
+        its bundle CLOSES strictly after ``super()``: ``append_entry``'s
+        idempotence scan is open-only, so every append this hook owns has to
+        land before a close can hide an already-filed row from it.
+        """
         self._carry_harvested_deferrals(task)
+        self._carry_review_budget_followups(task)
 
     def _harvest_carry_commit_may_degrade(self, ledger: Path) -> bool:
         """Whether a carry may remain uncommitted because git cannot own its path."""
@@ -4566,6 +4585,74 @@ class Engine:
             task.harvest_carry_commit_pending = False
             self._save()
         self.journal.append("harvest-carried", story_key=task.story_key, dw_ids=carried)
+
+    def _carry_review_budget_followups(self, task: StoryTask) -> None:
+        """Re-file an isolated unit's review-budget follow-ups into the main ledger.
+
+        The third producer in the ``git add -A`` family, and the last one left
+        uncovered (#425). ``_record_review_budget_followup`` runs on a finalized,
+        verify-green story that the review pass would not stop recommending a
+        follow-up for, and it is CORRECT for it to run under isolation — the
+        damped caller force-converges work that is being committed, not rescued,
+        so the ``not self._isolated`` its exhaustion counterpart carries guards
+        that rescue and not this write. The defect is only that the write can be
+        silently dropped, which is why this extends the carry rather than adding a
+        guard: a guard would suppress a legitimate entry on every isolated run,
+        including the tracked-ledger runs where it works today.
+
+        No ``_isolated`` predicate here either: ``refiled_followups`` is populated
+        by that one producer and this hook is reached only from the isolated DONE
+        leg and its replay, so the record IS the guard — the same reasoning as
+        ``SweepEngine._carry_isolated_ledger_writes``'s missing ``_generic_dev()``.
+
+        Unconditional and idempotent: ``append_entry`` dedupes an OPEN row with the
+        same ``origin:`` + ``source_spec:``, so a tracked ledger whose row already
+        arrived through the merge yields an empty ``carried`` and no commit. An
+        already-CLOSED row with that provenance is deliberately not deduped against
+        — a later recurrence earns a fresh entry, exactly as it does in place.
+
+        The commit is best effort, like ``SweepEngine``'s close and unlike
+        ``_carry_harvested_deferrals``: that method's re-raise is backed by
+        ``harvest_carry_commit_pending``, so a replay still owes the commit after
+        dedupe empties its list. This carry has no such latch, so a raise would buy
+        a replay that can only find its row already filed — at the cost of the
+        run's ``integrate_unit``. The row on disk is the value; the commit is
+        bookkeeping. Do NOT read that as "the commit cannot fail on a git-ownable
+        ledger": an untracked-but-not-ignored ledger reaches it and succeeds, and a
+        seeded one is shielded from the unit's ``git add -A`` regardless of what
+        the main checkout ignores.
+        """
+        if not task.refiled_followups:
+            return
+        ledger = self.paths.deferred_work
+        carried: list[str] = []
+        for item in task.refiled_followups:
+            severity = item.get("severity")
+            dw_id = deferredwork.append_entry(
+                ledger,
+                title=str(item["title"]),
+                origin=str(item["origin"]),
+                source_spec=str(item["source_spec"]),
+                reason=str(item["reason"]),
+                severity=str(severity) if severity else None,
+            )
+            if dw_id:
+                carried.append(dw_id)
+        if carried:
+            try:
+                verify.commit_paths(
+                    self.paths.repo_root,
+                    f"chore(deferred-work): carry {task.story_key}'s review follow-up",
+                    [ledger],
+                )
+            except verify.GitError as e:
+                self.journal.append(
+                    "review-followup-carry-uncommitted",
+                    story_key=task.story_key,
+                    dw_ids=carried,
+                    error=str(e),
+                )
+        self.journal.append("review-followup-carried", story_key=task.story_key, dw_ids=carried)
 
     def _stash_deferred_artifacts(self, task: StoryTask) -> None:
         """Move the deferred story's spec out of the artifacts dir into the run

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -895,10 +895,14 @@ class Engine:
             # are all closures has an empty `harvested_deferrals`, and skipping it
             # here would strand the close and re-triage resolved work for ever.
             # Every payload the hook carries has to be named here — a story whose
-            # only ledger write was a damped review-budget follow-up has both other
-            # lists empty, and omitting it strands that row in a deleted worktree.
+            # only ledger write was a damped review-budget follow-up, or a declared
+            # `closes_deferred:` flip, has every other list empty, and omitting it
+            # strands that write in a deleted worktree.
             if not task.worktree_path or not (
-                task.harvested_deferrals or task.bundle_closes_intended or task.refiled_followups
+                task.harvested_deferrals
+                or task.bundle_closes_intended
+                or task.refiled_followups
+                or task.story_closes_intended
             ):
                 continue
             if merged_key not in merged_units:
@@ -3162,11 +3166,21 @@ class Engine:
         verification, the verify commands, every checkpoint, the review loop,
         the ``pre_commit_gate`` workflows and the ``pre_commit`` veto — and
         still before ``finalize_commit``, whose ``git add -A`` stages an
-        in-repo annotation into the story's own commit (worktree isolation
-        included: the unit's ledger rides the unit commit and reaches the
-        target branch with the ordinary merge). Marking at dev-sync time
-        instead let a story that later failed verification or review leave the
-        ledger permanently claiming its work resolved.
+        in-repo annotation into the story's own commit. Marking at dev-sync
+        time instead let a story that later failed verification or review leave
+        the ledger permanently claiming its work resolved.
+
+        **In-repo is not stageable, and under isolation that is the difference
+        between a delivered close and a lost one (#458).** This paragraph used
+        to promise the opposite — "worktree isolation included: the unit's
+        ledger rides the unit commit and reaches the target branch with the
+        ordinary merge" — which holds only for a TRACKED ledger. A gitignored
+        one (the default shape, since the ledger lives under the BMAD artifacts
+        dir) is skipped by that ``git add -A`` in silence, brings nothing over
+        with the merge, and dies with the worktree, while this method has
+        already journaled ``story-deferred-closed``. ``story_closes_intended``
+        + ``_carry_story_deferred_closes`` is the delivery path; ``_ledger_in_repo``
+        below is a containment test and answers a different question.
 
         A ledger outside the repo (``ProjectPaths.rebased`` deliberately
         shares an external artifact dir between worktrees) is written at the
@@ -3185,6 +3199,16 @@ class Engine:
         freely — ids are classified against the ledger text, and an entry
         already ``done`` is a satisfied declaration, not an unmatched one."""
         ids = self._declared_deferred_ids(task)
+        # Reset before the early return, never after it. This method is the sole
+        # producer of the record and runs unconditionally at every commit boundary,
+        # and DONE/AWAITING_OPERATOR are reachable only through the caller — so a
+        # re-drive that reaches the carry has always re-entered here first, and this
+        # assignment IS the staleness guard (a `_dev_phase` clear like
+        # `refiled_followups`' would be a second branch saying the same thing, which
+        # no test could redden). The live read is authoritative: a resolve session
+        # that WITHDREW `closes_deferred:` must not have the abandoned attempt's
+        # declaration carried on its behalf.
+        task.story_closes_intended = []
         if not ids:
             return
         ledger = self.workspace.paths.deferred_work
@@ -3210,6 +3234,20 @@ class Engine:
             return
         if snapshot is not None:
             snapshot.append((ledger, text))
+        # The DECLARED set, never `marked` — the transposed lesson of `e88776a`. A
+        # host loss in this window resumes into `_finalize_commit_phase` again, and
+        # by then the worktree ledger already reads `done`, so `classify` returns
+        # every id as `already_done` and `marked` is EMPTY. A record derived from it
+        # would never be made on that replay, and the carry would find nothing while
+        # `close_unit_workspace` deletes the only copy. Recorded after the snapshot
+        # arm so the degraded read paths above, which write nothing, record nothing.
+        #
+        # No `_save()` here, unlike the follow-up producer: every crash path re-enters
+        # this method, which re-derives the ids from the spec and the manifest. A
+        # persisted record would instead SURVIVE a declaration edited across the
+        # crash, which is the stale snapshot `_declared_deferred_ids` reads live to
+        # avoid.
+        task.story_closes_intended = list(ids)
         marked = self._apply_deferred_closes(task, ids, ledger, text)
         if snapshot is not None and not marked:
             # `mark_done_many` writes only when it marks: the ledger is
@@ -3297,6 +3335,11 @@ class Engine:
                 "deferred-close-rolled-back", story_key=task.story_key, ledger=str(ledger)
             )
 
+    def _story_close_note(self, task: StoryTask) -> str:
+        """Resolution note shared by the commit-boundary close and its isolation
+        carry, so a carried row cannot drift from one the merge delivered."""
+        return f"resolved by story {task.story_key}"
+
     def _apply_deferred_closes(
         self, task: StoryTask, ids: Sequence[str], ledger: Path, text: str
     ) -> list[str]:
@@ -3309,7 +3352,7 @@ class Engine:
         underneath them."""
         declared = deferredwork.classify(text, ids)
         marked = deferredwork.mark_done_many(
-            ledger, declared.open_ids, self._today(), f"resolved by story {task.story_key}"
+            ledger, declared.open_ids, self._today(), self._story_close_note(task)
         )
         if marked:
             self.journal.append("story-deferred-closed", story_key=task.story_key, dw_ids=marked)
@@ -4541,13 +4584,25 @@ class Engine:
     def _carry_isolated_ledger_writes(self, task: StoryTask) -> None:
         """Apply Engine-owned ledger writes that an isolated merge may omit.
 
-        Both members APPEND, and that is what lets ``SweepEngine``'s override run
-        its bundle CLOSES strictly after ``super()``: ``append_entry``'s
-        idempotence scan is open-only, so every append this hook owns has to
-        land before a close can hide an already-filed row from it.
+        APPENDS FIRST, THEN CLOSES — the ordering is a correctness contract, not a
+        style. ``append_entry``'s idempotence scan is open-only, so a close that
+        ran first would hide an already-filed row from it and mint a duplicate
+        under a fresh id. That is why the two appends lead, why the story close
+        below trails them, and why ``SweepEngine``'s override runs its bundle
+        close strictly after ``super()``.
+
+        The collision is reachable, not theoretical: a story may declare
+        ``closes_deferred:`` on the very ``review-budget-followup`` row that
+        ``_carry_review_budget_followups`` is about to dedupe against. Close it
+        first and the follow-up is re-filed as a second entry.
+
+        The two closes never coexist on one task — ``SweepEngine`` overrides the
+        story producer to a no-op, and a story run has no bundle — so their
+        relative order is unobservable.
         """
         self._carry_harvested_deferrals(task)
         self._carry_review_budget_followups(task)
+        self._carry_story_deferred_closes(task)
 
     def _harvest_carry_commit_may_degrade(self, ledger: Path) -> bool:
         """Whether a carry may remain uncommitted because git cannot own its path."""
@@ -4723,6 +4778,77 @@ class Engine:
                     error=str(e),
                 )
         self.journal.append("review-followup-carried", story_key=task.story_key, dw_ids=carried)
+
+    def _carry_story_deferred_closes(self, task: StoryTask) -> None:
+        """Re-apply a story's declared ledger CLOSES to the main checkout (#458).
+
+        The fourth and last producer in the ``git add -A`` family.
+        ``_close_declared_deferred`` writes the ACTIVE workspace's ledger, so under
+        isolation a gitignored one is flipped inside a unit worktree, skipped by
+        ``finalize_commit``'s ``git add -A`` in silence, and deleted with the
+        worktree — while the run has already journaled ``story-deferred-closed``.
+        Left uncarried the entry stays ``open``, so ``deferredwork.open_ids``
+        re-bundles resolved work on every later sweep: unbounded re-triage, not a
+        one-time drop.
+
+        ``mark_done_many``, NOT the reopenable variant ``SweepEngine`` uses: a story
+        close carries no operation id and no ``resolution-undo:`` line, so this is
+        what keeps a carried row byte-identical to one the merge delivered. The note
+        goes through ``_story_close_note`` for the same reason. Only the date can
+        differ, and only across a midnight boundary — the same accepted drift the
+        park record carries.
+
+        Unconditional and idempotent, with no tracked/ignored predicate. Idempotence
+        here is stronger than the appends': ``_apply_done`` returns None for a row
+        that is absent OR already ``done``, and ``_mark_done_many`` then writes
+        nothing at all — not even a byte-identical rewrite. So a tracked ledger,
+        whose close rode the merge, yields an empty ``carried`` and no commit, and a
+        replay re-applying a landed carry is a no-op. ``story-deferred-close-carried``
+        with ``dw_ids == []`` is an ordinary outcome.
+
+        Best effort, like ``SweepEngine``'s close and unlike
+        ``_carry_harvested_deferrals`` — and, as with
+        ``_carry_review_budget_followups``, because the commit can only ever FAIL
+        here rather than because failure is rare. Of the three shapes the main
+        ledger can take, only a gitignored one reaches ``commit_paths`` at all: a
+        tracked one is already closed by the merge, and an untracked-but-not-ignored
+        one never reaches this frame because ``clean_incoming_collisions`` refuses
+        the merge first. ``git add`` then refuses that ignored path with rc 1 every
+        time, so a commit-pending latch would only retry a refusal.
+
+        ``self.paths``, not ``self.workspace.paths``, states the intent — the MAIN
+        checkout's ledger. Measured, the two are the same path at every call site
+        that reaches here: the workspace is swapped back before
+        ``integrate_unit`` runs the hook, and before the resume replay does. So no
+        test can tell the two apart, and none pretends to; the explicit form is
+        kept because the intent stops being obvious the moment that stops holding.
+        """
+        if not task.story_closes_intended:
+            return
+        ledger = self.paths.deferred_work
+        carried = deferredwork.mark_done_many(
+            ledger,
+            task.story_closes_intended,
+            self._today(),
+            self._story_close_note(task),
+        )
+        if carried:
+            try:
+                verify.commit_paths(
+                    self.paths.repo_root,
+                    f"chore(deferred-work): close {task.story_key}'s declared ids",
+                    [ledger],
+                )
+            except verify.GitError as e:
+                self.journal.append(
+                    "story-deferred-close-carry-uncommitted",
+                    story_key=task.story_key,
+                    dw_ids=carried,
+                    error=str(e),
+                )
+        self.journal.append(
+            "story-deferred-close-carried", story_key=task.story_key, dw_ids=carried
+        )
 
     def _stash_deferred_artifacts(self, task: StoryTask) -> None:
         """Move the deferred story's spec out of the artifacts dir into the run

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -1380,6 +1380,24 @@ class Engine:
                 # later isolated carry. Crash replay never enters this branch.
                 if feedback is None:
                     task.harvested_deferrals = []
+                    # Same rule, and the abandoned attempt's ledger row is already
+                    # gone: an escalation leaves the unit worktree mounted and
+                    # unmerged, and the re-drive that reaches here discarded it
+                    # (`_finish_inflight`'s resume-restart arm), taking the only
+                    # copy of that row. Carrying the record anyway files a
+                    # follow-up against the attempt that COMMITTED, whose review
+                    # recommended none — and `append_entry` has nothing to dedupe
+                    # it against, so a tracked ledger commits the wrong row rather
+                    # than absorbing it (#457's review). `rearm_escalation` already
+                    # voids the history behind the record by resetting
+                    # `followup_reviews_spent` for a fresh damping budget.
+                    #
+                    # The fixable-retry exemption above is inherited, not reasoned:
+                    # this field's one producer fires on a finalized, verify-green
+                    # story immediately before `_commit`, and no path leads from
+                    # there back into a `feedback is not None` iteration, so such an
+                    # iteration can never hold a record to preserve.
+                    task.refiled_followups = []
             advance(task, Phase.DEV_RUNNING)
             self._save()
             if resume_result is not None:
@@ -4649,7 +4667,15 @@ class Engine:
         bookkeeping.
 
         It is best effort because it can only ever FAIL here, not because failure
-        is rare. Measured over all three shapes the main ledger can take:
+        is rare. Measured over all three shapes the main ledger can take, and all
+        three rest on a premise ``_dev_phase`` enforces rather than one this frame
+        can check: every record belongs to the attempt now being committed. A
+        record left over from an ABANDONED attempt breaks the tracked row below --
+        that attempt's own write died with its discarded worktree, so nothing is
+        upstream to dedupe against and the carry appends AND commits a row about
+        work that never landed. That is why the fresh-attempt clear beside
+        ``harvested_deferrals`` is load-bearing for this docstring, not only for
+        the ledger (#457's review).
 
         * TRACKED -- an exclude never masks a tracked file's MODIFICATION, so the
           unit's write always rides the merge and ``append_entry`` dedupes it

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -4319,16 +4319,38 @@ class Engine:
                 "reason": reason,
                 "severity": "low",
             }
-            refiled = deferredwork.append_entry(ledger, **entry)
-            if refiled:
-                # This wrote the ACTIVE workspace's ledger, so under isolation the
-                # row is inside a unit worktree that `close_unit_workspace` deletes,
-                # and a gitignored one is skipped by `finalize_commit`'s `git add -A`
-                # in silence — the run journals `refiled: DW-n` having filed nothing
-                # a later sweep can reach (#425). Record the intent for the DONE-leg
-                # carry; `append_entry`'s open-entry dedupe makes replaying it into a
-                # ledger that DID merge normally a no-op.
+            # Persist the intent BEFORE the write, never after it succeeds. This
+            # writes the ACTIVE workspace's ledger, so under isolation the row is
+            # inside a unit worktree that `close_unit_workspace` deletes, and a
+            # gitignored one is skipped by `finalize_commit`'s `git add -A` in
+            # silence — the run journals `refiled: DW-n` having filed nothing a
+            # later sweep can reach (#425). The DONE-leg carry is the delivery
+            # path, and it reads only PERSISTED records.
+            #
+            # Recording after the append instead loses the row outright on a hard
+            # host loss: nothing saves between here and `_commit`'s COMMITTING
+            # save, and that window spans every blocking `pre_commit_gate`
+            # workflow (the shipped TEA plugin binds three, each a live session).
+            # The resumed run replays this same review result in the same
+            # worktree, `append_entry` dedupes the already-open row to None, the
+            # record is never made, and the carry finds an empty payload.
+            #
+            # Keyed dedupe, not an `if refiled:` gate, for the same reason
+            # `_harvest_spec_deferrals` keeps a stable union: a replay must not
+            # append a second copy, but it must not need a NEW id to record
+            # authorship either. Safe to pre-latch — `refiled_followups` is a
+            # record, not a suppression bit: both consumers (replay eligibility,
+            # the carry) only ever make the engine do more, and `append_entry`
+            # dedupes an already-open row, so recording an append that then fails
+            # costs at most a carry that files the row the operator was owed.
+            known = {
+                (str(item.get("origin", "")), str(item.get("source_spec", "")))
+                for item in task.refiled_followups
+            }
+            if (entry["origin"], entry["source_spec"]) not in known:
                 task.refiled_followups.append(entry)
+                self._save()
+            refiled = deferredwork.append_entry(ledger, **entry)
         if damped:
             self.journal.append(
                 "review-followup-damped",
@@ -4610,6 +4632,13 @@ class Engine:
         arrived through the merge yields an empty ``carried`` and no commit. An
         already-CLOSED row with that provenance is deliberately not deduped against
         — a later recurrence earns a fresh entry, exactly as it does in place.
+
+        That idempotence is what lets the producer record its intent BEFORE its own
+        append, which durability requires (see ``_record_review_budget_followup``).
+        So a payload here does NOT imply a row was newly filed upstream: a producer
+        whose append deduped still records, and this then carries it to an empty
+        ``carried``. ``review-followup-carried`` with ``dw_ids == []`` is therefore
+        an ordinary outcome, not a sign the carry ran on nothing.
 
         The commit is best effort, like ``SweepEngine``'s close and unlike
         ``_carry_harvested_deferrals``: that method's re-raise is backed by

--- a/src/bmad_loop/model.py
+++ b/src/bmad_loop/model.py
@@ -195,6 +195,9 @@ class StoryTask:
     # JSON-native containers only; callers persist these through state.json.
     harvested_deferrals: list[dict[str, Any]] = field(default_factory=list)
     bundle_closes_intended: list[str] = field(default_factory=list)
+    # `append_entry` kwargs for review-budget follow-ups this task filed into the
+    # ACTIVE workspace's ledger, which under isolation is the unit worktree's.
+    refiled_followups: list[dict[str, Any]] = field(default_factory=list)
     # Index of the append-only primary dev SessionRecord whose initial decision or
     # later verify-repair result durably returned PROCEED. Attempt numbers can be
     # reused after a human re-arm, so the exact record occurrence is the acceptance
@@ -349,6 +352,7 @@ class StoryTask:
             "ledger_changed_before_harvest": self.ledger_changed_before_harvest,
             "harvested_deferrals": self.harvested_deferrals,
             "bundle_closes_intended": self.bundle_closes_intended,
+            "refiled_followups": self.refiled_followups,
             "accepted_dev_session_index": self.accepted_dev_session_index,
             "harvest_carry_commit_pending": self.harvest_carry_commit_pending,
             "isolated_ledger_carried": self.isolated_ledger_carried,
@@ -418,6 +422,7 @@ class StoryTask:
             ledger_changed_before_harvest=bool(d.get("ledger_changed_before_harvest", False)),
             harvested_deferrals=[deepcopy(dict(item)) for item in d.get("harvested_deferrals", [])],
             bundle_closes_intended=[str(i) for i in d.get("bundle_closes_intended", [])],
+            refiled_followups=[deepcopy(dict(item)) for item in d.get("refiled_followups", [])],
             accepted_dev_session_index=(
                 int(d["accepted_dev_session_index"])
                 if d.get("accepted_dev_session_index") is not None

--- a/src/bmad_loop/model.py
+++ b/src/bmad_loop/model.py
@@ -198,6 +198,10 @@ class StoryTask:
     # `append_entry` kwargs for review-budget follow-ups this task filed into the
     # ACTIVE workspace's ledger, which under isolation is the unit worktree's.
     refiled_followups: list[dict[str, Any]] = field(default_factory=list)
+    # Deferred-work ids a story DECLARED it closes (`closes_deferred:`), recorded at
+    # the commit boundary. Same ledger, same isolation problem: a gitignored path
+    # never merges out of the unit worktree, so the flip has to be re-applied.
+    story_closes_intended: list[str] = field(default_factory=list)
     # Index of the append-only primary dev SessionRecord whose initial decision or
     # later verify-repair result durably returned PROCEED. Attempt numbers can be
     # reused after a human re-arm, so the exact record occurrence is the acceptance
@@ -353,6 +357,7 @@ class StoryTask:
             "harvested_deferrals": self.harvested_deferrals,
             "bundle_closes_intended": self.bundle_closes_intended,
             "refiled_followups": self.refiled_followups,
+            "story_closes_intended": self.story_closes_intended,
             "accepted_dev_session_index": self.accepted_dev_session_index,
             "harvest_carry_commit_pending": self.harvest_carry_commit_pending,
             "isolated_ledger_carried": self.isolated_ledger_carried,
@@ -423,6 +428,7 @@ class StoryTask:
             harvested_deferrals=[deepcopy(dict(item)) for item in d.get("harvested_deferrals", [])],
             bundle_closes_intended=[str(i) for i in d.get("bundle_closes_intended", [])],
             refiled_followups=[deepcopy(dict(item)) for item in d.get("refiled_followups", [])],
+            story_closes_intended=[str(i) for i in d.get("story_closes_intended", [])],
             accepted_dev_session_index=(
                 int(d["accepted_dev_session_index"])
                 if d.get("accepted_dev_session_index") is not None

--- a/src/bmad_loop/sweep.py
+++ b/src/bmad_loop/sweep.py
@@ -1340,7 +1340,11 @@ class SweepEngine(Engine):
         ``super()`` runs FIRST, and that is a contract rather than a style choice.
         ``deferredwork.append_entry``'s idempotence scan is OPEN-ONLY, so a close
         applied ahead of the harvest hides an already-filed row from it and mints a
-        duplicate under a fresh id. ``_carry_harvested_deferrals`` defends the same
+        duplicate under a fresh id. The base hook now ends with a CLOSE of its own
+        (``_carry_story_deferred_closes``, #458) and still satisfies the rule, since
+        both of its appends precede it; the two closes never coexist on one task,
+        because ``_close_declared_deferred`` is a no-op here and a story run has no
+        bundle. ``_carry_harvested_deferrals`` defends the same
         hazard a second time with its own status-agnostic pre-scan, which is exactly
         why the order is pinned by a test: with that second line of defence in place
         a reversal is silent today and would only surface if the pre-scan were ever

--- a/src/bmad_loop/worktree_flow.py
+++ b/src/bmad_loop/worktree_flow.py
@@ -761,6 +761,65 @@ class WorktreeFlow:
                 ids.append(agent)
         return ids
 
+    def _ledger_seed(self, worktree: Path) -> tuple[str, ...]:
+        """The deferred-work ledger, when a worktree checkout cannot deliver it.
+
+        A `git worktree add` checks out TRACKED files only, so a project that
+        gitignores its ledger — the default shape, since the ledger's home is the
+        BMAD artifacts dir and this repo's own is gitignored — gets a unit
+        worktree with no ledger at all. The orchestrator is the ledger's single
+        writer under the generic dev path and writes through
+        ``self.workspace.paths``, i.e. that missing copy: ``mark_done`` returns
+        False on an absent file, and ``verify_review_bundle`` then reads the same
+        absent file and never sees the ids `done`. Measured on the default
+        config, the bundle DEFERS on a fixable retry every run, so `open_ids`
+        re-bundles the same work for ever (#426).
+
+        No DONE-leg carry can rescue that: the unit never reaches DONE. Seeding
+        is what moves the failure onto a leg that has one — measured, the same
+        run then lands, and ``SweepEngine._carry_isolated_ledger_writes`` (which
+        until now only ran for an operator who had named the ledger in
+        ``scm.worktree_seed``) applies the close to the main checkout.
+
+        The copy is not what carries the close home. Every seeded rel is shielded
+        from the unit's ``git add -A`` by a worktree-scoped exclude, so the flip
+        made in the worktree still never rides the merge — the seeded ledger
+        exists so the GATE can read the orchestrator's own write, and the carry
+        remains the delivery path. That is why the landing run still journals
+        ``sweep-bundle-close-carry-uncommitted``: `git add -- <ignored path>`
+        refuses with rc 1, as it did before.
+
+        Three exclusions, each measured:
+
+        * **Already in the checkout** — the copy would be a no-op the seed loop
+          reports as ``worktree-seed-skipped``, i.e. a diagnostic that means "a
+          seed you asked for did nothing" fired on every isolated unit of every
+          ordinary tracked-ledger project. Asked of the worktree rather than of
+          git because that is the question the seed loop itself decides on, and
+          it costs no subprocess and cannot raise.
+        * **Absent from the main checkout** — nothing to copy. The seed loop
+          drops a non-existent source silently (no ``worktree-seed-skipped``, no
+          ``worktree-seed-dropped``), so an entry here would be invisible rather
+          than merely inert. The commonest case by far: the first harvest is what
+          CREATES `deferred-work.md`.
+        * **Configured outside the project tree** — ``ProjectPaths.rebased``
+          leaves an out-of-tree artifacts dir unmoved, so the worktree already
+          reads the very same file and there is nothing to deliver. `relative_to`
+          is the test, and it is also the containment the seed loop requires.
+
+        Deduped against ``scm.worktree_seed`` by the caller, so an operator who
+        already named the ledger keeps exactly one entry.
+        """
+        ledger = self.paths.deferred_work
+        repo = self.paths.repo_root
+        try:
+            rel = ledger.resolve().relative_to(repo.resolve()).as_posix()
+        except (OSError, RuntimeError, ValueError):
+            return ()
+        if not _is_file(ledger) or _is_file(worktree / rel):
+            return ()
+        return (rel,)
+
     def run_isolated(self, task: StoryTask, drive: Callable[[StoryTask], None]) -> None:
         """Run one unit's `drive` body in a fresh per-unit worktree, then merge
         it back into the target branch. `drive` either returns (DONE/DEFERRED →
@@ -815,6 +874,7 @@ class WorktreeFlow:
             for profile in profiles:
                 seeds.extend(profile.seed_files)
         seeds.extend(scm.worktree_seed)
+        seeds.extend(self._ledger_seed(unit.path))
         # plugins (e.g. the Unity engine) may prime an isolated checkout with
         # gitignored paths they need — e.g. an MCP-generated skill tree + client
         # config so the worktree's Editor MCP is reachable. Aggregate every loaded

--- a/src/bmad_loop/worktree_flow.py
+++ b/src/bmad_loop/worktree_flow.py
@@ -802,10 +802,23 @@ class WorktreeFlow:
           ``worktree-seed-dropped``), so an entry here would be invisible rather
           than merely inert. The commonest case by far: the first harvest is what
           CREATES `deferred-work.md`.
-        * **Configured outside the project tree** — ``ProjectPaths.rebased``
-          leaves an out-of-tree artifacts dir unmoved, so the worktree already
-          reads the very same file and there is nothing to deliver. `relative_to`
-          is the test, and it is also the containment the seed loop requires.
+        * **Resolving outside the project tree** — for an out-of-tree artifacts
+          *dir* ``ProjectPaths.rebased`` leaves the path unmoved, so the worktree
+          already reads the very same file and there is nothing to deliver.
+
+        That last rationale covers the DIRECTORY only. When ``deferred-work.md``
+        is itself a symlink the dir stays in-tree, ``rebased`` moves it, and the
+        worktree path the workspace reads does not exist — so the exclusion is
+        not "the worktree already reads it". It is still the right call for an
+        out-of-repo target, because ``provision_worktree`` refuses an out-of-repo
+        resolved source whatever rel it is handed; an in-repo target, though, is
+        seeded to the WRONG path and still hits #426 (#462). Resolving is
+        load-bearing the other way too: when the checkout delivers a TRACKED
+        ledger symlink whose target is untracked, the resolved rel names that
+        target — the only path the seed loop will write, since it never copies
+        through a link. ``relative_to`` here decides PLACEMENT, not the seed
+        loop's containment; that is re-checked against both roots at the copy
+        site.
 
         Deduped against ``scm.worktree_seed`` by the caller, so an operator who
         already named the ledger keeps exactly one entry.

--- a/tests/test_engine_worktree.py
+++ b/tests/test_engine_worktree.py
@@ -20,15 +20,17 @@ from conftest import (
     _spec_baseline,
     _touch_run,
     attach_profile,
+    crash_at_merge_back,
     git,
     ignore_before_commit,
     install_build_auto_skill,
     set_sprint,
+    write_ledger,
     write_spec,
     write_sprint,
 )
 
-from bmad_loop import sprintstatus, verify, worktree_flow
+from bmad_loop import deferredwork, sprintstatus, verify, worktree_flow
 from bmad_loop.adapters.base import SessionResult
 from bmad_loop.adapters.mock import MockAdapter
 from bmad_loop.bmadconfig import ProjectPaths
@@ -1598,6 +1600,155 @@ def test_worktree_followup_damped_commits_and_integrates(project):
         if e.open and "origin: review-budget-followup" in e.body
     ]
     assert len(open_refiled) == 1
+
+
+# --------------------------------------------- review-budget follow-up carry (#425)
+#
+# The third producer in the `git add -A` family. Every row here GITIGNORES the
+# ledger: with a tracked one the entry rides the unit commit and the merge
+# delivers it, which is why `test_worktree_followup_damped_commits_and_integrates`
+# passed all along while the reported defect was live.
+
+
+def _refiled_followups(project):
+    """Open `review-budget-followup` rows in the MAIN checkout's ledger."""
+    if not project.deferred_work.is_file():
+        return []
+    return [
+        entry
+        for entry in deferredwork.parse_ledger(project.deferred_work.read_text(encoding="utf-8"))
+        if entry.open and "origin: review-budget-followup" in entry.body
+    ]
+
+
+def _damping_script(project, story_key="1-1-a"):
+    """Dev, then three passes that keep recommending — the default cap 1 damps."""
+    return [wt_dev_effect(project, story_key)] + [
+        wt_review_effect(project, story_key, clean=False) for _ in range(3)
+    ]
+
+
+def test_gitignored_damped_followup_reaches_the_main_ledger(project):
+    """#425: `_record_review_budget_followup` writes `self.workspace.paths`, which
+    under isolation is the unit worktree's ledger. `finalize_commit`'s `git add -A`
+    skips a gitignored path in silence, the merge brings nothing over, and
+    `close_unit_workspace(success=True)` then deletes the worktree — the DONE leg
+    takes no `capture_diff`, so not even a `changes.patch` survives. Measured
+    before the carry: the run journals `refiled: DW-1` and the main checkout has no
+    ledger at all.
+
+    `check-ignore` is the oracle, not the presence of the rule: a row that reads
+    the tracked-ledger shape by accident is the vacuity this whole block exists to
+    avoid."""
+    ignore_before_commit(project, "deferred-work.md")
+    commit_sprint(project, {"1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(project, _damping_script(project))
+
+    summary = engine.run()
+
+    assert summary.done == 1 and summary.deferred == 0 and not summary.paused
+    rel = project.deferred_work.relative_to(project.project).as_posix()
+    assert git(project.project, "check-ignore", rel).strip() == rel
+    assert not verify.path_tracked(project.project, rel)
+    damped = [e for e in engine.journal.entries() if e["kind"] == "review-followup-damped"]
+    assert len(damped) == 1 and damped[0]["refiled"]
+    assert [e.title for e in _refiled_followups(project)] == [
+        "Follow-up review still recommended for 1-1-a after the damping cap was spent"
+    ]
+    carried = [e for e in engine.journal.entries() if e["kind"] == "review-followup-carried"]
+    assert len(carried) == 1 and carried[0]["dw_ids"] == [_refiled_followups(project)[0].id]
+    # `git add -- <ignored path>` refuses with rc 1: the row lands, the commit
+    # cannot, and that is recorded rather than raised.
+    uncommitted = [
+        e for e in engine.journal.entries() if e["kind"] == "review-followup-carry-uncommitted"
+    ]
+    assert len(uncommitted) == 1
+
+
+def test_tracked_damped_followup_is_not_refiled_twice_by_the_carry(project):
+    """A tracked ledger delivers the row through the merge, so the carry re-reads
+    its own provenance and appends nothing. `append_entry` dedupes on `origin:` +
+    `source_spec:` against OPEN entries, which is what makes running the carry
+    unconditionally safe rather than needing a tracked/ignored predicate."""
+    write_ledger(project, {})
+    commit_sprint(project, {"1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(project, _damping_script(project))
+
+    summary = engine.run()
+
+    assert summary.done == 1 and not summary.paused
+    assert verify.path_tracked(
+        project.project, project.deferred_work.relative_to(project.project).as_posix()
+    )
+    assert len(_refiled_followups(project)) == 1
+    carried = [e for e in engine.journal.entries() if e["kind"] == "review-followup-carried"]
+    assert len(carried) == 1 and carried[0]["dw_ids"] == []
+
+
+def test_a_deduped_followup_records_nothing_to_carry(project):
+    """The producer records only what it actually filed. A story whose follow-up
+    was already open in the ledger appends nothing, and recording it anyway would
+    journal a carry that carried nothing — indistinguishable from a real one that
+    deduped, which is the report this pair exists to keep honest."""
+    write_ledger(project, {})
+    deferredwork.append_entry(
+        project.deferred_work,
+        title="already recommended",
+        origin="review-budget-followup",
+        source_spec="spec-1-1-a.md",
+        reason="filed by an earlier run",
+        severity="low",
+    )
+    git(project.project, "add", "-A")
+    git(project.project, "commit", "-q", "-m", "prior follow-up")
+    commit_sprint(project, {"1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(project, _damping_script(project))
+
+    summary = engine.run()
+
+    assert summary.done == 1 and not summary.paused
+    damped = [e for e in engine.journal.entries() if e["kind"] == "review-followup-damped"]
+    assert len(damped) == 1 and damped[0]["refiled"] is None
+    assert not engine.state.tasks["1-1-a"].refiled_followups
+    assert "review-followup-carried" not in journal_kinds(engine)
+    assert len(_refiled_followups(project)) == 1
+
+
+def test_crashed_post_merge_followup_carry_replays_from_its_record(project):
+    """A story whose ONLY ledger write is a damped follow-up has both other carry
+    payloads empty, so the resume pass has to name this one to reach it: crash in
+    the merge-to-latch window and the row is otherwise stranded in a worktree that
+    is already gone."""
+    ignore_before_commit(project, "deferred-work.md")
+    commit_sprint(project, {"1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(project, _damping_script(project))
+    crash_at_merge_back(engine, after="merge")
+
+    assert engine.run().crashed
+
+    crashed = load_state(engine.run_dir).tasks["1-1-a"]
+    assert crashed.phase == Phase.DONE and not crashed.isolated_ledger_carried
+    assert crashed.refiled_followups and not crashed.harvested_deferrals
+    assert not project.deferred_work.exists()
+
+    state = load_state(engine.run_dir)
+    state.clear_pause()
+    adapter = MockAdapter([])
+    resumed = Engine(
+        paths=project,
+        policy=engine.policy,
+        adapter=adapter,
+        run_dir=engine.run_dir,
+        journal=engine.journal,
+        state=state,
+    )
+    summary = resumed.run()
+
+    assert summary.done == 1 and not summary.crashed and not summary.paused
+    assert adapter.sessions == []
+    assert "resume-ledger-carry" in journal_kinds(resumed)
+    assert len(_refiled_followups(project)) == 1
+    assert load_state(resumed.run_dir).tasks["1-1-a"].isolated_ledger_carried
 
 
 # ----------------------------------------------------------------- configured target

--- a/tests/test_engine_worktree.py
+++ b/tests/test_engine_worktree.py
@@ -1685,11 +1685,13 @@ def test_tracked_damped_followup_is_not_refiled_twice_by_the_carry(project):
     assert len(carried) == 1 and carried[0]["dw_ids"] == []
 
 
-def test_a_deduped_followup_records_nothing_to_carry(project):
-    """The producer records only what it actually filed. A story whose follow-up
-    was already open in the ledger appends nothing, and recording it anyway would
-    journal a carry that carried nothing — indistinguishable from a real one that
-    deduped, which is the report this pair exists to keep honest."""
+def test_a_deduped_followup_is_still_recorded_for_the_carry(project):
+    """The record is the INTENT, not a receipt for a new id. A story whose
+    follow-up was already open appends nothing, and the producer still records it,
+    because the record has to be durable before the append that may dedupe it —
+    otherwise a replay after a host loss can never reconstruct authorship. The
+    carry then dedupes in turn and journals an empty `dw_ids`, which the tracked
+    path already produces routinely."""
     write_ledger(project, {})
     deferredwork.append_entry(
         project.deferred_work,
@@ -1709,8 +1711,108 @@ def test_a_deduped_followup_records_nothing_to_carry(project):
     assert summary.done == 1 and not summary.paused
     damped = [e for e in engine.journal.entries() if e["kind"] == "review-followup-damped"]
     assert len(damped) == 1 and damped[0]["refiled"] is None
-    assert not engine.state.tasks["1-1-a"].refiled_followups
-    assert "review-followup-carried" not in journal_kinds(engine)
+    assert len(engine.state.tasks["1-1-a"].refiled_followups) == 1
+    carried = [e for e in engine.journal.entries() if e["kind"] == "review-followup-carried"]
+    assert len(carried) == 1 and carried[0]["dw_ids"] == []
+    # no duplicate: the pre-existing open row is the only one
+    assert len(_refiled_followups(project)) == 1
+
+
+def _host_loss_before_the_commit_save(engine, snap):
+    """A host loss inside `_commit`, before its `advance(COMMITTING)` + `_save()`.
+
+    `snap` captures the bytes that were DURABLE at that instant. Restoring them
+    over whatever `run()`'s unwind-`finally` wrote is what makes this a SIGKILL
+    rather than a SIGINT: the engine's own teardown save would otherwise persist
+    the very record whose durability is under test, and the row would arrive for
+    a reason the fix has nothing to do with.
+    """
+
+    def commit_with_host_loss(_task):
+        snap["state"] = (engine.run_dir / "state.json").read_bytes()
+        raise RuntimeError("host died between the ledger write and the COMMITTING save")
+
+    engine._commit = commit_with_host_loss
+
+
+def test_host_loss_before_the_commit_save_still_carries_the_followup(project):
+    """The producer's record must be persisted BEFORE its ledger append.
+
+    Nothing saves between `_record_review_budget_followup` and `_commit`'s
+    COMMITTING save, and that window spans every blocking `pre_commit_gate`
+    workflow — the shipped TEA plugin binds three, each a live session. Recording
+    after a successful append loses the row for good: the resumed run replays the
+    same review result in the same worktree, `append_entry` dedupes the row it
+    already wrote there to None, so the record is never made, the carry finds an
+    empty payload, and `close_unit_workspace` deletes the worktree holding the
+    only copy.
+    """
+    ignore_before_commit(project, "deferred-work.md")
+    commit_sprint(project, {"1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(project, _damping_script(project))
+    snap: dict = {}
+    _host_loss_before_the_commit_save(engine, snap)
+
+    assert engine.run().crashed
+
+    worktree = Path(engine.state.tasks["1-1-a"].worktree_path)
+    # the row exists, but only inside the unit worktree's gitignored ledger
+    assert [e.id for e in _refiled_followups(project.rebased(worktree))] == ["DW-1"]
+    assert not project.deferred_work.exists()
+
+    (engine.run_dir / "state.json").write_bytes(snap["state"])
+    durable = load_state(engine.run_dir).tasks["1-1-a"]
+    assert durable.phase == Phase.REVIEW_VERIFY
+    assert durable.refiled_followups
+
+    state = load_state(engine.run_dir)
+    state.clear_pause()
+    adapter = MockAdapter([])
+    resumed = Engine(
+        paths=project,
+        policy=engine.policy,
+        adapter=adapter,
+        run_dir=engine.run_dir,
+        journal=engine.journal,
+        state=state,
+    )
+    summary = resumed.run()
+
+    assert summary.done == 1 and not summary.crashed and not summary.paused
+    assert not worktree.is_dir()
+    assert [e.title for e in _refiled_followups(project)] == [
+        "Follow-up review still recommended for 1-1-a after the damping cap was spent"
+    ]
+
+
+def test_a_replayed_review_result_records_the_followup_once(project):
+    """The record is keyed on `origin:` + `source_spec:`, so the replay that
+    re-enters the damped path with the record already persisted appends no second
+    copy — and files no second ledger row."""
+    ignore_before_commit(project, "deferred-work.md")
+    commit_sprint(project, {"1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(project, _damping_script(project))
+    _host_loss_before_the_commit_save(engine, {})
+
+    assert engine.run().crashed
+    # the unwind-finally persisted the record, so the replay re-enters the damped
+    # path with it already in hand — the case the keyed dedupe exists for
+    assert len(load_state(engine.run_dir).tasks["1-1-a"].refiled_followups) == 1
+
+    state = load_state(engine.run_dir)
+    state.clear_pause()
+    resumed = Engine(
+        paths=project,
+        policy=engine.policy,
+        adapter=MockAdapter([]),
+        run_dir=engine.run_dir,
+        journal=engine.journal,
+        state=state,
+    )
+    summary = resumed.run()
+
+    assert summary.done == 1 and not summary.crashed
+    assert len(resumed.state.tasks["1-1-a"].refiled_followups) == 1
     assert len(_refiled_followups(project)) == 1
 
 

--- a/tests/test_engine_worktree.py
+++ b/tests/test_engine_worktree.py
@@ -3100,3 +3100,264 @@ def test_worktree_in_repo_ledger_closure_reaches_the_target_branch(project):
     assert entry.status.startswith("done") and not entry.open
     assert "resolution: resolved by story 1-1-a" in entry.body
     assert worktree_clean(project.project)
+    # #458's carry runs here too, and finds nothing to do: `_apply_done` returns
+    # None for a row that is already `done`, so `mark_done_many` writes nothing at
+    # all and no commit is attempted. That is what lets the carry be unconditional
+    # rather than needing a tracked/ignored predicate.
+    carried = [e for e in engine.journal.entries() if e["kind"] == "story-deferred-close-carried"]
+    assert [e["dw_ids"] for e in carried] == [[]]
+    assert "story-deferred-close-carry-uncommitted" not in journal_kinds(engine)
+    # exactly one annotation — a second close would append a second resolution line
+    assert entry.body.count("resolution:") == 1
+    assert "resolution-undo:" not in entry.body
+
+
+def test_gitignored_declared_closure_reaches_the_main_ledger(project):
+    """#458 — the fourth producer in the `git add -A` family, and the one whose
+    failure now reads as a SUCCESS.
+
+    `_close_declared_deferred` writes `self.workspace.paths.deferred_work`, which
+    under isolation is the unit worktree's ledger. With the ledger GITIGNORED —
+    the default shape, since the ledger lives in the BMAD artifacts dir — the flip
+    lands in the worktree, is skipped in silence by `finalize_commit`'s `git add
+    -A` (a worktree-scoped exclude shields every seeded rel), brings nothing over
+    with the merge, and dies with the worktree at `close_unit_workspace`. Nothing
+    in `_carry_isolated_ledger_writes` carries it: that hook owns the harvest and
+    the review-budget follow-up, both APPENDS, and a declared close is neither.
+
+    Measured on this commit (`628fe54`), verbatim.
+
+    The unit worktree's ledger at the moment of the close::
+
+        ### DW-1: item DW-1
+
+        origin: test, 2026-06-01
+        location: src.txt:1
+        reason: test entry.
+        status: done 2026-08-05
+        resolution: resolved by story 1-1-a
+
+    The main checkout's ledger after the run — unchanged::
+
+        ### DW-1: item DW-1
+
+        origin: test, 2026-06-01
+        location: src.txt:1
+        reason: test entry.
+        status: open
+
+    …and the journal carries `story-deferred-closed dw_ids=['DW-1']` with no
+    `deferred-close-unmatched`. That is the false success: `f798c1b` seeds the
+    ledger a worktree checkout cannot deliver, so the close now finds a file to
+    write and reports itself done. Ablating that seed (`_ledger_seed` -> `()`)
+    puts the pre-seed behavior back — the worktree ledger is ABSENT, `classify`
+    reports the id unmatched, and the run journals `deferred-close-unmatched
+    dw_ids=['DW-1']`. Louder, equally lost.
+
+    Tracked is the contrast, not a second defect: the sibling above measures the
+    same story against a TRACKED ledger and the close rides the unit commit into
+    the merge — no seed is made, so no exclude shields it. The fix therefore needs
+    no tracked/ignored predicate, only an idempotent carry (re-applying a close
+    the merge already delivered is a no-op, exactly as
+    `test_tracked_damped_followup_is_not_refiled_twice_by_the_carry` relies on).
+
+    RED here is the last three assertions: the main checkout must end up with the
+    annotation the worktree got. Everything above them holds today and must keep
+    holding — the fix delivers the close, it does not stop reporting one.
+    """
+    ignore_before_commit(project, "deferred-work.md")
+    write_ledger(project, {"DW-1": "open"})
+    rel = project.deferred_work.relative_to(project.project).as_posix()
+    # `check-ignore` is the oracle: a rule that is present is not necessarily
+    # effective, and a row that reads the tracked shape by accident is vacuous.
+    assert git(project.project, "check-ignore", rel).strip() == rel
+    assert not verify.path_tracked(project.project, rel)
+    commit_sprint(project, {"1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(
+        project,
+        [wt_dev_effect(project, "1-1-a", followup_review=False, closes_deferred=["DW-1"])],
+    )
+
+    summary = engine.run()
+
+    # the false success, in the order an operator meets it
+    assert summary.done == 1 and not summary.paused and not summary.crashed
+    closed = [e for e in engine.journal.entries() if e["kind"] == "story-deferred-closed"]
+    assert [e["dw_ids"] for e in closed] == [["DW-1"]]
+    assert "deferred-close-unmatched" not in journal_kinds(engine)
+    # the only checkout that ever held the flip is gone
+    assert [p.resolve() for p in worktree_list(project.project)] == [project.project.resolve()]
+    entry = _ledger_entry(project, "DW-1")
+    assert entry.status.startswith("done") and not entry.open
+    assert "resolution: resolved by story 1-1-a" in entry.body
+
+
+def test_crashed_post_merge_story_close_replays_from_its_record(project):
+    """A story whose ONLY ledger write is a declared close has every other carry
+    payload empty, so the resume pass has to name this one to reach it — the same
+    reachability the damped follow-up needed, for the fourth producer."""
+    ignore_before_commit(project, "deferred-work.md")
+    write_ledger(project, {"DW-1": "open"})
+    commit_sprint(project, {"1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(
+        project,
+        [wt_dev_effect(project, "1-1-a", followup_review=False, closes_deferred=["DW-1"])],
+    )
+    crash_at_merge_back(engine, after="merge")
+
+    assert engine.run().crashed
+
+    crashed = load_state(engine.run_dir).tasks["1-1-a"]
+    assert crashed.phase == Phase.DONE and not crashed.isolated_ledger_carried
+    # only the new disjunct can reach the carry
+    assert crashed.story_closes_intended == ["DW-1"]
+    assert not crashed.harvested_deferrals and not crashed.refiled_followups
+    assert _ledger_entry(project, "DW-1").open
+
+    state = load_state(engine.run_dir)
+    state.clear_pause()
+    adapter = MockAdapter([])
+    resumed = Engine(
+        paths=project,
+        policy=engine.policy,
+        adapter=adapter,
+        run_dir=engine.run_dir,
+        journal=engine.journal,
+        state=state,
+    )
+    summary = resumed.run()
+
+    assert summary.done == 1 and not summary.crashed and not summary.paused
+    assert adapter.sessions == []
+    assert "resume-ledger-carry" in journal_kinds(resumed)
+    entry = _ledger_entry(project, "DW-1")
+    assert entry.status.startswith("done") and not entry.open
+    assert load_state(resumed.run_dir).tasks["1-1-a"].isolated_ledger_carried
+
+
+def test_a_re_armed_story_does_not_carry_a_withdrawn_declaration(project, monkeypatch):
+    """The record is re-derived at every commit boundary, and that is the whole of
+    its staleness guard.
+
+    `_close_declared_deferred` reads `closes_deferred:` LIVE and reassigns
+    `story_closes_intended` before its own early return, so it needs no
+    `_dev_phase` clear the way `refiled_followups` does: DONE is reachable only
+    through `_finalize_commit_phase`, which always re-enters the producer. A human
+    who resolves an escalation by WITHDRAWING the declaration must not have the
+    abandoned attempt's ids closed on their behalf — the exact stale-snapshot case
+    `_declared_deferred_ids` reads live to avoid.
+    """
+    ignore_before_commit(project, "deferred-work.md")
+    write_ledger(project, {"DW-1": "open"})
+    commit_sprint(project, {"1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(
+        project,
+        [wt_dev_effect(project, "1-1-a", followup_review=False, closes_deferred=["DW-1"])],
+    )
+    real_finalize = verify.finalize_commit
+
+    def commit_fails(*_a, **_k):
+        raise verify.GitError("simulated commit failure")
+
+    monkeypatch.setattr(verify, "finalize_commit", commit_fails)
+
+    assert engine.run().paused
+
+    escalated = load_state(engine.run_dir).tasks["1-1-a"]
+    assert escalated.phase == Phase.ESCALATED
+    assert escalated.story_closes_intended == ["DW-1"]  # recorded, and now stale
+    # `_restore_deferred_closes` put the worktree ledger back; main never had it
+    assert _ledger_entry(project, "DW-1").open
+
+    monkeypatch.setattr(verify, "finalize_commit", real_finalize)
+    assert runs.rearm_escalation(engine.run_dir, "1-1-a") == "1-1-a"
+
+    state = load_state(engine.run_dir)
+    state.clear_pause()
+    resumed = Engine(
+        paths=project,
+        policy=engine.policy,
+        adapter=MockAdapter(
+            # the resolve outcome: the story no longer claims to close anything
+            [wt_dev_effect(project, "1-1-a", followup_review=False)]
+        ),
+        run_dir=engine.run_dir,
+        journal=engine.journal,
+        state=state,
+    )
+    summary = resumed.run()
+
+    assert summary.done == 1 and not summary.paused and not summary.crashed
+    assert _ledger_entry(project, "DW-1").open  # the withdrawn id stays open
+    assert not resumed.state.tasks["1-1-a"].story_closes_intended
+    carried = [e for e in resumed.journal.entries() if e["kind"] == "story-deferred-close-carried"]
+    assert [e["dw_ids"] for e in carried] == []
+
+
+def test_a_replayed_commit_still_records_the_story_close(project, monkeypatch):
+    """Record the DECLARED ids, never the ones `mark_done_many` actually flipped.
+
+    A host loss after `_close_declared_deferred` wrote the close but before the
+    DONE save leaves the phase at the COMMITTING that was already persisted, and
+    the resume arm re-enters `_finalize_commit_phase` — which re-runs the producer
+    against a worktree ledger that ALREADY reads `done`. `classify` then reports
+    every id `already_done` and `marked` is EMPTY. A record derived from `marked`
+    is therefore never made on that replay, the carry finds an empty payload, and
+    `close_unit_workspace` deletes the only copy — the exact defect `e88776a`
+    fixed for the damped follow-up, arriving through a different door.
+
+    Non-unwinding is the whole point: `_restore_deferred_closes` is neutralised
+    (a SIGKILL runs no except arm) so the close survives on disk, and the durable
+    state.json is put back over whatever `run()`'s unwind-`finally` wrote.
+    """
+    ignore_before_commit(project, "deferred-work.md")
+    write_ledger(project, {"DW-1": "open"})
+    commit_sprint(project, {"1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(
+        project,
+        [wt_dev_effect(project, "1-1-a", followup_review=False, closes_deferred=["DW-1"])],
+    )
+    snap: dict = {}
+
+    def host_loss(*_a, **_k):
+        # nothing has saved since the COMMITTING advance, so these bytes ARE the
+        # durable state at the instant of the kill — the record is memory-only
+        snap["state"] = (engine.run_dir / "state.json").read_bytes()
+        raise RuntimeError("host died after the declared close, before the DONE save")
+
+    monkeypatch.setattr(verify, "finalize_commit", host_loss)
+    monkeypatch.setattr(type(engine), "_restore_deferred_closes", lambda self, task, s: None)
+
+    assert engine.run().crashed
+
+    monkeypatch.undo()  # the host is back: the resume commits and unwinds normally
+
+    worktree = Path(engine.state.tasks["1-1-a"].worktree_path)
+    # the close exists, but only inside the unit worktree's gitignored ledger
+    assert not _ledger_entry(project.rebased(worktree), "DW-1").open
+    assert _ledger_entry(project, "DW-1").open
+
+    (engine.run_dir / "state.json").write_bytes(snap["state"])
+    durable = load_state(engine.run_dir).tasks["1-1-a"]
+    assert durable.phase == Phase.COMMITTING
+    assert not durable.story_closes_intended  # never reached disk — the replay re-derives it
+
+    state = load_state(engine.run_dir)
+    state.clear_pause()
+    resumed = Engine(
+        paths=project,
+        policy=engine.policy,
+        adapter=MockAdapter([]),
+        run_dir=engine.run_dir,
+        journal=engine.journal,
+        state=state,
+    )
+    summary = resumed.run()
+
+    assert summary.done == 1 and not summary.crashed and not summary.paused
+    # the replay's own close flipped nothing (already done in the worktree) and the
+    # carry still delivered, because the record is the declaration, not the receipt
+    assert not worktree.is_dir()
+    entry = _ledger_entry(project, "DW-1")
+    assert entry.status.startswith("done") and not entry.open
+    assert "resolution: resolved by story 1-1-a" in entry.body

--- a/tests/test_engine_worktree.py
+++ b/tests/test_engine_worktree.py
@@ -30,7 +30,7 @@ from conftest import (
     write_sprint,
 )
 
-from bmad_loop import deferredwork, sprintstatus, verify, worktree_flow
+from bmad_loop import deferredwork, runs, sprintstatus, verify, worktree_flow
 from bmad_loop.adapters.base import SessionResult
 from bmad_loop.adapters.mock import MockAdapter
 from bmad_loop.bmadconfig import ProjectPaths
@@ -1851,6 +1851,67 @@ def test_crashed_post_merge_followup_carry_replays_from_its_record(project):
     assert "resume-ledger-carry" in journal_kinds(resumed)
     assert len(_refiled_followups(project)) == 1
     assert load_state(resumed.run_dir).tasks["1-1-a"].isolated_ledger_carried
+
+
+def test_a_re_armed_story_does_not_carry_the_abandoned_attempt_s_followup(project, monkeypatch):
+    """The record is scoped to the attempt that made it, and `_dev_phase`'s
+    fresh-attempt clear is what enforces that.
+
+    An escalation between the damped record and the commit leaves the unit
+    worktree mounted and unmerged; the re-drive then DISCARDS it, taking the only
+    copy of the row with it. Without the clear the record outlives its attempt,
+    and the next attempt's DONE leg files a follow-up against the commit that
+    actually landed — one whose review recommended nothing. `rearm_escalation`
+    already resets `followup_reviews_spent` for a fresh damping budget, so keeping
+    the record contradicts the re-arm on its own terms.
+
+    Nothing upstream absorbs it either: the abandoned attempt's ledger write never
+    reached the main checkout, so `append_entry` has no open row to dedupe against
+    and a TRACKED ledger would commit the stale row rather than swallow it.
+    """
+    ignore_before_commit(project, "deferred-work.md")
+    commit_sprint(project, {"1-1-a": "ready-for-dev"})
+    engine, _ = make_engine(project, _damping_script(project))
+
+    real_finalize = verify.finalize_commit
+
+    def commit_fails(*_a, **_k):
+        raise verify.GitError("simulated commit failure")
+
+    monkeypatch.setattr(verify, "finalize_commit", commit_fails)
+
+    assert engine.run().paused
+
+    escalated = load_state(engine.run_dir).tasks["1-1-a"]
+    assert escalated.phase == Phase.ESCALATED
+    assert escalated.refiled_followups  # persisted by the producer, pre-append
+    assert not project.deferred_work.exists()  # the row is only in the doomed worktree
+
+    monkeypatch.setattr(verify, "finalize_commit", real_finalize)
+    assert runs.rearm_escalation(engine.run_dir, "1-1-a") == "1-1-a"
+
+    state = load_state(engine.run_dir)
+    state.clear_pause()
+    resumed = Engine(
+        paths=project,
+        policy=engine.policy,
+        adapter=MockAdapter(
+            [wt_dev_effect(project, "1-1-a"), wt_review_effect(project, "1-1-a", clean=True)]
+        ),
+        run_dir=engine.run_dir,
+        journal=engine.journal,
+        state=state,
+    )
+    summary = resumed.run()
+
+    assert summary.done == 1 and not summary.paused and not summary.crashed
+    # the re-drive converged on its own review: only the ABANDONED attempt damped
+    assert journal_kinds(resumed).count("review-followup-damped") == 1
+    # the harm, asserted before its cause: no follow-up row for the commit that
+    # landed, and no carry claiming to have filed one
+    assert [e.title for e in _refiled_followups(project)] == []
+    assert "review-followup-carried" not in journal_kinds(resumed)
+    assert not resumed.state.tasks["1-1-a"].refiled_followups
 
 
 # ----------------------------------------------------------------- configured target

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -170,6 +170,7 @@ _DEFERRED_STATE_KEYS = (
     "ledger_changed_before_harvest",
     "harvested_deferrals",
     "bundle_closes_intended",
+    "refiled_followups",
     "accepted_dev_session_index",
     "harvest_carry_commit_pending",
     "isolated_ledger_carried",
@@ -177,7 +178,7 @@ _DEFERRED_STATE_KEYS = (
 
 
 def test_deferred_work_state_fields_round_trip_through_json():
-    """All ten fields are hand-enumerated in both serializers. Non-default
+    """All eleven fields are hand-enumerated in both serializers. Non-default
     values make a missing line on either side observable, while the JSON leg pins
     the on-disk container shape rather than only an in-memory dataclass copy."""
     task = StoryTask(
@@ -190,6 +191,7 @@ def test_deferred_work_state_fields_round_trip_through_json():
         ledger_changed_before_harvest=True,
         harvested_deferrals=[{"origin": "spec-deferred abc", "title": "finding"}],
         bundle_closes_intended=["DW-3", "DW-7"],
+        refiled_followups=[{"origin": "review-budget-followup", "title": "follow-up"}],
         accepted_dev_session_index=3,
         harvest_carry_commit_pending=True,
         isolated_ledger_carried=True,
@@ -204,13 +206,16 @@ def test_deferred_work_state_fields_round_trip_through_json():
     assert restored.ledger_changed_before_harvest is True
     assert restored.harvested_deferrals == [{"origin": "spec-deferred abc", "title": "finding"}]
     assert restored.bundle_closes_intended == ["DW-3", "DW-7"]
+    assert restored.refiled_followups == [
+        {"origin": "review-budget-followup", "title": "follow-up"}
+    ]
     assert restored.accepted_dev_session_index == 3
     assert restored.harvest_carry_commit_pending is True
     assert restored.isolated_ledger_carried is True
 
 
 def test_deferred_work_state_fields_default_for_one_old_state_dict():
-    """A state.json written before this package has none of the ten keys.
+    """A state.json written before this package has none of the eleven keys.
     Every load must use ``d.get`` so resume reaches the old behavior instead of
     raising KeyError; one shared old document prevents testing only a subset."""
     doc = StoryTask(story_key="1-1-a", epic=1).to_dict()
@@ -225,6 +230,7 @@ def test_deferred_work_state_fields_default_for_one_old_state_dict():
     assert restored.ledger_changed_before_harvest is False
     assert restored.harvested_deferrals == []
     assert restored.bundle_closes_intended == []
+    assert restored.refiled_followups == []
     assert restored.accepted_dev_session_index is None
     assert restored.harvest_carry_commit_pending is False
     assert restored.isolated_ledger_carried is False
@@ -249,15 +255,21 @@ def test_deferred_work_state_containers_do_not_alias_the_persisted_doc():
             {"title": "original", "metadata": {"labels": ["review"]}},
         ],
         bundle_closes_intended=["DW-1"],
+        refiled_followups=[{"title": "followup", "metadata": {"labels": ["review"]}}],
     ).to_dict()
     restored = StoryTask.from_dict(doc)
     restored.harvested_deferrals[0]["title"] = "mutated"
     restored.harvested_deferrals[0]["metadata"]["labels"].append("follow-up")
     restored.bundle_closes_intended.append("DW-2")
+    restored.refiled_followups[0]["title"] = "mutated"
+    restored.refiled_followups[0]["metadata"]["labels"].append("follow-up")
     assert doc["harvested_deferrals"] == [
         {"title": "original", "metadata": {"labels": ["review"]}},
     ]
     assert doc["bundle_closes_intended"] == ["DW-1"]
+    assert doc["refiled_followups"] == [
+        {"title": "followup", "metadata": {"labels": ["review"]}},
+    ]
 
 
 def test_deferred_work_state_container_defaults_are_not_shared():
@@ -265,8 +277,10 @@ def test_deferred_work_state_container_defaults_are_not_shared():
     other = StoryTask(story_key="1-2-b", epic=1)
     one.harvested_deferrals.append({"title": "one"})
     one.bundle_closes_intended.append("DW-1")
+    one.refiled_followups.append({"title": "one"})
     assert other.harvested_deferrals == []
     assert other.bundle_closes_intended == []
+    assert other.refiled_followups == []
 
 
 def test_restore_patch_round_trips():

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -171,6 +171,7 @@ _DEFERRED_STATE_KEYS = (
     "harvested_deferrals",
     "bundle_closes_intended",
     "refiled_followups",
+    "story_closes_intended",
     "accepted_dev_session_index",
     "harvest_carry_commit_pending",
     "isolated_ledger_carried",
@@ -178,7 +179,7 @@ _DEFERRED_STATE_KEYS = (
 
 
 def test_deferred_work_state_fields_round_trip_through_json():
-    """All eleven fields are hand-enumerated in both serializers. Non-default
+    """All twelve fields are hand-enumerated in both serializers. Non-default
     values make a missing line on either side observable, while the JSON leg pins
     the on-disk container shape rather than only an in-memory dataclass copy."""
     task = StoryTask(
@@ -192,6 +193,7 @@ def test_deferred_work_state_fields_round_trip_through_json():
         harvested_deferrals=[{"origin": "spec-deferred abc", "title": "finding"}],
         bundle_closes_intended=["DW-3", "DW-7"],
         refiled_followups=[{"origin": "review-budget-followup", "title": "follow-up"}],
+        story_closes_intended=["DW-4"],
         accepted_dev_session_index=3,
         harvest_carry_commit_pending=True,
         isolated_ledger_carried=True,
@@ -209,13 +211,14 @@ def test_deferred_work_state_fields_round_trip_through_json():
     assert restored.refiled_followups == [
         {"origin": "review-budget-followup", "title": "follow-up"}
     ]
+    assert restored.story_closes_intended == ["DW-4"]
     assert restored.accepted_dev_session_index == 3
     assert restored.harvest_carry_commit_pending is True
     assert restored.isolated_ledger_carried is True
 
 
 def test_deferred_work_state_fields_default_for_one_old_state_dict():
-    """A state.json written before this package has none of the eleven keys.
+    """A state.json written before this package has none of the twelve keys.
     Every load must use ``d.get`` so resume reaches the old behavior instead of
     raising KeyError; one shared old document prevents testing only a subset."""
     doc = StoryTask(story_key="1-1-a", epic=1).to_dict()
@@ -231,6 +234,7 @@ def test_deferred_work_state_fields_default_for_one_old_state_dict():
     assert restored.harvested_deferrals == []
     assert restored.bundle_closes_intended == []
     assert restored.refiled_followups == []
+    assert restored.story_closes_intended == []
     assert restored.accepted_dev_session_index is None
     assert restored.harvest_carry_commit_pending is False
     assert restored.isolated_ledger_carried is False

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -579,6 +579,11 @@ def wt_bundle_dev(project, name="fix", dw_ids=("DW-1",), deferred=None):
         src = cwd / "src.txt"
         src.write_text(src.read_text() + f"change for dw-{name}\n")
         sp = wt.implementation_artifacts / f"spec-dw-{name}.md"
+        # A real dev session creates its artifacts dir. A worktree that seeds
+        # nothing into it has none — git does not track the template's empty one —
+        # so without this the session dies on the spec write and no test of the
+        # unseeded shape could reach the gate it is about.
+        sp.parent.mkdir(parents=True, exist_ok=True)
         # mirror bmad-dev-auto: self-finalize the spec, leave the ledger to the
         # orchestrator (single writer, marking inside the worktree)
         write_spec(sp, "done", baseline, deferred=deferred)
@@ -606,6 +611,86 @@ def bundle_plan(dw_ids=("DW-1",), name="fix"):
         list(dw_ids),
         bundles=[{"name": name, "dw_ids": list(dw_ids), "intent": "fix it"}],
     )
+
+
+def isolated_policy(**scm) -> Policy:
+    """`isolated_seeded_policy` without the seed — the SHIPPED default, since
+    `scm.worktree_seed` defaults to `()`."""
+    return Policy(
+        gates=GatesPolicy(mode="none"),
+        notify=QUIET,
+        scm=ScmPolicy(isolation="worktree", **scm),
+    )
+
+
+def test_isolated_bundle_lands_when_the_gitignored_ledger_was_never_seeded(project):
+    """#426, the default configuration: `worktree_seed` defaults to `()` and the
+    ledger's home is the artifacts dir, so a project that gitignores it gets a unit
+    worktree with NO ledger. The orchestrator writes the close through
+    `self.workspace.paths` — that absent file — `mark_done` returns False, and
+    `verify_review_bundle` reads the same absent file and fails `fixable=True`.
+    Measured before the auto-seed: `phase=deferred`, `DW-1` still `open`, a
+    `review-verify-failed` naming the worktree's path, and `open_ids` re-bundling
+    the same work on every later sweep.
+
+    No DONE-leg carry can rescue that — the unit never reaches DONE — so the fix
+    is upstream of the carry: seed the ledger the checkout cannot deliver, which
+    moves the failure onto the leg 6M's carry already covers.
+
+    The extra dev effects are the repair round the gate's `fixable=True` buys.
+    They go unused on the fixed path; without them a regression would exhaust the
+    script and fail as a crash rather than as the defer it actually is."""
+    ignored_ledger(project, {"DW-1": "open", "DW-2": "open"})
+    plan = triage_result(
+        ["DW-1", "DW-2"],
+        bundles=[{"name": "fix", "dw_ids": ["DW-1"], "intent": "fix it"}],
+        skip=[{"id": "DW-2", "reason": "moot"}],
+    )
+    engine, _ = make_sweep(
+        project,
+        [triage_effect(plan)] + [wt_bundle_dev(project)] * 6,
+        policy=isolated_policy(),
+    )
+
+    summary = engine.run()
+
+    assert not summary.paused and not summary.crashed and summary.deferred == 0
+    task = engine.state.tasks["dw-fix"]
+    assert task.phase == Phase.DONE and task.isolated_ledger_carried
+    entries = ledger_entries(project)
+    assert entries["DW-1"].status.startswith("done")
+    assert entries["DW-2"].open
+    assert "review-verify-failed" not in journal_kinds(engine)
+    # The seeded copy is shielded from the unit's `git add -A` like every other
+    # seed, so the close still does not ride the merge: the carry is what lands
+    # it, and `git add -- <ignored path>` still refuses with rc 1.
+    carried = [e for e in engine.journal.entries() if e["kind"] == "sweep-bundle-close-carried"]
+    assert [e["dw_ids"] for e in carried] == [["DW-1"]]
+    uncommitted = [
+        e for e in engine.journal.entries() if e["kind"] == "sweep-bundle-close-carry-uncommitted"
+    ]
+    assert len(uncommitted) == 1 and uncommitted[0]["dw_ids"] == ["DW-1"]
+    assert worktree_clean(project.project)
+
+
+def test_isolated_bundle_with_a_tracked_ledger_seeds_nothing(project):
+    """A tracked ledger is delivered by the checkout, so auto-seeding it would
+    report `worktree-seed-skipped` — "a seed you asked for did nothing" — on every
+    isolated unit of every ordinary project, burying the real ones."""
+    write_ledger(project, {"DW-1": "open"})
+    assert verify.path_tracked(project.project, ledger_rel(project))
+    engine, _ = make_sweep(
+        project,
+        [triage_effect(bundle_plan(["DW-1"]))] + [wt_bundle_dev(project)] * 6,
+        policy=isolated_policy(),
+    )
+
+    summary = engine.run()
+
+    assert not summary.paused and not summary.crashed
+    assert engine.state.tasks["dw-fix"].phase == Phase.DONE
+    assert ledger_entries(project)["DW-1"].status.startswith("done")
+    assert "worktree-seed-skipped" not in journal_kinds(engine)
 
 
 def test_isolated_bundle_carries_its_gitignored_ledger_close_to_the_main_checkout(project):

--- a/tests/test_worktree_flow.py
+++ b/tests/test_worktree_flow.py
@@ -15,6 +15,7 @@ import pytest
 from conftest import git
 
 from bmad_loop import verify
+from bmad_loop.bmadconfig import ProjectPaths
 from bmad_loop.gates import ATTENTION_FILE
 from bmad_loop.install import provision_worktree as install_provision_worktree
 from bmad_loop.model import Phase, StoryTask
@@ -169,6 +170,85 @@ def test_merge_message_format(tmp_path):
     task = StoryTask(story_key="1-1", epic=1)
     task.branch = "bmad-loop/1-1"
     assert flow.merge_message(task) == "Merge bmad-loop/1-1 into main (bmad-loop)"
+
+
+# ------------------------------------------------------------------- ledger seed
+#
+# `_ledger_seed` decides, per unit, whether the deferred-work ledger has to be
+# copied into the checkout because git will not carry it there (#426). Unit-level
+# because each exclusion has a distinct reason a run-level assertion blurs: two of
+# them are silent in the journal by design.
+
+
+def _ledger_flow(tmp_path, *, artifacts: Path | None = None) -> WorktreeFlow:
+    repo = tmp_path / "repo"
+    (repo / "_bmad-output" / "implementation-artifacts").mkdir(parents=True)
+    paths = ProjectPaths(
+        project=repo,
+        implementation_artifacts=(
+            artifacts
+            if artifacts is not None
+            else repo / "_bmad-output" / "implementation-artifacts"
+        ),
+        planning_artifacts=repo / "_bmad-output" / "planning-artifacts",
+    )
+    return _make_flow(tmp_path, paths=paths, policy=_policy(isolation="worktree"))
+
+
+def test_ledger_seed_names_a_ledger_the_checkout_cannot_deliver(tmp_path):
+    """The default shape: a gitignored ledger is absent from a tracked-only
+    checkout, so the orchestrator's own close would be written to — and read back
+    from — a file that does not exist."""
+    flow = _ledger_flow(tmp_path)
+    flow.paths.deferred_work.write_text("# Deferred Work\n", encoding="utf-8")
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+
+    assert flow._ledger_seed(worktree) == (
+        "_bmad-output/implementation-artifacts/deferred-work.md",
+    )
+
+
+def test_ledger_seed_skips_a_ledger_the_checkout_already_has(tmp_path):
+    """A tracked ledger is delivered by `git worktree add`. Seeding it anyway
+    copies nothing and journals `worktree-seed-skipped` — a diagnostic meaning "a
+    seed you asked for did nothing" — on every isolated unit of every ordinary
+    project."""
+    flow = _ledger_flow(tmp_path)
+    flow.paths.deferred_work.write_text("# Deferred Work\n", encoding="utf-8")
+    worktree = tmp_path / "wt"
+    delivered = worktree / "_bmad-output" / "implementation-artifacts" / "deferred-work.md"
+    delivered.parent.mkdir(parents=True)
+    delivered.write_text("# Deferred Work\n", encoding="utf-8")
+
+    assert flow._ledger_seed(worktree) == ()
+
+
+def test_ledger_seed_skips_an_absent_ledger(tmp_path):
+    """No ledger yet is the commonest state — the first harvest is what creates
+    it. A seed entry naming a non-existent source is dropped by the seed loop
+    without `worktree-seed-skipped` OR `worktree-seed-dropped`, so it would be
+    invisible rather than merely inert."""
+    flow = _ledger_flow(tmp_path)
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+
+    assert not flow.paths.deferred_work.exists()
+    assert flow._ledger_seed(worktree) == ()
+
+
+def test_ledger_seed_skips_a_ledger_outside_the_project_tree(tmp_path):
+    """`ProjectPaths.rebased` leaves an out-of-tree artifacts dir unmoved, so the
+    worktree already reads this very file and there is nothing to deliver."""
+    shared = tmp_path / "shared-artifacts"
+    shared.mkdir()
+    flow = _ledger_flow(tmp_path, artifacts=shared)
+    flow.paths.deferred_work.write_text("# Deferred Work\n", encoding="utf-8")
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+
+    assert flow.paths.rebased(worktree).deferred_work == flow.paths.deferred_work
+    assert flow._ledger_seed(worktree) == ()
 
 
 # --------------------------------------------------------------- profiles / agents


### PR DESCRIPTION
Phase 6N of the #433 forward-port program. Refs #433.

Closes #425
Closes #426
Closes #458

The last two members of the `git add -A` family that #405/#406 opened, plus what a review
round found in the second one: a durability fix (`e88776a`, confirmed) and a false
reachability claim in its own docstring (`d07a5e7`). Both originals are shapes where
an Engine-owned ledger write happens inside a unit worktree and never reaches the main
checkout — but they fail on opposite legs, which is why one is a seed and the other is
a carry.

```
f798c1b fix(worktree): seed a ledger the checkout cannot deliver          (#426)
6b41f0a fix(engine): carry a damped review follow-up out of isolation     (#425)
e88776a fix(engine): persist the review follow-up record before its ledger append
d07a5e7 docs(engine): correct the follow-up carry's reachability claim
628fe54 fix(engine): clear a follow-up record the re-drive abandons
1cd71e3 fix(engine): carry a story's declared ledger closes out of isolation  (#458)
f69d319 docs(worktree): correct the ledger seed's third exclusion rationale
```

> [!NOTE]
> **Scope grew by one carry, deliberately.** 6N originally shipped two and disclosed
> #458 — the fourth, uncarried producer — as a reviewer's call. That call was made:
> take care of it here. `1cd71e3` adds the fourth carry, so the whole `git add -A`
> family is now covered and #458 closes with this PR.

## #426 — auto-seed a ledger the checkout cannot deliver

A `git worktree add` checks out **tracked files only**, and `scm.worktree_seed`
defaults to `()`. A project that gitignores its ledger — the default shape, since the
ledger lives under the BMAD artifacts dir — gets a unit worktree with **no ledger at
all**. `deferredwork.mark_done` returns False on an absent file, and
`verify_review_bundle` then reads that same absent file and never sees the ids `done`.
The bundle defers on a fixable retry, `open_ids` re-bundles it, and the next sweep
drives the same work again.

`WorktreeFlow._ledger_seed` adds the ledger's repo-relative path to the seed list,
deduped against `scm.worktree_seed` by the existing `dict.fromkeys`. Three exclusions,
each measured: already in the checkout, absent from the main checkout, or configured
outside the project tree.

**No DONE-leg carry could have reached this shape** — the unit never reaches DONE.
Seeding is what moves the failure onto a leg that already has a carry.

### The seeded copy is NOT what carries the close home

The single most likely misreading of this PR, so it is stated in the docstring too.
Every seeded rel is shielded from the unit's `git add -A` by the worktree-scoped
exclude (#384/#385), so the flip made in the worktree still never rides the merge. The
seeded ledger exists so **the GATE can read the orchestrator's own write**; 6M's
`SweepEngine._carry_isolated_ledger_writes` remains the delivery path — it just stops
being reachable only by operators who had already named the ledger in `worktree_seed`.

That is why the now-landing run **still** journals
`sweep-bundle-close-carry-uncommitted`: `git add -- <ignored path>` refuses with rc 1,
exactly as before. It is not a regression and not an incomplete fix.

## #425 — carry a damped review-budget follow-up

`_record_review_budget_followup` writes the **active** workspace's ledger. Under
isolation that is the unit worktree's, `finalize_commit`'s `git add -A` skips a
gitignored path in silence, and `close_unit_workspace(success=True)` removes the
worktree — the DONE leg takes no `capture_diff`, so there is not even a
`changes.patch`. The run journals `refiled: DW-n` having filed nothing any later sweep
can reach.

New persisted `StoryTask.refiled_followups` records the `append_entry` kwargs;
`Engine._carry_review_budget_followups` replays them into the main ledger from
`_carry_isolated_ledger_writes`, and `refiled_followups` joins the replay-eligibility
disjunction in `_replay_unlatched_ledger_carries` so a crash between merge and
integrate does not strand it.

### Three things a reviewer should know

**It extends the carry rather than adding a guard, and #425's own first framing was
wrong about that.** The `not self._isolated` on the *exhaustion* caller guards the
**rescue**, not the ledger write. The damped caller force-converges a finalized,
verify-green story that is being committed, not rescued, so it is correct for it to run
under isolation. A guard would suppress a legitimate entry on every isolated run,
including the tracked-ledger runs where it works today.

**No `_isolated` / `_generic_dev()` predicate — the record IS the guard.**
`refiled_followups` is populated by exactly one producer, and the hook is reached only
from the isolated DONE leg and its replay. Same reasoning as the missing `_generic_dev()`
in `SweepEngine._carry_isolated_ledger_writes` (6M).

**The commit is best effort, unlike `_carry_harvested_deferrals`'s re-raise.** That
method's raise is backed by `harvest_carry_commit_pending`, so a replay still owes the
commit after dedupe empties its list. This carry has no such latch and `append_entry`
dedupes open rows, so raising would buy a replay that can only find its row already
filed — at the cost of the run's `integrate_unit`. It is best effort because the commit
can only ever **fail** here, not because failure is rare — see the reachability table in
`d07a5e7` below.

`super()`-first ordering is preserved: both members of `_carry_isolated_ledger_writes`
APPEND, and `append_entry`'s idempotence scan is open-only, so every append the hook
owns has to land before `SweepEngine`'s CLOSE can hide an already-filed row from it.

### `e88776a` — persist the record before the append (Codex P2, confirmed)

As first written, `6b41f0a` recorded `refiled_followups` **after** `append_entry` and
only when it returned a new id. A review round showed that loses the row outright on a
hard host loss, and a runnable proof (LOST vs DELIVERED, only variable = the durability
of the record) confirmed it before the code was touched:

- Nothing saves between that append and `_commit`'s `COMMITTING` save, and the window
  spans every blocking `pre_commit_gate` workflow — the shipped TEA plugin binds three,
  each a live coding-CLI session.
- The resumed run replays the same review result **in the same worktree** — no
  re-provision, so no re-seed — `append_entry` dedupes the row it already wrote there to
  `None`, and the record is never made.
- The carry then finds an empty payload while `close_unit_workspace` deletes the
  worktree holding the only copy.

Only a **non-unwinding** death reaches it: `run()`'s `finally: self._save()` covers
SIGINT/SIGTERM/exceptions, so the trigger is SIGKILL/OOM/eviction.

Fix is `_harvest_spec_deferrals`' stable-union checkpoint verbatim — record first,
`_save()`, then append — keyed on `origin:` + `source_spec:` rather than gated on
`if refiled:`, so a replay records authorship without appending a second copy. That
method's comments already state the rule: *"Persist the full intended set, not only
newly-filed rows. A replay can dedupe every append while a later isolation carry still
needs the data."*

Pre-latching is safe here and is **not** the suppression-bit hazard: `refiled_followups`
is a record, not a suppression bit. Both consumers (replay eligibility, the carry) only
ever make the engine do *more*, and `append_entry` dedupes an already-open row — so
recording an append that then fails costs at most a carry that files the row the
operator was owed.

**One test changed meaning, deliberately.**
`test_a_deduped_followup_records_nothing_to_carry` became
`test_a_deduped_followup_is_still_recorded_for_the_carry`: the producer now records a
deduped intent and the carry journals `dw_ids: []`. Journal honesty was that test's
stated rationale; durability outranks it, and the tracked-ledger sibling row already
produced exactly that shape.

### `d07a5e7` — a second review P2, refuted, but it found a false docstring

The same review round asked for a `harvest_carry_commit_pending`-style retry latch here:
a host loss between the carry's `append_entry` and its `commit_paths` leaves the replay
dedupe-ing to an empty `carried`, and `if carried:` then skips the commit permanently.
The mechanism is real; the premise that it strands a commit that would have succeeded is
not. That needs a shape where this carry **appends** to a git-ownable main ledger, and
all three shapes were measured end to end:

| main ledger | carry appends? | reaches `commit_paths`? | commit result |
|---|---|---|---|
| tracked | no — journals `dw_ids: []` | no | n/a, nothing to commit |
| untracked, not ignored | **carry never runs** | no | merge blocked first |
| gitignored | yes — `dw_ids: ['DW-1']` | yes | **fails rc 1, every time** |

An exclude never masks a *tracked* file's modification, so a tracked ledger's write always
rides the merge and dedupes here. An untracked-not-ignored one never reaches this frame at
all: `_merge_local` runs `verify.clean_incoming_collisions` before every unit merge and it
refuses a checkout dirtied outside the branch's incoming set, so the unit escalates. Only
a gitignored ledger appends, and `git add` refuses an ignored path unconditionally. So the
latch would only re-run a `git add` that refuses identically, and this carry cannot leave a
dirty tree — the one shape it writes is the one git does not see.

**`6b41f0a`'s docstring justified the missing latch with a claim that is false**, though:
*"an untracked-but-not-ignored ledger reaches it and succeeds."* It does not reach it.
`d07a5e7` replaces that sentence with the measured table above. Prose only — no behavior
change, and no ablation row moves.

> [!NOTE]
> That table rests on a premise it did not state, and a third review round found the
> case that breaks it — see `628fe54` below. It holds for every row above **because**
> the record and the ledger write belong to the same attempt. They now always do; before
> `628fe54` they did not.

### `628fe54` — a third review P2, confirmed: an abandoned record outlives its attempt

The record `e88776a` made durable was scoped to nothing. An escalation between it and the
commit — a `pre_commit` pause veto or a `finalize_commit` failure, both unconditional —
leaves it on a `StoryTask` whose unit worktree the re-drive then **discards**, taking the
only copy of the ledger row with it. `rearm_escalation` resets
`phase`/`attempt`/`review_cycle`/`followup_reviews_spent`/`defer_reason` and nothing else,
and `_dev_phase`'s fresh-attempt branch cleared `harvested_deferrals` but not this. So the
next, successful attempt's DONE leg carried the abandoned record and filed a follow-up
against the commit that actually landed — whose review recommended none.

Reproduced three ways independently, in both ledger shapes, with a causality control
(clear the record after the re-arm, change nothing else → no carry event, no ledger, no
row). The filed row is not merely redundant but **false**: its `reason:` asserts *"The work
was committed by bmad-loop run &lt;id&gt;"* about an attempt whose commit failed. And
`rearm_escalation` already resets `followup_reviews_spent = 0` — *"human-resolved re-drive
gets a fresh damping budget"* — so the re-arm was voiding the damping history while leaving
the record that history produced.

Fix is one line beside the precedent it mirrors, in `_dev_phase`'s fresh-attempt branch:
every abandon shape funnels through it (the re-arm *and* the crash-restart abandon), while
crash replay never enters it, so `e88776a`'s durability fix is untouched. The
`feedback is not None` exemption is inherited rather than reasoned — this field's one
producer fires immediately before `_commit`, and no path leads from there back into a
fixable-retry iteration, so such an iteration can never hold a record to preserve.

**It falsifies the `d07a5e7` table's TRACKED row on the stale path.** Measured: the carry
appends **and commits**, `chore(deferred-work): carry 1-1-a's review follow-up` landing on
the target branch — because the abandoned attempt's own write never reached the main
checkout to be deduped against. The clear restores the premise rather than invalidating the
table, and that was measured too (tracked-ledger escalate → re-arm → re-drive post-fix
files nothing, commits nothing). The docstring now states the premise and names the clear
as what enforces it.

Two corrections to the report, both narrowing it: a `pre_commit_gate` veto is only a
reachable leg when `result.env_fault` is set (the plain arm **defers**, and a DEFERRED task
is refused by `rearm_escalation`), and the defect is isolation-only — in place the record
is inert because the carry never runs.

## #458 — carry a story's declared ledger closes (the fourth producer)

`Engine._close_declared_deferred` (#234) is a **fourth** producer in the #351 family and
has no carry. `StoryTask` has no field for a story-declared close, so nothing records
the intent and nothing replays it. Measured on this branch: gitignored ledger under
isolation → `done=1`, `unit-merged`, `run-complete`, and the main ledger still reads
`status: open`.

`f798c1b`'s seed changes how that failure **reports**. Measured both ways in the same
run, `_ledger_seed` monkeypatched off for the second row:

```
_ledger_seed ON  (this PR): journals story-deferred-closed  dw_ids=['DW-1']
                            MAIN ledger DW-1: status='open'   -> FALSE SUCCESS
_ledger_seed OFF (before):  journals deferred-close-unmatched
                            MAIN ledger DW-1: status='open'   -> HONEST MISS
```

**The outcome is identical either way** — the close never reaches the main checkout in
either row, so this PR does not introduce the data loss. What it removes is the loud
signal: without the seed the worktree has no ledger at all, `deferredwork.classify` puts
every declared id in `unknown`, and `_apply_deferred_closes` journals
`deferred-close-unmatched`. With the seed the flip succeeds locally, journals
`story-deferred-closed`, and is then discarded with the worktree.

That was an argument for the carry rather than against the seed — the seed is required
for #426, and the honest-miss journal was only ever an accident of the ledger being
absent. `1cd71e3` adds it.

### The shape, and the two lessons this PR already paid for

New persisted `StoryTask.story_closes_intended` records the declared ids;
`_carry_story_deferred_closes` re-applies them to the main checkout from
`_carry_isolated_ledger_writes` and joins the replay disjunction.
`deferredwork.mark_done_many` — **not** the reopenable variant `SweepEngine` uses, since
a story close carries no operation id — so a carried row is byte-identical to one the
merge delivered, with the note shared through `_story_close_note` so the two cannot
drift. Only the date can differ, and only across midnight, the same drift the park
record already accepts.

**Record the DECLARED ids, never `marked` — `e88776a`'s lesson through a different
door.** A host loss after the close but before the DONE save leaves the phase at the
already-persisted COMMITTING, and the resume arm re-enters `_finalize_commit_phase`
against a worktree ledger that already reads `done`. `classify` then returns every id
`already_done` and `marked` is EMPTY, so a record derived from it is never made on the
replay while `close_unit_workspace` deletes the only copy. But **no `_save()` here**,
unlike the follow-up producer: every crash path re-enters this method, which re-derives
from the spec — and a persisted record would instead *survive* a declaration edited
across the crash, which is the stale snapshot `_declared_deferred_ids` reads live to
avoid.

**Reset before the early return — `628fe54`'s lesson, and it needs no `_dev_phase`
clear.** The producer runs unconditionally at every commit boundary, and DONE /
AWAITING_OPERATOR are reachable only through its caller, so any re-drive that reaches a
carry has re-entered it first and the assignment overwrites the stale record. A
`_dev_phase` clear beside `refiled_followups`' would be a second branch saying the same
thing, which no test could redden — exactly what `SweepEngine`'s own docstring warns
against. Placing the reset *before* `if not ids: return` is what closes the real hole: a
resolve session that WITHDRAWS the declaration must not have the abandoned attempt's ids
closed on its behalf. B4 below reddens, so this is pinned rather than argued.

**Ordering: the carry goes last, after both appends.** `append_entry`'s idempotence scan
is open-only, and the collision is reachable — a story may declare `closes_deferred:` on
the very `review-budget-followup` row the follow-up carry is about to dedupe against.
Close it first and the follow-up is re-filed under a fresh id.

### A docstring that asserted the bug as a guarantee

`_close_declared_deferred`'s own **Placement** paragraph promised the opposite of the
truth: *"worktree isolation included: the unit's ledger rides the unit commit and reaches
the target branch with the ordinary merge."* True for a TRACKED ledger only — "in-repo"
and "stageable" are not the same predicate, and `_ledger_in_repo` answers the former.
That sentence is why a reader would never look for this bug. Corrected, along with
`_carry_isolated_ledger_writes`' "Both members APPEND" and `SweepEngine`'s `super()`-first
rationale.

## Verification

- `uv run pytest -q -n 8`: **4265 passed / 24 skipped** (collected **4289** = the 4284
  below, plus `628fe54`'s row and `1cd71e3`'s four). The 11-row matrix and its 4284
  totals were measured on both the 3.13 and 3.14 lanes at `d07a5e7`; A12 and the B-rows
  were measured on 3.13.
- `uv run pyright`: 0 errors. `trunk check --no-fix`: clean.
- **12-row A matrix + 8-row B matrix**, every row's collected total unchanged from its
  baseline.

| row | red | pins |
|---|---|---|
| A1 no ledger seed | 1 | `test_isolated_bundle_lands_when_the_gitignored_ledger_was_never_seeded` |
| A2 seed even when present | 2 | `..._with_a_tracked_ledger_seeds_nothing` + `test_ledger_seed_skips_a_ledger_the_checkout_already_has` |
| A3 seed an absent ledger | 1 | `test_ledger_seed_skips_an_absent_ledger` |
| A4 seed an external ledger | 1 | `test_ledger_seed_skips_a_ledger_outside_the_project_tree` |
| A5 no follow-up carry | 6 | the six #425 rows |
| A6 no follow-up record | 6 | same six |
| A7 `refiled_followups` out of the replay disjunction | 1 | `test_crashed_post_merge_followup_carry_replays_from_its_record` |
| A9 seed the bare filename, not the repo-relative path | 4 | `test_ledger_seed_names_a_ledger_the_checkout_cannot_deliver` + 3 |
| **A8 record after the append** (the pre-`e88776a` shape) | **2** | `test_a_deduped_followup_is_still_recorded_for_the_carry`, `test_host_loss_before_the_commit_save_still_carries_the_followup` |
| **A10 record early, drop the `_save()`** | **1** | `test_host_loss_before_the_commit_save_still_carries_the_followup` — isolates the persist from the ordering |
| **A11 drop the keyed dedupe** (`if True:`) | **1** | `test_a_replayed_review_result_records_the_followup_once` |
| **A12 drop the fresh-attempt clear** (the pre-`628fe54` shape) | **1** | `test_a_re_armed_story_does_not_carry_the_abandoned_attempt_s_followup` |

`1cd71e3`'s own matrix, against the whole suite (4289 collected on every row):

| row | red | pins |
|---|---|---|
| B1 drop the carry from the hook | 4 | all four #458 rows |
| B2 drop the record | 5 | the four, plus the withdrawn-declaration row |
| B3 record `marked`, not `ids` (the transposed `e88776a` shape) | 1 | `test_a_replayed_commit_still_records_the_story_close` |
| B4 drop the top-of-method reset | 1 | `test_a_re_armed_story_does_not_carry_a_withdrawn_declaration` |
| B5 out of the replay disjunction | 1 | `test_crashed_post_merge_story_close_replays_from_its_record` |
| **B6 carry `self.workspace.paths`, not `self.paths`** | **0** | nothing — see below |
| B7 carry with a different note | 2 | pins `_story_close_note` being shared |
| B8 carry with the reopenable variant | 4 | pins `mark_done_many` (a `resolution-undo:` line breaks byte-identity) |

**B3 reddened NOTHING on the first pass, and that was the finding.** The decision it
ablates — record the declaration, not the receipt — is only observable on a COMMITTING
replay whose worktree ledger already reads `done`, and nothing exercised that. It became
`test_a_replayed_commit_still_records_the_story_close`, which emulates a genuine
non-unwinding death: `_restore_deferred_closes` neutralised (a SIGKILL runs no except
arm) so the close survives on disk, and the durable state.json put back over whatever
`run()`'s unwind-`finally` wrote.

**B6 reddens nothing and is recorded as unpinned rather than given a fake test.**
Measured: `self.workspace.paths.deferred_work` and `self.paths.deferred_work` are the
*same path* at every call site that reaches the carry — the workspace is swapped back
before `integrate_unit` runs the hook and before the resume replay does. No test can
distinguish the two expressions. The explicit form is kept for intent and the docstring
says so.

A8/A10/A11 are the rows that pin `e88776a`. A10 exists because A8 alone would leave
"record early" and "persist early" fused — it ablates only the `self._save()` and still
reddens the host-loss row, so the durability requirement is pinned independently of the
ordering.

**A9 exists because the seed rows could not redden the positive row.** A1–A4 all ablate
a *guard*, so `test_ledger_seed_names_a_ledger_the_checkout_cannot_deliver` — the row
asserting the exact path returned — passed under every one of them, which leaves it
unpinned. A9 breaks the path instead of a guard (`rel = ledger.name`), and it also
reddens the sweep landing test: it pins that the seed must name **the path the gate
reads**, not merely produce a copy somewhere in the worktree.

**A3 and A4 redden only their unit rows, and that is honest rather than a gap.** Both
guards prevent a seed entry that the seed loop would drop **silently** — no
`worktree-seed-skipped`, no `worktree-seed-dropped` — so a unit test is the only
possible pin for either.

Two corrections to the matrix inherited from earlier sessions, both now guarded by the
runner: A6's first run read as **0 red with a blank summary** because deleting the
`append` left an `if refiled:` whose body was comments only — an `IndentationError`, so
nothing collected at all. And `trunk fmt` later collapsed the replay disjunction onto one
line, silently un-matching A7's anchor. The runner now `compile()`s each patched source
and flags any row whose collected total drifts from the baseline.

## Out of scope, filed not fixed

- **#456** — `scm.worktree_seed = [""]` copies the whole repo root, untracked and
  gitignored files included, into every unit worktree. Deliberately not touched here:
  the fix already exists as `b3dc7e7` in the unmerged PR #386 and needs that PR
  retargeted to `main`, which is a config-validation change rather than a carry.
  #456 also records a correction that matters beyond it: the `"/"` exclude pattern is
  **inert** on every git since 2.0, not a whole-worktree blanket. Four places in this
  repo state the opposite (`worktree_flow.py:610-611`, `install.py:2685-2686`,
  `tests/test_install.py:5473,5478`, and `b3dc7e7`'s own message). None of the guards
  they justify should change; only the prose. Verified against `dir.c` from v1.7.0 to
  v2.55.0 and measured through every exclude source including this repo's
  worktree-scoped one.
- **#460** — `clean_incoming_collisions` runs before **every** unit merge and treats any
  untracked file as blocking dirt, so a stray `notes.txt` in the main checkout halts an
  unattended run at the first story — with an escalation message blaming a Unity Editor
  on repos that have no Unity. Measured four ways including a clean-tree control.
  Pre-existing (predates the `bmad-auto` → `bmad-loop` rename); found while measuring the
  `d07a5e7` reachability table, since an untracked ledger is itself the stray path.
- **#459** — `tests/test_engine.py::test_review_timeout_salvage_skipped_under_isolation`
  is vacuous: it passes with its `self._isolated` guard deleted. Pre-existing
  (`71e18ce`), found while ablating this family. Its mechanism is *not* `fm is None` —
  `_observed_frontmatter` returns `{}` and it is `verify.status_of({}) == ""` that fails
  the `("done", "in-review")` check.

- **#462** — `_ledger_seed` resolves the ledger before taking its rel, so a symlinked
  `deferred-work.md` is seeded to its target's path (target in-repo) or not at all
  (target outside), and the isolated unit still hits the #426 loop this seed exists to
  close. Codex's P2 on this PR: the diagnosis holds, the one-line remedy does not.
  Measured across six link/target cells, naming the configured path fixes two,
  **regresses** the tracked-link/untracked-target cell that works today — the checkout
  delivers a dangling link and `provision_worktree` never copies through one
  (`worktree_flow.py:453-456`) — and cannot fix the out-of-repo cell at all, whose
  source is refused independently at `:411-415` and deliberately so (`:237-239`, "the
  canonical entry the seed loop refuses"). Introduced by `f798c1b` here, so this PR
  covers one shape short rather than breaking one; `git log -S"_ledger_seed"` returns
  that commit alone. #462 folds in a second resolved-vs-raw comparison in the same
  function: `src.is_relative_to(repo_root)` measures a resolved `src` against a raw
  `repo_root`, silently dropping *every* seed entry under an unresolved root —
  unreachable today, since `load_paths` resolves `project` and isolation is refused
  under a `repo_root` override. The docstring sentence that hid all of this is
  corrected in `f69d319`.

No CHANGELOG entry: sub-phases of #433 do not touch it (6L/6M did not either); 6O
curates the whole program's entry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Review-budget follow-ups now persist correctly across isolated worktree runs.
  * Follow-up records and declared deferred-work closures are carried into the main ledger.
  * Deferred-work ledgers are automatically available in isolated worktrees when needed.
  * Duplicate follow-ups and unnecessary ledger provisioning are avoided.

* **Reliability**
  * Improved recovery and replay after interrupted merges or carry operations.
  * Ledger updates are journaled even when no changes occur or commits fail.
  * Added compatibility for existing saved task data without follow-up records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



