### PR TITLE
docs: #384 exclude upgrade note + early-open-beta banner in the README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -356,6 +356,18 @@ whose seams had diverged enough that several ports needed a different fix, and t
   change is made, since git that old refuses a repo carrying it. Concurrent runs serialize on a
   `.git` lock; lines an older bmad-loop wrote into `.git/info/exclude` stay — delete them by hand.
 
+- **Upgrading from 0.9.1 or earlier: delete the shield lines left in `.git/info/exclude` (#384).**
+  Those versions appended the git-add shield's patterns to the shared `.git/info/exclude` of every
+  project they provisioned worktrees in, and upgrading does not remove them — while a line stays,
+  **new** files under the path it names silently never appear in `git status` or `git add -A` in
+  that checkout. To clean a repo once: open the file (`git rev-parse --git-path info/exclude` names
+  it from any checkout) and delete each line the shield wrote that you did not write yourself —
+  typically `/.claude/skills` or `/.agents/skills`, a hook config such as `/.claude/settings.json`,
+  the `/_bmad` family (`/_bmad`, `/_bmad/custom`, `/_bmad/render/`, or per-file `/_bmad/...`
+  lines), and any `[scm] worktree_seed` path rendered as `/<path>`. Then run `git status` and
+  review what reappears. `git check-ignore -v <path>` names the exact file and line hiding any
+  given path.
+
 - **The git-add shield's git calls run on the shared chokepoint (#389).** They were the last bare
   `git` spawns outside `verify._run_git`, so they missed its `LC_ALL=C` pin and used a hardcoded
   120s timeout instead of the configured `[limits] git_timeout_s`. Both now apply.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -360,13 +360,14 @@ whose seams had diverged enough that several ports needed a different fix, and t
   Those versions appended the git-add shield's patterns to the shared `.git/info/exclude` of every
   project they provisioned worktrees in, and upgrading does not remove them — while a line stays,
   **new** files under the path it names silently never appear in `git status` or `git add -A` in
-  that checkout. To clean a repo once: open the file (`git rev-parse --git-path info/exclude` names
-  it from any checkout) and delete each line the shield wrote that you did not write yourself —
-  typically `/.claude/skills` or `/.agents/skills`, a hook config such as `/.claude/settings.json`,
-  the `/_bmad` family (`/_bmad`, `/_bmad/custom`, `/_bmad/render/`, or per-file `/_bmad/...`
-  lines), and any `[scm] worktree_seed` path rendered as `/<path>`. Then run `git status` and
-  review what reappears. `git check-ignore -v <path>` names the exact file and line hiding any
-  given path.
+  that checkout. Clean each affected repo once:
+  - Open the file — `git rev-parse --git-path info/exclude` names it from any checkout.
+  - Delete each line the shield wrote, not your own. Typically `/.claude/skills` or
+    `/.agents/skills`, a hook config such as `/.claude/settings.json`, the `/_bmad` family
+    (`/_bmad`, `/_bmad/custom`, `/_bmad/render/`, or per-file `/_bmad/...` lines), and any
+    `[scm] worktree_seed` path rendered as `/<path>`.
+  - Run `git status` and review what reappears. `git check-ignore -v <path>` names the exact file
+    and line still hiding a given path.
 
 - **The git-add shield's git calls run on the shared chokepoint (#389).** They were the last bare
   `git` spawns outside `verify._run_git`, so they missed its `LC_ALL=C` pin and used a hardcoded

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 Plain Python drives the loop — **pick story → implement → adversarially review → verify → commit** — while LLMs do only the creative work, inside disposable, fresh-context coding-agent sessions you can attach to and watch.
 
+![Status: early open beta](https://img.shields.io/badge/status-early%20open%20beta-orange)
 [![CI](https://github.com/bmad-code-org/bmad-loop/actions/workflows/ci.yml/badge.svg)](https://github.com/bmad-code-org/bmad-loop/actions/workflows/ci.yml)
 ![Python](https://img.shields.io/badge/python-3.11%E2%80%933.14-blue)
 ![CLIs](https://img.shields.io/badge/agents-claude%20%C2%B7%20codex%20%C2%B7%20gemini%20%C2%B7%20copilot%20%C2%B7%20antigravity%20%C2%B7%20opencode-8a2be2)
@@ -23,6 +24,17 @@ Plain Python drives the loop — **pick story → implement → adversarially re
 </div>
 
 ---
+
+> ⚠️ **Early open beta — experimental, and moving fast.** bmad-loop is a young project that
+> only just started shipping publicly. Expect rough edges, docs that lag the code, and
+> **breaking changes in any release while it is pre-1.0** — CLI flags, policy keys, on-disk
+> run state, and skill contracts can all shift between versions. It also drives real coding
+> agents that write and commit in your repository, so point it at work you can review and
+> roll back (`[scm] isolation = "worktree"` keeps a failed attempt off your main checkout),
+> pin a release tag if you want a stable base, and read the [CHANGELOG](CHANGELOG.md) before
+> upgrading. Bug reports and feedback are what the beta is for — open an
+> [issue](https://github.com/bmad-code-org/bmad-loop/issues) with `bmad-loop diagnose` output
+> attached, or come talk to us on [Discord](https://discord.gg/gk8jAdXWmj).
 
 ## Why bmad-loop
 
@@ -297,7 +309,7 @@ The orchestrator drives the upstream dev primitive — `bmad-build-auto`, or `bm
 uv tool install "bmad-loop[tui] @ git+https://github.com/bmad-code-org/bmad-loop.git"
 
 # OR a pinned release tag (reproducible — recommended for day-to-day use):
-uv tool install "bmad-loop[tui] @ git+https://github.com/bmad-code-org/bmad-loop.git@v0.8.1"
+uv tool install "bmad-loop[tui] @ git+https://github.com/bmad-code-org/bmad-loop.git@v0.9.1"
 
 bmad-loop init --project /path/to/project --cli claude   # add --cli codex/gemini as needed
 claude "/bmad-loop-setup accept all defaults"            # installs the tool + wires the project
@@ -320,7 +332,7 @@ claude "/bmad-loop-setup upgrade"
 #    `uv tool upgrade` reuses the cached commit and won't pull new code.
 uv tool upgrade bmad-loop --reinstall                      # follows main or your pinned tag
 #    to move to a newer tag, re-run install with the new ref:
-#    uv tool install --force "bmad-loop[tui] @ git+https://github.com/bmad-code-org/bmad-loop.git@v0.8.1"
+#    uv tool install --force "bmad-loop[tui] @ git+https://github.com/bmad-code-org/bmad-loop.git@v0.9.1"
 
 # 2. re-lay the refreshed skills into EACH project that uses bmad-loop:
 bmad-loop init --project /path/to/project --force-skills


### PR DESCRIPTION
Two docs-only changes; no code touched.

## 1. CHANGELOG — `.git/info/exclude` upgrade note (#384)

One entry under Unreleased, next to the existing #384 fix family: tells operators upgrading from bmad-loop 0.9.1 or earlier how to find and delete the git-add shield patterns those versions left in the shared `.git/info/exclude`, which silently hide new files under tracked paths (`git rev-parse --git-path info/exclude` to locate the file, the typical pattern list, `git check-ignore -v` to attribute any still-hidden path).

**Why.** Maintainer decision replacing PR #386 (the `validate` warning for this residue), which is being closed unmerged. Rationale recorded there: the check was a transitional diagnostic for a finite, shrinking population — the user base is small and largely known — and six review rounds converged on one grading step, which per AGENTS.md is evidence about the approach. The remediation moves here: a release-note instruction instead of a shipped detector. Current versions already stopped writing the shared file (#385, merged).

## 2. README — early-open-beta banner

The README read as a settled tool. It now says what it is: a status badge in the hero row, plus a banner above **Why bmad-loop** stating this is an early open beta — young, experimental, moving fast, with breaking changes possible in any pre-1.0 release (CLI flags, policy keys, on-disk run state, skill contracts). It also names the practical consequence — the loop drives real agents that commit into the reader's repo, so point it at work you can review and roll back, `isolation = "worktree"` keeps a failed attempt off the main checkout, read the CHANGELOG before upgrading — and where to send feedback (issues with `bmad-loop diagnose` output, or Discord).

Drive-by in the same file: the pinned-release install example still named `v0.8.1`; the latest published tag is `v0.9.1`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added upgrade guidance for removing legacy Git shield entries when upgrading from version 0.9.1 or earlier.
  - Clarified that the project is in early open beta and may include experimental features and breaking changes.
  - Added guidance for rollback, release pinning, diagnostics, and feedback.
  - Updated installation and upgrade examples to reference version 0.9.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->