### PR TITLE
docs(comments): correct three stale in-code claims (#433)

### DIFF
--- a/src/bmad_loop/install.py
+++ b/src/bmad_loop/install.py
@@ -2681,9 +2681,11 @@ def _worktree_local_exclude(worktree: Path, patterns: Sequence[str]) -> str | No
                 # read-modify-REWRITE carrying the operator's own excludes in
                 # `prefix` — so a short write (ENOSPC) left the file truncated
                 # mid-content while the degrade reason still said "could not update".
-                # Worse, the surviving tail is a valid git pattern and a prefix of the
-                # intended one: cut one char in and the last line is "/", which
-                # excludes the entire worktree.
+                # The harm runs the opposite way from a blanket exclusion: the cut
+                # loses shield lines, so the unit's `git add -A` stages the tool files
+                # provisioning wrote into the story's own commit. (A truncation landing
+                # on a bare "/" is inert — git strips it to a zero-length pattern that
+                # matches nothing; only the LOST lines matter.)
                 #
                 # The helper rather than a hand-rolled tmp+replace: it fsyncs before
                 # the replace and carries the target's mode over, which a bare replace

--- a/src/bmad_loop/verify.py
+++ b/src/bmad_loop/verify.py
@@ -477,10 +477,10 @@ def path_tracked(repo: Path, rel: str) -> bool:
     never authorize a delete. The message keeps the BARE ``rel``: the operator's path is
     its informative half and the magic prefix is our own plumbing.
 
-    Ships with no caller — `git.render-tracked` (`cmd_validate`) and
-    `_ledger_is_gits_to_restore` (the harvest revert) are its consumers and land in
-    later sub-phases of #433. Inert, not silent: neither ruff's `E4,E7,E9,F` set nor
-    pyright basic reports an unused module-level function."""
+    Three live callers, all reached through this one chokepoint: `git.render-tracked`
+    (`cmd_validate`), `_ledger_is_gits_to_restore` (the harvest revert) and
+    `_harvest_carry_commit_may_degrade` (the isolation carry). It shipped inert in an
+    earlier sub-phase of #433 and was wired up by later ones."""
     proc = _run_git(["git", "-C", str(repo), "ls-files", "--", *_literal_specs([rel])], repo)
     if proc.returncode != 0:
         merged = (proc.stdout + proc.stderr).strip()

--- a/src/bmad_loop/worktree_flow.py
+++ b/src/bmad_loop/worktree_flow.py
@@ -568,8 +568,9 @@ def provision_worktree(
         raw_config_path = worktree / profile.hooks.config_path
         # Refuse before mkdir, read, or write: hook commands are worktree-specific
         # and must never mutate a shared dotfile through a live or dangling link.
-        # Inspect every component because Python 3.14's non-strict resolve leaves a
-        # symlink cycle unresolved (and therefore textually equal to the raw path).
+        # Inspect every component because on Python 3.13 and 3.14 a non-strict resolve
+        # leaves a symlink cycle unresolved (and therefore textually equal to the raw
+        # path); 3.11 and 3.12 raise RuntimeError instead, which the except below takes.
         # The resolved comparison additionally refuses ``..`` and absolute profiles.
         refused = not raw_config_path.is_relative_to(worktree)
         cursor = raw_config_path
@@ -607,8 +608,11 @@ def provision_worktree(
     # paths projects legitimately TRACK, so a repo-wide exclude here went on
     # hiding their new files from the operator's own checkout (#384).
     patterns = {f"/{p.skill_tree}" for p in profiles}
-    # hookless profiles have no config_path — and their empty string would render
-    # as the pattern "/", git-excluding the entire worktree.
+    # hookless profiles have no config_path, so there is nothing to shield: their
+    # empty string would render as a bare "/", which git strips to a zero-length
+    # pattern (the trailing slash becomes MUSTBEDIR) that matches nothing —
+    # measured on 2.55.0 against "/*" and "*", which do blanket. An inert junk
+    # line in a generated file, then, not a worktree-wide exclusion.
     patterns |= {f"/{p.hooks.config_path}" for p in profiles if not p.hookless}
     patterns |= {f"/{rel}" for rel in seeded}
     patterns |= {f"/{rel}" for rel in seeded_bmad}

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -5468,14 +5468,16 @@ def test_worktree_local_exclude_short_write_leaves_exclude_intact(project, tmp_p
     byte-identical, not truncated. `write_bytes` opens "wb" (truncate-then-write)
     and this is a read-modify-REWRITE carrying their content in `prefix`, so a
     direct write left the file cut mid-content while the reason still said
-    "could not update". The surviving tail is a valid git pattern and a prefix of
-    the intended one — cut one character in and the last line is `/`, which
-    excludes the whole worktree.
+    "could not update". The harm is the LOST lines, not the surviving tail: a cut
+    exclude stops shielding, so the unit's `git add -A` stages the tool files
+    provisioning wrote into the story's own commit. (A cut landing on a bare `/`
+    is inert — git strips the trailing slash to a zero-length pattern that matches
+    nothing, measured on 2.55.0 against `/*` and `*`, which do blanket.)
 
     Blast radius is smaller since #384 (the file is this worktree's own, not the
     main repo's shared exclude) but the fault is not: the content carried through
     `prefix` is the operator's global excludes, copied in when the private file was
-    created, and `/` still swallows the whole worktree.
+    created, and a truncation drops however many of them the short write cost.
 
     The fault is injected at `Path.open`, NOT at `Path.write_bytes`: patching
     write_bytes means the file is never opened, so the truncation cannot happen
@@ -6174,10 +6176,13 @@ def test_provision_worktree_hookless_skips_hook_merge(tmp_path):
     assert not (wt / ".bmad-loop").exists()
 
 
-def test_provision_worktree_hookless_exclude_never_blankets_worktree(project, tmp_path):
-    """A hookless profile has config_path == "", which must not become the git
-    exclude pattern "/" (that would exclude the entire worktree from the unit's
-    `git add -A` commit). Only the skill tree is shielded."""
+def test_provision_worktree_hookless_exclude_has_no_bare_slash(project, tmp_path):
+    """A hookless profile has config_path == "", which must not reach the exclude
+    as a bare "/". That pattern is INERT rather than dangerous — git strips the
+    trailing slash to a zero-length pattern matching nothing, measured on 2.55.0
+    against "/*" and "*", which do blanket — so what this pins is that a profile
+    with nothing to shield contributes no line at all. Only the skill tree is
+    shielded."""
     repo = project.project
     wt = tmp_path / "wt"
     verify.worktree_add(repo, wt, "feat", "main")


### PR DESCRIPTION
Comment and docstring corrections only — plus one test rename. No behavior change; the guards and
assertions they describe are all correct and unchanged.

These were found while auditing the CHANGELOG for #433's Phase 6O and reported in that issue's
close-out. Each is a comment that asserts something false about its own code, so each would have
propagated into a released changelog entry had it been trusted as a source. Fixing them is
cheaper than re-deriving them next time.

## 1. `verify.path_tracked` claims it has no caller

Its docstring still ends "Ships with no caller … Inert". It has three, all through this one
chokepoint: `cli.py:318` (`git.render-tracked`), `engine.py:3499`
(`_ledger_is_gits_to_restore`) and `engine.py:4614` (`_harvest_carry_commit_may_degrade`). It
shipped inert in 6D and 6F/6K wired it up without retiring the sentence.

## 2. The symlink-cycle guard credits Python 3.14 alone

`worktree_flow`'s hook-config guard walks every path component because a non-strict `resolve()`
leaves a cycle textually unchanged. Measured on 3.11.13 / 3.12.13 / 3.13.13 / 3.14.6:

| interpreter | `Path.resolve()` on a self-referential link |
| --- | --- |
| 3.11, 3.12 | raises `RuntimeError` |
| **3.13, 3.14** | returns the path **unchanged** |

The code is already right on all four — the `except (OSError, RuntimeError)` arm covers the first
pair, the per-component `is_symlink()` walk the second. Only the attribution was wrong. (This is a
*different* mechanism from the 3.14-only `OSError` suppression in `is_file()`/`is_dir()`/
`exists()`, which the same file describes correctly elsewhere; the two are easy to conflate.)

## 3. A lone `/` gitignore pattern is inert, and three sites said it blankets the worktree

Measured on git 2.55.0 through `.git/info/exclude`, with positive controls:

| pattern | `git add -A --dry-run` | `check-ignore top.txt` |
| --- | --- | --- |
| `/` | **2 paths — everything** | no match |
| `/*` | 0 | match |
| `*` | 0 | match |
| `/top.txt` | 1 | match |

The controls blanket, so the method can detect a blanket exclusion; `/` genuinely matches nothing.
`parse_path_pattern` strips the trailing `/` into `MUSTBEDIR`, leaving a zero-length pattern.

The guards stay — a hookless profile has nothing to shield, and a short write to the exclude is
real harm — but the stated reason ran backwards. A truncated exclude **loses** shield lines, so the
unit's `git add -A` stages the tool files provisioning wrote into the story's own commit. That is
the harm; a truncation landing on a bare `/` is the harmless part.

Sites: the hookless-profile filter (`worktree_flow.py`), the `atomic_write_bytes` rationale
(`install.py`), and two test docstrings. `test_provision_worktree_hookless_exclude_never_blankets_worktree`
is renamed to `…_has_no_bare_slash` — the old name was the most visible copy of the claim. Its
assertion is unchanged.

The CHANGELOG's own copy of this claim was corrected in `e7a9bab` (PR #463).

## Verification

- Full suite: **4265 passed, 24 skipped**
- `uv run pyright` — 0 errors, 0 warnings, 0 informations
- `trunk check --no-fix` — no issues
- **Ablation** of the renamed test: dropping the `if not p.hookless` filter reddens it with
  `assert '/' not in ['**/.claude/settings.local.json', '/', '/.claude/skills', '/_bmad/render/']`;
  restored, it passes. The negative assertion still bites.
- The git table above re-measured from scratch for this PR, not carried over from the audit.

Reference: #433