### PR TITLE
docs(code): strip review archaeology, probe records, and run data from comments

### DIFF
--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -1392,7 +1392,7 @@ class Engine:
                     # follow-up against the attempt that COMMITTED, whose review
                     # recommended none — and `append_entry` has nothing to dedupe
                     # it against, so a tracked ledger commits the wrong row rather
-                    # than absorbing it (#457's review). `rearm_escalation` already
+                    # than absorbing it (#457). `rearm_escalation` already
                     # voids the history behind the record by resetting
                     # `followup_reviews_spent` for a fresh damping budget.
                     #
@@ -4703,6 +4703,11 @@ class Engine:
         ``dw_ids == []`` is an ordinary outcome and not a carry that ran on
         nothing.
 
+        A TRACKED ledger is safe unconditionally: no exclude or ignore rule masks a
+        tracked file's MODIFICATION, so the unit's own write always rides the merge
+        and its row arrives already deduped — yielding an empty ``carried`` and no
+        commit.
+
         The commit is best effort — unlike ``_carry_harvested_deferrals``, whose
         re-raise is backed by ``harvest_carry_commit_pending`` — because it can
         only ever FAIL: the sole ledger shape that reaches it is a gitignored one,
@@ -4713,10 +4718,10 @@ class Engine:
 
         Every record must belong to the attempt now being committed — a premise
         ``_dev_phase`` enforces, not this frame. A record left over from an
-        ABANDONED attempt has nothing upstream to dedupe against, so the carry
-        would append AND commit a row about work that never landed; the
-        fresh-attempt clear beside ``harvested_deferrals`` is what prevents that
-        (#457).
+        ABANDONED attempt died with its discarded worktree, so it has nothing
+        upstream to dedupe against and the carry would append AND commit a row
+        about work that never landed; the fresh-attempt clear beside
+        ``harvested_deferrals`` is what prevents that (#457).
         """
         if not task.refiled_followups:
             return

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -4684,68 +4684,39 @@ class Engine:
     def _carry_review_budget_followups(self, task: StoryTask) -> None:
         """Re-file an isolated unit's review-budget follow-ups into the main ledger.
 
-        The third producer in the ``git add -A`` family, and the last one left
-        uncovered (#425). ``_record_review_budget_followup`` runs on a finalized,
-        verify-green story that the review pass would not stop recommending a
-        follow-up for, and it is CORRECT for it to run under isolation — the
-        damped caller force-converges work that is being committed, not rescued,
-        so the ``not self._isolated`` its exhaustion counterpart carries guards
-        that rescue and not this write. The defect is only that the write can be
-        silently dropped, which is why this extends the carry rather than adding a
-        guard: a guard would suppress a legitimate entry on every isolated run,
-        including the tracked-ledger runs where it works today.
+        The third producer in the ``git add -A`` family (#425).
+        ``_record_review_budget_followup`` runs on a finalized, verify-green story
+        the review pass would not stop recommending a follow-up for; under
+        isolation that write is correct but is silently dropped when the main
+        ledger is gitignored. Hence a carry rather than a guard, which would
+        suppress a legitimate entry on every isolated run.
 
-        No ``_isolated`` predicate here either: ``refiled_followups`` is populated
-        by that one producer and this hook is reached only from the isolated DONE
-        leg and its replay, so the record IS the guard — the same reasoning as
-        ``SweepEngine._carry_isolated_ledger_writes``'s missing ``_generic_dev()``.
+        No ``_isolated`` predicate: ``refiled_followups`` is populated by that one
+        producer and this hook is reached only from the isolated DONE leg and its
+        replay, so the record IS the guard.
 
-        Unconditional and idempotent: ``append_entry`` dedupes an OPEN row with the
-        same ``origin:`` + ``source_spec:``, so a tracked ledger whose row already
-        arrived through the merge yields an empty ``carried`` and no commit. An
-        already-CLOSED row with that provenance is deliberately not deduped against
-        — a later recurrence earns a fresh entry, exactly as it does in place.
+        Unconditional and idempotent — ``append_entry`` dedupes an OPEN row with
+        the same ``origin:`` + ``source_spec:``, while an already-CLOSED row with
+        that provenance earns a fresh entry, exactly as a recurrence does in
+        place. That is what lets the producer record its intent BEFORE its own
+        append, which durability requires, so ``review-followup-carried`` with
+        ``dw_ids == []`` is an ordinary outcome and not a carry that ran on
+        nothing.
 
-        That idempotence is what lets the producer record its intent BEFORE its own
-        append, which durability requires (see ``_record_review_budget_followup``).
-        So a payload here does NOT imply a row was newly filed upstream: a producer
-        whose append deduped still records, and this then carries it to an empty
-        ``carried``. ``review-followup-carried`` with ``dw_ids == []`` is therefore
-        an ordinary outcome, not a sign the carry ran on nothing.
+        The commit is best effort — unlike ``_carry_harvested_deferrals``, whose
+        re-raise is backed by ``harvest_carry_commit_pending`` — because it can
+        only ever FAIL: the sole ledger shape that reaches it is a gitignored one,
+        and ``git add`` refuses an ignored path with rc 1 every time, so a
+        commit-pending latch would just retry a refusal. Nor can it leave the tree
+        dirty, the shape it writes being the one git does not see. The row on disk
+        is the value; the commit is bookkeeping.
 
-        The commit is best effort, like ``SweepEngine``'s close and unlike
-        ``_carry_harvested_deferrals``: that method's re-raise is backed by
-        ``harvest_carry_commit_pending``, so a replay still owes the commit after
-        dedupe empties its list. This carry has no such latch, so a raise would buy
-        a replay that can only find its row already filed — at the cost of the
-        run's ``integrate_unit``. The row on disk is the value; the commit is
-        bookkeeping.
-
-        It is best effort because it can only ever FAIL here, not because failure
-        is rare. Measured over all three shapes the main ledger can take, and all
-        three rest on a premise ``_dev_phase`` enforces rather than one this frame
-        can check: every record belongs to the attempt now being committed. A
-        record left over from an ABANDONED attempt breaks the tracked row below --
-        that attempt's own write died with its discarded worktree, so nothing is
-        upstream to dedupe against and the carry appends AND commits a row about
-        work that never landed. That is why the fresh-attempt clear beside
-        ``harvested_deferrals`` is load-bearing for this docstring, not only for
-        the ledger (#457's review).
-
-        * TRACKED -- an exclude never masks a tracked file's MODIFICATION, so the
-          unit's write always rides the merge and ``append_entry`` dedupes it
-          here. ``carried`` is empty and no commit is attempted.
-        * UNTRACKED, NOT IGNORED -- this frame is never reached at all.
-          ``_merge_local`` runs ``verify.clean_incoming_collisions`` before every
-          unit merge, and it refuses a target checkout dirtied outside the
-          branch's incoming set, so the unit escalates and the DONE leg with it.
-        * GITIGNORED -- the only shape that appends here, and ``git add`` refuses
-          an ignored path with rc 1 every time.
-
-        So a commit-pending latch would only retry a ``git add`` that refuses
-        identically, which is why this carry does not carry one (asked for in
-        #457's review). It also cannot leave the tree dirty for a later run to
-        trip on: the one shape it writes is the one git does not see.
+        Every record must belong to the attempt now being committed — a premise
+        ``_dev_phase`` enforces, not this frame. A record left over from an
+        ABANDONED attempt has nothing upstream to dedupe against, so the carry
+        would append AND commit a row about work that never landed; the
+        fresh-attempt clear beside ``harvested_deferrals`` is what prevents that
+        (#457).
         """
         if not task.refiled_followups:
             return
@@ -4817,8 +4788,8 @@ class Engine:
         time, so a commit-pending latch would only retry a refusal.
 
         ``self.paths``, not ``self.workspace.paths``, states the intent — the MAIN
-        checkout's ledger. Measured, the two are the same path at every call site
-        that reaches here: the workspace is swapped back before
+        checkout's ledger. The two are the same path at every call site that
+        reaches here: the workspace is swapped back before
         ``integrate_unit`` runs the hook, and before the resume replay does. So no
         test can tell the two apart, and none pretends to; the explicit form is
         kept because the intent stops being obvious the moment that stops holding.

--- a/src/bmad_loop/install.py
+++ b/src/bmad_loop/install.py
@@ -1369,8 +1369,8 @@ _WORKTREE_CONFIG_GIT = (2, 20)
 _SHIELD_LOCK_NAME = "bmad-loop-shield.lock"
 
 # THE ALTERNATIVE ARCHITECTURE, EVALUATED AND REJECTED — recorded here the way the
-# `--includes` finding below is, so a later reader or bot round does not re-propose
-# it as a simplification of the whole block.
+# `--includes` note below is, so a later reader does not re-propose it as a
+# simplification of the whole block.
 #
 # Every finding in this family (an empty seed plus an activation that shadows what
 # the seed failed to copy) exists because the shield SHADOWS a config key. One
@@ -1671,7 +1671,8 @@ def _shield_enable_worktree_config(worktree: Path, common_dir: Path) -> tuple[st
     #
     # All of that is undocumented IMPLEMENTATION DETAIL, not a compatibility
     # contract: git has converted reads to respect includes before (2.39, protected
-    # config).
+    # config). Flag availability was never the question: `--includes` dates to git
+    # 1.7.10, far below the 2.20 floor the gate above enforces.
     shared = str(common_dir / "config")
     carried = _shield_shared_config(worktree, shared, "extensions.worktreeConfig", "--type=bool")
     if carried is not None and os.fsdecode(carried).strip() == "true":
@@ -1752,7 +1753,8 @@ def _shield_undo_extension(worktree: Path, git_dir: Path, common_dir: Path) -> s
         # The tuple mirrors the caller's tail minus `GitError` (nothing here spawns
         # git), and the members beyond `OSError` are what keeps the "never raises"
         # promise true: on the 3.11/3.12 floor `Path.resolve()` raises `RuntimeError`
-        # for a symlink loop rather than `OSError`.
+        # for a symlink loop rather than `OSError`, and `UnicodeError` covers the
+        # `fsdecode` of a worktree admin-dir name on Windows.
         dependent = f"the scan for sibling worktrees failed ({e})"
     if dependent is not None:
         return (
@@ -1849,7 +1851,10 @@ def _shield_inherited_excludes(worktree: Path) -> bytes:
 
     BYTES, never decoded text: exclude entries are path patterns, POSIX paths are
     arbitrary bytes, and one non-UTF-8 byte collapsed a `read_text` seed to empty —
-    after which the activation SHADOWED what it failed to copy.
+    after which the activation SHADOWED what it failed to copy. Copying verbatim
+    also keeps every pattern intact for the caller's dedupe; git reads the result
+    either way, stripping a trailing `\\r` from an exclude line and skipping a
+    UTF-8 BOM.
 
     FOUR outcomes (#384). The first two are silent; the other two RAISE, and the
     caller's tail turns that into the degrade reason that skips the activation.
@@ -2036,7 +2041,9 @@ def _worktree_local_exclude(worktree: Path, patterns: Sequence[str]) -> str | No
 
     - git unqueryable BEFORE GIT HAS ANSWERED AT ALL (not a repo, git missing, a
       timeout or spawn failure on the FIRST `rev-parse` — both `GitError`) is an
-      EXPECTED skip: returns None silently. That scope is the whole of it.
+      EXPECTED skip: returns None silently. That scope is the whole of it, and
+      nothing is DECODED in this arm — git's stdout stays bytes until the tail
+      below, because a decode fault is a degrade, not this arm's silent skip (#374).
     - anything AFTER git answered degrades to a returned reason string; only a
       definite ABSENT answer stays silent. Silence is not cosmetic: without the
       exclude the unit's `git add -A` commits the tool files just provisioned.
@@ -2075,6 +2082,7 @@ def _worktree_local_exclude(worktree: Path, patterns: Sequence[str]) -> str | No
         # `except` of its own: a non-zero rc returns the reason below, a raise lands in
         # this try's tail — which also catches the `UnicodeError` the `fsdecode` of
         # git's stderr can raise on Windows, hence that read sits inside the guard.
+        # #394 records that same decode escaping at a sibling block that lacks it.
         shared_answer = git_bytes(worktree, "rev-parse", "--git-common-dir")
         if shared_answer.returncode != 0:
             detail = (
@@ -2239,7 +2247,9 @@ def _worktree_local_exclude(worktree: Path, patterns: Sequence[str]) -> str | No
                 # "wb" TRUNCATES before writing, and this is a read-modify-REWRITE
                 # carrying the operator's own excludes in `prefix`, so a short write
                 # (ENOSPC) left the file truncated mid-content — losing shield lines —
-                # while the degrade reason still said "could not update". The helper
+                # while the degrade reason still said "could not update". A truncation
+                # landing on a bare "/" is inert: git strips it to a zero-length
+                # pattern that matches nothing, so only the LOST lines matter. The helper
                 # rather than a hand-rolled tmp+replace: it fsyncs before the replace
                 # and carries the target's mode over, which a bare replace resets.
                 # #381's interleaving race is moot here — the file is one worktree's

--- a/src/bmad_loop/install.py
+++ b/src/bmad_loop/install.py
@@ -132,9 +132,9 @@ RENDERER_SCRIPT_UNIT_REL: tuple[str, ...] = (
 # not `_bmad/bmm/config.yaml`, which configures bmad-loop's artifact paths.
 CENTRAL_CONFIG_REL = f"{BMAD_DIR}/config.toml"
 
-# Reserved completeness sentinels for the worktree seeding half in phase 6H. They
-# intentionally ship without a reader here: the validate-side contract must exist
-# before provisioning can report these exact strings across the install/engine seam.
+# The renderer surface a worktree must carry, in the exact strings provisioning
+# reports when it comes up short. Worktree seeding reports these two from dedicated
+# completeness checks, and escalates only when a renderer stub is what resolved.
 BMAD_SCRIPTS_SEED_REL = f"{BMAD_DIR}/scripts"
 RENDERER_SEED_SENTINELS: tuple[str, ...] = (BMAD_SCRIPTS_SEED_REL, CENTRAL_CONFIG_REL)
 
@@ -146,8 +146,8 @@ RENDERER_ENTRY_REL = "workflow.md"
 SNAPSHOT_TOKEN_RE = re.compile(r"\[\[bmad-snapshot:([A-Za-z0-9_./-]+\.md)\]\]")
 
 # Renderer output is regenerated with checkout-absolute paths and must never be
-# copied into a worktree or committed. BMAD_SEED_EXCLUDES is consumed by the 6H
-# seeding half; RENDER_DIR_REL is already live in init and validate in this phase.
+# copied into a worktree or committed. BMAD_SEED_EXCLUDES skips it while seeding
+# `_bmad/`; RENDER_DIR_REL is the one spelling init gitignores and validate checks.
 RENDER_DIR_NAME = "render"
 BMAD_SEED_EXCLUDES = (RENDER_DIR_NAME,)
 RENDER_DIR_REL = f"{BMAD_DIR}/{RENDER_DIR_NAME}"
@@ -349,8 +349,8 @@ def renderer_stub_resolved(project: Path, trees: Sequence[str]) -> bool:
     """Whether any active tree resolves to a renderer-backed dev primitive.
 
     Resolution is per tree and deduplicated exactly like :func:`missing_base_skills`.
-    This public predicate intentionally lands before its 6H engine reader so the
-    later seed-escalation decision can reuse the exact preflight discriminator.
+    Public because the engine's seed-escalation decision reuses this exact preflight
+    discriminator rather than re-deriving one (`worktree_flow`).
     """
     for tree in dict.fromkeys(trees):
         resolved = resolve_dev_primitive(project, tree)
@@ -1411,9 +1411,9 @@ def _git_version_at_least(reported: str, want: tuple[int, int]) -> bool:
     `2.39.5 (Apple Git-154)`) and searching the whole string for the first two
     dotted numbers would happily read a version out of a build tag.
 
-    Refusing an unparseable answer is the point rather than a fallback. The only
+    Refusing an unparseable answer is the point rather than a fallback: the only
     caller uses this to decide whether to make a PERMANENT repo-format change, so
-    the failure it must not have is the optimistic one; a git that will not say
+    the failure it must not have is the optimistic one — a git that will not say
     what it is does not get that change made on its behalf.
     """
     match = re.match(r"git version (\d+)\.(\d+)", reported.strip())
@@ -1424,15 +1424,13 @@ def _shield_shared_config(worktree: Path, shared: str, key: str, *opts: str) -> 
     """`key`'s raw value in the SHARED config, or None when it is definitely ABSENT.
 
     Raises `GitError` when git did not answer. **rc 1 is the only non-zero rc that
-    means "no such key"** — the funnel `_shield_inherited_excludes` already applies to
-    its own read (round 9), applied here to the three probes that were still reading
-    every non-zero rc as an absence (#384, Codex round 10). Routing those to ABSENT
+    means "no such key"** (#384) — reading any other non-zero rc as an absence
     degrades the `core.bare` / `core.worktree` gates OPEN, and what they guard is
     irreversible: enabling `extensions.worktreeConfig` drops the exception that
     confined those keys to the main worktree, after which a genuine `core.worktree`
     starts applying to every linked worktree.
 
-    Measured at git 2.20.4 AND 2.55.0, identical at both ends of the supported range:
+    The rc mapping, stable from the 2.20 floor to current git:
 
         absent key ......................... 1     malformed config file ..... 128
         missing file ....................... 1     --type=bool on a non-bool . 128
@@ -1440,19 +1438,18 @@ def _shield_shared_config(worktree: Path, shared: str, key: str, *opts: str) -> 
         unreadable file (EACCES, non-root) . 1     empty or valueless key ..... 0
 
     git-config(1) prefaces its own list with "Some exit codes are:", i.e. the list is
-    not closed, and it documents a malformed file as ret=3 while both versions
-    actually answer 128 — so a `{0,1}`-closed reading is wrong on git's documentation
-    AND on its behavior. Hence a funnel rather than a per-rc taxonomy (round 7).
+    not closed, and it documents a malformed file as ret=3 while git actually answers
+    128 — so a `{0,1}`-closed reading is wrong on git's documentation AND on its
+    behavior. Hence a funnel rather than a per-rc taxonomy.
 
-    THE RESIDUAL THIS CANNOT CLOSE, stated rather than left for another round: a
-    momentarily missing or unreadable `.git/config` answers **rc 1**, byte-identical
-    to "no such key" — all four rc-1 rows above are the same answer from here. git
-    exposes no way to separate them, so this is a bound on the interface rather than a
-    defect. Deliberately NOT narrowed with a pre-`--get` stat: that is TOCTOU, which
-    shrinks the window instead of closing it, adds a syscall to every probe, and
-    trades a very rare silent-wrong for a less rare noisy-degrade. Bounded in practice
-    because git rewrites config atomically (lock + rename), so only a non-git tool
-    truncating in place can produce it.
+    THE RESIDUAL THIS CANNOT CLOSE: a momentarily missing or unreadable `.git/config`
+    answers **rc 1**, byte-identical to "no such key" — all four rc-1 rows above are
+    the same answer from here. git exposes no way to separate them, so this is a
+    bound on the interface rather than a defect. Deliberately NOT narrowed with a
+    pre-`--get` stat: that is TOCTOU, which shrinks the window instead of closing it,
+    adds a syscall to every probe, and trades a very rare silent-wrong for a less
+    rare noisy-degrade. Bounded in practice because git rewrites config atomically
+    (lock + rename), so only a non-git tool truncating in place can produce it.
 
     Returns the value RAW and undecoded — `core.worktree` is a path — so callers test
     presence with `is not None`, never truthiness. See the call sites for why.
@@ -1477,31 +1474,17 @@ def _shared_repository_is_private(value: str) -> bool:
     booleans are not, and an octal value is a FILEMODE with the legacy 0/1/2
     special-cased ahead of it.
 
-    Measured at git 2.20.4 AND 2.55.0, byte-identical at both ends of the supported
-    range, by the mode of a loose object git writes under `umask 077` — git's OWN
-    answer, not a reading of `setup.c`:
-
-        0 / 00 / 0000 ....... r--------  PRIVATE     0400 / 0200 ... REJECTED (128)
-        0600 / 0700 / 0711 .. r--------  PRIVATE     -0600 ......... REJECTED
-        +0600 ............... r--------  PRIVATE     0o600 / 0_600 . REJECTED
-        01 / 1 .............. r--r-----  group       0600x ......... REJECTED
-        0640 / 0660 ......... r--r-----  group
-        02 / 2 / 07777 ...... r--r--r--  everybody
-        0666 / 0755 ......... r--r--r--  everybody
-        0604 ................ r-----r--  other
-
-    So the mask is `value & 0666` and private is `& 0066 == 0` — NOT "no execute
-    bits" and NOT "equals 0600". `0711` IS private, because the mask discards the
-    execute bits; `0755` is NOT, because its group/other READ bits survive it. Those
-    two rows are why this is a mask test and not a literal set, and both were
-    mispredicted before they were measured.
+    For a filemode git masks the value with 0666, so private is `& 0066 == 0` — NOT
+    "no execute bits" and NOT "equals 0600". `0711` IS private, because the mask
+    discards the execute bits; `0755` is NOT, because its group/other READ bits
+    survive it. Those two cases are why this is a mask test and not a literal set.
 
     `(mode & 0600) != 0600` is git's own `die()` condition, so such a value reaches
     us only in a repository git already refuses to operate on. It stays off the
     accept side with every other value git rejects.
 
     THE PATTERN IS DELIBERATELY STRICTER THAN `strtol`, in the refusing direction.
-    git accepts leading whitespace and a leading `+` (measured: `+0600` is private)
+    git accepts leading whitespace and a leading `+` (`+0600` is private to git)
     which `[0-7]+` refuses — a false refusal, which this gate is contracted to
     prefer. Strictness in the other direction is the load-bearing half: Python's
     `int(value, 8)` accepts `0o600` and `0_600`, which git REJECTS, so parsing with
@@ -1521,11 +1504,10 @@ def _shared_repository_is_private(value: str) -> bool:
     mode = int(value, 8)
     if mode == 0:  # PERM_UMASK
         return True
-    # The legacy 1 (PERM_GROUP) and 2 (PERM_EVERYBODY) need NO special case here even
+    # The legacy 1 (PERM_GROUP) and 2 (PERM_EVERYBODY) need no special case here,
     # though git special-cases them ahead of its filemode branch: neither satisfies
-    # `& 0600`, so both land on the same refusal this line already returns. Written as
-    # one test rather than three because a `mode in (1, 2)` arm would be indistinguish-
-    # able from dead code — no test could fail without it (#384, round 10's rule).
+    # `& 0600`, so both land on the refusal this line already returns. A
+    # `mode in (1, 2)` arm would be indistinguishable from dead code (#384).
     return mode & 0o600 == 0o600 and mode & 0o066 == 0
 
 
@@ -1534,87 +1516,62 @@ def _shield_shared_repository(worktree: Path, common_dir: Path) -> str | None:
 
     A repository shared between OS users is not a supported configuration
     (maintainer decision, #384): the shield creates files of its own inside `.git`,
-    and making those work across OS users is out of scope. Refusing the
-    configuration up front is what makes that decision visible — it fails LOUDLY and
-    identically for every user, with a reason that is journaled and notified, rather
-    than behaving differently depending on which user provisioned first and leaving
-    state behind for the next run to meet.
+    and making those work across OS users is out of scope. Refusing up front fails
+    LOUDLY and identically for every user — journaled and notified — rather than
+    behaving differently depending on who provisioned first.
 
-    This gate runs ABOVE the shield's lock, which is the point of it: nothing is
-    created in a shared repository at all. That is safe here and would not be for
-    `extensions.worktreeConfig` — this key is static configuration the tool never
-    writes, so there is no shared mutable state to serialize.
-
-    It adds no version floor: a plain `--get` with no `--type=`, so it does not
-    reintroduce the 2.18 trap that keeps the version gate above the probes in
+    The gate runs ABOVE the shield's lock, so nothing is created in a shared
+    repository at all. That is safe here and would not be for
+    `extensions.worktreeConfig`: this key is static configuration the tool never
+    writes, so there is no shared mutable state to serialize. It adds no version
+    floor either — a plain `--get` with no `--type=`, so it does not reintroduce the
+    2.18 trap that keeps the version gate above the probes in
     `_shield_enable_worktree_config`.
 
-    AN ALLOWLIST, NOT AN ENUMERATION OF SHARED SHAPES (round 7's funnel). git accepts
-    keywords, booleans, the legacy 0/1/2, and bare octal modes; enumerating the
-    shared ones leaves every value git adds later, and every value git rejects,
-    silently opening the gate. Measured at git 2.20.4 AND 2.55.0, byte-identical at
-    both ends of the supported range. The verdict column is git's OWN answer — the
-    mode of a loose object git writes under `umask 077` — not a reading of `config.c`:
+    AN ALLOWLIST, NOT AN ENUMERATION OF SHARED SHAPES: git accepts keywords,
+    booleans, the legacy 0/1/2 and bare octal modes, so enumerating the shared ones
+    leaves every value git adds later — and every value git rejects — silently
+    opening the gate. Values git rejects really do reach here, since `rev-parse
+    --absolute-git-dir` answers rc 0 for every one of them, `banana` included; the
+    "it would have fatalled earlier" reasoning that fits other probes in this file
+    does not hold. They fall off the allowlist deliberately: such a repository is
+    already unusable (`git status` exits 128), so refusing costs nothing while
+    guessing at a malformed value would.
 
-        absent .................. rc 1              (no key)
-        umask / false/no/off / 0  rc 0   r--------  PRIVATE
-        FALSE, Off .............. rc 0   r--------  PRIVATE
-        empty      (`= ""`) ..... rc 0   r--------  PRIVATE   <- stdout is b"\\n"
-        valueless  (no `=`) ..... rc 0   r--r-----  group     <- stdout is b"\\n" TOO
-        true/yes/on / group / 1 . rc 0   r--r-----  group
-        all/world/everybody / 2 . rc 0   r--r--r--  everybody
-        octal filemodes ......... rc 0   varies     `_shared_repository_is_private`
+    AN EMPTY VALUE AND A VALUELESS `sharedRepository` LINE ARE INDISTINGUISHABLE AND
+    MEAN OPPOSITE THINGS: explicitly empty is PERM_UMASK (private), a valueless line
+    is PERM_GROUP (shared), and `--get` answers both rc 0 with a lone b"\\n". Nothing
+    separates them, so the empty answer REFUSES — a false refusal is a reported skip,
+    a false accept is the bug this gate prevents.
 
-    THE MIDDLE TWO ROWS ARE INDISTINGUISHABLE AND MEAN OPPOSITE THINGS: an explicitly
-    empty value is PERM_UMASK (private) and a VALUELESS `sharedRepository` line is
-    PERM_GROUP (shared), while `--get` answers both rc 0 with a lone b"\\n". git
-    exposes nothing that separates them, so the empty answer REFUSES — a false refusal
-    is a reported skip, a false accept is the bug this gate exists to prevent.
+    `removesuffix("\\n")`, NEVER `.strip()`: `--get` returns edge whitespace VERBATIM
+    (a quoted `" umask"` comes back as b" umask\\n"), so stripping would widen a value
+    git itself rejects straight into the accept set below. The case handling is
+    asymmetric because git's is — keywords compared with strcmp, booleans with
+    strcasecmp — so `FALSE` and `Off` are accepted while `UMASK` and `GROUP` are
+    values git REJECTS.
 
-    `removesuffix("\\n")`, NEVER `.strip()`, and that is live rather than defensive
-    here: `--get` returns edge whitespace VERBATIM (a quoted `" umask"` comes back as
-    b" umask\\n", measured at both versions), so stripping would widen a value git
-    itself rejects straight into the accept set below. Round 15's lesson at a second
-    site in this same function.
-
-    The case handling is measured rather than inferred from the accept list's shape:
-    `FALSE` and `Off` really are not shared at both versions and are accepted, while
-    `UMASK` and `GROUP` are values git REJECTS — git comparing the keywords with
-    strcmp and the booleans with strcasecmp. Values git rejects DO reach this gate:
-    `rev-parse --absolute-git-dir` answers rc 0 for every one of them, `banana`
-    included, so the "it would have fatalled earlier" reasoning that fits some other
-    probes in this file does not hold here. They fall off the allowlist into a
-    refusal deliberately — their repository is already unusable (`git status` exits
-    128, `fatal: bad boolean config value ... for 'core.sharedrepository'`), so
-    refusing costs nothing while guessing at a malformed value would.
-
-    SCOPE, stated because this is NARROWER than git's own resolution: the read names
-    the repository's SHARED CONFIG, as every probe in `_shield_enable_worktree_config`
-    does. Measured, git honors `core.sharedRepository` from a GLOBAL config too (an
-    object written under a global `= group` came back `r--r-----` with the repo config
-    empty), so an operator's global setting is not consulted here and such a
-    repository is still shielded — unchanged from the behavior before this gate
-    existed, and deliberately so, since a global preference is not a statement that
+    SCOPE, NARROWER THAN GIT'S OWN RESOLUTION: the read names the repository's
+    SHARED CONFIG. git honors `core.sharedRepository` from a GLOBAL config too, so
+    an operator's global setting is not consulted here and such a repository is
+    still shielded — deliberately, since a global preference is not a statement that
     THIS repository is shared. What is refused is a repository CONFIGURED as shared,
-    which is the shape `git init --shared` writes: measured, `--shared=group` records
-    `sharedrepository = 1`, the legacy numeric form the table above lists as group.
+    the shape `git init --shared` writes (`--shared=group` records the legacy
+    `sharedrepository = 1`).
 
-    WORKTREE SCOPE is unread too, and unlike the global case that omission rests on a
-    barrier two modules away rather than on anything this function does. git DOES honor
-    `core.sharedRepository` from a linked worktree's own `config.worktree` — measured at
-    2.20.4 and 2.55.0, an object written from such a worktree under `umask 077` came back
-    `r--r-----` against a `r--------` control, while the `--file` read below answers rc 1
-    for it. What makes that unreachable is the provisioning flow: the shield only ever
-    runs on a worktree this process just created (`workspace.open_unit_workspace` ->
-    `verify.worktree_add` -> `worktree_flow.provision_worktree`), `git worktree add`
-    creates the admin dir with NO `config.worktree` at either version, and a re-mount
-    prunes `.git/worktrees/<id>` whole. The MAIN worktree's `.git/config.worktree` does
-    not reach a linked one either (measured, `r--------`), and the tree's only
-    worktree-scoped write is the shield's own `core.excludesFile`, further down this
-    file. So the value has no writer and no window. If a re-provision path onto an
-    EXISTING worktree is ever added, or anything upstream of the shield starts writing
-    the unit worktree's config, this read must grow a second
-    `--file <git_dir>/config.worktree` probe in the same change.
+    WORKTREE SCOPE is unread too, and git DOES honor `core.sharedRepository` from a
+    linked worktree's own `config.worktree`, which the `--file` read below answers
+    rc 1 for. What makes that unreachable is the provisioning flow rather than
+    anything here: the shield only ever runs on a worktree this process just created
+    (`workspace.open_unit_workspace` -> `verify.worktree_add` ->
+    `worktree_flow.provision_worktree`), `git worktree add` creates the admin dir
+    with NO `config.worktree`, a re-mount prunes `.git/worktrees/<id>` whole, the
+    MAIN worktree's `.git/config.worktree` does not reach a linked one, and the
+    tree's only worktree-scoped write is the shield's own `core.excludesFile`. So
+    the value has no writer and no window. If a re-provision path onto an EXISTING
+    worktree is ever added, or anything upstream starts writing the unit worktree's
+    config, this read must grow a second `--file <git_dir>/config.worktree` probe in
+    the same change.
     """
     raw = _shield_shared_config(worktree, str(common_dir / "config"), "core.sharedRepository")
     if raw is None:
@@ -1623,8 +1580,7 @@ def _shield_shared_repository(worktree: Path, common_dir: Path) -> str | None:
     if _shared_repository_is_private(value):
         return None
     # {value!r}: operator-authored text going into a journaled reason, and repr
-    # neutralizes a newline in it. The version gate above renders git's own answer
-    # the same way.
+    # neutralizes a newline in it — as the version gate above does.
     return (
         f"skipped the git-add shield ({worktree}): the repository's shared config sets "
         f"core.sharedRepository = {value!r}, and a repository shared between OS users is "
@@ -1639,63 +1595,42 @@ def _shield_enable_worktree_config(worktree: Path, common_dir: Path) -> tuple[st
     PROBE ONLY — it does not write. `needs_enable` is True when every gate passed
     and the caller must still set `extensions.worktreeConfig` itself; False when the
     repo already carries it (or when `reason` is set and nothing may be written).
-    Splitting the answer from the write is round 5's fix: enabling the extension is
-    a PERMANENT repo-format change, and performed here it landed BEFORE the seed,
-    the mkdir, the write and the activation — so every degrade below it, including
-    the `_shield_inherited_excludes` one, left the operator's repo permanently
-    marked for a shield that never applied. The caller now enables it immediately
-    before the activation, and rolls the flag back when the shield then fails to
-    hold — including when the ENABLE ITSELF fails in a way that leaves the outcome
-    unknown, which is round 10. The flag outlives a failed shield only where the
-    rollback was DECLINED because a sibling worktree depends on it, or could not be
-    made at all; both are named in the returned reason.
+
+    Answering is split from writing because enabling the extension is a PERMANENT
+    repo-format change: performed here it precedes the seed, the write and the
+    activation, so any degrade below it left the repo marked for a shield that never
+    applied. The caller enables it immediately before the activation and rolls the
+    flag back when the shield then fails to hold — including when the ENABLE ITSELF
+    fails in a way that leaves the outcome unknown. The flag outlives a failed
+    shield only where the rollback was DECLINED because a sibling worktree depends
+    on it, or could not be made at all; the reason says which.
 
     `extensions.worktreeConfig` is what makes a per-worktree config file exist at
     all; without it `git config --worktree` either refuses outright (a repo with
-    linked worktrees) or silently writes the SHARED config. Already-true is the
-    common case after the first isolated run — reported as `needs_enable` False, so
-    the caller never rewrites it.
+    linked worktrees) or silently writes the SHARED config.
 
-    Enabling it is a PERMANENT, repo-wide format change this code never reverses,
-    so it is refused in the two shapes git's own documentation calls out
-    (git-worktree(1), CONFIGURATION FILE): with `core.bare = true` or
-    `core.worktree` in the shared config, enabling the extension drops the
-    exception that confined those keys to the main worktree, and they would start
-    applying to every worktree. Git says to move them into the main worktree's
-    `config.worktree` first — a repo-layout edit the installer has no business
-    making behind an operator's back — so the shield degrades instead, and the
-    run continues with the tool files unshielded rather than the repo rearranged.
+    Enabling it is refused in the two shapes git-worktree(1) (CONFIGURATION FILE)
+    calls out: with `core.bare = true` or `core.worktree` in the shared config,
+    enabling drops the exception that confines those keys to the main worktree, so
+    they would start applying to every worktree. Git's remedy is a repo-layout edit
+    the installer will not make behind an operator's back, so the shield degrades
+    instead.
 
-    The version gate and both refusal probes STAY HERE, ahead of everything, and
-    deferring them the way the write was deferred would be a bug. `git config
+    The version gate and both refusal probes STAY HERE, first. `git config
     --worktree` does not exist before 2.20, so on an older git the enable buys a
-    permanent format change with nothing to show for it — and git-worktree(1) says
-    older git refuses a repository carrying the extension. And `--type=` is itself
-    git 2.18: on an older git the two probes below exit non-zero, which this
-    function USED to read as "not enabled" and, worse, as "not bare" — silently
-    opening the core.bare gate the paragraph above exists to hold shut. That is the
-    safety-gate-degrading-open trap, and it had a second door: ANY unanswerable rc
-    did the same thing, not just an old git's. `_shield_shared_config` now closes
-    that one by raising on every rc but 0 and 1 (round 10).
-
-    THAT IS DEFENCE IN DEPTH BEHIND THIS GATE, NOT A REPLACEMENT FOR IT, and the
-    distinction is worth stating because the funnel makes the 2.18 pair fail closed
-    on its own and a later round could read that as licence to relax the floor. It is
-    not: this gate rests on two arguments the funnel does not touch — a permanent
-    format change bought on a git that cannot use it, and git-worktree(1)'s older-git
-    refusal — and it keeps the 2.18 pair UNREACHABLE rather than merely survivable.
-    The caller's own `--type=path` excludesFile read depends on the same floor.
-    So: the GATES run first and early, the WRITE runs last and late.
+    permanent format change with nothing to show for it, and git-worktree(1) says
+    older git refuses a repository carrying the extension. `--type=` is itself git
+    2.18, so on an older git the two `--type=bool` probes below cannot answer —
+    `_shield_shared_config`'s raise on any rc but 0 or 1 is defence in depth BEHIND
+    this gate, not licence to relax the floor. The caller's `--type=path`
+    excludesFile read rests on it too.
     """
-    # Polarity note, deliberately recorded: this gate reads `returncode != 0` as
-    # REFUSE, while the funnel below reads it as "git did not answer" and raises.
-    # Both fail closed, by opposite-looking means, and unifying them would reverse
-    # one of them — an unanswerable `git version` must refuse here, not degrade into
-    # a question about a key. Nor can this gate catch a bad repo config on git's
-    # behalf: `{ "version", cmd_version }` carries no flags at all in git.c, so it
-    # never does repository setup, and measured at 2.20.4 and 2.55.0 `git version`
-    # exits 0 under both a malformed `.git/config` and a non-bool `core.bare` while
-    # `rev-parse` fatals 128 on each.
+    # Polarity note: this gate reads `returncode != 0` as REFUSE, while the funnel
+    # below reads it as "git did not answer" and raises. Both fail closed, by
+    # opposite-looking means, and unifying them would reverse one — an unanswerable
+    # `git version` must refuse here, not degrade into a question about a key. Nor is
+    # it a repo-config check: `git version` does no repository setup, so it exits 0
+    # where `rev-parse` fatals 128 on a malformed `.git/config`.
     version = git_bytes(worktree, "version")
     if version.returncode != 0 or not _git_version_at_least(
         os.fsdecode(version.stdout), _WORKTREE_CONFIG_GIT
@@ -1708,58 +1643,35 @@ def _shield_enable_worktree_config(worktree: Path, common_dir: Path) -> tuple[st
             f"{found!r} — enabling the extension on an older git is a permanent "
             "repo-format change that would shield nothing"
         ), False
-    # EVERY read below names the SHARED config as a file rather than going by
-    # scope. `--local` from a linked worktree already resolves to this same file,
-    # but naming it keeps the checks honest if that ever stops being true — and,
-    # load-bearing for the first of them, it stops a value the operator set
-    # GLOBALLY from answering a question about this repository's format.
+    # EVERY read below names the SHARED config as a file rather than going by scope
+    # (`--local` resolves to it today; naming it keeps the checks honest if that
+    # stops being true). Load-bearing for the first of them: `extensions.*` is
+    # repo-format state git honors only from the repo's own config, so a
+    # `worktreeConfig = true` in `~/.gitconfig` answering an unscoped read would be a
+    # false "already enabled" — the write below skipped, the activation left to fatal
+    # for want of the extension.
     #
-    # `extensions.*` is repo-format state git honors only from the repo's own
-    # config, so an unscoped `--get extensions.worktreeConfig` asks the wrong file:
-    # a `worktreeConfig = true` in ~/.gitconfig answers it, this returns "already
-    # enabled", the write below never happens, and the activation dies with
-    # `fatal: --worktree cannot be used with multiple working trees unless the
-    # config extension worktreeConfig is enabled` — the shield skipped over a repo
-    # that was one write away from supporting it.
+    # And NO `--includes` on any of the three, which is the asymmetry a later reader
+    # will want to "fix" — `--file` without it does miss a value an `include.path`
+    # supplies. Adding it breaks both gates, because git's worktree SETUP reads
+    # `core.bare` / `core.worktree` from the common config LITERALLY: it goes through
+    # `git_config_from_file`, which does not respect includes (config.h).
     #
-    # And NO `--includes` on any of the three, which is the asymmetry a later
-    # reader (or bot round) will want to "fix" — `--file` without it does miss a
-    # value an `include.path` supplies. Adding it would break both gates:
-    #
-    # - The two REFUSAL probes ask whether enabling the extension would break the
-    #   operator's worktrees, and git's worktree SETUP reads `core.bare` /
-    #   `core.worktree` only from the common config literally. It reaches them
-    #   through `git_config_from_file` (setup.c's `check_repo_format`), and include
-    #   expansion is not a parser feature but a callback wrapper installed in
-    #   `config_with_options()` alone — so `git_config_from_file` does not respect
-    #   includes, in git's own header's words (config.h). An `include.path` arrives
-    #   there as an ordinary unmatched key. Measured with the extension enabled at
-    #   git 2.20.4 / 2.32.7 / 2.43.7 / 2.49.1 / 2.55.0, identical at all five: a
-    #   LITERAL `core.worktree` moves a linked worktree's toplevel to the main
-    #   checkout and a literal `core.bare = true` fatals every command, while
-    #   include-supplied values of either do nothing at all. `--includes` here
-    #   would therefore refuse repos git is perfectly happy to shield — leaving the
-    #   provisioned tool files unshielded, the harm this shield exists to prevent.
+    # - The REFUSAL probes would start refusing repos git is perfectly happy to
+    #   shield, leaving the provisioned tool files unshielded: include-supplied
+    #   values of either key do nothing, while literal ones move a linked worktree's
+    #   toplevel to the main checkout or fatal every command. (`core.bare` only
+    #   because `is_bare_repository()` also requires no work tree, which every
+    #   worktree here has — its inertness is a conjunction, not an absence.)
     # - The ENABLED probe is worse: an include-supplied `extensions.worktreeConfig`
-    #   is not honored either (`git config --worktree` still fatals at all five
-    #   versions), because the `config.worktree` read is gated on the flag harvested
-    #   by that same include-blind setup read. `--includes` there is a false
-    #   "already enabled" → the write is skipped → the activation dies → nothing is
-    #   shielded. That is commit c6d5960's bug re-entering through the include door.
+    #   is not honored either (`git config --worktree` still fatals), because the
+    #   `config.worktree` read is gated on the flag harvested by that same
+    #   include-blind setup read — so `--includes` there is the same false "already
+    #   enabled", and nothing is shielded.
     #
-    # Two bounds on the claim, so a later reader knows what would invalidate it.
-    # It is an undocumented IMPLEMENTATION DETAIL, not a compatibility contract:
-    # git has deliberately converted reads to respect includes before (ecec57b3c973,
-    # git 2.39, "config: respect includes in protected config"), and a future
-    # `config_with_options()` conversion could flip it with no release note. And
-    # `core.bare`'s inertness is a CONJUNCTION, not an absence — an include-supplied
-    # `core.bare = true` does reach `repo->bare_cfg` on the normal
-    # include-respecting path; what keeps it harmless is `is_bare_repository()`
-    # requiring `bare_cfg && !repo_get_work_tree(repo)`, and every worktree this
-    # shield touches has a work tree. `core.worktree` needs no such caveat: it is
-    # read as a config key only in setup.c. Flag availability was never the
-    # question either way — `--includes` dates to git 1.7.10, far below the 2.20
-    # floor the gate above enforces.
+    # All of that is undocumented IMPLEMENTATION DETAIL, not a compatibility
+    # contract: git has converted reads to respect includes before (2.39, protected
+    # config).
     shared = str(common_dir / "config")
     carried = _shield_shared_config(worktree, shared, "extensions.worktreeConfig", "--type=bool")
     if carried is not None and os.fsdecode(carried).strip() == "true":
@@ -1769,14 +1681,11 @@ def _shield_enable_worktree_config(worktree: Path, common_dir: Path) -> tuple[st
         refused = "core.bare = true"
     elif _shield_shared_config(worktree, shared, "core.worktree") is not None:
         # `is not None`, NEVER truthiness: any value refuses, including an empty one.
-        # Measured at 2.20.4 and 2.55.0 — `core.worktree = ""` and a valueless
-        # `worktree` line BOTH answer rc 0 with a lone b"\n", so raw truthiness
-        # happens to hold today, but it is one `.strip()` away from b"", which is
-        # falsy, and that would re-open this gate for a key that IS set. The rc is the
-        # only thing separating present-but-empty from absent, and returning it as
-        # None-or-value is exactly what the helper exists to do. Never decoded, and
-        # the value never inspected: this key is a path, and its mere PRESENCE is the
-        # refusal — unlike `core.bare`, where only a true value disqualifies.
+        # `core.worktree = ""` and a valueless `worktree` line both answer rc 0 with a
+        # lone b"\n", so truthiness holds today — but one `.strip()` makes it b"",
+        # which is falsy, re-opening this gate for a key that IS set. The value is
+        # never decoded or inspected: this key is a path and its mere PRESENCE refuses,
+        # unlike `core.bare`, where only a true value disqualifies.
         refused = "core.worktree"
     else:
         # Cleared, not enabled. The write itself is the caller's, deferred to the
@@ -1793,63 +1702,37 @@ def _shield_undo_extension(worktree: Path, git_dir: Path, common_dir: Path) -> s
     """Undo the `extensions.worktreeConfig` THIS provisioning just enabled.
 
     Returns `""` when the repository is back in the state it was found in, or a
-    clause naming the fault when it is not — never raises, because every caller is
-    already reporting a degrade and this exists to say what it could not undo.
+    clause naming the fault otherwise — never raises: every caller is already
+    reporting a degrade, and this says what it could not undo.
 
-    Callers MUST gate this on having enabled the flag themselves — or, since round
-    10, on not having been able to FIND OUT whether they did, which is what the
-    enable's own raise means. Unsetting one the repository already carried would stop
-    git reading the `config.worktree` files other worktrees may depend on — the
-    reason the shield's rollback is conditional rather than unconditional cleanup.
+    Callers MUST gate this on having enabled the flag themselves, or on not having
+    been able to FIND OUT whether they did — which is what the enable's own raise
+    means. Unsetting one the repository already carried would stop git reading the
+    `config.worktree` files other worktrees may depend on, so the rollback is
+    conditional, never unconditional cleanup.
 
-    That caller-side gate is necessary and NOT sufficient, which is round 8 (#384,
-    Codex P2). `needs_enable` records what the probe saw, and the enable itself is an
-    idempotent rc-0 no-op against a flag that is already `true` — so two concurrent
-    provisionings that both probed an absent flag both believe they own it, and
-    whichever one's activation fails then unsets a flag the other's LIVE shield
-    depends on: git stops reading its `config.worktree`, its `core.excludesFile`
-    goes inert, and its shielded tool paths become stageable again mid-run. The
-    caller serializes the whole transaction under a repository lock, which closes
-    that window for processes taking the lock. This scan is the fallback for the
-    flag having been enabled OUTSIDE that discipline — an older bmad-loop, a
-    concurrently running different version, an operator, or another tool entirely
-    (`git sparse-checkout` enables this same extension) — so it is not redundant
-    with the lock and must not be deleted as such. A lock binds only its holders.
+    That caller-side gate is necessary and NOT sufficient (#384): `needs_enable`
+    records what the PROBE saw, and the enable is an idempotent rc-0 no-op against a
+    flag already `true`, so two concurrent provisionings that both probed an absent
+    flag both believe they own it, and whichever one's activation fails would unset a
+    flag the other's LIVE shield depends on — leaving its tool files stageable
+    mid-run. The caller serializes the transaction under a repository lock, but a lock
+    binds only its holders: an operator, an older bmad-loop, or `git sparse-checkout`
+    can set the same flag outside it.
 
-    EXCLUDING OUR OWN `git_dir` IS LOAD-BEARING, not tidiness: a `config.worktree`
-    in it is the half-written product of the very activation whose failure prompted
-    this rollback (a timeout can leave one behind), and treating that as a dependent
-    would suppress every rollback the round-6/7 fixes exist to make.
+    EXCLUDING OUR OWN `git_dir` IS LOAD-BEARING: a `config.worktree` there is the
+    half-written product of the very activation whose failure prompted this rollback
+    (a timeout can leave one behind), so counting it as a dependent would suppress
+    the rollback.
 
-    WHAT THIS DOES NOT COVER, stated rather than left for another round to find (the
-    round-6 lesson: a rationale of "now nothing can go wrong" has to enumerate its own
-    remaining cases). The scan reads an EXISTING file, so a non-lock-taking party
-    sitting between its own enable and its own activation owns the flag while having
-    written nothing yet, and this rollback will unset it. The consequence is bounded
-    and different in kind from the finding above: that party's `git config --worktree`
-    then fatals for want of the extension, so its shield degrades with a REPORTED
-    reason instead of silently going inert mid-run. That bound depends on a
-    precondition this scenario supplies for free, and it is worth naming because the
-    other branch is #384 itself: `git config --worktree` only REFUSES (rc 128) once a
-    repository has more than one worktree, and in a single-worktree repo it exits 0
-    and writes the SHARED config instead. Here a sibling exists by construction — it
-    is the other party — so the refusal is the one git gives. The reverse asymmetry is also
-    accepted — a stale admin dir git has not pruned yet counts as a dependent, which
-    costs a flag left enabled and nothing else.
-
-    Round 10 widened that window's APERTURE without changing its bound: this rollback
-    now also runs from the enable's own raise, one call earlier, so there are two
-    occasions on which a non-lock-taking party can be caught mid-transaction rather
-    than one. Same class and same bounded consequence, twice as often.
-
-    Measured, because "the key is gone" and "the extension is off" are two claims:
-    the unset exits 0, removes the key AND the now-empty `[extensions]` section (the
-    config file returns to its original bytes), and `git config --worktree` refuses
-    again afterwards with git's own fatal — so this is a real rollback, not cosmetic.
-    An ABSENT key exits 5, which used to be unreachable ("the gate above means we
-    never do") and stopped being so in round 10: the enable's raise routes here
-    without knowing whether anything was written. See the call below for why that
-    makes rc 5 a success and why the spelling is `--unset-all`.
+    WHAT IT DOES NOT COVER: a non-lock-taking party between its own enable and its
+    own activation owns the flag while having written nothing yet, so the scan cannot
+    see it and this rollback unsets it. Bounded — its `git config --worktree` then
+    fatals for want of the extension (rc 128 — a sibling exists by construction here;
+    in a single-worktree repo `--worktree` instead exits 0 and writes the SHARED
+    config), so its shield degrades with a REPORTED reason rather than going silently
+    inert. The opposite error is accepted too: a stale admin dir git has not pruned yet
+    counts as a dependent, costing a flag left enabled and nothing else.
     """
     try:
         # The main worktree's own, then every SIBLING's — never ours (above).
@@ -1862,22 +1745,14 @@ def _shield_undo_extension(worktree: Path, git_dir: Path, common_dir: Path) -> s
         dependent = next((str(p) for p in others if p.exists()), None)
     except (OSError, RuntimeError, UnicodeError) as e:
         # Conservative on purpose, and the asymmetry is the argument: skipping
-        # leaves a reported flag this call did not earn, while unsetting one that
-        # IS depended on silently un-shields a live worktree. A cosmetic residue
-        # beats silent file loss, so an unreadable scan counts as a dependent.
+        # leaves a reported flag this call did not earn, while unsetting one that IS
+        # depended on silently un-shields a live worktree. So an unreadable scan
+        # counts as a dependent.
         #
         # The tuple mirrors the caller's tail minus `GitError` (nothing here spawns
-        # git), and the two beyond `OSError` are what keeps this function's "never
-        # raises" promise true rather than merely stated — round 9 (#384,
-        # CodeRabbit), and measured, not reasoned: with `resolve()` made to fail the
-        # way a symlink loop does, the bare `OSError` tuple let it escape. On the
-        # Python 3.11/3.12 floor `Path.resolve()` raises `RuntimeError` for a
-        # symlink loop rather than `OSError` (the caller's own tail already carries
-        # it for exactly that), and `UnicodeError` covers the fsdecode of a
-        # directory name on Windows. Escaping here is not a crash — the caller's
-        # tail catches all three — but it replaces the activation fault AND the
-        # retained-flag disclosure with a generic reason, losing precisely what
-        # rounds 6 and 7 added.
+        # git), and the members beyond `OSError` are what keeps the "never raises"
+        # promise true: on the 3.11/3.12 floor `Path.resolve()` raises `RuntimeError`
+        # for a symlink loop rather than `OSError`.
         dependent = f"the scan for sibling worktrees failed ({e})"
     if dependent is not None:
         return (
@@ -1886,38 +1761,28 @@ def _shield_undo_extension(worktree: Path, git_dir: Path, common_dir: Path) -> s
             "on the flag and unsetting it would stop git reading that file"
         )
     try:
-        # `--unset-all`, and rc 5 counts as SUCCESS. Both halves are round 10's, and
-        # neither is cosmetic. Routing an uncertain ENABLE into this rollback makes an
-        # absent flag reachable here for the first time, and `--unset` of an absent
-        # key exits 5 — which rendered as "could NOT be rolled back (git exited 5)"
-        # for a repository whose flag is in fact gone: a false disclosure.
+        # `--unset-all`, and rc 5 counts as SUCCESS: an uncertain ENABLE routed here
+        # makes an absent flag reachable, and `--unset` of an absent key exits 5 —
+        # reporting that as a failed rollback would be false.
         #
         # `--unset` alone could not simply treat 5 as success, because git-config(1)
-        # gives that code TWO meanings — "unset an option which does not exist" and
-        # "unset/set an option for which multiple lines match" — so a doubled key that
-        # SURVIVED would report a clean rollback. Measured at 2.20.4 and 2.55.0,
-        # identical: `--unset` against a doubled key exits 5 and removes NOTHING,
-        # while `--unset-all` exits 0 and removes both lines. `--unset-all` therefore
-        # collapses rc 5 to the single meaning "no line matched", which makes the
-        # guarantee structural instead of resting on a four-step argument about which
-        # doubled values can reach here. It is also what this function actually
-        # promises: a statement about the KEY, not about one line.
+        # gives that code TWO meanings — the key did not exist, or MULTIPLE LINES
+        # matched — so a doubled key that SURVIVED would report a clean rollback.
+        # Stable from the 2.20 floor to current git: `--unset` against a doubled key
+        # exits 5 and removes NOTHING, while `--unset-all` exits 0 and removes both
+        # lines, collapsing rc 5 to the single meaning "no line matched".
         undone = git_bytes(worktree, "config", "--unset-all", "extensions.worktreeConfig")
         if undone.returncode in (0, 5):
             return ""
         detail = os.fsdecode(undone.stderr).strip() or f"git exited {undone.returncode}"
     except GitError as e:
-        # the rollback's OWN git can time out or fail to spawn. Both writes failing
-        # is the coherent case rather than a contrived one: a read-only `.git` or a
-        # dead git fails the unset for the same reason it failed the activation.
+        # the rollback's OWN git can time out or fail to spawn: a read-only `.git` or
+        # a dead git fails this unset for the same reason it failed the activation.
         detail = str(e)
-    # Both clauses HEDGE whether this shield set the flag, which round 10 made
-    # necessary: reached from the enable's own raise, a spawn failure can kill the
-    # enable and this unset for the same reason, having written nothing at all — and
-    # the old wording ("was enabled for this shield and could NOT be rolled back")
-    # then asserted a format change the repository does not carry. No real precision
-    # is lost: `needs_enable` is probe-derived and already cannot tell "we enabled it"
-    # from "we and a concurrent run both thought we did".
+    # Both clauses HEDGE whether this shield set the flag, and must: reached from the
+    # enable's own raise, a spawn failure can kill the enable and this unset alike,
+    # having written nothing at all. No precision is lost — `needs_enable` is
+    # probe-derived and cannot tell "we enabled it" from "we both thought we did".
     return (
         "; extensions.worktreeConfig could NOT be "
         f"rolled back ({detail}) — if this shield set the flag, the repository keeps "
@@ -1928,62 +1793,40 @@ def _shield_undo_extension(worktree: Path, git_dir: Path, common_dir: Path) -> s
 def _shield_home_git_ignore(worktree: Path) -> Path:
     """`$HOME/.config/git/ignore` — git's XDG fallback — asked of GIT, not of Python.
 
-    `Path.home()` is the obvious spelling here and it is WRONG on Windows, the one
-    platform where git's home and Python's home are derived differently. Git locates
-    this fallback with `getenv("HOME")` on every platform (`path.c::xdg_config_home`,
-    semantics unchanged 2.20.0 → 2.55) — but on Windows
-    `compat/mingw.c::setup_windows_environment()` DERIVES `HOME` inside the git
-    process before that runs, preferring `HOMEDRIVE`+`HOMEPATH` (and only when that
-    names a real directory) over `USERPROFILE`. Python's `ntpath.expanduser` has the
-    OPPOSITE precedence — `USERPROFILE` first — and never consults `HOME` at all. Two
-    ordinary setups therefore disagree:
+    `Path.home()` is the obvious spelling and it is WRONG on Windows, the one
+    platform where git's home and Python's are derived differently. Git locates this
+    fallback with `getenv("HOME")` everywhere (`path.c::xdg_config_home`), but on
+    Windows `compat/mingw.c::setup_windows_environment()` DERIVES `HOME` inside the
+    git process first, preferring `HOMEDRIVE`+`HOMEPATH` (only when that names a real
+    directory) over `USERPROFILE`; Python's `ntpath.expanduser` has the OPPOSITE
+    precedence and never consults `HOME` at all. Git Bash and MSYS2 set `HOME`; a
+    domain-joined machine's `HOMEDRIVE`+`HOMEPATH` may be a network home share.
+    Either makes the two disagree.
 
-    * anything that sets `HOME` (Git Bash and MSYS2 do), where git obeys it and
-      Python cannot see it; and
-    * a domain-joined machine whose `HOMEDRIVE`+`HOMEPATH` is a network home share,
-      where git reads `H:\\…\\.config\\git\\ignore` and Python reads `C:\\Users\\…`.
-
-    The miss is SILENT, and it is #384's own harm reached through the platform split:
-    the wrong path is simply not a file, the seed comes back empty, and the caller's
-    activation then SHADOWS the global ignore file git really reads — un-ignoring
-    inside the worktree exactly what this branch exists to preserve.
+    The miss is SILENT, and it is #384's own harm through the platform split: the
+    wrong path is simply not a file, the seed comes back empty, and the caller's
+    activation then SHADOWS the global ignore file git really reads.
 
     So ask git. `--type=path` interpolates a leading `~/` through the same
-    `getenv("HOME")` git uses for the fallback itself, which makes the answer correct
-    by construction on every platform and names no environment variable — round 18's
-    lesson (ask what git RESOLVED, not how the environment might have told it) at the
-    sibling site. `-c` is COMMAND scope, the most specific git has, so the probe's
-    value cannot be outranked by the operator's config: the very precedence rule that
-    caused round 18 is what makes this reliable.
+    `getenv("HOME")` git uses for the fallback itself, so the answer is correct by
+    construction on every platform and names no environment variable. `-c` is COMMAND
+    scope, the most specific git has, so the probe's value cannot be outranked by the
+    operator's config. The answer comes back NUL-terminated at rc 0; with `HOME`
+    unset git exits 128 and applies no fallback at all.
 
-    MEASURED at git 2.20.4 (docker `alpine:3.9`, non-root, `id -u` checked) and
-    2.55.0, byte-identical: the probe returns `$HOME/.config/git/ignore` NUL-
-    terminated at rc 0, and that is the file git really loads patterns from — proven
-    through `git status` hiding a name the file lists, not inferred from the path.
-    With `HOME` unset it exits 128 and git applies no fallback at all.
+    KNOWN GAP: this answers "where is git's `$HOME`", which is the whole of the
+    fallback UPSTREAM but not on **Git for Windows >= 2.46**, whose fork patches
+    `xdg_config_home_for` to prefer `%APPDATA%/Git/<file>` whenever that file EXISTS.
+    An operator there keeping global ignores at `%APPDATA%\\Git\\ignore` still gets
+    the wrong file seeded. Not fixed here: a downstream fork's behavior, gated well
+    above this shield's floor.
 
-    KNOWN GAP, recorded so this is not read as complete: this answers "where is
-    git's `$HOME`", which is the whole of the fallback UPSTREAM but not on **Git for
-    Windows >= 2.46**, whose fork patches `xdg_config_home_for` to prefer
-    `%APPDATA%/Git/<file>` whenever that file EXISTS — it even warns that the `$HOME`
-    one "was ignored because" the APPDATA one is there. Verified by reading the
-    fork's `path.c` and bounded by version: 1 occurrence of `APPDATA` at
-    `v2.46.0.windows.1`, 0 at `v2.45.0.windows.1`, `v2.20.0.windows.1`, and 0
-    upstream at master. So an operator on a current Git for Windows who keeps their
-    global ignores at `%APPDATA%\\Git\\ignore` still gets the wrong file seeded here.
-    Deliberately NOT fixed in this pass: it is a downstream fork's behavior, gated on
-    a version well above this shield's floor, and there is no way to MEASURE it from
-    a POSIX box — which is this branch's standing bar for a git claim.
-
-    Raises `GitError` when git did not answer, INCLUDING that `HOME`-unset rc.
-    Proceeding on a non-zero rc would be a guess, and a guess here is silent: the
-    caller seeds nothing and activates over whatever git does read. git's message is
-    deliberately NOT matched to tell "no HOME" apart from a transient fault, because
-    that wording is version-dependent (it differs between 2.20.4 and 2.55.0 for other
-    config faults on this same branch). The cost is that a genuinely `HOME`-less
-    environment now skips the shield with a journaled reason instead of proceeding
-    with an empty seed — and that direction is REPORTED, which is the whole taxonomy
-    of the caller: only a definite absent may be silent.
+    Raises `GitError` on any non-zero rc, INCLUDING the `HOME`-unset one. Proceeding
+    would be a guess, and a guess here is silent: the caller seeds nothing and
+    activates over whatever git does read. git's message is deliberately NOT matched
+    to tell "no HOME" apart from a transient fault, because that wording is
+    version-dependent. A `HOME`-less environment therefore skips the shield with a
+    reported reason; only a definite absent may be silent in this caller.
     """
     key = "bmadloop.xdghomeprobe"
     probe = git_bytes(
@@ -1998,197 +1841,97 @@ def _shield_home_git_ignore(worktree: Path) -> Path:
 def _shield_inherited_excludes(worktree: Path) -> bytes:
     """The BYTES of whatever `core.excludesFile` this worktree resolves to now.
 
-    A worktree-scoped `core.excludesFile` SHADOWS the operator's own: git reads
-    the key from the most specific scope that sets it and does not concatenate
-    across scopes (verified — with a worktree value set, a path listed in the
-    global excludes file shows up as untracked inside the worktree and stays
-    ignored in the main checkout). Activating the shield without carrying their
-    patterns over would therefore un-ignore, inside the worktree, everything they
-    ignore globally — and the unit's `git add -A` would commit it.
+    A worktree-scoped `core.excludesFile` SHADOWS the operator's own: git reads the
+    key from the most specific scope that sets it, never concatenating scopes. Not
+    carrying their patterns over would un-ignore, inside the worktree, everything
+    they ignore globally — and `git add -A` would commit it. The caller seeds once,
+    at creation, so the copy never fights later edits to the private file.
 
-    Seeded once, at creation, so the copy never fights later edits to the private
-    file.
+    BYTES, never decoded text: exclude entries are path patterns, POSIX paths are
+    arbitrary bytes, and one non-UTF-8 byte collapsed a `read_text` seed to empty —
+    after which the activation SHADOWED what it failed to copy.
 
-    BYTES, never decoded text, and the return type is the fix: an exclude file is
-    a list of path patterns, POSIX paths are arbitrary bytes, and a `read_text`
-    here made one non-UTF-8 byte anywhere in the operator's file collapse the whole
-    seed to empty — after which the activation SHADOWED the excludes it had failed
-    to copy, and `git add -A` staged what they told git to ignore (measured
-    end-to-end). Copying verbatim also keeps every pattern intact for the caller's
-    dedupe, which a text round trip could not promise. Git reads the result either
-    way: it strips a trailing `\\r` from an exclude line and skips a UTF-8 BOM.
+    FOUR outcomes (#384). The first two are silent; the other two RAISE, and the
+    caller's tail turns that into the degrade reason that skips the activation.
 
-    FOUR outcomes, and which answer means what is the whole subtlety. The first
-    two are silent; this function RAISES for the other two, and the caller's tail
-    turns that into the degrade reason that skips the activation. Only ABSENT has a
-    fallback, and routing DISABLED into it was round 8's bug.
-
-    - ABSENT is silent and empty, and the only outcome that falls back. The common
-      case — no `core.excludesFile`, no XDG fallback file — and not a reason to skip
-      the shield. It is an ANSWER: `--get` of an unset key exits 1, and `is_file()`
-      false says the file is not there. One caveat added with the `$HOME` probe:
-      REACHING the fallback path can itself fail, and `_shield_home_git_ignore`
-      raises when it does. That is not this outcome — an unresolvable home is
-      UNKNOWN, not absent, and gets the loud arm like every other unknown here.
-    - DISABLED is silent and empty too, and it is NOT absent (#384, Codex round 8).
-      An explicitly EMPTY `core.excludesFile` is the operator saying "no excludes
-      file at all", and git honors that literally rather than treating it as unset:
-      measured at 2.55.0, `-z --get` answers rc 0 with a lone NUL, after which git
-      loads no patterns and does NOT reach for XDG (`git check-ignore` exits 1
-      against a name the XDG file lists). The mechanism is in git's source, not
-      inferred: `dir.c::setup_standard_excludes` guards the XDG fallback on
-      `if (!excludes_file)` — a NULL POINTER — while `config.c` resolves an empty
-      value through `interpolate_path("")`, which returns a non-NULL empty string.
-      Byte-identical guard at v2.20.0, this shield's own floor, and at master.
-      Reading that as unset (the pre-round-8 `and raw`) seeded the XDG file's
-      patterns in and activated them, which is the MIRROR IMAGE of every other
-      fault here: instead of shadowing patterns it failed to copy it OVER-ignores,
-      so session-created files the operator deliberately stopped ignoring go
-      silently missing from the unit's `git add -A` and from the story's commit.
-      Same silent-file-loss class as #384 itself, in the other direction.
-    - PRESENT BUT UNREADABLE propagates. A read `OSError` (EACCES, EIO) reaches the
-      caller's degrade arm, which skips the activation — the only safe answer, since
-      activating over patterns that could not be copied shadows them exactly as an
-      empty seed did.
-    - UNKNOWN propagates too, and it arrives in TWO shapes that this function
-      deliberately funnels rather than enumerates — a raised `GitError`, and any
-      returncode that is neither 0 nor 1.
-
-      The raise is round 5's fix (#384, Codex P1). A `GitError` out of the read below
-      used to be swallowed here on the premise that "git unqueryable ⇒ no key to
-      resolve ⇒ nothing to copy". The premise is a false inference: a raised fault
-      means we did not FIND OUT — so the code mapped UNKNOWN onto ABSENT and then
-      activated a key that shadowed the file it had failed to read. Measured,
-      and pinned by the ablation on
-      `test_shield_degrades_when_git_will_not_say_what_the_users_excludes_are`:
-      inject a fault on this one call and a file the operator ignores globally comes
-      back `?? <name>` inside the worktree, ready for the unit's `git add -A`, with
-      no reason returned at all. Nor is a permanently
-      unqueryable git reachable here — by the time this runs `git_bytes` has
-      answered at least four times, so such a git already left through the caller's
-      silent `rev-parse` arm. What arrives is a TRANSIENT fault, and for those the
-      premise is false by construction: the key is there, we just cannot see it.
-      The accepted cost is that such a fault now loses the shield for that run,
-      which the caller surfaces; the harm it buys off is unbounded and silent.
-
-      The rc shape is round 9's (#384, CodeRabbit). Round 5's bullet used to justify
-      itself by saying the swallow "holds for `rc != 0`, which is an answer" — and
-      that generalization was too broad, which is the correction worth recording
-      here rather than quietly dropping. Only **rc 1** means "no such key"; every
-      other non-zero rc is git reporting that it could not answer, and routed to
-      ABSENT it seeded and activated the XDG file over patterns it had not read.
-      What can actually occupy that branch is narrower than it looks, and the
-      comment at the call below carries the measurement: not a static config value
-      — those fatal the `rev-parse` in the caller first, which skips the shield
-      silently — but a fault arriving inside the window the caller holds its lock.
+    - ABSENT is silent, empty, and the ONLY outcome that falls back: `--get` of an
+      unset key exits 1, and `is_file()` false says the fallback file is not there.
+      Reaching that fallback can itself fail — `_shield_home_git_ignore` raises, and
+      an unresolvable home is UNKNOWN, not absent.
+    - DISABLED is silent and empty too, and is NOT absent. An explicitly EMPTY
+      `core.excludesFile` means "no excludes file at all", and git honors that
+      literally: `-z --get` answers rc 0 with a lone NUL, git loads no patterns, and
+      does NOT reach for XDG (`dir.c` guards that fallback on a NULL `excludes_file`;
+      an empty value is not NULL — unchanged from the v2.20 floor to master).
+      Reading it as unset instead seeds and activates the XDG file's patterns —
+      OVER-ignoring, so files the operator deliberately stopped ignoring go silently
+      missing from `git add -A`.
+    - PRESENT BUT UNREADABLE propagates: a read `OSError` (EACCES, EIO) reaches the
+      caller's degrade arm — activating over patterns that could not be copied
+      shadows them exactly as an empty seed did.
+    - UNKNOWN propagates too, in TWO shapes: a raised `GitError`, and any returncode
+      that is neither 0 nor 1. A fault means we did not FIND OUT; swallowing it maps
+      UNKNOWN onto ABSENT and activates a key shadowing the file it failed to read.
     """
-    # -z, not a bare read plus `.strip()` — round 5, Codex P2. A `.strip()` here
-    # DESTROYED a legal POSIX path: `--type=path --get` returns leading and
+    # -z, not a bare read plus `.strip()`. `--type=path --get` returns leading and
     # trailing whitespace VERBATIM, because git writes such a value quoted and it
     # round-trips. So an operator whose excludesFile ended in a space had the strip
     # mangle the path, `is_file()` read absent, the seed come back empty, and the
-    # activation shadow the file it never copied — the same leak as the encoding bug
-    # above, through a different door. `-z` terminates the value with NUL instead,
-    # which git-config(1) recommends for exactly this ("allows for secure parsing of
-    # the output without getting confused by values that contain line breaks").
+    # activation shadow the file it never copied. `-z` terminates the value with NUL
+    # instead.
     #
-    # Everything below is measured at git 2.20.4 AND 2.55.0 — both ends of the
-    # supported range, the flag checked AT the floor rather than inferred from
-    # git-config(1), since the 2.20 refusal in `_shield_enable_worktree_config` has
-    # already run by the time this does and 2.20 is therefore the oldest git that
-    # can reach this line. `-z` still expands `~`, gives an unset key rc 1 + empty
-    # stdout, an empty value a lone NUL at rc 0, a multi-valued key the LAST value +
-    # NUL at rc 0, and a relative value verbatim.
-    #
-    # That empty-value branch is the one round 5 got WRONG, and how is worth
-    # recording: this comment used to say the lone NUL "falls to XDG the way it
-    # did" — a measurement of OUR READER's classification and of behavior
-    # preservation, which never asked what GIT does with the same value. Preserving
-    # a behavior is not the same as that behavior being correct. Git treats it as
-    # "no excludes file", so the value is an ANSWER and gets its own branch below;
-    # see the docstring's DISABLED outcome for git's own source.
-    #
-    # The sibling `rev-parse` strips below are deliberately NOT getting the same
-    # treatment, and this is the note that stops a later round re-raising it:
-    # `rev-parse` has no `-z` (it echoes one back as a literal argument), and it
-    # cannot answer with edge whitespace anyway — git SANITIZES the worktree admin
-    # id, so a worktree at `…/wt ` gets `.git/worktrees/wt-` (measured), and
-    # `--git-common-dir` ends in `.git`.
+    # The answers below hold at the 2.20 floor (the version refusal in
+    # `_shield_enable_worktree_config` has already run, so 2.20 is the oldest git that
+    # reaches this line) and at 2.55: `-z` expands `~`, gives an unset key rc 1 +
+    # empty stdout, an empty value a lone NUL at rc 0, a multi-valued key the LAST
+    # value + NUL at rc 0, and a relative value verbatim.
     answer = git_bytes(worktree, "config", "-z", "--type=path", "--get", "core.excludesFile")
     raw = answer.stdout.split(b"\0", 1)[0]
-    # rc FIRST, and the value only once rc says there IS one — the condition used to
-    # be `returncode == 0 and raw`, which collapsed DISABLED onto ABSENT. Round 8's
-    # fix is the branch below, not this reordering; the reordering is what makes the
-    # two answers nameable apart.
     if answer.returncode == 0:
         if not raw:
             # DISABLED: an explicit "no excludes file", so there is nothing to copy
-            # and NO fallback to reach for — see the docstring. Note for a later
-            # reader (or ablation): deleting this arm does not restore the bug, it
-            # only hides it, because `Path(os.fsdecode(b""))` is `.`, which resolves
-            # to the worktree directory and reads `is_file()` false. The bug is the
-            # ROUTING of this answer into the XDG branch, so the only faithful
-            # ablation is restoring `and raw` on the condition above.
+            # and NO fallback to reach for — see the docstring. The arm is inert on
+            # its own (`Path(os.fsdecode(b""))` is `.`, which reads `is_file()` false),
+            # so what separates DISABLED from ABSENT is the rc-FIRST condition above,
+            # and restoring `and raw` on it is the only faithful ablation.
             return b""
         source = Path(os.fsdecode(raw))
         if not source.is_absolute():
-            # `--type=path` expands `~` and stops there: a RELATIVE value comes
-            # back verbatim. Git resolves such a value against the worktree's
-            # top level (MEASURED — git 2.20.4, 2.49.1, 2.55.0 — and NOT
-            # specified: relative values for this key were deliberately never
-            # implemented, and the worktree-top result is an artifact of git's
-            # setup chdir, so a consumer reached through RUN_SETUP alone with an
-            # explicit git dir and an outside cwd resolves it against the
-            # CALLER's cwd instead. bmad-loop is not exposed to that: every git
-            # call here goes through `_run_git`'s `git -C <repo>`, and the
-            # activation below writes an absolute path.) Python would resolve it
-            # against this process's cwd, which is wherever the orchestrator was
-            # launched. Left alone that reads the wrong file or, far more often,
-            # none — and `is_file()` false is silent, so the operator's patterns
-            # would simply not be carried and the activation below would shadow
-            # them anyway. Un-ignoring inside the worktree exactly what this
-            # function exists to preserve.
+            # `--type=path` expands `~` and stops there: a RELATIVE value comes back
+            # verbatim. Git resolves such a value against the worktree's TOP LEVEL —
+            # observed rather than specified (it falls out of git's setup chdir), and
+            # it holds here because every git call goes through `_run_git`'s
+            # `git -C <worktree>`. Python would resolve it against this process's cwd,
+            # wherever the orchestrator was launched — the wrong file or, far more
+            # often, none, and `is_file()` false is SILENT: the operator's patterns
+            # would not be carried and the activation below would shadow them anyway.
             source = worktree / source
     elif answer.returncode != 1:
         # UNKNOWN, through git's OTHER failure shape. rc 1 is the ONLY non-zero rc
         # that means "no such key"; every other one is git saying it could not answer,
         # and routing those to the fallback below is the same UNKNOWN-as-ABSENT
-        # mistake round 5 fixed for the RAISED shape (#384, CodeRabbit round 9).
+        # mistake the raised shape is caught for.
         #
-        # WHAT CAN REACH HERE is narrower than the finding's own example, and the
-        # measurement is worth keeping because the plausible version of it is wrong.
-        # `core.excludesFile = ~nosuchuser/ignore` — an ordinary thing to inherit from
-        # a `.gitconfig` synced between machines — does make THIS read exit 128
-        # (`fatal: failed to expand user dir`). But git expands that same value while
-        # parsing core config for any command that sets the repository up, so
-        # `rev-parse --absolute-git-dir` in the caller fatals identically and the
-        # shield SILENTLY SKIPS there, above this line. Measured at git 2.20.4 and
-        # 2.55.0, both ends of the supported range. No static config value reaches
-        # this branch: its occupants are faults that appear BETWEEN that rev-parse
-        # and this read.
+        # No STATIC config value reaches this branch: a `core.excludesFile` of
+        # `~nosuchuser/ignore` does make THIS read exit 128, but git expands that same
+        # value while parsing core config for any command that sets the repository up,
+        # so `rev-parse --absolute-git-dir` in the caller fatals identically and the
+        # shield SILENTLY SKIPS above this line. What occupies this branch is a fault
+        # arriving BETWEEN that rev-parse and this read, and the caller sets that
+        # window's width: the rev-parse runs before the repo-scoped lock, this read
+        # after it, and POSIX `flock` blocks INDEFINITELY, so a run waiting on a
+        # sibling worktree's shield sits in it for the sibling's whole git
+        # transaction. Such a fault can CLEAR while an activation performed over it
+        # lasts as long as the worktree.
         #
-        # That window is structural rather than theoretical, and the caller sets its
-        # width: the rev-parse runs before the repo-scoped lock, this read runs after
-        # it, and POSIX `flock` blocks INDEFINITELY — so a run waiting on a sibling
-        # worktree's shield sits between the two calls for that sibling's whole git
-        # transaction. A dotfile manager writing `~otheruser/ignore` in, or an
-        # `~alice` whose NSS/LDAP lookup fails for a moment, lands here.
-        #
-        # "The repo is broken anyway, so the harm is bounded" does not survive that:
-        # the fault can CLEAR (the sync finishes, LDAP answers) while an activation
-        # performed over it lasts as long as the worktree — a `core.excludesFile`
-        # shadowing the operator's real excludes with the XDG file's patterns. #384's
-        # own harm, reached through a transient.
-        #
-        # Deliberately shaped as a FUNNEL rather than a per-rc taxonomy, which is
-        # round 7's lesson: git-config(1) allocates several failure codes and
-        # enumerating them one per review round is how the activation arm took three.
-        # Anything that is not "answered" or "no such key" is not an answer.
+        # A FUNNEL rather than a per-rc taxonomy: git-config(1) allocates several
+        # failure codes, and anything that is not "answered" or "no such key" is not
+        # an answer.
         detail = os.fsdecode(answer.stderr).strip() or f"git exited {answer.returncode}"
         raise GitError(f"git could not resolve core.excludesFile: {detail}")
     else:
         # ABSENT (rc 1, an unset key): git's documented fallback (gitignore(5)), and
-        # the ONLY outcome that gets one. Not reachable for an empty value any more.
+        # the ONLY outcome that gets one.
         #
         # `XDG_CONFIG_HOME` this process may read for itself: git reads the same
         # variable from the same environment (`_run_git` passes `os.environ`
@@ -2199,24 +1942,13 @@ def _shield_inherited_excludes(worktree: Path) -> bytes:
         xdg = os.environ.get("XDG_CONFIG_HOME")
         source = Path(xdg) / "git" / "ignore" if xdg else _shield_home_git_ignore(worktree)
         if not source.is_absolute():
-            # THE SAME DEFECT AS THE RELATIVE `core.excludesFile` ABOVE, at the
-            # sibling site (#384, Codex round 12) — this branch reproduces git's
-            # fallback, so it has to reproduce git's RESOLUTION too, and it did not.
-            #
-            # A relative XDG_CONFIG_HOME is invalid per the XDG base-directory spec
-            # ("All paths ... must be absolute. If an implementation encounters a
-            # relative path ... it should consider the path invalid and ignore it"),
-            # but git does not ignore it: measured at 2.20.4 and 2.55.0, git HONORS
-            # the value and resolves it against the worktree's TOP LEVEL. Measured
-            # from a SUBDIR to tell top-level from cwd, the same way the branch above
-            # was — `git -C <wt>/sub` with `XDG_CONFIG_HOME=rel` read
-            # `<wt>/rel/git/ignore`, not `<wt>/sub/rel/git/ignore`.
-            #
-            # Python resolves it against the orchestrator's launch cwd instead, and
-            # the miss is SILENT: `is_file()` false, an empty seed, and then the
-            # activation shadows the file git really reads. Un-ignoring inside the
-            # worktree exactly what this function exists to preserve — #384's harm
-            # reached through a misconfigured environment rather than a fault.
+            # THE SAME DEFECT AS THE RELATIVE `core.excludesFile` ABOVE: this branch
+            # reproduces git's fallback, so it must reproduce git's RESOLUTION too. A
+            # relative XDG_CONFIG_HOME is invalid per the XDG base-directory spec, but
+            # git does not ignore it: it HONORS the value and resolves it against the
+            # worktree's TOP LEVEL, while Python would resolve it against the
+            # orchestrator's launch cwd. The miss is SILENT — `is_file()` false, an
+            # empty seed, and then the activation shadows the file git really reads.
             source = worktree / source
     # `is_file()` is the ABSENT test and swallows its own OSError; `read_bytes`
     # on a file that exists but cannot be read raises, deliberately (docstring).
@@ -2228,55 +1960,35 @@ def _shield_verify_activation(worktree: Path, exclude: Path) -> str | None:
 
     A successful `git config --worktree core.excludesFile` proves the value was
     WRITTEN, not that it is in FORCE. git resolves the key from the most specific
-    scope that carries it, and `worktree` is not the most specific one — `command`
-    outranks it, and that scope is fed by the ENVIRONMENT the orchestrator was
-    launched with. So an operator carrying an ambient `core.excludesFile` gets a
-    shield that reports success, writes the private file, and never has it read:
-    the provisioned tool files stay stageable by the unit's `git add -A`, with no
-    degrade reason to journal. Round 17 was "a pattern PRESENT in the file is not
-    EFFECTIVE"; this is the same gap one level up — WRITTEN is not EFFECTIVE.
+    scope that carries it, and `command` — a scope fed by the ENVIRONMENT the
+    orchestrator was launched with — outranks `worktree`. So an operator carrying an
+    ambient `core.excludesFile` gets a shield that reports success and whose private
+    file is never read: the provisioned tool files stay stageable by the unit's
+    `git add -A`, with no degrade reason to journal.
 
-    So the post-condition is asked of git rather than assumed, and the shape is the
-    point. The obvious fix is to detect the ORIGIN — look for `GIT_CONFIG_COUNT`
-    and friends in `os.environ` — and it is the enumeration this function exists to
-    avoid, because the channels are neither one nor stable. Measured end to end, on
-    a real linked worktree with the shield fully installed, at BOTH ends of the
-    supported range:
+    So the post-condition is asked of git. Detecting the ORIGIN instead —
+    `GIT_CONFIG_COUNT` and friends in `os.environ` — is the enumeration this function
+    exists to avoid: `GIT_CONFIG_COUNT` does not exist at this shield's own 2.20
+    floor, `GIT_CONFIG_PARAMETERS` does but in two mutually incompatible encodings
+    across the supported range, and a `git -c` on a session's own command line never
+    appears in our environment at all. Asking git what it RESOLVED costs one call and
+    covers all of them, and whatever git adds next.
 
-                                        git 2.20.4        git 2.55.0
-        GIT_CONFIG_COUNT/KEY_n/VALUE_n  inert (2.31)      shield defeated
-        GIT_CONFIG_PARAMETERS 'k=v'     shield defeated   shield defeated
-        GIT_CONFIG_PARAMETERS 'k'='v'   fatal: bogus      shield defeated
-        what `git -c` itself emits      'k=v'             'k'='v'
+    `--show-scope` would name the winning scope, and is deliberately not used: it is
+    git 2.26, above the 2.20 floor, and a probe flag with its own version floor turns
+    every rc-branch below it into a silent default.
 
-    Three names in two mutually incompatible encodings, and the one the finding
-    that prompted this named does not exist at this shield's own floor. A `git -c`
-    on a session's own command line is a fourth and is not visible in our
-    environment at all. Asking git what it RESOLVED costs one call and covers every
-    one of them, including whatever git adds next.
+    The read shape is the seed read's: `-z` because a legal POSIX path may carry edge
+    whitespace, `--type=path` because that is how git itself resolves the key. Any
+    non-zero rc is a fault here, not an ABSENT answer — this call asks about a key we
+    have just written, so "there is no such key" is not good news about it. That is a
+    DIFFERENT taxonomy from `_shield_inherited_excludes`, which reads a key the
+    operator may never have set; the two must not be unified.
 
-    `--show-scope` would name the winning scope and make the reason better, and is
-    deliberately not used: it is git 2.26, above the 2.20 floor, and a probe flag
-    with its own version floor turns every rc-branch below it into a silent default
-    (the `--type=` 2.18 trap, one round-1 finding away from this one).
-
-    The read shape is the seed read's, already measured at 2.20.4 and 2.55.0: `-z`
-    because a legal POSIX path may carry edge whitespace, `--type=path` because
-    that is how git itself resolves the key. Any non-zero rc is a fault here rather
-    than an ABSENT answer — this call asks about a key we have just written, so
-    "there is no such key" is not good news about it. That is a DIFFERENT taxonomy
-    from `_shield_inherited_excludes`, which reads a key the operator may simply
-    not have set; the two must not be unified.
-
-    The comparison is byte-exact and stays that way. Round-tripping a path through
-    `git config` and back was measured for every hazard this shield has already
-    been burned by — a space, leading and trailing whitespace, an embedded newline,
-    a non-UTF-8 byte, an interior `~` — all seven exact at both versions, so an
-    inexact comparison would be buying nothing and could only mask a real
-    mismatch. Windows CI is the oracle for the one platform not measured here: git
-    escapes a backslash path it is handed as an ARGUMENT and reads it back intact,
-    which is why the shield's other tests pass there, but that claim is about the
-    config file rather than about `--type=path`.
+    The comparison is byte-exact and stays that way: `git config` round-trips a path
+    verbatim through every hazard this shield has been burned by — edge whitespace,
+    an embedded newline, a non-UTF-8 byte, an interior `~` — so loosening it would
+    buy nothing and could only mask a real mismatch.
     """
     resolved = git_bytes(worktree, "config", "-z", "--type=path", "--get", "core.excludesFile")
     if resolved.returncode != 0:
@@ -2293,182 +2005,76 @@ def _shield_verify_activation(worktree: Path, exclude: Path) -> str | None:
 
 def _worktree_local_exclude(worktree: Path, patterns: Sequence[str]) -> str | None:
     """Shield the just-provisioned tool files from the unit's `git add -A`, in a
-    private exclude file scoped to THIS worktree alone.
+    private exclude scoped to THIS worktree.
 
-    Two properties, both load-bearing, and both of them were wrong before #384:
+    SCOPE — the patterns land in `<worktree gitdir>/info/exclude`, activated by
+    `git config --worktree core.excludesFile`. Git's only per-repo exclude is
+    `$GIT_COMMON_DIR/info/exclude`, so the private file is inert without that key,
+    which applies it to this worktree alone — main checkout and siblings untouched.
 
-    - SCOPE — the patterns land in `<worktree gitdir>/info/exclude`
-      (`.git/worktrees/<id>/info/exclude`), activated by
-      `git config --worktree core.excludesFile <that path>`. Git only ever reads
-      `$GIT_COMMON_DIR/info/exclude`, so the private file does nothing on its own;
-      the worktree-scoped config key is what makes it apply, and it applies to
-      this worktree only. The main checkout and every sibling worktree are
-      untouched. Writing that key is not the same as it being in FORCE — `command`
-      scope outranks `worktree`, and it is fed by the environment the orchestrator
-      was launched with — so the activation is VERIFIED against what git actually
-      resolves rather than trusted; see `_shield_verify_activation`.
-    - LIFETIME — `git worktree remove`/`prune` deletes the whole per-worktree
-      gitdir, taking the private exclude AND the `config.worktree` that points at
-      it. The shield expires exactly when the thing it shields does; there is no
-      remover to keep in step with it.
+    LIFETIME — `git worktree remove`/`prune` deletes the per-worktree gitdir, taking
+    the exclude and the `config.worktree` pointing at it: the shield expires with
+    what it shields.
 
-    The repository-wide `.git/info/exclude` is NEVER written again, on any path.
-    That file is what #384 reported: shared by every worktree, permanent, and
-    unversioned, so patterns naming directories a project legitimately tracks
-    (`.claude/skills`, `.claude/settings.json`) went on hiding every NEW file
-    under them from `git add -A` in the operator's own checkout, long after the
-    run that wrote them. The old docstring's defense — that an exclude "does not
-    affect already-tracked files" — is precisely what made it invisible: the
-    tracked files kept diffing normally while their new siblings vanished. So a
-    refusal below SKIPS the shield and reports; falling back to the shared file
-    would reintroduce the bug this function exists to fix.
+    The repository-wide `.git/info/exclude` is NEVER written again on any path
+    (#384): a refusal SKIPS the shield rather than falling back to it.
 
-    The price is a permanent one: `extensions.worktreeConfig` is repo-wide format
-    state, enabled once and never removed here, and git versions older than 2.20
-    refuse to access a repository carrying it (git-worktree(1)). See
-    `_shield_enable_worktree_config` for the two shapes where enabling it is
-    refused outright. It is paid at the LAST possible moment, so no degrade above it
-    can charge it: that function probes, and the write itself happens here, one line
-    above the activation. Enabling it up front — where it used to be — charged the operator's
-    repo that permanent price on every path that then degraded away without
-    shielding anything. Moving it down leaves exactly two writes able to set it
-    without shielding anything — the enable itself and the activation — and each
-    classifies both of the ways a chokepoint call can fail (a non-zero rc and a
-    raise). The ACTIVATION rolls the flag back on either shape, and on a third
-    outcome that is not a failure at all — a write that succeeds without taking
-    effect, which a later round showed is reachable whenever the environment
-    supplies the same key at `command` scope. The ENABLE rolls it
-    back on the raise ONLY, because an rc from that write is git declining to make
-    it: nothing was written, so there is nothing to undo, and undoing it anyway
-    would unset a concurrent writer's flag. That asymmetry is load-bearing, not an
-    unfinished enumeration. Getting here took five review rounds, because the early
-    attempts enumerated failure shapes instead of funnelling them, the funnel was
-    then applied to the activation but not to the enable one line above it, and even
-    a complete funnel over the ways a CALL can fail said nothing about whether the
-    call achieved what it was for. Rollback
-    only when this call is what set the flag, and only when no other worktree's
-    `config.worktree` depends on it; see `_shield_undo_extension`.
+    PRICE — `extensions.worktreeConfig` is repo-wide format state a successful shield
+    leaves permanently enabled, and git older than 2.20 refuses to access a repository
+    carrying it (git-worktree(1)). It is enabled at the LAST possible moment,
+    immediately before the activation. The ACTIVATION rolls it back on a non-zero rc,
+    on a raise, and on a write that succeeded without taking effect
+    (`_shield_verify_activation`); the ENABLE only on the raise, since an rc means git
+    declined to write and an unset would remove a concurrent writer's flag. Both are
+    gated on this call having set the flag and no sibling worktree depending on it
+    (`_shield_undo_extension`).
 
-    CONCURRENCY — the probe→enable→activate→rollback sequence runs under an exclusive
-    `file_lock` on `<common dir>/bmad-loop-shield.lock`, because that flag is the one
-    piece of state two simultaneous runs in one repository share (round 8). Without
-    it both probe an absent flag, both believe they own it, and a failed activation
-    in one rolls the flag back out from under the other's live shield. The lock is
-    per REPOSITORY, not per worktree, and it leaves a residue: a zero-length file in
-    `.git/` — never in the working tree, so nothing the operator's `git add -A` can
-    see, and nothing that needs a stale-lock scheme, since the kernel drops the lock
-    when a holder dies. Its wait is platform-asymmetric by inheritance: POSIX `flock`
-    blocks indefinitely (the transaction is ~7 git spawns, each bounded by
-    `limits.git_timeout_s`), while `msvcrt.locking` gives up after ~10 s and raises
-    `OSError`, which this function reports as a skipped shield naming the lock.
+    Every git call goes through `verify.git_bytes`: the returncode is an ANSWER, not
+    a raise, and stdout arrives as BYTES.
 
-    Every git call goes through `verify.git_bytes`, the chokepoint accessor whose
-    two properties this function is built on: the returncode comes back as an
-    ANSWER rather than a raised fault (`config --get` of an unset key exits 1, and
-    that reply is what tells the shield to enable the extension or fall through to
-    the XDG default), and stdout arrives as BYTES, since POSIX filenames are bytes
-    and a strict decode would raise `UnicodeDecodeError` out of the silent arm
-    below, which promises never to propagate (#374). Standing inside it also buys
-    the `LC_ALL=C` pin and the `limits.git_timeout_s` bound the engine configures.
-
-    Best-effort in two arms that must stay separate, because a fault means the
-    opposite thing in each:
+    Best-effort in two arms, separate because a fault means the opposite in each:
 
     - git unqueryable BEFORE GIT HAS ANSWERED AT ALL (not a repo, git missing, a
-      timeout or spawn failure on the first `rev-parse` — both `GitError`) is an
-      EXPECTED skip — returns None silently. That scope is the whole of it, and the
-      qualifier is load-bearing: read loosely as "any `GitError` is silent" it
-      licensed the swallow round 5 deleted from `_shield_inherited_excludes`, which
-      is BELOW this arm and therefore in the one below. Callers hand this
-      plain temp dirs routinely. Nothing is DECODED in this arm: git's stdout is
-      captured as bytes and decoded in the tail below, because a decode fault is a
-      degrade (git answered; we could not read it), not the silent skip this arm
-      means (#374). A git too old for a flag is NOT here: rev-parse echoes an
-      option it does not know and exits 0, so that lands in the arm below, via
-      the version refusal in `_shield_enable_worktree_config`.
-    - anything AFTER git answered degrades to a returned reason string the caller
-      can surface: the `--git-common-dir` probe failing once `--absolute-git-dir`
-      has already answered (round 11 — it sat in the silent arm above from round 3,
-      when one combined `rev-parse` became two calls, until this list was read as
-      the specification it is), a main checkout passed in (nothing to scope to), a
-      repository configured to be shared between OS users (refused above the lock —
-      see `_shield_shared_repository`), a
-      shield lock that could not be taken (contention on Windows, or an `os.open`
-      fault in the common dir), a refused or
-      failed extension enable, a failed activation, `.resolve()` (pre-3.13 a
-      symlink loop raises RuntimeError, not OSError), `mkdir`, read/write
-      `OSError` — including the operator's own excludes file existing but being
-      unreadable, which must NOT be silent, because activating over patterns that
-      could not be copied shadows them — a later git call timing out or failing to
-      spawn (`GitError`), and a `UnicodeError` (below). Since round 5 that
-      `GitError` case explicitly covers a git that will not say WHICH excludes file
-      applies: not knowing whether there is anything to copy is the same standing as
-      knowing there is and failing to read it, because the activation shadows it
-      either way. Only a definite ABSENT answer stays silent. Silence here is not
-      cosmetic: without the exclude the unit's `git add -A` commits the tool files
-      this provisioning just wrote into the story's merge.
+      timeout or spawn failure on the FIRST `rev-parse` — both `GitError`) is an
+      EXPECTED skip: returns None silently. That scope is the whole of it.
+    - anything AFTER git answered degrades to a returned reason string; only a
+      definite ABSENT answer stays silent. Silence is not cosmetic: without the
+      exclude the unit's `git add -A` commits the tool files just provisioned.
 
-    The exclude PAYLOAD is bytes end-to-end — read, dedupe and write — so nothing
-    on this path decodes or encodes an exclude file at all. That leaves two real
-    sources for the `UnicodeError` in the tail's tuple, neither of them a
-    file-content codec fault: the `os.fsdecode` of git's own stdout, which can raise
-    on Windows only (#374/#377), and `os.fsencode` of a caller's pattern when that
-    pattern carries a surrogate POSIX surrogateescape never produced — a
-    hand-authored `"\\ud800"` in a config string rather than a real filename, which
-    fsencode's surrogateescape rejects. The seed_globs case the tuple was originally
-    written for is GONE: a pattern built from a genuinely non-UTF-8 filename arrives
-    surrogate-escaped and `os.fsencode` returns its exact original bytes (POSIX);
-    Windows' utf-8/surrogatepass encodes such a name to WTF-8 without raising.
+    The exclude PAYLOAD is bytes end-to-end, so the tail's `UnicodeError` has two
+    sources: `os.fsdecode` of git's stdout, Windows-only (#374/#377), and
+    `os.fsencode` of a pattern carrying a surrogate POSIX surrogateescape never
+    produced.
     """
     # Callers pass POSIX-slash patterns (glob rels via as_posix; config strings as
     # authored); git's exclude is POSIX-slash on every platform, so nothing to fix here.
     try:
         # ONE path per call, never both in one answer. `rev-parse` separates its
-        # answers with a newline, which is a legal BYTE IN A POSIX PATH — asking
-        # for both at once made the split of a repo directory carrying one produce
-        # four "paths" instead of two, and the length check below then degraded the
-        # shield away *after* provisioning had copied the very files it exists to
-        # hide (verified, git 2.55: the newlines come back raw, unquoted). No
-        # NUL-delimited mode to reach for instead — `rev-parse` has no `-z`; it
-        # echoes one back as a literal argument. A path that ENDS in a newline is
-        # still beyond this parse, and beyond rev-parse's output format itself.
+        # answers with a newline, a legal BYTE IN A POSIX PATH: asking for both at once
+        # mis-split a repo directory carrying one, degrading the shield away *after*
+        # provisioning had copied the very files it exists to hide. No NUL-delimited
+        # mode to reach for instead — `rev-parse` has no `-z`. A path ENDING in a
+        # newline is beyond this parse either way.
         answered = git_bytes(worktree, "rev-parse", "--absolute-git-dir")
         if answered.returncode != 0:
-            # Not a repo (rc 128) — the expected skip the previous `check=True` raised
-            # its way into. NOT "a git too old for `--absolute-git-dir`", which this
-            # comment used to also claim: rev-parse ECHOES an option it does not know
-            # and exits 0 (measured), so a git predating the flag (2.13) answers with
-            # the flag's own name. That lands in the git 2.20 refusal in
-            # `_shield_enable_worktree_config`, which returns above any write — a
-            # degrade, not this silent skip.
+            # Not a repo (rc 128), the expected skip — NOT "a git too old for
+            # `--absolute-git-dir`": rev-parse ECHOES an option it does not know and
+            # exits 0, so a git predating the flag lands in the git 2.20 refusal in
+            # `_shield_enable_worktree_config` — a degrade, not this silent skip.
             return None
     except GitError:
-        # GitError alone, and it is not a narrowing: this `try` wraps ONE git call
-        # and nothing else that can raise, and every fault the chokepoint raises out
-        # of it is a GitError — a timeout directly, a spawn failure as
-        # GitSpawnError, which subclasses it. The `OSError` that used to belong here
-        # was the spawn fault's raw form and is now translated before it arrives.
+        # GitError alone is the whole taxonomy here: this `try` wraps ONE git call, and
+        # the chokepoint raises a timeout as GitError and a spawn failure as its
+        # GitSpawnError subclass — the translated form of the `OSError` this arm once
+        # caught.
         return None
     try:
-        # The COMMON-DIR probe lives in THIS try, not the silent one above, and that
-        # placement IS the fix (round 11). Once `--absolute-git-dir` has answered,
-        # git has identified the repository, so every later fault is on the degrade
-        # side of the two-arm taxonomy — which the silent arm's own docstring already
-        # said ("a timeout or spawn failure on the FIRST rev-parse ... that scope is
-        # the whole of it, and the qualifier is load-bearing"), and which
-        # `worktree_flow`'s contract says too ("any fault after that ... is reported
-        # to on_degraded rather than swallowed"). Round 3 split one combined
-        # `rev-parse` into two calls to survive a newline in a repo path, and the
-        # second call inherited the first's silent arm — leaving a timeout on it to
-        # skip the shield with NO reason, after provisioning had already copied the
-        # files the shield exists to hide.
-        #
-        # Both failure shapes are handled without an `except` of its own, per round
-        # 7's funnel lesson: a non-zero rc returns the specific reason below, and a
-        # raise is caught by this try's tail, which reports a reason too. The tail
-        # also catches the `UnicodeError` this `fsdecode` of git's stderr can raise
-        # on Windows — the same defect #394 records at a sibling block, so the stderr
-        # read is deliberately INSIDE a guarded region rather than above one.
+        # The COMMON-DIR probe belongs in THIS try, not the silent one above: once
+        # `--absolute-git-dir` has answered, git has identified the repository, so every
+        # later fault degrades with a reason instead of skipping the shield silently. No
+        # `except` of its own: a non-zero rc returns the reason below, a raise lands in
+        # this try's tail — which also catches the `UnicodeError` the `fsdecode` of
+        # git's stderr can raise on Windows, hence that read sits inside the guard.
         shared_answer = git_bytes(worktree, "rev-parse", "--git-common-dir")
         if shared_answer.returncode != 0:
             detail = (
@@ -2480,43 +2086,26 @@ def _worktree_local_exclude(worktree: Path, patterns: Sequence[str]) -> str | No
                 f"repository but could not name its common dir: {detail} — the "
                 "provisioned tool files are not shielded from the unit's `git add -A`"
             )
-        # fsdecode, so a non-UTF-8 repo path round-trips back to the filesystem
-        # instead of faulting. It can still raise on Windows (utf-8/surrogatepass
-        # rejects a lone invalid byte), which is why it sits inside this try —
-        # defensive placement rather than a path under test: the regression test
-        # is POSIX-only because git on Windows has no such path to hand back.
+        # fsdecode, so a non-UTF-8 repo path round-trips back to the filesystem instead
+        # of faulting; it can still raise on Windows (utf-8/surrogatepass rejects a lone
+        # invalid byte), which is why it sits inside this try.
         #
         # removesuffix("\n"), NOT strip() — rev-parse terminates its answer with one
-        # newline and every other byte belongs to the path (#384, Codex round 15).
+        # newline and every other byte belongs to the path. A BARE repo's common dir IS
+        # the repository directory, so one at `…/common ` comes back with its trailing
+        # space (`--absolute-git-dir` stays safe: git sanitizes the admin id). Stripping
+        # pointed every later step at `…/common`, which does not exist, where `--file
+        # <that>/config` reads rc 1, i.e. ABSENT — so the `core.bare = true` refusal was
+        # MISSED and the shield made its permanent format change on a bare repository.
         #
-        # This comment used to argue strip() was harmless because "a final component
-        # is `.git` or `worktrees/<id>`". That is true for a NON-bare repo and false
-        # for a bare one, whose common dir IS the repository directory. Measured at
-        # 2.55.0, a worktree of a bare repo at `…/common ` answers
-        # `--git-common-dir` = `…/common ` — trailing space and all — while
-        # `--absolute-git-dir` stays safe at `…/common /worktrees/<id>`, since git
-        # sanitizes the admin id (round 5). So exactly one of the two answers was
-        # exposed, and stripping it pointed every later step at `…/common`, which does
-        # not exist: `--file <that>/config` reads rc 1, i.e. ABSENT (round 10), so the
-        # `core.bare = true` refusal was MISSED and the shield went on to make the
-        # permanent format change on a bare repository. The lock's own
-        # `mkdir(parents=True)` then CREATED the stripped directory as a side effect.
-        # A safety gate defeated by whitespace in a path, which is why this is the
-        # parse and not a cosmetic.
-        #
-        # The dropped CRLF absorption is deliberate: git writes LF here on every
-        # platform, and a path legitimately ending in `\r` is indistinguishable from a
-        # CRLF terminator — so guessing would trade this bug for a rarer one. Windows
-        # CI is the oracle: were git to emit CRLF there, every shield test would fail
-        # on the malformed path rather than degrade quietly.
+        # CRLF is deliberately not absorbed: git writes LF here on every platform, and a
+        # path legitimately ending in `\r` is indistinguishable from a CRLF terminator.
         raw_git_dir = os.fsdecode(answered.stdout).removesuffix("\n")
         raw_common = os.fsdecode(shared_answer.stdout).removesuffix("\n")
         if not raw_git_dir or not raw_common:
-            # Defensive, and deliberately still a REASON rather than a silent skip:
-            # git answered, so the two-arm taxonomy in the docstring puts an
-            # unreadable answer on the degrade side. Unreachable with real git — an
-            # rc of 0 from `rev-parse` always prints a path — which is the same
-            # standing the fsdecode placement above has.
+            # Defensive, and deliberately a REASON rather than a silent skip: git
+            # answered. Unreachable with real git — an rc 0 from `rev-parse` always
+            # prints a path.
             return (
                 f"could not read this worktree's git dirs ({worktree}): "
                 f"{raw_git_dir!r}, {raw_common!r}"
@@ -2525,7 +2114,7 @@ def _worktree_local_exclude(worktree: Path, patterns: Sequence[str]) -> str | No
         common_dir = Path(raw_common)
         if not common_dir.is_absolute():
             # a PLAIN checkout answers with a relative ".git"; a linked worktree
-            # answers with the main repo's absolute .git (verified, git 2.55).
+            # answers with the main repo's absolute .git.
             common_dir = worktree / common_dir
         # resolve BOTH before comparing: --absolute-git-dir is absolute but not
         # canonical, so a symlinked repo path would otherwise read as two
@@ -2534,51 +2123,38 @@ def _worktree_local_exclude(worktree: Path, patterns: Sequence[str]) -> str | No
         if git_dir == common_dir:
             # The main checkout itself: its gitdir IS the common dir, so the only
             # exclude file to write would be the shared one — the #384 bug.
-            # Nothing here is transient enough to shield, so say so and stop.
             return (
                 f"skipped the git-add shield ({worktree}): not a linked worktree, and the "
                 "shield never writes the repository-wide exclude (#384)"
             )
-        # ABOVE THE LOCK DELIBERATELY, and the placement is the whole value of this
-        # gate: a repository shared between OS users is refused before anything is
-        # created in it, so every user gets this same reason rather than the second
-        # one meeting a lock file the first left behind. Safe above the lock because
-        # `core.sharedRepository` is static config the tool never writes — unlike
-        # `extensions.worktreeConfig` there is no shared mutable state to serialize.
-        # It is one deletion point if shared repositories are ever supported for real.
-        # A `GitError` from the read lands in this try's tail, which returns a reason.
+        # ABOVE THE LOCK DELIBERATELY: a repository shared between OS users is refused
+        # before anything is created in it, so every user gets the same reason rather
+        # than the second one meeting a lock file the first left behind. Safe there
+        # because `core.sharedRepository` is static config the tool never writes — no
+        # shared mutable state to serialize. A `GitError` from the read hits this tail.
         shared_repository = _shield_shared_repository(worktree, common_dir)
         if shared_repository is not None:
             return shared_repository
-        # EVERYTHING BELOW IS ONE TRANSACTION, serialized per repository — round 8
-        # (#384, Codex P2). `_shield_enable_worktree_config` PROBES the flag and the
-        # enable further down is an idempotent no-op when it is already `true`, so two
-        # concurrent provisionings in one repo both read an absent flag, both believe
-        # they enabled it, and whichever one's activation then fails rolls the flag
-        # back out from under the other's LIVE shield — git stops reading its
-        # `config.worktree`, its `core.excludesFile` goes inert, and its shielded tool
-        # files become stageable again mid-run. Nothing else collides first: every
-        # other per-run name is keyed on the run id (worktree path, branch, tmux
-        # session, run dir), so the flag is the one piece of state two runs share.
-        # `cmd_run` has no liveness check and the TUI's warning modal offers "launch
-        # anyway", so concurrent runs against one repo are permitted by design.
+        # EVERYTHING BELOW IS ONE TRANSACTION, serialized per repository.
+        # `_shield_enable_worktree_config` only PROBES the flag, so two concurrent
+        # provisionings both read it absent, both believe they enabled it, and whichever
+        # one's activation fails rolls the flag back out from under the other's LIVE
+        # shield — its `core.excludesFile` goes inert and its shielded tool files become
+        # stageable again mid-run. That flag is the one piece of state two runs share;
+        # every other per-run name is keyed on the run id. Concurrent runs in one repo
+        # are permitted by design — `cmd_run` has no liveness check and the TUI offers
+        # "launch anyway".
         #
-        # The lock also removes a benign second consequence: `git config` writes take
-        # `.git/config.lock`, so a concurrent writer got an rc≠0 the enable read as a
-        # degrade and skipped the shield for that unit.
+        # The span cannot be narrowed to those writes: the enable must stay immediately
+        # above the activation, the private exclude must exist before it, and the
+        # version + `core.bare`/`core.worktree` gates inside the probe must stay above
+        # the seed read, which shares the same `--type=` floor. So the file write sits
+        # inside the locked span.
         #
-        # It spans the probe→enable→activate→rollback sequence and cannot be narrowed
-        # to just those: the enable must stay immediately above the activation (round
-        # 5), the private exclude must exist before the activation, and the version +
-        # `core.bare`/`core.worktree` gates inside the probe must stay above the seed
-        # read, which depends on the same `--type=` floor. So the file write sits in
-        # the middle of the locked span rather than outside it.
-        #
-        # The acquisition's own `OSError` is caught HERE rather than left to the tail,
-        # only so the operator is told which step failed: POSIX `flock` blocks
-        # indefinitely, but `msvcrt.locking` bounds the wait at ~10 s and then raises,
-        # so on Windows contention is a real, reportable outcome. Behaviorally the
-        # tail would also return a reason — this arm names the lock in it.
+        # The acquisition's own `OSError` is caught HERE only so the operator is told
+        # which step failed: POSIX `flock` blocks indefinitely, but `msvcrt.locking`
+        # bounds the wait at ~10 s and then raises, so Windows contention is a real,
+        # reportable outcome.
         held = ExitStack()
         try:
             held.enter_context(file_lock(common_dir / _SHIELD_LOCK_NAME))
@@ -2593,71 +2169,54 @@ def _worktree_local_exclude(worktree: Path, patterns: Sequence[str]) -> str | No
                 return refusal
             exclude = git_dir / "info" / "exclude"
             exclude.parent.mkdir(parents=True, exist_ok=True)
-            # Zero bytes is an INTERRUPTED creation, not an initialized exclude. The
-            # `touch()` below creates the target before `atomic_write_bytes` fills it, and
-            # a fault in between (ENOSPC, or a kill) leaves that placeholder behind —
-            # harmless on its own, since the degrade arm returns above the activation and
-            # an unactivated private exclude does nothing. The harm would be deferred:
-            # read as authoritative, it skips the seed below and then points a shadowing
-            # `core.excludesFile` at a file missing the operator's own excludes,
-            # un-ignoring inside the worktree everything they ignore globally. Size
-            # rather than unlinking the placeholder on the way out, because no handler
-            # runs when the process is KILLED in that window. Re-seeding costs nothing
-            # either way: git treats an empty exclude and an absent one alike.
+            # Zero bytes is an INTERRUPTED creation (a kill or ENOSPC between the
+            # `touch()` and the fill below), not an initialized exclude: read as
+            # authoritative it skips the seed below and then points a shadowing
+            # `core.excludesFile` at a file missing the operator's own excludes. Sized
+            # rather than unlinked on the way out, because no handler runs on a KILL.
             existed = exclude.is_file() and exclude.stat().st_size > 0
             # On creation the operator's own excludes are copied in, because the
-            # activation below shadows them (see _shield_inherited_excludes). On a
-            # re-provision a non-empty file's content is authoritative and the copy is
-            # not repeated, so the two stay idempotent together.
+            # activation below shadows them (see _shield_inherited_excludes); on a
+            # re-provision a non-empty file is authoritative, so the two are idempotent.
             #
-            # A COPY FAULT SKIPS THE ACTIVATION. `_shield_inherited_excludes` raises on
-            # anything but a definite "absent" — an unreadable file, and since round 5 a
-            # git that will not say which file applies — and the raise lands in this
-            # function's tail, which returns a reason. That is the whole point of it
-            # raising rather than returning empty: an empty seed plus the activation
-            # below is not "the seed was lost", it is the operator's global ignores
-            # SHADOWED inside this worktree, and `git add -A` staging what they told git
-            # to ignore. There is nothing to clean up on that path — the raise is above
-            # `exclude.touch()`, so no placeholder is left for a later provisioning to
-            # read as authoritative, and the `mkdir` above leaves an inert empty `info/`
-            # that dies with the worktree.
+            # A COPY FAULT SKIPS THE ACTIVATION: `_shield_inherited_excludes` raises on
+            # anything but a definite ANSWER — an unreadable file, or a git that will
+            # not say which file applies — and the raise lands in this function's tail,
+            # which returns a reason. It raises rather than returning empty
+            # because an empty seed plus the activation below is not a lost seed but
+            # the operator's global ignores SHADOWED inside this worktree, with `git
+            # add -A` staging what they told git to ignore. The raise is above
+            # `exclude.touch()`, so no placeholder is left behind.
             #
-            # BYTES on both sides of that choice, and never decoded text: an exclude
-            # file holds path patterns, POSIX paths are arbitrary bytes, and a legacy
-            # 8-bit encoding is a perfectly ordinary thing for an operator's own file to
-            # be in. `bytes.splitlines()` is also the git-CORRECT line split, not merely
-            # the type-consistent one — `str.splitlines()` breaks on \x0b, \x0c, \x1c,
-            # \x1d, \x1e and \x85, none of which git treats as a line boundary, so a
-            # legitimate pattern containing one fragmented into wrong dedupe keys.
+            # BYTES, never decoded text: an exclude holds path patterns, POSIX paths
+            # are arbitrary bytes, and an operator's own file may be in any legacy
+            # 8-bit encoding. `bytes.splitlines()` is also the git-CORRECT split —
+            # `str.splitlines()` breaks on \x0b, \x0c, \x1c, \x1d, \x1e and \x85, none
+            # of which git treats as a line boundary, so a legitimate pattern carrying
+            # one fragments into wrong dedupe keys.
             existing = exclude.read_bytes() if existed else _shield_inherited_excludes(worktree)
             lines = existing.splitlines()
-            # PRESENT IS NOT THE SAME AS EFFECTIVE (#384, Codex round 17). gitignore's
-            # rule is LAST MATCH WINS, so a pattern this file already contains can be
-            # cancelled by a `!` line below it — and a plain set-membership dedupe then
-            # declined to append the shield's own pattern, leaving the provisioned tool
-            # files stageable with NO degrade reason at all, because nothing failed.
-            # Measured end-to-end through this function: seeded from an operator's
-            # `core.excludesFile` holding `/.claude/skills` then `!/.claude/skills`,
-            # `git status --porcelain -uall` in the worktree answers
-            # `?? .claude/skills/tool.md` and `git add -A` stages it.
+            # PRESENT IS NOT THE SAME AS EFFECTIVE (#384). gitignore is LAST MATCH
+            # WINS, so a pattern this file already contains can be cancelled by a `!`
+            # line below it, and a plain set-membership dedupe then declined to append
+            # the shield's own pattern — leaving the provisioned tool files stageable
+            # with NO degrade reason at all, because nothing failed. So a pattern may
+            # be skipped only where it is GUARANTEED effective: it sits after the LAST
+            # negation. No later line can negate it, so the last pattern matching any
+            # path it covers is either this one or a positive below it, and both
+            # ignore. Anything earlier is appended, which is always safe — the appended
+            # copy is last, so it decides.
             #
-            # So a pattern may be skipped only where it is already GUARANTEED effective:
-            # it sits after the LAST negation in the file. That is airtight without
-            # reimplementing git's matching — no later line can negate it, so the last
-            # pattern matching any path it covers is either this one or a positive below
-            # it, and both ignore. Anything earlier is appended instead, which is always
-            # safe: the appended copy is last, so it is the one that decides.
+            # Deliberately CONSERVATIVE rather than exact: the only negation that
+            # actually defeats the shield re-includes the pattern's own directory
+            # (`!.claude/skills` does it too — it need not repeat the positive's
+            # spelling), while `!*.md` below it does not, since git never descends into
+            # an excluded directory, and neither does `!/.claude`, since re-including a
+            # parent leaves the child matched. Telling those apart is git's matcher, so
+            # this appends a duplicate in the harmless cases instead of guessing.
             #
-            # Deliberately CONSERVATIVE rather than exact. Measured, the only negation
-            # that actually defeats the shield is one re-including the pattern's own
-            # directory (`!.claude/skills` does it too — the negation need not repeat the
-            # positive's spelling); a `!*.md` below it does NOT, since git never descends
-            # into an excluded directory, and neither does `!/.claude`, since re-including
-            # a parent leaves the child matched. Telling those apart is git's matcher, so
-            # this appends a duplicate line in the harmless cases instead of guessing.
-            #
-            # `startswith(b"!")` with NO lstrip, which is git-correct twice over: git does
-            # not strip leading whitespace from a pattern, and `\!` escapes a literal
+            # `startswith(b"!")` with NO lstrip is git-correct twice over: git does not
+            # strip leading whitespace from a pattern, and `\!` escapes a literal
             # leading `!` — both then read as positives here, as they do in git.
             last_negation = max(
                 (i for i, line in enumerate(lines) if line.startswith(b"!")), default=-1
@@ -2676,96 +2235,51 @@ def _worktree_local_exclude(worktree: Path, patterns: Sequence[str]) -> str | No
                 # not in the tail's except tuple — it would escape a function contracted
                 # never to propagate.
                 prefix = existing if not existing or existing.endswith(b"\n") else existing + b"\n"
-                # atomic_write_bytes, never write_bytes onto `exclude` directly (#375).
-                # write_bytes opens "wb", which TRUNCATES before writing, and this is a
-                # read-modify-REWRITE carrying the operator's own excludes in
-                # `prefix` — so a short write (ENOSPC) left the file truncated
-                # mid-content while the degrade reason still said "could not update".
-                # The harm runs the opposite way from a blanket exclusion: the cut
-                # loses shield lines, so the unit's `git add -A` stages the tool files
-                # provisioning wrote into the story's own commit. (A truncation landing
-                # on a bare "/" is inert — git strips it to a zero-length pattern that
-                # matches nothing; only the LOST lines matter.)
-                #
-                # The helper rather than a hand-rolled tmp+replace: it fsyncs before
-                # the replace and carries the target's mode over, which a bare replace
-                # resets.
-                #
-                # #381's interleaving race is mooted for NEW writes rather than fixed:
-                # this file lives in one worktree's private gitdir, so the two runs
-                # that used to race here — every linked worktree of a repo resolved to
-                # the same shared common dir — no longer share a target at all. Only a
-                # second provisioning of the SAME worktree can reach this file, which
-                # the engine does serially. The atomic write stays for #375, whose
-                # fault (a short write) needs no second writer.
+                # atomic_write_bytes, never write_bytes onto `exclude` directly (#375):
+                # "wb" TRUNCATES before writing, and this is a read-modify-REWRITE
+                # carrying the operator's own excludes in `prefix`, so a short write
+                # (ENOSPC) left the file truncated mid-content — losing shield lines —
+                # while the degrade reason still said "could not update". The helper
+                # rather than a hand-rolled tmp+replace: it fsyncs before the replace
+                # and carries the target's mode over, which a bare replace resets.
+                # #381's interleaving race is moot here — the file is one worktree's
+                # private gitdir, so no two runs share the target — but the atomic
+                # write stays for #375, whose fault needs no second writer.
                 if not existed:
-                    # Create it first, the way the write_text this replaced did:
-                    # O_CREAT under the umask, giving the helper a mode to carry.
-                    # BEHAVIOR PRESERVATION is the whole of the rationale (#375).
-                    # `atomic_write_bytes` carries a mode over only when the target
-                    # already EXISTS — its own docstring says a fresh one gets
-                    # mkstemp's private 0600 — so dropping this line would narrow
-                    # every private exclude's mode as an unannounced side effect of
-                    # that refactor.
-                    #
-                    # The mode is load-bearing only where another OS user reads this
-                    # gitdir, and that configuration no longer reaches here:
-                    # `_shield_shared_repository` refuses a repository configured
-                    # `core.sharedRepository` above the lock (#384). What keeps the
-                    # line anyway is the SHAPE the mode's failure takes — measured,
-                    # git treats an exclude it cannot read as one that is not there:
-                    # it warns, exits 0, and `git add -A` stages the very files the
-                    # exclude was written to shield, with no degrade reason at all
-                    # because the write SUCCEEDED. Silence is the one outcome this
-                    # function's docstring rules out, so a line that cannot produce
-                    # it is worth its cost.
-                    #
-                    # Safe against the tail below: an empty exclude is equivalent to
-                    # an absent one for git, so a fault after this leaves no more
-                    # damage than the missing file it replaced.
+                    # Create it first: O_CREAT under the umask gives the helper
+                    # a mode to carry. `atomic_write_bytes` preserves a mode only
+                    # when the target already EXISTS (a fresh one gets mkstemp's
+                    # private 0600), so dropping this line would narrow every
+                    # private exclude's mode — and git treats an exclude it
+                    # cannot read as one that is not there: it warns, exits 0,
+                    # and the shield silently protects nothing, with no degrade
+                    # reason because the write SUCCEEDED. A fault right after
+                    # this leaves an empty exclude, which git treats as absent.
                     exclude.touch()
                 atomic_write_bytes(exclude, prefix + b"".join(p + b"\n" for p in new))
             # The PERMANENT repo-format change, deliberately the last-but-one thing
-            # this function does. `_shield_enable_worktree_config` probed the gates
-            # above and reported that the write is still owed; performing it there —
-            # where it used to live — put a format change the operator's repo carries
-            # forever AHEAD of the seed, the mkdir and the write, so every degrade
-            # below it (including the `_shield_inherited_excludes` fault that round 5
-            # turned from a swallow into a degrade) left the repo marked for a shield
-            # that never applied. Nothing BETWEEN this write and the activation can
-            # degrade — and that sentence used to stop right there, which is what
-            # round 10 caught: "nothing between here and X" never covered the ENABLE
-            # ITSELF, precisely as round 6 found it did not cover the activation
-            # itself. This call has its own two failure shapes. So the paths that can
-            # still set the flag without shielding anything are the enable's own raise
-            # (handled immediately below) and the activation's failure (handled after
-            # it), and each rolls the flag back.
-            #
-            # It cannot move BELOW the activation: `git config --worktree` is what the
-            # extension unlocks, so the activation fatals without it.
+            # this function does. `_shield_enable_worktree_config` probed the gates and
+            # reported the write still owed; paying it here is what keeps every degrade
+            # above from charging the operator's repo a format change it carries
+            # forever for a shield that never applied. Two writes can still set the
+            # flag without shielding anything — this enable's own raise and the
+            # activation's failure — and each rolls it back. It cannot move BELOW the
+            # activation either: `git config --worktree` is what the extension unlocks.
             if needs_enable:
-                # BOTH of the chokepoint's failure shapes, classified into one value
-                # before anything is decided — round 7's funnel, applied to the one
-                # call that never received it (#384, Codex round 10). Handling only
-                # the rc left a raise (a timeout, a spawn failure) to the tail, which
-                # cannot roll anything back: `git config` can be killed AFTER it has
-                # renamed the new config into place, so the flag survived with no
-                # shield ever activated.
+                # BOTH of the chokepoint's failure shapes classified into one value
+                # before anything is decided: handling only the rc left a raise (a
+                # timeout, a spawn failure) to the tail, which cannot roll anything
+                # back, and `git config` can be killed AFTER renaming the new config
+                # into place — flag set, no shield ever activated.
                 #
                 # THE ROLLBACK FIRES ON THE RAISE ONLY, and that asymmetry is
-                # deliberate — it is NOT the enumeration defect it resembles, so do
-                # not "finish" it by rolling back the rc too. Round 5's taxonomy draws
-                # the line: an rc IS an answer. git refused, which means the lock file
-                # was never renamed into place and there is nothing to undo; the
-                # likeliest cause is `.git/config.lock` contention with a concurrent
-                # writer, and that writer is exactly the party whose flag an `--unset`
-                # would then remove. A raise is NOT an answer — we did not find out —
-                # and only the uncertain case may trigger repair. Both shapes are
-                # still CLASSIFIED in one place, which is the part round 7 was about.
-                #
-                # `needs_enable` is True on this branch, so `_shield_undo_extension`'s
-                # caller-side gate is satisfied by construction; the callee applies
-                # its own sibling-ownership gate on top.
+                # deliberate: an rc IS an answer — git refused, the lock file was never
+                # renamed into place, there is nothing to undo, and the likeliest cause
+                # is `.git/config.lock` contention with the very concurrent writer whose
+                # flag an `--unset` would then remove. A raise is NOT an answer, and
+                # only the uncertain case may trigger repair; do not "finish" this by
+                # rolling back the rc too. `needs_enable` is True on this branch, so
+                # `_shield_undo_extension`'s caller-side gate holds by construction.
                 rolled_back = ""
                 try:
                     enabled = git_bytes(worktree, "config", "extensions.worktreeConfig", "true")
@@ -2785,47 +2299,28 @@ def _worktree_local_exclude(worktree: Path, patterns: Sequence[str]) -> str | No
                         f"from the unit's `git add -A`{rolled_back}"
                     )
             # LAST, after the file it names exists: git reads core.excludesFile lazily,
-            # but a config pointing at a file that a fault above left unwritten would
-            # be a shield that silently excludes nothing while reporting a reason.
+            # but a config pointing at a file a fault above left unwritten would be a
+            # shield that silently excludes nothing.
+            #
             # ONE rollback covering EVERY way this step can fail to leave a working
-            # shield, and the shape of this arm is the lesson rather than an incidental
-            # style choice. `git_bytes` can fail two ways — a non-zero rc (git refused)
-            # and a RAISE (a timeout, or a spawn failure as its GitSpawnError subclass)
-            # — and two consecutive rounds each fixed ONE of them, because each fix
-            # ENUMERATED the failure it had been shown. Enumeration is what kept being
-            # incomplete. So every shape converges on one `fault` string BEFORE
-            # anything is decided.
-            #
-            # A later round then supplied the shape that sentence could not have
-            # anticipated, because it is not a FAILURE at all: the write SUCCEEDS and
-            # the shield still does not apply, since `command` scope outranks
-            # `worktree` and git resolves the key from the most specific scope that
-            # carries it. So the `try` now spans the write AND the verification that
-            # it took effect, and rc-0 is no longer an exit from this block — see
-            # `_shield_verify_activation`. The rule that survived all of it: ask what
-            # the POST-CONDITION is and confirm it, rather than enumerating the ways
-            # the call in front of you can go wrong.
-            #
-            # What that first paragraph used to add — "and there is a single place
-            # where the flag can be rolled back" — was true of the failure SHAPES and
-            # false of the WRITES: round 10 added a second rollback point at the
-            # enable above, because rollback sites track the number of writes that can
-            # fail, not the number of ways each one fails.
+            # shield. `git_bytes` fails two ways — a non-zero rc (git refused) and a
+            # RAISE (a timeout, or a spawn failure as its GitSpawnError subclass) — and
+            # a third outcome is not a failure at all: a write that succeeds without
+            # taking effect (`_shield_verify_activation`, below). So the `try` spans the
+            # write AND the verification, every shape converges on one `fault` string
+            # before anything is decided, and rc 0 is no longer an exit from this block.
+            # The rule: confirm the POST-CONDITION rather than enumerate the ways the
+            # call in front of you can go wrong.
             #
             # The rollback exists because the enable one line above is a PERMANENT
-            # repo-format change, and the guarantee this code owes (docstring, CHANGELOG,
-            # docs/FEATURES.md) is that the flag outlives a failed shield only where a
-            # rollback was declined or could not be made, and the reason says which.
-            # That wording is round 10's: it used to read "survives only a shield that
-            # actually activated", which the enable's own raise falsified. When a
-            # fix's value proposition is a GUARANTEE, the same edit has to reach every
-            # copy of it — these three, plus this function's own docstring.
-            # `needs_enable` gates it — see `_shield_undo_extension` for why
-            # that condition is a safety property and not a micro-optimization, and for
-            # the second gate it applies itself: `needs_enable` records what the PROBE
-            # saw, so it cannot tell "we enabled it" from "we and a concurrent run both
-            # thought we did", and the callee declines when a sibling worktree's
-            # `config.worktree` would stop being read.
+            # repo-format change, and the guarantee this code owes (docstring,
+            # CHANGELOG, docs/FEATURES.md) is that the flag outlives a failed shield
+            # only where a rollback was DECLINED or could not be made, and the reason
+            # says which. `needs_enable` gates it — a safety property, not a
+            # micro-optimization, and see `_shield_undo_extension` for the second gate
+            # the callee adds: `needs_enable` records only what the PROBE saw, so it
+            # cannot tell "we enabled it" from "we and a concurrent run both thought
+            # we did".
             try:
                 activated = git_bytes(
                     worktree, "config", "--worktree", "core.excludesFile", str(exclude)
@@ -2837,41 +2332,35 @@ def _worktree_local_exclude(worktree: Path, patterns: Sequence[str]) -> str | No
                     or f"git exited {activated.returncode}"
                 )
                 if fault is None:
-                    # An rc 0 here means the value was WRITTEN, not that it is in
-                    # FORCE — `command` scope outranks `worktree` and is fed by the
-                    # environment we were launched with. Verified rather than
-                    # assumed, INSIDE this same `try` and above the one decision
-                    # below, so the verification's own two failure shapes reach the
-                    # existing rollback instead of growing a second one. See
-                    # `_shield_verify_activation` for why this asks git what it
-                    # resolved instead of looking for the override's origin.
+                    # An rc 0 means the value was WRITTEN, not that it is in
+                    # FORCE — `command` scope outranks `worktree` and is fed by
+                    # the environment we were launched with. Verified INSIDE this
+                    # same `try` and above the one decision below, so the
+                    # verification's own failure shapes reach the existing
+                    # rollback instead of growing a second one.
                     fault = _shield_verify_activation(worktree, exclude)
             except GitError as e:
-                # Deliberately NOT left to the tail: the tail cannot roll the flag back,
-                # and a GitError from EITHER call in this block means exactly what a
-                # refusal means — the shield is not in force. That now covers the
-                # verification's own fault as well as the write's, which is the point of
-                # putting it inside this `try` rather than after it. The tail's own
-                # GitError guard stays load-bearing for the seed read above, which round
-                # 5 turned into a degrade, so this is a narrowing of what reaches it,
-                # not a bypass.
+                # Deliberately NOT left to the tail, which cannot roll the flag back: a
+                # GitError from EITHER call in this block means what a refusal means —
+                # the shield is not in force. Putting this except inside the `try` is
+                # what extends that to the verification's own fault. The tail's GitError
+                # guard stays load-bearing for the seed read above, so this narrows what
+                # reaches it rather than bypassing it.
                 fault = str(e)
             if fault is not None:
                 if needs_enable:
                     fault += _shield_undo_extension(worktree, git_dir, common_dir)
                 return f"could not activate the worktree git exclude ({worktree}): {fault}"
-    # GitError is every fault a chokepoint git call can raise here — a timeout, or
-    # a spawn failure as its GitSpawnError subclass. It replaces the
-    # `subprocess.SubprocessError` this tuple used to carry for exactly that pair,
-    # which the chokepoint now translates before it ever reaches this frame.
+    # GitError is every fault a chokepoint git call can raise here — a timeout, or a
+    # spawn failure as its GitSpawnError subclass. OSError and RuntimeError cover the
+    # mkdir and read/write faults plus `.resolve()`'s pre-3.13 symlink loop, which
+    # raises RuntimeError rather than OSError.
     #
-    # UnicodeError, not UnicodeDecodeError, and NOT for the exclude file any more:
-    # the payload is bytes end-to-end, so neither its read nor its write can raise a
-    # codec fault at all. What is left for it is stated in the docstring — the
-    # `os.fsdecode` of git's stdout (Windows-only) and `os.fsencode` of a pattern
-    # carrying a surrogate that POSIX surrogateescape never produced. Both are
-    # ENCODE-or-DECODE depending on which, hence the shared base class. Still far
-    # short of ValueError-broad, so a programming error still escapes.
+    # UnicodeError, not UnicodeDecodeError, and NOT for the exclude file — that payload
+    # is bytes end-to-end. What is left is the `os.fsdecode` of git's stdout
+    # (Windows-only) and the `os.fsencode` of a pattern carrying a surrogate POSIX
+    # surrogateescape never produced: ENCODE or DECODE depending on which, hence the
+    # shared base class, and still far short of ValueError-broad.
     #
     # TypeError is deliberately absent: a str/bytes mixup on the payload path is a
     # programming error, and letting it crash beats reporting it as an operator's

--- a/src/bmad_loop/verify.py
+++ b/src/bmad_loop/verify.py
@@ -391,13 +391,13 @@ def _exclude_specs(dirs: tuple[str, ...]) -> list[str]:
     `_path_under_any` already implements, which is why fixing the git half is the right
     direction and not a coin flip.
 
-    Only a `*` (which crosses `/`) reaches a sibling DIRECTORY's contents; a
-    same-length `[…]`/`?` collision reaches a sibling FILE only, because the pathspec
-    has to match the whole path. Both magic words go in ONE comma-separated `:(...)`
-    prefix — the global `--literal-pathspecs` / `GIT_LITERAL_PATHSPECS` form would
-    disarm the `:(exclude)` magic too and silently stop excluding anything at all.
-    Stable from the git 2.20 floor `install._WORKTREE_CONFIG_GIT` declares to
-    current."""
+    `*` and `?` both cross `/` here — `FNM_PATHNAME` is opt-in via `:(glob)`, which this
+    never sets — but only a `*` reaches a sibling DIRECTORY's contents; a same-length
+    `[…]`/`?` collision reaches a sibling FILE only, because the pathspec has to match
+    the whole path. Both magic words go in ONE comma-separated `:(...)` prefix — the
+    global `--literal-pathspecs` / `GIT_LITERAL_PATHSPECS` form would disarm the
+    `:(exclude)` magic too and silently stop excluding anything at all. Stable from the
+    git 2.20 floor `install._WORKTREE_CONFIG_GIT` declares to current."""
     return [f":(exclude,literal){d}" for d in dirs]
 
 

--- a/src/bmad_loop/verify.py
+++ b/src/bmad_loop/verify.py
@@ -391,13 +391,13 @@ def _exclude_specs(dirs: tuple[str, ...]) -> list[str]:
     `_path_under_any` already implements, which is why fixing the git half is the right
     direction and not a coin flip.
 
-    Measured, not read off the docs: only a `*` (which crosses `/`) reaches a sibling
-    DIRECTORY's contents; a same-length `[…]`/`?` collision reaches a sibling FILE
-    only, because the pathspec has to match the whole path. Both magic words go in ONE
-    comma-separated `:(...)` prefix — the global `--literal-pathspecs` /
-    `GIT_LITERAL_PATHSPECS` form would disarm the `:(exclude)` magic too and silently
-    stop excluding anything at all. Verified identical at git 2.20.4 (the floor
-    `install._WORKTREE_CONFIG_GIT` declares) and 2.55.0."""
+    Only a `*` (which crosses `/`) reaches a sibling DIRECTORY's contents; a
+    same-length `[…]`/`?` collision reaches a sibling FILE only, because the pathspec
+    has to match the whole path. Both magic words go in ONE comma-separated `:(...)`
+    prefix — the global `--literal-pathspecs` / `GIT_LITERAL_PATHSPECS` form would
+    disarm the `:(exclude)` magic too and silently stop excluding anything at all.
+    Stable from the git 2.20 floor `install._WORKTREE_CONFIG_GIT` declares to
+    current."""
     return [f":(exclude,literal){d}" for d in dirs]
 
 
@@ -467,10 +467,10 @@ def path_tracked(repo: Path, rel: str) -> bool:
     prefix, so `_bmad/render` still lists everything beneath it (`cmd_validate`'s
     render-tracked warning), and it additionally disarms a ``rel`` that itself begins
     with `:`, which git would otherwise parse as magic and answer the empty set for.
-    Measured identical at git 2.20.4 — the floor `install._WORKTREE_CONFIG_GIT`
-    declares — and at 2.55.0; below a version that understands the prefix it would read
-    as a literal FILENAME, match nothing and answer False, which is the one direction
-    that authorizes a delete.
+    Stable from the git 2.20 floor `install._WORKTREE_CONFIG_GIT` declares to current;
+    below a version that understands the prefix it would read as a literal FILENAME,
+    match nothing and answer False, which is the one direction that authorizes a
+    delete.
 
     Raises GitError like every other probe in this module. Callers inside a rollback
     `finally` catch it and degrade toward leaving the file alone: uncertainty must
@@ -479,8 +479,7 @@ def path_tracked(repo: Path, rel: str) -> bool:
 
     Three live callers, all reached through this one chokepoint: `git.render-tracked`
     (`cmd_validate`), `_ledger_is_gits_to_restore` (the harvest revert) and
-    `_harvest_carry_commit_may_degrade` (the isolation carry). It shipped inert in an
-    earlier sub-phase of #433 and was wired up by later ones."""
+    `_harvest_carry_commit_may_degrade` (the isolation carry)."""
     proc = _run_git(["git", "-C", str(repo), "ls-files", "--", *_literal_specs([rel])], repo)
     if proc.returncode != 0:
         merged = (proc.stdout + proc.stderr).strip()

--- a/src/bmad_loop/verify.py
+++ b/src/bmad_loop/verify.py
@@ -1731,7 +1731,7 @@ class CommandResult:
 # seeded worktrees that lost +x burned dev attempts on no-op repairs).
 ENV_FAULT_RCS = frozenset({126, 127})
 
-# cmd has no such convention (issue #302, measured on Windows 11): `cmd /c
+# cmd has no such convention (issue #302): `cmd /c
 # <missing tool>` exits 1 — the same code an ordinary test failure uses — and
 # 9009 surfaces only as %ERRORLEVEL% *inside* a batch file, so it reaches us
 # only when the verify command is itself a .cmd/.bat propagating it. Worse,

--- a/src/bmad_loop/worktree_flow.py
+++ b/src/bmad_loop/worktree_flow.py
@@ -568,10 +568,11 @@ def provision_worktree(
         raw_config_path = worktree / profile.hooks.config_path
         # Refuse before mkdir, read, or write: hook commands are worktree-specific
         # and must never mutate a shared dotfile through a live or dangling link.
-        # Inspect every component because on Python 3.13 and 3.14 a non-strict resolve
-        # leaves a symlink cycle unresolved (and therefore textually equal to the raw
-        # path); 3.11 and 3.12 raise RuntimeError instead, which the except below takes.
-        # The resolved comparison additionally refuses ``..`` and absolute profiles.
+        # Inspect every component: a non-strict resolve either leaves a symlink cycle
+        # unresolved — and so textually equal to the raw path — or raises RuntimeError,
+        # which the except below takes; which of the two happens is interpreter-version
+        # dependent. The resolved comparison additionally refuses ``..`` and absolute
+        # profiles.
         refused = not raw_config_path.is_relative_to(worktree)
         cursor = raw_config_path
         try:
@@ -610,9 +611,9 @@ def provision_worktree(
     patterns = {f"/{p.skill_tree}" for p in profiles}
     # hookless profiles have no config_path, so there is nothing to shield: their
     # empty string would render as a bare "/", which git strips to a zero-length
-    # pattern (the trailing slash becomes MUSTBEDIR) that matches nothing —
-    # measured on 2.55.0 against "/*" and "*", which do blanket. An inert junk
-    # line in a generated file, then, not a worktree-wide exclusion.
+    # pattern (the trailing slash becomes MUSTBEDIR) that matches nothing — inert,
+    # unlike "/*" or "*", which do blanket. A junk line in a generated file, then,
+    # not a worktree-wide exclusion.
     patterns |= {f"/{p.hooks.config_path}" for p in profiles if not p.hookless}
     patterns |= {f"/{rel}" for rel in seeded}
     patterns |= {f"/{rel}" for rel in seeded_bmad}
@@ -768,64 +769,39 @@ class WorktreeFlow:
     def _ledger_seed(self, worktree: Path) -> tuple[str, ...]:
         """The deferred-work ledger, when a worktree checkout cannot deliver it.
 
-        A `git worktree add` checks out TRACKED files only, so a project that
-        gitignores its ledger — the default shape, since the ledger's home is the
-        BMAD artifacts dir and this repo's own is gitignored — gets a unit
-        worktree with no ledger at all. The orchestrator is the ledger's single
-        writer under the generic dev path and writes through
-        ``self.workspace.paths``, i.e. that missing copy: ``mark_done`` returns
-        False on an absent file, and ``verify_review_bundle`` then reads the same
-        absent file and never sees the ids `done`. Measured on the default
-        config, the bundle DEFERS on a fixable retry every run, so `open_ids`
-        re-bundles the same work for ever (#426).
+        `git worktree add` checks out TRACKED files only, so a project that
+        gitignores its ledger — the default shape — gets a unit worktree with
+        none. The orchestrator is the ledger's single writer under the generic
+        dev path and writes through ``self.workspace.paths``, i.e. that missing
+        copy: ``mark_done`` returns False on an absent file,
+        ``verify_review_bundle`` reads the same absent file and never sees the
+        ids `done`, so the bundle defers on a fixable retry and `open_ids`
+        re-bundles the same work for ever (#426). No DONE-leg carry can rescue
+        that — the unit never reaches DONE. Seeding moves the failure onto a leg
+        that has one, where ``SweepEngine._carry_isolated_ledger_writes`` applies
+        the close to the main checkout.
 
-        No DONE-leg carry can rescue that: the unit never reaches DONE. Seeding
-        is what moves the failure onto a leg that has one — measured, the same
-        run then lands, and ``SweepEngine._carry_isolated_ledger_writes`` (which
-        until now only ran for an operator who had named the ledger in
-        ``scm.worktree_seed``) applies the close to the main checkout.
+        The copy is not what delivers the close: every seeded rel is shielded
+        from the unit's ``git add -A``, so the worktree's flip never rides the
+        merge. The seeded ledger exists so the GATE can read the orchestrator's
+        own write; the carry stays the delivery path, hence
+        ``sweep-bundle-close-carry-uncommitted`` on a run that lands.
 
-        The copy is not what carries the close home. Every seeded rel is shielded
-        from the unit's ``git add -A`` by a worktree-scoped exclude, so the flip
-        made in the worktree still never rides the merge — the seeded ledger
-        exists so the GATE can read the orchestrator's own write, and the carry
-        remains the delivery path. That is why the landing run still journals
-        ``sweep-bundle-close-carry-uncommitted``: `git add -- <ignored path>`
-        refuses with rc 1, as it did before.
+        Excluded: a ledger already in the checkout (the copy is a no-op the seed
+        loop reports as ``worktree-seed-skipped``, on every tracked-ledger
+        project); one absent from the main checkout (dropped silently, so the
+        entry would be invisible rather than merely inert — the common case,
+        since the first harvest is what CREATES the file); and one resolving
+        outside the project tree, which for an out-of-tree artifacts DIR
+        ``ProjectPaths.rebased`` leaves unmoved, so the worktree already reads
+        it. A ledger that is itself a symlink keeps the dir in-tree: an in-repo
+        target is seeded to the WRONG path and still hits #426 (#462). Resolving
+        also names the target of a TRACKED ledger symlink whose target is
+        untracked — the only path the seed loop will write, since it refuses to
+        copy through a link. ``relative_to`` decides PLACEMENT; containment is
+        re-checked against both roots at the copy site.
 
-        Three exclusions, each measured:
-
-        * **Already in the checkout** — the copy would be a no-op the seed loop
-          reports as ``worktree-seed-skipped``, i.e. a diagnostic that means "a
-          seed you asked for did nothing" fired on every isolated unit of every
-          ordinary tracked-ledger project. Asked of the worktree rather than of
-          git because that is the question the seed loop itself decides on, and
-          it costs no subprocess and cannot raise.
-        * **Absent from the main checkout** — nothing to copy. The seed loop
-          drops a non-existent source silently (no ``worktree-seed-skipped``, no
-          ``worktree-seed-dropped``), so an entry here would be invisible rather
-          than merely inert. The commonest case by far: the first harvest is what
-          CREATES `deferred-work.md`.
-        * **Resolving outside the project tree** — for an out-of-tree artifacts
-          *dir* ``ProjectPaths.rebased`` leaves the path unmoved, so the worktree
-          already reads the very same file and there is nothing to deliver.
-
-        That last rationale covers the DIRECTORY only. When ``deferred-work.md``
-        is itself a symlink the dir stays in-tree, ``rebased`` moves it, and the
-        worktree path the workspace reads does not exist — so the exclusion is
-        not "the worktree already reads it". It is still the right call for an
-        out-of-repo target, because ``provision_worktree`` refuses an out-of-repo
-        resolved source whatever rel it is handed; an in-repo target, though, is
-        seeded to the WRONG path and still hits #426 (#462). Resolving is
-        load-bearing the other way too: when the checkout delivers a TRACKED
-        ledger symlink whose target is untracked, the resolved rel names that
-        target — the only path the seed loop will write, since it never copies
-        through a link. ``relative_to`` here decides PLACEMENT, not the seed
-        loop's containment; that is re-checked against both roots at the copy
-        site.
-
-        Deduped against ``scm.worktree_seed`` by the caller, so an operator who
-        already named the ledger keeps exactly one entry.
+        Deduped against ``scm.worktree_seed`` by the caller.
         """
         ledger = self.paths.deferred_work
         repo = self.paths.repo_root

--- a/src/bmad_loop/worktree_flow.py
+++ b/src/bmad_loop/worktree_flow.py
@@ -787,19 +787,26 @@ class WorktreeFlow:
         own write; the carry stays the delivery path, hence
         ``sweep-bundle-close-carry-uncommitted`` on a run that lands.
 
-        Excluded: a ledger already in the checkout (the copy is a no-op the seed
-        loop reports as ``worktree-seed-skipped``, on every tracked-ledger
-        project); one absent from the main checkout (dropped silently, so the
-        entry would be invisible rather than merely inert — the common case,
-        since the first harvest is what CREATES the file); and one resolving
-        outside the project tree, which for an out-of-tree artifacts DIR
-        ``ProjectPaths.rebased`` leaves unmoved, so the worktree already reads
-        it. A ledger that is itself a symlink keeps the dir in-tree: an in-repo
-        target is seeded to the WRONG path and still hits #426 (#462). Resolving
-        also names the target of a TRACKED ledger symlink whose target is
-        untracked — the only path the seed loop will write, since it refuses to
-        copy through a link. ``relative_to`` decides PLACEMENT; containment is
-        re-checked against both roots at the copy site.
+        Excluded: a ledger already in the checkout (without the exclusion the copy
+        would be a no-op the seed loop reports as ``worktree-seed-skipped`` on every
+        tracked-ledger project); one absent from the main checkout (dropped
+        silently, so the entry would be invisible rather than merely inert — the
+        common case, since the first harvest is what CREATES the file); and one
+        resolving outside the project tree, which for an out-of-tree artifacts DIR
+        ``ProjectPaths.rebased`` leaves unmoved, so the worktree already reads it.
+        Presence is asked of the WORKTREE, not of git: that is the predicate the
+        seed loop itself decides on, and unlike ``verify.path_tracked`` it costs no
+        subprocess and cannot raise.
+
+        A ledger that is itself a symlink keeps the dir in-tree, so ``rebased``
+        moves it and the worktree path does not exist: the exclusion is still right
+        for an out-of-repo target (``provision_worktree`` refuses that source
+        whatever rel it is handed), but an in-repo target is seeded to the WRONG
+        path and still hits #426 (#462). Resolving also names the target of a
+        TRACKED ledger symlink whose target is untracked — the only path the seed
+        loop will write, since it refuses to copy through a link. ``relative_to``
+        decides PLACEMENT; containment is re-checked against both roots at the copy
+        site.
 
         Deduped against ``scm.worktree_seed`` by the caller.
         """

--- a/tests/test_engine_worktree.py
+++ b/tests/test_engine_worktree.py
@@ -549,8 +549,8 @@ def test_worktree_squash_merge_linear_history(project):
 def _defer_script(project, key):
     """Dev succeeds, then review never converges → plateau defer. Consumers must
     pin ``limits=LimitsPolicy(max_followup_reviews=99)`` so the default damping cap
-    (1) doesn't force-converge round 2 — this script tests the exhaustion/defer
-    plateau, not damping."""
+    (1) doesn't force-converge the second review pass — this script tests the
+    exhaustion/defer plateau, not damping."""
     return [wt_dev_effect(project, key)] + [
         wt_review_effect(project, key, clean=False, patched=1) for _ in range(3)
     ]
@@ -1633,9 +1633,9 @@ def test_gitignored_damped_followup_reaches_the_main_ledger(project):
     under isolation is the unit worktree's ledger. `finalize_commit`'s `git add -A`
     skips a gitignored path in silence, the merge brings nothing over, and
     `close_unit_workspace(success=True)` then deletes the worktree — the DONE leg
-    takes no `capture_diff`, so not even a `changes.patch` survives. Measured
-    before the carry: the run journals `refiled: DW-1` and the main checkout has no
-    ledger at all.
+    takes no `capture_diff`, so not even a `changes.patch` survives. Without the
+    carry the run journals `refiled: DW-1` while the main checkout has no ledger at
+    all.
 
     `check-ignore` is the oracle, not the presence of the rule: a row that reads
     the tracked-ledger shape by accident is the vacuity this whole block exists to
@@ -2886,16 +2886,12 @@ def test_isolated_exclude_degrade_is_journaled_and_notified(project, monkeypatch
     (worktree_flow.py:35) — patching `install._worktree_local_exclude` would not be
     seen here.
 
-    BOTH CHANNELS, and round 5 added the second. This was journal-only, on the
-    reasoning that the run is unharmed and continues — so it matched
-    `worktree-teardown-degraded` rather than the notify-worthy
-    `worktree-open-failed`. What that missed is that the shield's entire degrade
-    policy is to SKIP rather than widen (activating over patterns it could not copy
-    would shadow the operator's own excludes), and a skip is only defensible if the
-    operator finds out. Round 5 also turned a swallowed `GitError` into a degrade,
-    so the path is now reachable from a transient git fault rather than only from a
-    write fault. A journal line nobody reads is how the provisioned tool files reach
-    a story's merge unnoticed.
+    BOTH CHANNELS are asserted. A journal line alone will not do: the shield's
+    degrade policy is to SKIP rather than widen (activating over patterns it could
+    not copy would shadow the operator's own excludes), and a skip is only
+    defensible if the operator finds out — a journal line nobody reads is how the
+    provisioned tool files reach a story's merge unnoticed. The path is reachable
+    from a transient `GitError` as well as from a write fault.
 
     Ablations, one per channel: delete the `on_degraded=` lambda at the
     `provision_worktree` call in `run_isolated` and both assertions fail; drop the
@@ -3125,34 +3121,13 @@ def test_gitignored_declared_closure_reaches_the_main_ledger(project):
     in `_carry_isolated_ledger_writes` carries it: that hook owns the harvest and
     the review-budget follow-up, both APPENDS, and a declared close is neither.
 
-    Measured on this commit (`628fe54`), verbatim.
-
-    The unit worktree's ledger at the moment of the close::
-
-        ### DW-1: item DW-1
-
-        origin: test, 2026-06-01
-        location: src.txt:1
-        reason: test entry.
-        status: done 2026-08-05
-        resolution: resolved by story 1-1-a
-
-    The main checkout's ledger after the run — unchanged::
-
-        ### DW-1: item DW-1
-
-        origin: test, 2026-06-01
-        location: src.txt:1
-        reason: test entry.
-        status: open
-
-    …and the journal carries `story-deferred-closed dw_ids=['DW-1']` with no
-    `deferred-close-unmatched`. That is the false success: `f798c1b` seeds the
-    ledger a worktree checkout cannot deliver, so the close now finds a file to
-    write and reports itself done. Ablating that seed (`_ledger_seed` -> `()`)
-    puts the pre-seed behavior back — the worktree ledger is ABSENT, `classify`
-    reports the id unmatched, and the run journals `deferred-close-unmatched
-    dw_ids=['DW-1']`. Louder, equally lost.
+    The fixture encodes that false success: the worktree ledger ends `status: done`
+    with the resolution annotation, the main checkout's ledger still reads
+    `status: open`, and the journal carries `story-deferred-closed dw_ids=['DW-1']`
+    with no `deferred-close-unmatched` — the run reports a close it never delivered.
+    Ablating the seed (`_ledger_seed` -> `()`) puts the pre-seed behavior back: the
+    worktree ledger is ABSENT, `classify` reports the id unmatched, and the run
+    journals `deferred-close-unmatched dw_ids=['DW-1']`. Louder, equally lost.
 
     Tracked is the contrast, not a second defect: the sibling above measures the
     same story against a TRACKED ledger and the close rides the unit commit into

--- a/tests/test_engine_worktree.py
+++ b/tests/test_engine_worktree.py
@@ -3122,12 +3122,12 @@ def test_gitignored_declared_closure_reaches_the_main_ledger(project):
     the review-budget follow-up, both APPENDS, and a declared close is neither.
 
     The fixture encodes that false success: the worktree ledger ends `status: done`
-    with the resolution annotation, the main checkout's ledger still reads
-    `status: open`, and the journal carries `story-deferred-closed dw_ids=['DW-1']`
-    with no `deferred-close-unmatched` — the run reports a close it never delivered.
-    Ablating the seed (`_ledger_seed` -> `()`) puts the pre-seed behavior back: the
-    worktree ledger is ABSENT, `classify` reports the id unmatched, and the run
-    journals `deferred-close-unmatched dw_ids=['DW-1']`. Louder, equally lost.
+    with the resolution annotation, and the journal carries `story-deferred-closed
+    dw_ids=['DW-1']` with no `deferred-close-unmatched`. Without the carry the main
+    checkout's ledger still reads `status: open` — the run reports a close it never
+    delivered. Ablating the seed (`_ledger_seed` -> `()`) puts the pre-seed behavior
+    back: the worktree ledger is ABSENT, `classify` reports the id unmatched, and the
+    run journals `deferred-close-unmatched dw_ids=['DW-1']`. Louder, equally lost.
 
     Tracked is the contrast, not a second defect: the sibling above measures the
     same story against a TRACKED ledger and the close rides the unit commit into

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -3800,14 +3800,14 @@ def test_shield_rolls_back_the_extension_when_activation_fails(project, tmp_path
     rolls the flag back. The other such degrade is the ENABLE's own raise, covered by
     `test_shield_rolls_back_an_enable_whose_git_faulted`.
 
-    `--unset` removes the key *and* the now-empty `[extensions]` section, and `git config
-    --worktree` refuses again afterwards, so the repo is genuinely returned to the state
-    we found rather than cosmetically tidied.
+    `--unset-all` removes the key *and* the now-empty `[extensions]` section, and `git
+    config --worktree` refuses again afterwards, so the repo is genuinely returned to the
+    state we found rather than cosmetically tidied.
 
     Only `--worktree` writes are failed, so the enable itself succeeds — which is
     what makes this the enable-then-fail ordering rather than a short-circuit.
 
-    Ablation: drop the `--unset` rollback and this fails — `worktreeConfig` is left
+    Ablation: drop the `--unset-all` rollback and this fails — `worktreeConfig` is left
     in the shared config after a degrade that shielded nothing."""
     repo = project.project
     wt = tmp_path / "wt"

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -3184,9 +3184,9 @@ def test_shield_refuses_a_repository_shared_between_os_users(project, tmp_path):
 
     Ablation: delete the `_shield_shared_repository` call in `_worktree_local_exclude`
     and this fails. What the deletion falls through to was checked by RUNNING the
-    ablated helper rather than inferred from the first failing assertion, because
-    twice on this PR a deleted arm landed on an adjacent guard that also returned a
-    reason: it falls through to a clean SUCCESS — `reason is None`, the lock file
+    ablated helper rather than inferred from the first failing assertion, because a
+    deleted arm can land on an adjacent guard that also returns a reason: it falls
+    through to a clean SUCCESS — `reason is None`, the lock file
     created, `worktreeConfig` written — so every assertion below is load-bearing and
     none of them can pass against the bug."""
     repo = project.project
@@ -3387,8 +3387,8 @@ def test_shield_refuses_a_valueless_shared_repository_key(project, tmp_path):
 
     Hand-written because `git config` cannot express a key with no value. Appended as
     a fresh `[core]` section rather than edited into the existing one: a repeated
-    section is legal in git config, and it carries no path, so none of this PR's
-    Windows fixture hazards (a backslash is a config ESCAPE) apply.
+    section is legal in git config, and it carries no path, so the Windows fixture
+    hazard (a backslash is a config ESCAPE) does not apply.
 
     Ablation: add "" to the accepted values and this fails — the shield proceeds."""
     repo = project.project
@@ -3415,8 +3415,9 @@ def test_shield_refuses_a_valueless_shared_repository_key(project, tmp_path):
 def test_shield_reads_shared_repository_without_stripping_it(project, tmp_path):
     """The gate removes `--get`'s TERMINATOR and nothing else. `git config --get`
     returns edge whitespace VERBATIM (a quoted `" umask"` comes back as
-    b" umask\\n"), so `.strip()` would widen a value into the accept set — the same
-    defect at a second site in this same function, and live
+    b" umask\\n"), so `.strip()` would widen a value into the accept set — the defect
+    `test_shield_keeps_edge_whitespace_in_the_common_dir` pins in the common-dir
+    parse, at a second site in this same function, and live
     rather than defensive: `rev-parse --absolute-git-dir` answers rc 0 for such a
     repository, so the gate really is reached with this value in hand.
 
@@ -3426,8 +3427,8 @@ def test_shield_reads_shared_repository_without_stripping_it(project, tmp_path):
     verdict on that value.
 
     No Windows skip: the fixture is a config value, not a path, and it carries no
-    backslash — the escape that made a hand-written config fixture unparseable on
-    Windows CI earlier in this PR.
+    backslash — the escape that makes a hand-written config fixture unparseable on
+    Windows.
 
     Ablation: use `.strip()` instead of `removesuffix("\\n")` and this fails — but NOT
     in the shape the obvious note would claim, which is why the assertions below are
@@ -3602,9 +3603,10 @@ def test_shield_refuses_when_the_core_bare_probe_cannot_answer(project, tmp_path
     both, and a fix applied to one arm only would leave this one open.
 
     `--type=bool` gives this probe a second way to fail that the plain read has not:
-    measured at 2.20.4 and 2.55.0, `--type=bool` over a non-bool value exits 128
-    (2.20.4 words it "bad numeric config value", 2.55.0 "bad boolean config value" —
-    same rc). Note that no STATIC config value can reach that: a repo whose
+    across the supported git range, `--type=bool` over a non-bool value exits 128
+    (the wording differs by version — "bad numeric config value" at the floor, "bad
+    boolean config value" at current — same rc). Note that no STATIC config value
+    can reach that: a repo whose
     `core.bare` is a non-bool fatals the caller's earlier `rev-parse` first (measured
     128 at both). What reaches here is a transient fault inside the caller's lock.
 
@@ -3730,7 +3732,7 @@ def test_shield_refuses_to_enable_extension_over_old_git(project, tmp_path, monk
 
 def test_shield_degrade_leaves_no_permanent_repo_format_change(project, tmp_path, monkeypatch):
     """`extensions.worktreeConfig` is a PERMANENT repo-format change bmad-loop never
-    reverses, so it must not be paid for a shield that then degrades away. Round 5:
+    reverses, so it must not be paid for a shield that then degrades away.
     `_shield_enable_worktree_config` used to perform the enable itself, ahead of the
     seed, the mkdir, the write and the activation — so every degrade below it left
     the operator's repo marked forever for a shield that never applied. It now only
@@ -4019,7 +4021,7 @@ def test_shield_rollback_treats_an_absent_flag_as_completed(project, tmp_path):
 def test_shield_rollback_removes_every_line_of_a_doubled_flag(project, tmp_path):
     """The other half of the `--unset-all` decision, and the one that makes the
     spelling load-bearing rather than cosmetic. git-config(1) gives rc 5 two meanings,
-    and a key written on TWO lines is the second: measured at 2.20.4 and 2.55.0,
+    and a key written on TWO lines is the second: across the supported git range,
     `--unset` against it exits 5 and removes NOTHING, while `--unset-all` exits 0 and
     removes both.
 
@@ -4899,8 +4901,8 @@ def test_shield_appends_a_pattern_an_inherited_negation_would_cancel(project, tm
     # fixture expresses the scenario rather than merely naming it
     assert b"!/.claude/skills\n" in _wt_private_exclude(wt).read_bytes()
     # THE HARM, through git's own answer. A substring rather than whole-worktree
-    # cleanliness: that form has already failed on Windows CI in this PR over unrelated
-    # CRLF churn, and the subject here is this one path.
+    # cleanliness: that form is fragile on Windows CI over unrelated CRLF churn,
+    # and the subject here is this one path.
     (wt / ".claude" / "skills").mkdir(parents=True, exist_ok=True)
     (wt / ".claude" / "skills" / "tool.md").write_text("generated\n", encoding="utf-8")
     assert "tool.md" not in git(wt, "status", "--porcelain", "-uall")
@@ -5167,8 +5169,8 @@ def test_shield_honors_an_explicitly_empty_excludesfile(project, tmp_path, monke
     NULL POINTER, while an empty value resolves through `interpolate_path("")` to a
     non-NULL empty string, and that guard is unchanged from this shield's 2.20 floor to
     current. It is undocumented: `core.adoc` says only "Defaults to
-    $XDG_CONFIG_HOME/git/ignore" — the same standing as the relative- value behavior the
-    sibling test above pins.
+    $XDG_CONFIG_HOME/git/ignore" — the same standing as the relative-value behavior
+    the sibling test above pins.
 
     `GIT_CONFIG_NOSYSTEM` is deliberately NOT pinned, unlike the XDG sibling: a
     repo-LOCAL key already outranks a global one, so there is nothing to suppress, and
@@ -5276,8 +5278,8 @@ def test_shield_survives_a_newline_in_the_repository_path(tmp_path):
 
     `git rev-parse` separates its answers with a newline, so asking ONE call for both
     `--absolute-git-dir` and `--git-common-dir` read a legal path byte as a record
-    delimiter: measured on git 2.55, the two answers below split into FOUR entries and
-    the helper returned a degrade instead. Degrading is not a safe default here —
+    delimiter: the two answers below split into FOUR entries and the helper returned
+    a degrade instead. Degrading is not a safe default here —
     `provision_worktree` has already copied the tool files by the time the shield runs,
     so the unit's `git add -A` commits them into the story's merge.
 
@@ -5457,7 +5459,7 @@ def test_worktree_local_exclude_short_write_leaves_exclude_intact(project, tmp_p
     exclude stops shielding, so the unit's `git add -A` stages the tool files
     provisioning wrote into the story's own commit. (A cut landing on a bare `/`
     is inert — git strips the trailing slash to a zero-length pattern that matches
-    nothing, measured on 2.55.0 against `/*` and `*`, which do blanket.)
+    nothing, unlike `/*` and `*`, which do blanket.)
 
     Blast radius is smaller since #384 (the file is this worktree's own, not the
     main repo's shared exclude) but the fault is not: the content carried through
@@ -5799,8 +5801,8 @@ def test_worktree_local_exclude_common_dir_probe_rc_degrades(project, tmp_path, 
     """The SECOND `rev-parse` is past the silent arm: `--absolute-git-dir` has already
     answered, so git has identified the repository and a failure here is a degrade.
 
-    Round 3 split one combined `rev-parse` into two calls (a newline is a legal byte
-    in a POSIX path), and the second call inherited the FIRST call's silent arm. That
+    Splitting one combined `rev-parse` into two calls (a newline is a legal byte in a
+    POSIX path) let the second call inherit the FIRST call's silent arm. That
     left a shield that was owed, did not happen, and said nothing — after provisioning
     had already copied the files it exists to hide. Both the function's own docstring
     ("a timeout or spawn failure on the FIRST rev-parse ... that scope is the whole of

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -118,11 +118,12 @@ def _is_unset(args):
     """Does this `git_bytes` argv unset a key, in ANY of git's spellings?
 
     A PREFIX test rather than `"--unset" in args`, and the reason is a trap this
-    suite walked into: `args` is a tuple, so membership is exact-token, and round
-    10's switch from `--unset` to `--unset-all` silently stopped four fakes from
-    matching. Two were assertions and failed loudly; the other two were TRIPWIRES,
-    which simply went quiet — a tripwire that no longer matches passes exactly like
-    a gate that works, and it takes the ablations built on it down with it.
+    suite walked into: `args` is a tuple, so membership is exact-token, and switching
+    the production spelling from `--unset` to `--unset-all` silently stopped four
+    fakes from matching. Two were assertions and failed loudly; the other two were
+    TRIPWIRES, which simply went quiet — a tripwire that no longer matches passes
+    exactly like a gate that works, and it takes the ablations built on it down with
+    it.
     """
     return any(a.startswith("--unset") for a in args)
 
@@ -2858,13 +2859,12 @@ def test_shield_degrades_when_a_command_scope_excludesfile_outranks_it(
     ambient `core.excludesFile` got a shield that reported success and never applied:
     the provisioned tool files stayed stageable, with no reason to journal.
 
-    Round 17 was "a pattern PRESENT in the file is not EFFECTIVE"; this is that gap one
-    level up — WRITTEN is not EFFECTIVE.
+    A pattern PRESENT in the file is not EFFECTIVE; this is that gap one level up —
+    WRITTEN is not EFFECTIVE.
 
-    PARAMETRIZED BECAUSE THE ENUMERATION FIX WOULD PASS ONE AND FAIL THE OTHER, which
-    is the whole argument for verifying the post-condition instead of detecting the
-    override's origin. Measured end to end on real linked worktrees at both ends of the
-    supported range:
+    PARAMETRIZED BECAUSE THE ENUMERATION FIX WOULD PASS ONE AND FAIL THE OTHER, which is
+    the whole argument for verifying the post-condition instead of detecting the
+    override's origin. The channels themselves differ across the supported git range:
 
                                         git 2.20.4        git 2.55.0
         GIT_CONFIG_COUNT/KEY_n/VALUE_n  inert (2.31)      shield defeated
@@ -2880,10 +2880,10 @@ def test_shield_degrades_when_a_command_scope_excludesfile_outranks_it(
     `'k=v'` is the encoding used below because it is the only one honored at BOTH ends;
     the newer `'k'='v'` form is `fatal: bogus format in GIT_CONFIG_PARAMETERS` at 2.20.4.
 
-    The reason string is the discriminator here, and deliberately so — unlike round 17,
-    where it could not bite. `git status` shows the tool file with the bug AND with the
-    fix; what changes is whether the operator is told. Non-vacuity is pinned separately,
-    by asserting the override really is in force before trusting the degrade.
+    The reason string is the discriminator here, and deliberately so: `git status` shows
+    the tool file with the bug AND with the fix; what changes is whether the operator is
+    told. Non-vacuity is pinned separately, by asserting the override really is in force
+    before trusting the degrade.
 
     The sibling that keeps this from being a blanket refusal already exists:
     `test_shield_seeds_users_excludesfile` sets `core.excludesFile` at LOCAL scope and
@@ -2943,11 +2943,11 @@ def test_shield_outranked_degrade_leaves_no_permanent_repo_format_change(
     worktree-scoped `core.excludesFile` is really there in `config.worktree`.
 
     Two claims, and they are separate: the permanent flag must be gone, and the key the
-    activation did land must be harmless. Measured rather than assumed — unsetting
-    `extensions.worktreeConfig` makes git stop reading `config.worktree` at all, so the
-    leftover key is inert and needs no second `--unset`. That is why this arm has one
-    rollback rather than two; a second write would be a second failure shape and a
-    second rollback site, which is the enumeration this block exists to avoid.
+    activation did land must be harmless. Unsetting `extensions.worktreeConfig` makes git
+    stop reading `config.worktree` at all, so the leftover key is inert and needs no
+    second `--unset`. That is why this arm has one rollback rather than two; a second
+    write would be a second failure shape and a second rollback site, which is the
+    enumeration this block exists to avoid.
 
     Ablation: drop the `needs_enable` rollback and the first assertion fails —
     `worktreeConfig` survives a degrade that shielded nothing."""
@@ -3172,12 +3172,12 @@ def test_shield_refuses_a_repository_shared_between_os_users(project, tmp_path):
     """A repository configured as shared between OS users is not supported (#384), and
     is refused UP FRONT rather than shielded — loudly, and identically for every user.
 
-    The refusal sits ABOVE the shield's lock, which is why the last four assertions
-    matter more than the first. A reason string alone cannot distinguish a clean
-    refusal from one that left state behind: that is exactly the gap that let round 7's
-    defect sit under a passing fault-injection test for two review rounds. So this pins
-    that NOTHING was created — no lock file for a peer's run to meet, no permanent
-    repo-format change, no private exclude, and the repository-wide exclude untouched.
+    The refusal sits ABOVE the shield's lock, which is why the last four assertions matter
+    more than the first. A reason string alone cannot distinguish a clean refusal from one
+    that left state behind: that is exactly the gap a fault-injection test asserting only
+    the reason string leaves open. So this pins that NOTHING was created — no lock file
+    for a peer's run to meet, no permanent repo-format change, no private exclude, and the
+    repository-wide exclude untouched.
 
     Set after the worktree is mounted, as the `core.bare` sibling above is: git honors
     the key for files it creates, and nothing here needs it applied during the mount.
@@ -3217,10 +3217,9 @@ def test_shield_runs_in_a_repository_that_is_not_shared(project, tmp_path):
     being PRESENT is not the refusal — being present with a value git resolves to
     something other than "private" is.
 
-    `umask` rather than `false` on purpose. Measured at git 2.20.4 and 2.55.0, git
-    compares this keyword with strcmp while it compares the booleans with strcasecmp,
-    so the two sides of the accept test are separate code paths and this is the one a
-    bool-only reading would drop.
+    `umask` rather than `false` on purpose: git compares this keyword with strcmp while it
+    compares the booleans with strcasecmp, so the two sides of the accept test are
+    separate code paths and this is the one a bool-only reading would drop.
 
     Ablation: refuse whenever the key is present (drop the value test) and this
     fails — an ordinary repository stops being shielded."""
@@ -3301,11 +3300,10 @@ def test_shield_runs_in_a_repository_that_is_not_shared(project, tmp_path):
 def test_shared_repository_private_verdicts(value, private):
     """git's `core.sharedRepository` verdicts, mirrored value by value.
 
-    The pure-core layer for the octal support: `0600` is an owner-only filemode, not
-    a shared repository, so refusing it skipped the shield for a single-user repo
-    (#384, Codex round 20). Every row was measured at git 2.20.4 AND 2.55.0 —
-    byte-identical at both ends — by the mode of a loose object git writes under
-    `umask 077`, which is git's own answer rather than a reading of `setup.c`.
+    The pure-core layer for the octal support: `0600` is an owner-only filemode, not a
+    shared repository, so refusing it skipped the shield for a single-user repo (#384).
+    Every row is git's own answer — the mode of a loose object git writes under `umask
+    077` — rather than a reading of `setup.c`, and holds across the supported git range.
 
     Ablation, per row group: restore the old literal accept set
     (`value in ("umask", "0") or value.lower() in ("false", "no", "off")`) and the
@@ -3319,7 +3317,7 @@ def test_shared_repository_private_verdicts(value, private):
 def test_shield_runs_in_a_repository_with_an_owner_only_octal_mode(project, tmp_path):
     """`core.sharedRepository = 0600` is a filemode granting no peer access at all —
     a repository private to its owner, not one shared between OS users — so the
-    shield runs (#384, Codex round 20).
+    shield runs (#384).
 
     The refusal is deliberately coarse everywhere else in this gate, but it may not
     be coarse HERE: an owner-only octal mode is exactly the shape the refusal exists
@@ -3352,8 +3350,8 @@ def test_shield_runs_in_a_repository_with_an_owner_only_octal_mode(project, tmp_
 
 def test_shield_refuses_a_group_readable_octal_mode(project, tmp_path):
     """`core.sharedRepository = 0640` is a filemode granting GROUP access, so it is
-    refused exactly like the `group` keyword — the octal support added for round 20
-    accepts owner-only modes and must not widen past them.
+    refused exactly like the `group` keyword — the octal support accepts owner-only
+    modes and must not widen past them.
 
     `0640` rather than `0666` on purpose: it is the row immediately across the
     boundary from the accepted `0600`, so it fails first if the mask is loosened.
@@ -3377,9 +3375,9 @@ def test_shield_refuses_a_group_readable_octal_mode(project, tmp_path):
 def test_shield_refuses_a_valueless_shared_repository_key(project, tmp_path):
     """`sharedRepository` with NO value is git's `PERM_GROUP` — a shared repository —
     and `--get` answers it rc 0 with a lone newline, byte-identical to an explicitly
-    EMPTY value, which git reads as `PERM_UMASK`, i.e. private. Measured at 2.20.4 and
-    2.55.0 by the mode of a loose object git writes under `umask 077`: valueless gives
-    `r--r-----`, empty gives `r--------`.
+    EMPTY value, which git reads as `PERM_UMASK`, i.e. private. The mode of a loose
+    object git writes under `umask 077` is the oracle: valueless gives `r--r-----`,
+    empty gives `r--------`.
 
     git exposes nothing that separates the two answers, so the gate refuses the
     ambiguous one. That is the deliberate direction of error — a false refusal is a
@@ -3416,9 +3414,9 @@ def test_shield_refuses_a_valueless_shared_repository_key(project, tmp_path):
 
 def test_shield_reads_shared_repository_without_stripping_it(project, tmp_path):
     """The gate removes `--get`'s TERMINATOR and nothing else. `git config --get`
-    returns edge whitespace VERBATIM (measured at 2.20.4 and 2.55.0: a quoted
-    `" umask"` comes back as b" umask\\n"), so `.strip()` would widen a value into the
-    accept set — round 15's defect at a second site in this same function, and live
+    returns edge whitespace VERBATIM (a quoted `" umask"` comes back as
+    b" umask\\n"), so `.strip()` would widen a value into the accept set — the same
+    defect at a second site in this same function, and live
     rather than defensive: `rev-parse --absolute-git-dir` answers rc 0 for such a
     repository, so the gate really is reached with this value in hand.
 
@@ -3433,7 +3431,7 @@ def test_shield_reads_shared_repository_without_stripping_it(project, tmp_path):
 
     Ablation: use `.strip()` instead of `removesuffix("\\n")` and this fails — but NOT
     in the shape the obvious note would claim, which is why the assertions below are
-    written the way they are. Measured with the ablation applied: the value reads as
+    written the way they are. With the ablation applied the value reads as
     `umask`, the gate lets it through, the shield takes the lock and then degrades one
     step later with git's OWN rejection of the value ("could not enable
     extensions.worktreeConfig ... fatal: bad boolean config value ' umask' for
@@ -3467,22 +3465,21 @@ def test_shield_reads_shared_repository_without_stripping_it(project, tmp_path):
 @pytest.mark.skipif(sys.platform == "win32", reason="a trailing space is not a legal Windows path")
 def test_shield_keeps_edge_whitespace_in_the_common_dir(tmp_path):
     """`rev-parse` terminates its answer with one newline; every other byte belongs to
-    the path — so the parse may remove only that terminator (#384, Codex round 15).
+    the path — so the parse may remove only that terminator (#384).
 
     A comment here used to justify `.strip()` on the grounds that "a final component is
     `.git` or `worktrees/<id>`". True for a NON-bare repo, false for a BARE one, whose
-    common dir IS the repository directory. Measured at 2.55.0, a worktree of a bare
-    repo at `…/common ` answers `--git-common-dir` = `…/common `, while
-    `--absolute-git-dir` stays safe at `…/common /worktrees/<id>` because git sanitizes
-    the admin id — so exactly ONE of the two answers was exposed.
+    common dir IS the repository directory: a worktree of a bare repo at `…/common `
+    answers `--git-common-dir` = `…/common `, while `--absolute-git-dir` stays safe at
+    `…/common /worktrees/<id>` because git sanitizes the admin id — so exactly ONE of the
+    two answers was exposed.
 
-    THE HARM IS A DEFEATED SAFETY GATE, which is why this is a P1 and not a cosmetic
-    path bug: stripped, every later step points at `…/common`, which does not exist,
-    and `config --file <that>/config --get core.bare` answers rc 1 — ABSENT, not
-    "unreadable" (round 10). So `core.bare = true` is MISSED and the shield proceeds to
-    make its permanent repo-format change on a bare repository. The lock's own
-    `mkdir(parents=True)` then creates the stripped directory as a side effect, which
-    is the visible symptom.
+    THE HARM IS A DEFEATED SAFETY GATE, not a cosmetic path bug: stripped, every later
+    step points at `…/common`, which does not exist, and `config --file <that>/config
+    --get core.bare` answers rc 1 — ABSENT, not "unreadable". So `core.bare = true` is
+    MISSED and the shield proceeds to make its permanent repo-format change on a bare
+    repository. The lock's own `mkdir(parents=True)` then creates the stripped directory
+    as a side effect, which is the visible symptom.
 
     The three assertions are one per consequence, and the sibling-directory one is what
     makes the others non-vacuous: a refusal for the WRONG reason would still satisfy
@@ -3556,17 +3553,15 @@ def test_shield_refuses_when_the_core_worktree_probe_cannot_answer(project, tmp_
     `extensions.worktreeConfig` drops the exception confining `core.worktree` to the
     main worktree, after which it applies to every linked one (git-worktree(1)).
 
-    THE ANSWER IS INJECTED, NOT THE ILLNESS — round 9's lesson, and the reason this
-    fixture is not a repo with a broken config. A genuinely malformed `.git/config`
-    fatals the caller's own earlier `rev-parse --absolute-git-dir` (measured 128 at
-    both 2.20.4 and 2.55.0), which takes the SILENT-SKIP arm above this branch, so
-    such a fixture would be vacuous. Keeping git healthy is also what leaves the harm
-    assertable through git itself once the gate is ablated.
+    THE ANSWER IS INJECTED, NOT THE ILLNESS, which is why this fixture is not a repo with
+    a broken config. A genuinely malformed `.git/config` fatals the caller's own earlier
+    `rev-parse --absolute-git-dir` at rc 128, which takes the SILENT-SKIP arm above this
+    branch, so such a fixture would be vacuous. Keeping git healthy is also what leaves
+    the harm assertable through git itself once the gate is ablated.
 
-    rc 128 is what git really answers for a config it cannot parse (measured at 2.20.4
-    and 2.55.0); git-config(1) documents that case as ret=3 and prefaces its whole list
-    with "Some exit codes are:", so neither the docs nor the behavior support treating
-    every non-1 rc as an absence.
+    rc 128 is what git really answers for a config it cannot parse; git-config(1)
+    documents that case as ret=3 and prefaces its whole list with "Some exit codes are:",
+    so neither the docs nor the behavior support treating every non-1 rc as an absence.
 
     Ablation: in `_shield_shared_config`, replace the raise with `return None` (the old
     `else` semantics) and this fails — the gate opens and `extensions.worktreeConfig`
@@ -3741,9 +3736,9 @@ def test_shield_degrade_leaves_no_permanent_repo_format_change(project, tmp_path
     the operator's repo marked forever for a shield that never applied. It now only
     PROBES; the write happens one line above the activation.
 
-    Driven through the seed fault the round-5 GitError fix introduced, because that
-    is the degrade path this reordering exists for — a fault the old code could not
-    even reach, since it swallowed instead of degrading.
+    Driven through the seed fault, because that is the degrade path this reordering exists
+    for — a fault the old code could not even reach, since it swallowed instead of
+    degrading.
 
     Read as TEXT rather than via `git config --get`, for the reason the sibling
     refusal tests give: conftest's git() is check=True and an unset key exits 1.
@@ -3797,17 +3792,15 @@ def test_shield_enables_the_extension_on_the_path_that_activates(project, tmp_pa
 
 def test_shield_rolls_back_the_extension_when_activation_fails(project, tmp_path, monkeypatch):
     """One of the two degrades that can still have made a permanent repo-format
-    change: the ACTIVATION's own failure, which happens one line after the enable.
-    Round 5 moved the enable down to close every path above it; Codex then pointed out
-    this one, and it is real — read-only `.git` and a lock on `config.worktree` both
-    reach it. So the arm rolls the flag back. (This docstring said "the one degrade
-    left" until round 10, which found the other: the ENABLE's own raise, covered by
-    `test_shield_rolls_back_an_enable_whose_git_faulted`.)
+    change: the ACTIVATION's own failure, which happens one line after the enable. The
+    enable sits as far down as it can, which closes every path above it; this one is
+    real — read-only `.git` and a lock on `config.worktree` both reach it — so the arm
+    rolls the flag back. The other such degrade is the ENABLE's own raise, covered by
+    `test_shield_rolls_back_an_enable_whose_git_faulted`.
 
-    Measured, not assumed: `--unset` removes the key *and* the now-empty
-    `[extensions]` section, and `git config --worktree` refuses again afterwards, so
-    the repo is genuinely returned to the state we found rather than cosmetically
-    tidied.
+    `--unset` removes the key *and* the now-empty `[extensions]` section, and `git config
+    --worktree` refuses again afterwards, so the repo is genuinely returned to the state
+    we found rather than cosmetically tidied.
 
     Only `--worktree` writes are failed, so the enable itself succeeds — which is
     what makes this the enable-then-fail ordering rather than a short-circuit.
@@ -3913,25 +3906,24 @@ def test_shield_reports_a_rollback_whose_own_git_faulted(project, tmp_path, monk
 
 @pytest.mark.parametrize("fault", [verify.GitError, verify.GitSpawnError])
 def test_shield_rolls_back_an_enable_whose_git_faulted(project, tmp_path, monkeypatch, fault):
-    """The ENABLE's own raise, which is round 10 (#384, Codex P2). `git_bytes` fails
+    """The ENABLE's own raise (#384). `git_bytes` fails
     two ways and this call handled only the rc, so a fault left the permanent
     repo-format change in place with no shield ever activated: the raise went to the
     caller's tail, which returns a reason and cannot roll anything back.
 
-    THE FAKE PERFORMS THE WRITE AND THEN RAISES, and that is the whole difference
-    between this test and a vacuous one. `git config` can be killed after it has
-    renamed the new config into place — the write landed, we never learned it — so
-    without the pass-through the flag would never have been set, "the flag is absent
-    afterwards" would hold trivially, and the assertion below would prove nothing.
-    That is the exact failure mode round 7 recorded, where a fault-injection test
-    asserting only the reason string sat on a live defect for two rounds.
+    THE FAKE PERFORMS THE WRITE AND THEN RAISES, and that is the whole difference between
+    this test and a vacuous one. `git config` can be killed after it has renamed the new
+    config into place — the write landed, we never learned it — so without the
+    pass-through the flag would never have been set, "the flag is absent afterwards" would
+    hold trivially, and the assertion below would prove nothing. That is the failure mode
+    of a fault-injection test that asserts only the reason string: it sits on a live
+    defect and cannot see it.
 
     The `--unset-all` is deliberately let through to the real git, so the rollback
     asserted here is the real one rather than the fake's.
 
-    Ordering matters as much as the outcome: round 9 found that hoisting a rollback
-    out of the `with` passed all 53 shield tests, so the rollback is pinned INSIDE
-    the lock here too.
+    Ordering matters as much as the outcome: hoisting a rollback out of the `with` passes
+    every other shield test, so the rollback is pinned INSIDE the lock here too.
 
     Parametrized over both classes because they enter differently — a timeout as
     `GitError`, a spawn failure as the `GitSpawnError` subclass. The message says
@@ -3993,19 +3985,17 @@ def test_shield_rolls_back_an_enable_whose_git_faulted(project, tmp_path, monkey
 
 def test_shield_rollback_treats_an_absent_flag_as_completed(project, tmp_path):
     """`--unset-all` of a key that is not there exits 5, and that is a COMPLETED
-    rollback, not a failed one. Round 10 made this reachable for the first time: the
-    enable's raise routes into the rollback without knowing whether anything was
-    written, so "nothing was" is now an ordinary outcome rather than an impossible
-    one, and reporting it as a failure would tell the operator their repository keeps
-    a format change it does not have.
+    rollback, not a failed one. The enable's raise made this reachable: it routes into
+    the rollback without knowing whether anything was written, so "nothing was" is now
+    an ordinary outcome rather than an impossible one, and reporting it as a failure
+    would tell the operator their repository keeps a format change it does not have.
 
     `--unset-all` rather than `--unset`, and the spelling is load-bearing because
     git-config(1) gives rc 5 TWO meanings — "unset an option which does not exist" and
-    "unset/set an option for which multiple lines match". Measured at 2.20.4 and
-    2.55.0, identical at both: `--unset` against a DOUBLED key exits 5 and removes
-    nothing, while `--unset-all` exits 0 and removes both lines. So under `--unset`,
-    "treat 5 as success" would have reported a clean rollback for a key that survived;
-    under `--unset-all` rc 5 can only mean "no line matched".
+    "unset/set an option for which multiple lines match": `--unset` against a DOUBLED key
+    exits 5 and removes nothing, while `--unset-all` exits 0 and removes both lines. So
+    under `--unset`, "treat 5 as success" would have reported a clean rollback for a key
+    that survived; under `--unset-all` rc 5 can only mean "no line matched".
 
     Driven directly rather than through the shield: the caller reaches this state only
     via an injected fault, and the claim under test is about the helper's own contract.
@@ -4071,7 +4061,7 @@ def test_shield_hedges_a_rollback_it_could_not_make_after_an_uncertain_enable(
 ):
     """When the ENABLE raised and the rollback then also failed, the reason may not
     assert that this shield set the flag — because nothing may have been written at
-    all. That is the double fault round 10 introduced a path to: a spawn failure kills
+    all. That is the double fault: a spawn failure kills
     the enable, so we never learn whether the config was replaced, and if the unset
     fails too the operator is handed a clause about a format change that may not exist.
 
@@ -4122,7 +4112,7 @@ def test_shield_does_not_claim_a_format_change_it_never_made(project, tmp_path, 
     """The message-honesty half of the same fix. A spawn failure can kill the enable
     before anything is written at all, and the rollback then finds nothing to undo —
     so the reason must not tell the operator their repository keeps a permanent format
-    change. Before round 10 this path rendered as "extensions.worktreeConfig was
+    change. This path used to render as "extensions.worktreeConfig was
     enabled for this shield and could NOT be rolled back (git exited 5)": a claim that
     was false twice over, about a flag that was never set and a rollback that in fact
     completed.
@@ -4203,7 +4193,7 @@ def test_shield_never_unsets_an_extension_the_repo_already_carried(project, tmp_
 def test_shield_never_unsets_an_extension_a_sibling_worktree_depends_on(
     project, tmp_path, monkeypatch
 ):
-    """`needs_enable` is necessary and NOT sufficient (#384, Codex round 8). It records
+    """`needs_enable` is necessary and NOT sufficient (#384). It records
     what the PROBE saw, and the enable is an idempotent rc-0 no-op against a flag that
     is already `true` — so two concurrent provisionings in one repository both read an
     absent flag and both believe they own it. Whichever one's activation then fails
@@ -4213,7 +4203,7 @@ def test_shield_never_unsets_an_extension_a_sibling_worktree_depends_on(
     `config.worktree` that is not ours exists.
 
     THE FIRST TEST IN THIS SUITE WITH TWO WORKTREES IN ONE REPOSITORY, which is why the
-    finding survived eight rounds: the flag is repo-wide state, and a single-worktree
+    finding stayed hidden so long: the flag is repo-wide state, and a single-worktree
     fixture cannot express a dependent.
 
     The interleaving is reproduced rather than mimed. The sibling's shield is run for
@@ -4323,14 +4313,13 @@ def test_shield_rolls_back_despite_its_own_partial_config_worktree(project, tmp_
 def test_shield_rollback_scan_fault_is_reported_not_raised(project, tmp_path, monkeypatch):
     """`_shield_undo_extension` is contracted never to raise — every caller is already
     reporting a degrade, and a raise escaping it would replace the activation fault
-    AND the retained-flag disclosure with the caller's generic tail reason, losing
-    exactly what rounds 6 and 7 added.
+    AND the retained-flag disclosure with the caller's generic tail reason.
 
-    The dependents scan added in round 8 broke that promise for two fault shapes its
-    `except OSError` did not name (#384, CodeRabbit round 9). On the 3.11/3.12 floor
-    `Path.resolve()` raises `RuntimeError` for a symlink loop rather than `OSError` —
-    the caller's own tail already carries `RuntimeError` for precisely that reason, so
-    the gap was internally inconsistent as well as wrong.
+    The dependents scan broke that promise for two fault shapes its `except OSError` did
+    not name (#384). On the 3.11/3.12 floor `Path.resolve()` raises `RuntimeError` for a
+    symlink loop rather than `OSError` — the caller's own tail already carries
+    `RuntimeError` for precisely that reason, so the gap was internally inconsistent as
+    well as wrong.
 
     Driven at the helper rather than through `_worktree_local_exclude`, which is the
     lowest layer that can catch this regression: the shield resolves its own `git_dir`
@@ -4368,13 +4357,12 @@ def test_shield_rolls_back_inside_the_lock(project, tmp_path, monkeypatch):
     """The ROLLBACK has to happen while the lock is still held, and that placement is
     load-bearing rather than incidental: released first, a second run probes in the
     gap, sees the flag this run is about to unset, skips its own enable as redundant,
-    activates against it — and then this run's `--unset` lands. That is the round-8
-    race rebuilt out of the fix for it.
+    activates against it — and then this run's `--unset` lands. That is the same race,
+    rebuilt out of the fix for it.
 
-    The sibling lock test cannot pin this: its activation SUCCEEDS, so no rollback
-    ever runs and `activation < lock_exit` is all it can show. Ablation proved the gap
-    was real — hoisting the rollback out of the `with` passed all 53 shield tests
-    (#384, CodeRabbit round 9).
+    The sibling lock test cannot pin this: its activation SUCCEEDS, so no rollback ever
+    runs and `activation < lock_exit` is all it can show. Ablation proved the gap was real
+    — hoisting the rollback out of the `with` passed every other shield test (#384).
 
     Ablation: move the rollback below the `with` block and this fails — the rollback
     is recorded after the lock's exit."""
@@ -4435,13 +4423,13 @@ def test_shield_takes_the_repo_scoped_lock(project, tmp_path, monkeypatch):
     - it is taken BEFORE the extension probe and held past the ACTIVATION, since the
       race is the window between the probe's answer and the activation's outcome.
 
-    That third bullet is the whole span only in company: this test's activation
-    SUCCEEDS, so no rollback runs in it and `activation < lock-exit` is the strongest
-    ordering it can witness. The rollback half — released only after the `--unset` —
-    is a separate property with its own test, `test_shield_rolls_back_inside_the_lock`,
-    which had to exist because hoisting the rollback out of the `with` passed all 53
-    shield tests including this one (#384, CodeRabbit round 9). A success-path ordering
-    test cannot pin a rollback-path ordering property.
+    That third bullet is the whole span only in company: this test's activation SUCCEEDS,
+    so no rollback runs in it and `activation < lock-exit` is the strongest ordering it
+    can witness. The rollback half — released only after the `--unset` — is a separate
+    property with its own test, `test_shield_rolls_back_inside_the_lock`, which had to
+    exist because hoisting the rollback out of the `with` passed every other shield test
+    including this one (#384). A success-path ordering test cannot pin a rollback-path
+    ordering property.
 
     Ordering is recorded from the calls themselves rather than asserted on the lock's
     existence: a lock taken after the probe, or released before the activation, leaves
@@ -4633,14 +4621,13 @@ def test_shield_seeds_users_excludesfile(project, tmp_path):
     sys.platform == "win32", reason="POSIX-only: Windows strips a trailing space from a filename"
 )
 def test_shield_seeds_an_excludesfile_whose_path_has_edge_whitespace(project, tmp_path):
-    """Round 5 (#384, Codex P2): the same leak as the encoding bug, through the PATH
-    rather than the content. A `.strip()` on git's answer destroyed a legal POSIX
-    path — `git config --type=path --get` returns leading and trailing whitespace
-    VERBATIM (git writes such a value quoted, so it round-trips; measured at 2.20.4
-    and 2.55.0) — so the stripped path read absent via `is_file()`, the seed came
-    back empty, and the activation then SHADOWED the excludes it had failed to copy.
-    Silent: `_shield_inherited_excludes` returned empty rather than raising, and the
-    caller only journals a non-None reason.
+    """The same leak as the encoding bug (#384), through the PATH rather than the
+    content. A `.strip()` on git's answer destroyed a legal POSIX path — `git config
+    --type=path --get` returns leading and trailing whitespace VERBATIM (git writes
+    such a value quoted, so it round-trips) — so the stripped path read absent via
+    `is_file()`, the seed came back empty, and the activation then SHADOWED the
+    excludes it had failed to copy. Silent: `_shield_inherited_excludes` returned empty
+    rather than raising, and the caller only journals a non-None reason.
 
     `-z` is the fix: it terminates the value with NUL, so the path survives whatever
     whitespace it carries.
@@ -4676,8 +4663,8 @@ def test_shield_seeds_an_excludesfile_whose_path_has_edge_whitespace(project, tm
     sys.platform == "win32", reason="POSIX-only: a 0xff byte cannot be a Windows filename"
 )
 def test_shield_preserves_a_non_utf8_excludesfile(project, tmp_path):
-    """THE round-4 regression (#384, Codex P1): the seed is a VERBATIM BYTE COPY, so
-    an operator's excludes file that is not UTF-8 survives it intact.
+    """The regression the bytes conversion fixed (#384): the seed is a VERBATIM BYTE
+    COPY, so an operator's excludes file that is not UTF-8 survives it intact.
 
     A `read_text(encoding="utf-8")` inside a handler naming `UnicodeError` made one
     non-UTF-8 byte anywhere in their file collapse the WHOLE seed to empty — and the
@@ -4715,7 +4702,7 @@ def test_shield_degrades_when_the_users_excludesfile_cannot_be_read(project, tmp
     activate over patterns it never copied. Absent is silent (the common case, and
     there is nothing to shadow); unreadable is a degrade, because the shadow is real.
 
-    The other half of the round-4 fix, and untested in either direction before it:
+    The other half of the bytes conversion, and untested in either direction before it:
     `OSError` was swallowed beside the decode fault, so an EACCES/EIO on their file
     produced the identical silent empty seed — and then the shadow.
 
@@ -4797,11 +4784,11 @@ def test_shield_reseeds_after_an_interrupted_creation(project, tmp_path, monkeyp
     def boom(*a, **kw):
         raise OSError("no space left on device")
 
-    # patched at install's OWN binding, as everywhere else in this file: the write
-    # goes through atomic_write_bytes (#375, #384 round 4) on an mkstemp fd via
-    # os.fdopen, so a Path.write_bytes patch never fires and would pass vacuously.
-    # The NAME matters as much as the binding — left pointing at atomic_write_text
-    # this patch became a silent no-op and the test failed on the degrade assertion.
+    # patched at install's OWN binding, as everywhere else in this file: the write goes
+    # through atomic_write_bytes (#375, #384) on an mkstemp fd via os.fdopen, so a
+    # Path.write_bytes patch never fires and would pass vacuously. The NAME matters as
+    # much as the binding — left pointing at atomic_write_text this patch became a silent
+    # no-op and the test failed on the degrade assertion.
     monkeypatch.setattr(install_mod, "atomic_write_bytes", boom)
     assert _worktree_local_exclude(wt, ["/probe-384"]) is not None
     monkeypatch.undo()  # the assertions below do their own file and git I/O
@@ -4819,8 +4806,8 @@ def test_shield_reprovision_does_not_duplicate_patterns(project, tmp_path):
     """Provisioning the SAME worktree twice must leave the private exclude
     byte-identical. The dedupe is what makes that true, and it compares the
     already-present lines against the patterns being added — so both sides have to
-    be the same type. Left as `str` against a `bytes` set (the shape the round-4
-    bytes conversion invites), every pattern reads as absent and is re-appended on
+    be the same type. Left as `str` against a `bytes` set — the shape the bytes
+    conversion invites — every pattern reads as absent and is re-appended on
     every single re-provision, growing the file without bound.
 
     Nothing pinned this before: `test_shield_reseeds_after_an_interrupted_creation`
@@ -4850,7 +4837,7 @@ def test_shield_reprovision_does_not_duplicate_patterns(project, tmp_path):
 
 def test_shield_dedupe_does_not_split_on_non_git_line_breaks(project, tmp_path):
     """The dedupe splits the existing content into lines the way GIT does, which is
-    the second thing the bytes conversion bought (#384 round 4).
+    the second thing the bytes conversion bought (#384).
 
     `str.splitlines()` breaks on `\\x0b`, `\\x0c`, `\\x1c`, `\\x1d`, `\\x1e` and
     `\\x85` as well as on newlines; git treats none of those as a line boundary, and
@@ -4881,22 +4868,21 @@ def test_shield_dedupe_does_not_split_on_non_git_line_breaks(project, tmp_path):
 
 def test_shield_appends_a_pattern_an_inherited_negation_would_cancel(project, tmp_path):
     """A pattern the file already CONTAINS can still be ineffective: gitignore's rule
-    is LAST MATCH WINS, so a `!` line below it cancels it (#384, Codex round 17).
+    is LAST MATCH WINS, so a `!` line below it cancels it (#384).
 
-    The plain set-membership dedupe therefore declined to append the shield's own
-    pattern, and the provisioned tool files stayed stageable — SILENTLY, because
-    nothing failed. That is why the assertions here go through git rather than through
-    the return value: `_worktree_local_exclude` answers None both with the bug and
-    with the fix, so a `reason` assertion cannot bite at all. Same shape as the
-    fault-injection test that sat on a live defect for two rounds by asserting only
-    the reason string.
+    The plain set-membership dedupe therefore declined to append the shield's own pattern,
+    and the provisioned tool files stayed stageable — SILENTLY, because nothing failed.
+    That is why the assertions here go through git rather than through the return value:
+    `_worktree_local_exclude` answers None both with the bug and with the fix, so a
+    `reason` assertion cannot bite at all — the same shape as a fault-injection test that
+    asserts only the reason string.
 
-    Measured, the negation need not repeat the positive's spelling — `!.claude/skills`
-    cancels `/.claude/skills` too. What does NOT cancel it is a negation leaving the
-    directory itself excluded (`!*.md` below it, or `!/.claude`, which re-includes only
-    the parent): git never descends into an excluded directory. The fix is deliberately
-    conservative across that line, appending a harmless duplicate in those cases rather
-    than reimplementing git's matcher, so this test pins the defeating shape only.
+    The negation need not repeat the positive's spelling — `!.claude/skills` cancels
+    `/.claude/skills` too. What does NOT cancel it is a negation leaving the directory
+    itself excluded (`!*.md` below it, or `!/.claude`, which re-includes only the parent):
+    git never descends into an excluded directory. The fix is deliberately conservative
+    across that line, appending a harmless duplicate in those cases rather than
+    reimplementing git's matcher, so this test pins the defeating shape only.
 
     Ablation (run): restore `settled = set(existing.splitlines())` and this fails at the
     status assertion with `?? .claude/skills/tool.md`."""
@@ -5087,9 +5073,9 @@ def test_shield_degrades_when_git_will_not_resolve_its_home_directory(
 
     def fail_home_probe(worktree, *args):
         # A PREFIX predicate, not tuple membership: the key travels both as the `-c`
-        # assignment and as the bare `--get` argument (#384, round 10's de-fanged
-        # fakes). Recording it is what proves this faulted the probe and not the
-        # seed read, whose argv is otherwise byte-identical.
+        # assignment and as the bare `--get` argument (#384). Recording it is what proves
+        # this faulted the probe and not the seed read, whose argv is otherwise
+        # byte-identical.
         if any(a.startswith("bmadloop.xdghomeprobe") for a in args):
             seen.append(args)
             return subprocess.CompletedProcess(
@@ -5118,16 +5104,15 @@ def test_shield_degrades_when_git_will_not_resolve_its_home_directory(
 
 def test_shield_seeds_a_relative_xdg_config_home_resolved_like_git(project, tmp_path, monkeypatch):
     """The relative-path defect of the `core.excludesFile` branch, at the XDG fallback
-    branch (#384, Codex round 12). This branch exists to REPRODUCE git's fallback, so
+    branch (#384). This branch exists to REPRODUCE git's fallback, so
     it has to reproduce git's resolution too.
 
-    A relative `XDG_CONFIG_HOME` is invalid per the XDG base-directory spec, which says
-    an implementation "should consider the path invalid and ignore it". Git does not
-    ignore it. Measured at 2.20.4 and 2.55.0: git honors the value and resolves it
-    against the worktree's TOP LEVEL — and measured from a SUBDIR to separate
-    top-level from cwd, `git -C <wt>/sub` with `XDG_CONFIG_HOME=rel` read
-    `<wt>/rel/git/ignore` rather than `<wt>/sub/rel/git/ignore`. So "git ignores an
-    invalid value" is the plausible guess this test exists to refute.
+    A relative `XDG_CONFIG_HOME` is invalid per the XDG base-directory spec, which says an
+    implementation "should consider the path invalid and ignore it". Git does not ignore
+    it: git honors the value and resolves it against the worktree's TOP LEVEL rather than
+    cwd — from a SUBDIR, `git -C <wt>/sub` with `XDG_CONFIG_HOME=rel` reads
+    `<wt>/rel/git/ignore`, not `<wt>/sub/rel/git/ignore`. So "git ignores an invalid
+    value" is the plausible guess this test exists to refute.
 
     `monkeypatch.chdir` is load-bearing here for the same reason as in the
     `core.excludesFile` sibling: run from inside the worktree, the unfixed code
@@ -5169,21 +5154,21 @@ def test_shield_honors_an_explicitly_empty_excludesfile(project, tmp_path, monke
     """An EXPLICITLY EMPTY `core.excludesFile` is an ANSWER, not an unset key: it is the
     operator saying "no excludes file at all", and git honors that literally — no
     patterns, and NO fallback to `$XDG_CONFIG_HOME/git/ignore`. Reading it as unset
-    (#384, Codex round 8) imported the XDG file's patterns and ACTIVATED them, which is
+    (#384) imported the XDG file's patterns and ACTIVATED them, which is
     the mirror image of every other finding in this family: instead of shadowing
     patterns it failed to copy it OVER-ignores, so session-created files the operator
     deliberately stopped ignoring go silently missing from the unit's `git add -A` and
     from the story's commit. Same silent-file-loss class as #384 itself, inverted.
 
-    Measured at git 2.55.0 on a fixture built for exactly this: `-z --type=path --get`
-    answers rc 0 with a lone NUL, `git check-ignore -v` then exits 1 against a name the
-    XDG file lists, and `git status` shows it untracked. The mechanism is in git's
-    source rather than inferred — `dir.c::setup_standard_excludes` guards the XDG
-    fallback on `if (!excludes_file)`, a NULL POINTER, while an empty value resolves
-    through `interpolate_path("")` to a non-NULL empty string. Byte-identical guard at
-    v2.20.0, this shield's floor, and at master. It is undocumented: `core.adoc` says
-    only "Defaults to $XDG_CONFIG_HOME/git/ignore" — the same standing as the relative-
-    value behavior the sibling test above pins.
+    On a fixture built for exactly this, `-z --type=path --get` answers rc 0 with a lone
+    NUL, `git check-ignore -v` then exits 1 against a name the XDG file lists, and `git
+    status` shows it untracked. The mechanism is in git's source rather than inferred —
+    `dir.c::setup_standard_excludes` guards the XDG fallback on `if (!excludes_file)`, a
+    NULL POINTER, while an empty value resolves through `interpolate_path("")` to a
+    non-NULL empty string, and that guard is unchanged from this shield's 2.20 floor to
+    current. It is undocumented: `core.adoc` says only "Defaults to
+    $XDG_CONFIG_HOME/git/ignore" — the same standing as the relative- value behavior the
+    sibling test above pins.
 
     `GIT_CONFIG_NOSYSTEM` is deliberately NOT pinned, unlike the XDG sibling: a
     repo-LOCAL key already outranks a global one, so there is nothing to suppress, and
@@ -5192,7 +5177,7 @@ def test_shield_honors_an_explicitly_empty_excludesfile(project, tmp_path, monke
     demanding whole-worktree cleanliness.
 
     Ablation: restore `and raw` on the rc branch of `_shield_inherited_excludes` (the
-    pre-round-8 condition) and this fails — `xdg-ignored.tmp` is seeded into the private
+    old condition) and this fails — `xdg-ignored.tmp` is seeded into the private
     exclude and disappears from git's status. Deleting the `if not raw:` arm alone does
     NOT reproduce the bug: `os.fsdecode(b"")` makes `Path(".")`, which resolves to the
     worktree directory and reads `is_file()` false, so the seed comes back empty
@@ -5391,10 +5376,10 @@ def test_worktree_local_exclude_degrades_on_write_fault(project, tmp_path, monke
     def boom(*a, **kw):
         raise OSError("read-only .git")
 
-    # patched at install's OWN binding: the exclude write goes through
-    # atomic_write_bytes (#375, #384 round 4), which writes via os.fdopen on an
-    # mkstemp fd, so a Path.write_bytes/Path.open patch never fires and would pass
-    # vacuously — and so would a patch left on the atomic_write_TEXT this replaced.
+    # patched at install's OWN binding: the exclude write goes through atomic_write_bytes
+    # (#375, #384), which writes via os.fdopen on an mkstemp fd, so a
+    # Path.write_bytes/Path.open patch never fires and would pass vacuously — and so would
+    # a patch left on the atomic_write_TEXT this replaced.
     monkeypatch.setattr(install_mod, "atomic_write_bytes", boom)
 
     reason = _worktree_local_exclude(wt, ["/probe-359"])
@@ -5403,7 +5388,7 @@ def test_worktree_local_exclude_degrades_on_write_fault(project, tmp_path, monke
 
 
 def test_worktree_local_exclude_appends_to_a_non_utf8_private_exclude(project, tmp_path):
-    """REPURPOSED, and the reversal is the fix (#384 review round 4). This case used
+    """REPURPOSED, and the reversal is the fix (#384). This case used
     to assert that a private exclude which is not UTF-8 DEGRADES the shield away,
     because `read_text` raised UnicodeDecodeError on it. The payload is bytes
     end-to-end now, so those bytes survive untouched *and* the shield still applies
@@ -5434,7 +5419,7 @@ def test_worktree_local_exclude_appends_to_a_non_utf8_private_exclude(project, t
     reason="fsencode uses utf-8/surrogatepass on Windows, which encodes any surrogate",
 )
 def test_worktree_local_exclude_degrades_on_unencodable_pattern(project, tmp_path):
-    """RE-POINTED (#384 review round 4) at the one shape that still raises. The
+    """RE-POINTED (#384) at the one shape that still raises. The
     encode fault used to be reachable from a real filename: `provision_worktree`
     builds a `seed_globs` pattern via `rel.as_posix()`, a non-UTF-8 name arrived
     surrogate-escaped, and `write_text` could not encode it back. The payload is
@@ -5567,12 +5552,12 @@ def test_worktree_local_exclude_undecodable_git_output_degrades(tmp_path, monkey
     root = os.fsencode(str(tmp_path)) + b"/repo-\377-name/.git"
     gitdir = root + b"/worktrees/wt"  # distinct from the common dir: a LINKED worktree
 
-    # SINGLE-QUOTED into the script. Unquoted, a temp root carrying whitespace
-    # (TMPDIR, --basetemp, a username with a space) word-splits into a second
-    # printf argument, and `printf '%s\n'` repeats its format per argument — so
-    # the helper is handed a path with an embedded NEWLINE and mkdir(parents=True)s
-    # it as a sibling of the basetemp pytest reaps. Measured with a spaced
-    # --basetemp: it leaked such a directory and the test still passed.
+    # SINGLE-QUOTED into the script. Unquoted, a temp root carrying whitespace (TMPDIR,
+    # --basetemp, a username with a space) word-splits into a second printf argument, and
+    # `printf '%s\n'` repeats its format per argument — so the helper is handed a path
+    # with an embedded NEWLINE and mkdir(parents=True)s it as a sibling of the basetemp
+    # pytest reaps — with a spaced --basetemp it leaks such a directory while every
+    # assertion still passes.
     def sq(raw):
         return b"'" + raw.replace(b"'", b"'\\''") + b"'"
 
@@ -5633,13 +5618,12 @@ def test_worktree_local_exclude_undecodable_git_output_degrades(tmp_path, monkey
     reason = _worktree_local_exclude(tmp_path / "wt", ["/probe-374"])
 
     assert reason is None or "could not update" in reason
-    # The tail actually RAN, against the decoded path. Not decoration: without
-    # it this test is vacuous whenever the stub cannot exec — a noexec temp dir
-    # (ordinary CI hardening), no /bin/sh, a filesystem that drops the exec bit.
-    # subprocess.run then raises OSError, the git-query arm swallows it as the
-    # expected skip it is, `reason is None` holds, and the ablation above
-    # evaporates with it. Measured: at mode 0644 the stub never runs and every
-    # assertion above still passes.
+    # The tail actually RAN, against the decoded path. Not decoration: without it this
+    # test is vacuous whenever the stub cannot exec — a noexec temp dir (ordinary CI
+    # hardening), no /bin/sh, a filesystem that drops the exec bit. subprocess.run then
+    # raises OSError, the git-query arm swallows it as the expected skip it is, `reason is
+    # None` holds, and the ablation above evaporates with it: at mode 0644 the stub never
+    # runs and every assertion above still passes.
     #
     # This also pins containment better than globbing shared /tmp for a leak:
     # that glob is non-recursive and tmp_path sits three levels down, so it
@@ -5744,10 +5728,10 @@ def test_provision_worktree_exclude_fault_reports_on_degraded(project, tmp_path,
     def boom(*a, **kw):
         raise OSError("read-only .git")
 
-    # patched at install's OWN binding: the exclude write goes through
-    # atomic_write_bytes (#375, #384 round 4), which writes via os.fdopen on an
-    # mkstemp fd, so a Path.write_bytes/Path.open patch never fires and would pass
-    # vacuously — and so would a patch left on the atomic_write_TEXT this replaced.
+    # patched at install's OWN binding: the exclude write goes through atomic_write_bytes
+    # (#375, #384), which writes via os.fdopen on an mkstemp fd, so a
+    # Path.write_bytes/Path.open patch never fires and would pass vacuously — and so would
+    # a patch left on the atomic_write_TEXT this replaced.
     monkeypatch.setattr(install_mod, "atomic_write_bytes", boom)
     msgs: list[str] = []
 
@@ -5824,20 +5808,20 @@ def test_worktree_local_exclude_common_dir_probe_rc_degrades(project, tmp_path, 
     on_degraded rather than swallowed") already specified the fix; only the code
     disagreed.
 
-    Name-filtered onto `--git-common-dir` alone, so `--absolute-git-dir` answers for
-    real and this pins the boundary BETWEEN the two arms rather than the first arm.
-    If the production flag ever changes, this filter stops matching, the shield
-    succeeds, and `reason is not None` fails loudly — the opposite polarity to a
-    tripwire that goes quiet (round 10).
+    Name-filtered onto `--git-common-dir` alone, so `--absolute-git-dir` answers for real
+    and this pins the boundary BETWEEN the two arms rather than the first arm. If the
+    production flag ever changes, this filter stops matching, the shield succeeds, and
+    `reason is not None` fails loudly — the opposite polarity to a tripwire that goes
+    quiet.
 
     The stderr detail is asserted, not just non-None: deleting the new arm lets the
     empty stdout fall through to the `could not read this worktree's git dirs` guard,
     which ALSO returns a reason. Asserting only `is not None` would pass against the
     bug.
 
-    Ablation: replace this arm's `return (...)` with `return None` — the round-8 rule
-    that a gate whose deletion does not reproduce the bug must be ablated by restoring
-    the OLD behavior, since deleting it lands on that other guard instead."""
+    Ablation: replace this arm's `return (...)` with `return None`, per the rule that a
+    gate whose deletion does not reproduce the bug must be ablated by restoring the OLD
+    behavior — deleting it lands on that other guard instead."""
     repo = project.project
     wt = tmp_path / "wt"
     verify.worktree_add(repo, wt, "feat", "main")
@@ -5869,22 +5853,21 @@ def test_worktree_local_exclude_common_dir_probe_raise_degrades(
     """The raise half of the same boundary, which is the shape that is actually
     reachable.
 
-    A non-zero rc from `--git-common-dir` after `--absolute-git-dir` answered rc 0 has
-    no static occupant — measured at 2.20.4 and 2.55.0, a healthy linked worktree
-    answers both rc 0, and an unknown flag is ECHOED at rc 0 rather than refused, so
-    "a git too old for the flag" cannot land there either. What reaches this boundary
-    is a TRANSIENT fault on the second spawn: the two probes are two separate
-    processes, each bounded by `limits.git_timeout_s`. Same standing round 9 accepted
-    one function away, and the reason it is worth a guard at all.
+    A non-zero rc from `--git-common-dir` after `--absolute-git-dir` answered rc 0 has no
+    static occupant — a healthy linked worktree answers both rc 0, and an unknown flag is
+    ECHOED at rc 0 rather than refused, so "a git too old for the flag" cannot land there
+    either. What reaches this boundary is a TRANSIENT fault on the second spawn: the two
+    probes are two separate processes, each bounded by `limits.git_timeout_s`. Same
+    standing as the guard one function away, and the reason it is worth a guard at all.
 
-    Both classes, because they enter differently — a timeout raises `GitError`
-    itself, a spawn failure the `GitSpawnError` subclass. Neither is caught locally:
-    the call sits inside the tail's `try`, so the raise is funnelled into a reason
-    there rather than by an `except` of its own (round 7 — enumerating one failure
-    shape per round is what cost this PR three of them).
+    Both classes, because they enter differently — a timeout raises `GitError` itself, a
+    spawn failure the `GitSpawnError` subclass. Neither is caught locally: the call sits
+    inside the tail's `try`, so the raise is funnelled into a reason there rather than by
+    an `except` of its own — enumerating one failure shape at a time is what leaves the
+    next one live.
 
     Ablation: wrap the `--git-common-dir` call in `try: ... except GitError: return
-    None`, restoring the pre-round-11 structure — both cases then return None."""
+    None`, restoring the earlier structure — both cases then return None."""
     repo = project.project
     wt = tmp_path / "wt"
     verify.worktree_add(repo, wt, "feat", "main")
@@ -5914,18 +5897,17 @@ def test_worktree_local_exclude_git_fault_after_answering_degrades(
     Name-filtered onto the activation so everything before it runs for real; that
     is also what makes this the SECOND arm rather than the first.
 
-    THE FLAG ASSERTION IS THE POINT OF THE SECOND HALF. This test injected exactly
-    the raised activation fault for two review rounds while asserting only the
-    returned reason — so it sat directly on top of a live defect and could not see
-    it: the enable one line above had already made a permanent repo-format change,
-    and the raise bypassed the rollback that the non-zero-rc arm had. Codex found it
-    by reading this test rather than the code. A degrade assertion that stops at the
-    reason string cannot tell a clean degrade from one that left state behind.
+    THE FLAG ASSERTION IS THE POINT OF THE SECOND HALF. This test injected exactly the
+    raised activation fault while asserting only the returned reason — so it sat directly
+    on top of a live defect and could not see it: the enable one line above had already
+    made a permanent repo-format change, and the raise bypassed the rollback that the
+    non-zero-rc arm had. A degrade assertion that stops at the reason string cannot tell a
+    clean degrade from one that left state behind.
 
     Name-filtering on `--worktree` is what keeps this pinned to the ACTIVATION. The
-    enable's own raise is a different degrade with its own rollback (round 10) — see
-    `test_shield_rolls_back_an_enable_whose_git_faulted` — so this test no longer
-    covers "every way the flag can be left behind", only this one.
+    enable's own raise is a different degrade with its own rollback — see
+    `test_shield_rolls_back_an_enable_whose_git_faulted` — so this test no longer covers
+    "every way the flag can be left behind", only this one.
 
     Parametrized over both classes because they enter differently — a timeout is
     raised as `GitError` itself, a spawn failure as the `GitSpawnError` subclass.
@@ -5963,19 +5945,19 @@ def test_shield_degrades_when_git_will_not_say_what_the_users_excludes_are(
     """A git fault reading `core.excludesFile` means we did NOT FIND OUT which file
     applies — and that must skip the shield, not activate over it.
 
-    THIS TEST REVERSES what it asserted before round 5. It used to pin the swallow,
-    on the premise that "git unqueryable ⇒ no key to resolve ⇒ nothing to copy" and
-    that skipping was "strictly worse than losing the seed". Both halves were wrong:
+    THIS TEST REVERSES what it once asserted. It used to pin the swallow, on the premise
+    that "git unqueryable ⇒ no key to resolve ⇒ nothing to copy" and that skipping was
+    "strictly worse than losing the seed". Both halves were wrong:
 
     - The premise is a false inference. It holds for `rc != 0`, which is an ANSWER
       (an unset key exits 1, and that arm is still correctly silent). A raised fault
       is not an answer, so the code mapped UNKNOWN onto ABSENT.
     - The outcome was never "a lost seed". It was a lost seed PLUS a worktree-scoped
-      key that SHADOWS the file the seed failed to read — the compound harm round 4
-      named as the bug. Skipping stages a bounded, journaled set of bmad-loop's own
-      files; continuing silently un-ignores whatever the operator's personal excludes
-      cover, which is by definition what their `.gitignore` does not, and merges it
-      back into their checkout as tracked content.
+      key that SHADOWS the file the seed failed to read — the compound harm that is the
+      bug. Skipping stages a bounded, journaled set of bmad-loop's own files; continuing
+      silently un-ignores whatever the operator's personal excludes cover, which is by
+      definition what their `.gitignore` does not, and merges it back into their checkout
+      as tracked content.
 
     Assertion 3 is the harm and is why the operator's excludes are planted FIRST: the
     version of this test that pinned the swallow planted none at all, so it could not
@@ -6028,25 +6010,23 @@ def test_shield_degrades_when_the_excludes_read_answers_with_a_fault_rc(
 ):
     """The sibling above is UNKNOWN arriving as a RAISE; this is UNKNOWN arriving as an
     rc. They are one funnel deliberately: `git_bytes` has exactly these two failure
-    shapes, and this PR's activation arm took three review rounds precisely because
-    each fix enumerated the shape it had just been shown.
+    shapes, and a fix that enumerates only the shape it was just shown leaves the
+    other live.
 
-    rc 1 is the ONLY non-zero rc that means "no such key". Every other one is git
-    saying it could not answer, and the `else:` used to route all of them into the XDG
-    fallback — seeding ignore patterns the operator never chose for this repository and
-    then ACTIVATING them over the file it had failed to read (#384, CodeRabbit round 9).
+    rc 1 is the ONLY non-zero rc that means "no such key". Every other one is git saying
+    it could not answer, and the `else:` used to route all of them into the XDG fallback —
+    seeding ignore patterns the operator never chose for this repository and then
+    ACTIVATING them over the file it had failed to read (#384).
 
-    INJECTED rather than provoked from a config value, and the measurement behind that
-    is why this docstring is long, because the plausible version is wrong.
-    `core.excludesFile = ~nosuchuser/ignore` really does make this read exit 128
-    (`fatal: failed to expand user dir`) — but git expands that same value while
-    parsing core config for any command that sets the repository up, so
-    `rev-parse --absolute-git-dir` in the caller fatals identically and the shield
-    silently skips ABOVE this branch. Measured at git 2.20.4 and 2.55.0, both ends of
-    the supported range. Nothing static reaches this arm; its occupants appear between
-    that rev-parse and this read, and the repo-scoped lock in between — `flock`, which
-    blocks indefinitely on POSIX — is what makes the window wide enough to hold a
-    dotfile sync or an NSS/LDAP hiccup.
+    INJECTED rather than provoked from a config value, because the plausible version is
+    wrong. `core.excludesFile = ~nosuchuser/ignore` really does make this read exit 128
+    (`fatal: failed to expand user dir`) — but git expands that same value while parsing
+    core config for any command that sets the repository up, so `rev-parse
+    --absolute-git-dir` in the caller fatals identically and the shield silently skips
+    ABOVE this branch. Nothing static reaches this arm; its occupants appear between that
+    rev-parse and this read, and the repo-scoped lock in between — `flock`, which blocks
+    indefinitely on POSIX — is what makes the window wide enough to hold a dotfile sync or
+    an NSS/LDAP hiccup.
 
     Injecting the ANSWER rather than breaking the repository is also what lets the harm
     be asserted through git's own status: the fault clears, the activation does not, so
@@ -6122,10 +6102,10 @@ def test_shield_git_calls_carry_the_locale_pin(project, tmp_path, monkeypatch):
     bin_dir.mkdir()
     seen = tmp_path / "locale-seen"
     stub = bin_dir / "git"
-    # shlex.quote, for the reason the `sq()` helper further up exists: unquoted, a
-    # temp root carrying whitespace (a spaced `--basetemp`, or TMPDIR) word-splits
-    # this redirect, so the stub appends to the wrong path and leaks a stray file
-    # outside the basetemp pytest reaps (#384, CodeRabbit at round 15).
+    # shlex.quote, for the reason the `sq()` helper further up exists: unquoted, a temp
+    # root carrying whitespace (a spaced `--basetemp`, or TMPDIR) word-splits this
+    # redirect, so the stub appends to the wrong path and leaks a stray file outside the
+    # basetemp pytest reaps (#384).
     stub.write_text(
         f'#!/bin/sh\nprintf "%s\\n" "${{LC_ALL-<unset>}}" >> {shlex.quote(str(seen))}\nexit 1\n',
         encoding="utf-8",
@@ -6179,8 +6159,8 @@ def test_provision_worktree_hookless_skips_hook_merge(tmp_path):
 def test_provision_worktree_hookless_exclude_has_no_bare_slash(project, tmp_path):
     """A hookless profile has config_path == "", which must not reach the exclude
     as a bare "/". That pattern is INERT rather than dangerous — git strips the
-    trailing slash to a zero-length pattern matching nothing, measured on 2.55.0
-    against "/*" and "*", which do blanket — so what this pins is that a profile
+    trailing slash to a zero-length pattern matching nothing, unlike "/*" or "*",
+    which do blanket — so what this pins is that a profile
     with nothing to shield contributes no line at all. Only the skill tree is
     shielded."""
     repo = project.project

--- a/tests/test_platform_util.py
+++ b/tests/test_platform_util.py
@@ -208,7 +208,7 @@ def test_atomic_write_text_fsyncs_before_it_publishes(tmp_path, monkeypatch):
     page cache, so the rename can be durable while the data is not, and the new
     name comes back pointing at a zero-length file. An empty ledger *parses* — as
     no entries — so the failure reads as every hand-written entry having vanished
-    rather than as corruption (CodeRabbit, review round 3)."""
+    rather than as corruption."""
     order = []
     real_fsync, real_replace = os.fsync, os.replace
     monkeypatch.setattr(
@@ -294,10 +294,10 @@ def test_atomic_write_bytes_replaces_contents(tmp_path):
 
 
 def test_atomic_write_bytes_writes_bytes_no_codec_can_decode(tmp_path):
-    """The reason this variant exists (#384 review round 4): the payload is an
-    operator's git exclude file, whose patterns are POSIX paths and therefore
-    arbitrary bytes. `atomic_write_text` would have to encode, and a strict UTF-8
-    encode of a legacy-encoded file's content raises."""
+    """The reason this variant exists (#384): the payload is an operator's git
+    exclude file, whose patterns are POSIX paths and therefore arbitrary bytes.
+    `atomic_write_text` would have to encode, and a strict UTF-8 encode of a
+    legacy-encoded file's content raises."""
     target = tmp_path / "exclude"
     target.write_bytes(b"before\n")
 
@@ -443,8 +443,8 @@ def test_atomic_write_bytes_stages_in_the_targets_own_directory(tmp_path, monkey
 
     Recorded from `os.replace`'s source argument, because the pre-existing
     "leaves no temp behind" assertion cannot see this: it lists the TARGET's
-    directory, which a temp staged in `/tmp` is trivially absent from. Measured —
-    with `dir=` dropped, that test passed."""
+    directory, which a temp staged in `/tmp` is trivially absent from — with
+    `dir=` dropped, that assertion still passes."""
     target = tmp_path / "sub" / "exclude"
     target.parent.mkdir()
     target.write_bytes(b"before")

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -629,13 +629,13 @@ def test_isolated_bundle_lands_when_the_gitignored_ledger_was_never_seeded(proje
     worktree with NO ledger. The orchestrator writes the close through
     `self.workspace.paths` — that absent file — `mark_done` returns False, and
     `verify_review_bundle` reads the same absent file and fails `fixable=True`.
-    Measured before the auto-seed: `phase=deferred`, `DW-1` still `open`, a
+    Without the auto-seed that leaves `phase=deferred`, `DW-1` still `open`, a
     `review-verify-failed` naming the worktree's path, and `open_ids` re-bundling
     the same work on every later sweep.
 
     No DONE-leg carry can rescue that — the unit never reaches DONE — so the fix
     is upstream of the carry: seed the ledger the checkout cannot deliver, which
-    moves the failure onto the leg 6M's carry already covers.
+    moves the failure onto the leg `_carry_isolated_ledger_writes` already covers.
 
     The extra dev effects are the repair round the gate's `fixable=True` buys.
     They go unused on the fixed path; without them a regression would exhaust the
@@ -3416,7 +3416,10 @@ def test_generic_bundle_harvests_new_spec_deferrals_alongside_its_ids(project):
 
 
 def test_bundle_harvest_alone_is_not_proof_of_work(project):
-    """Scope this 6J witness to the gate action; 6L moves bundle close timing."""
+    """A bundle session that files a spec deferral but changes nothing still reads
+    as "no changes": the harvest's own ledger write is not the session's proof of
+    work. The harvest itself still lands, so what this pins is the gate's action,
+    not a lost harvest."""
     write_ledger(project, {"DW-1": "open"})
     plan = triage_result(
         ["DW-1"],

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1374,9 +1374,9 @@ async def test_start_sweep_and_checkpoint_buttons_reachable(project):
 async def test_short_confirm_modal_stays_compact(project):
     """The bounded modals keep BaseDialog #dialog at height: auto on purpose, so a
     short body sizes to content instead of filling the screen. Guards the compact
-    tier against the #280 CodeRabbit suggestion of a definite `#dialog` height: on
-    a tall terminal a one-line confirm must stay a handful of rows, not balloon to
-    the 90% cap (a definite height took this from 7 → 23 rows when measured)."""
+    tier against a definite `#dialog` height (#280): on a tall terminal a one-line
+    confirm must stay a handful of rows, not balloon to the 90% cap — a definite
+    height takes this modal from 7 rows to 23."""
     app = BmadLoopApp(project.project)
     async with app.run_test(size=(64, 40)) as pilot:
         await until(pilot, lambda: isinstance(app.screen, DashboardScreen))


### PR DESCRIPTION
Second half of the post-0.9.0 editorial pass. PR A (#466) did CHANGELOG and markdown; this does in-code comments and docstrings. Comment/docstring bodies only — **no executable line changes**.

## What came out

`round N` citations, bot attributions (`CodeRabbit`, `Codex round`), `MEASURED at git 2.20.4 (docker alpine:3.9…)` probe records, verbatim run transcripts, `phase 6H`-style port archaeology, and incident data. Kept: behavioral invariants, version floors, user-actionable caveats, maintainer rationale ("what breaks if you change this"), and every issue ref.

Whole-file counts: `round N` 85 → 0, `Measured/MEASURED` 40 → 0, `CodeRabbit` 10 → 0, `628fe54` 1 → 0, `phase 6[A-Z]` 1 → 0.

## Docstring word counts

| docstring | before | after |
|---|---|---|
| `install._worktree_local_exclude` | 1394 | 377 |
| `install._shield_inherited_excludes` | 959 | 379 |
| `install._shield_shared_repository` | 877 | 580 |
| `install._shield_undo_extension` | 686 | 347 |
| `install._shield_home_git_ignore` | 603 | 345 |
| `install._shield_enable_worktree_config` | 591 | 345 |
| `install._shield_verify_activation` | 555 | 349 |
| `worktree_flow._ledger_seed` | 556 | 389 |
| `engine._carry_review_budget_followups` | 617 | 351 |

`_shield_shared_repository` stays at 580 deliberately: what remains is six independent trap rationales, each of the "a maintainer would break the code by not knowing" kind. Reaching ~350 means deleting one whole, not compressing further.

File totals: 29,816 → 29,210 lines; 89,313 → 82,573 comment/docstring words. `install.py` carries most of it (18,266 → 12,462 words, −32%).

## Verification

Four mechanical oracles, each ablated against an injected executable-line change to confirm it fails:

1. **AST equivalence** — parse before/after, strip every docstring, compare `ast.dump()`. 9/9 pass vs `main`.
2. **Code-token equality** — non-COMMENT/NL token streams identical with docstring STRINGs masked. 9/9 pass.
3. **`git diff main -U0` line audit** — every one of the 1,554 changed lines is a comment, docstring, or blank. 9/9 pass.
4. **Tooling-pragma survival** — `noqa` / `type: ignore` / `nosec` multisets unchanged (invisible to 1 and 2, but behaviour-affecting). 9/9 pass.

Plus a token-survival triage: grep-shaped identifiers set-diffed out of comment prose and bucketed by where they still survive. Every drop resolved to a probe record, git-source archaeology, or a token still spelled by code or tests — with one exception, fixed below.

## Audit findings, fixed in `eeaf112`

A verification pass (no rewriting) found the rewrite had introduced two false claims and dropped several durable facts.

**False claims corrected**

- `test_engine_worktree` — the gitignored-close docstring asserted the main checkout's ledger "still reads `status: open`", which its own assertions contradict. The dropped transcript was pinned to a pre-carry commit, so that state is counterfactual now; restated as "without the carry", matching the two sibling sites that already used that framing.
- `worktree_flow._ledger_seed` — the `worktree-seed-skipped` exclusion read as a live report when the exclusion exists precisely so it never fires (`test_sweep` asserts its absence).

**Durable facts restored**

- `engine` — "no exclude masks a tracked file's MODIFICATION" was absent from `src/` entirely after the rewrite, and it is the premise for the surviving claim that only a gitignored ledger reaches the commit.
- `worktree_flow` — why presence is asked of the worktree rather than of git (`verify.path_tracked` spawns a subprocess and raises), and why the exclusion is still correct for an out-of-repo symlink target.
- `install` — the `UnicodeError` tuple member's reason, the "nothing is decoded in the silent arm" rule that keeps #374 out, `--includes` predating the 2.20 floor, git's trailing-CR and BOM tolerance, and a bare `/` truncation being inert.
- **`#394` restored.** It was the only issue reference to leave the repository, and it is open — *"`_shield_undo_extension` can still raise through its stderr decode"*. Two earlier sessions independently rediscovered that defect and recorded it as unfiled, because the pointer that would have told them otherwise had been deleted.

**Archaeology the first pass missed** — its grep was case-sensitive and did not cover hyphenated forms: two `Round N` citations, four `in this PR` incident references, a `bot round` note, one `#457's review` attribution, and five lowercase `measured at 2.20.4 and 2.55.0` probe records (a form appearing nowhere else in `src/` or `tests/`).

Mandated keeps verified present: git 2.20 floor, `extensions.worktreeConfig` permanence, #426, #457, #462, #384 (53 refs). #460 is on the keep-list but has never appeared anywhere in this repository, including on `main` — nothing was dropped and none was invented.

## Gates

`uv run pytest -q -n auto` → 4265 passed, 24 skipped. `uv run pyright` → 0 errors. `trunk fmt` → no issues. `trunk check --no-fix` → ✔ No issues.

No CHANGELOG entry: this changes no user-visible behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installer safety when validating Git repositories, configuring worktrees, handling exclusions, and rolling back failed activation.
  * Enhanced path, encoding, atomic-write, and configuration handling during installation.

* **Documentation**
  * Clarified workflow behavior, Git compatibility, symlink handling, ledger processing, installer safeguards, and test coverage.
  * Expanded explanations for platform-specific behavior and interface regression checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->