### PR TITLE
fix(config): recover the stranded seed guards and TOML conversion funnels (#456)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,12 +156,24 @@ whose seams had diverged enough that several ports needed a different fix, and t
   `""` made `provision_worktree`'s seed loop resolve source to the repo root and destination to the
   worktree — both pass its containment checks — so it copied the whole project in, untracked files
   included, then recursed into its own destination. `.`, `./` and `.\` are the same value and were
-  never rejected. `scm.worktree_seed`, a profile's `seed_files`, `skill_tree` and
-  `hooks.config_path`, and a plugin manifest's `seed_files`/`seed_globs` now refuse every spelling.
+  never rejected. Neither were the Windows spellings: Win32 strips every trailing period and space
+  from a path's final component, so `". "`, `".. "`, `"..."` and `"   "` name the root there while
+  both pure pathlib flavours read them as ordinary child names. `scm.worktree_seed`, a profile's
+  `seed_files`, `skill_tree` and `hooks.config_path`, a plugin manifest's `seed_files`/`seed_globs`
+  and its `[python] module`, and the Unity seeder's `scene_guard_dir` now refuse every spelling.
   The seed lists are shape-checked too: a bare string iterated into per-character entries that each
   passed the per-entry guard, and a scalar raised an untyped error out of the loader.
   **Behavior change:** `worktree_seed = [1]` and an int plugin seed entry are now rejected rather
   than silently `str()`-coerced.
+
+- **`init` no longer follows a config path that symlinks out of the project (#456).** The
+  profile/manifest guards are lexical and run at load, so a `skill_tree`, `hooks.config_path` or
+  plugin `[python] module` naming an ordinary project-relative directory passed all of them even
+  when that directory was a link out of the tree. `provision_worktree` already compared
+  resolved-vs-raw before writing; the `init` path reached mkdir/rmtree/write with no such check, and
+  `_copy_skills` supplied `_copy_traversable` neither containment root, so both of its legs were
+  inert there. Each now refuses after resolution — the plugin loader before `exec_module`, where a
+  slipped path is arbitrary code execution rather than a copy.
 
 - **A wrongly-typed field in a profile or plugin TOML is reported, not crashed on.** `float()`,
   `int()` and `.items()` over TOML-legal values of the wrong type raised bare

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,25 @@ whose seams had diverged enough that several ports needed a different fix, and t
 
 ### Fixed
 
+- **A seed path naming the project root is refused at load, in every source that feeds it (#456).**
+  `""` made `provision_worktree`'s seed loop resolve source to the repo root and destination to the
+  worktree — both pass its containment checks — so it copied the whole project in, untracked files
+  included, then recursed into its own destination. `.`, `./` and `.\` are the same value and were
+  never rejected. `scm.worktree_seed`, a profile's `seed_files`, `skill_tree` and
+  `hooks.config_path`, and a plugin manifest's `seed_files`/`seed_globs` now refuse every spelling.
+  The seed lists are shape-checked too: a bare string iterated into per-character entries that each
+  passed the per-entry guard, and a scalar raised an untyped error out of the loader.
+  **Behavior change:** `worktree_seed = [1]` and an int plugin seed entry are now rejected rather
+  than silently `str()`-coerced.
+
+- **A wrongly-typed field in a profile or plugin TOML is reported, not crashed on.** `float()`,
+  `int()` and `.items()` over TOML-legal values of the wrong type raised bare
+  `ValueError`/`TypeError`/`AttributeError`, and `inf` or an oversized integer raised
+  `OverflowError`, past every consumer's `ProfileError`/`PluginError` handling — the command died
+  with one `error:` line naming neither the file nor the key. Both parsers now funnel at their load
+  boundary, over a fault set closed on the nine value types `tomllib` can yield. `policy.toml`'s own
+  conversions are still raw (#474).
+
 - **The worktree git-add shield no longer marks a project's tracked files as ignored (#392).**
   It wrote a pattern for every path it shields, including hook configs and skill trees a project
   tracks. Over a tracked file that pattern shields nothing — git applies ignore rules only to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,27 +153,23 @@ whose seams had diverged enough that several ports needed a different fix, and t
 ### Fixed
 
 - **A seed path naming the project root is refused at load, in every source that feeds it (#456).**
-  `""` made `provision_worktree`'s seed loop resolve source to the repo root and destination to the
-  worktree — both pass its containment checks — so it copied the whole project in, untracked files
-  included, then recursed into its own destination. `.`, `./` and `.\` are the same value and were
-  never rejected. Neither were the Windows spellings: Win32 strips every trailing period and space
-  from a path's final component, so `". "`, `".. "`, `"..."` and `"   "` name the root there while
-  both pure pathlib flavours read them as ordinary child names. `scm.worktree_seed`, a profile's
+  A root-naming entry made `provision_worktree`'s seed loop resolve source to the repo root and
+  destination to the worktree — both pass its containment checks — so it copied the whole project
+  in, untracked files included, then recursed into its own destination. `""` was one spelling of
+  several: `.`, `./`, `.\`, and on Windows `". "`, `".. "`, `"..."` and `"   "`, which Win32 trims
+  to the root while pathlib reads them as ordinary child names. `scm.worktree_seed`, a profile's
   `seed_files`, `skill_tree` and `hooks.config_path`, a plugin manifest's `seed_files`/`seed_globs`
-  and its `[python] module`, and the Unity seeder's `scene_guard_dir` now refuse every spelling.
-  The seed lists are shape-checked too: a bare string iterated into per-character entries that each
-  passed the per-entry guard, and a scalar raised an untyped error out of the loader.
-  **Behavior change:** `worktree_seed = [1]` and an int plugin seed entry are now rejected rather
-  than silently `str()`-coerced.
+  and its `[python] module`, and the Unity seeder's `scene_guard_dir` now refuse every spelling, and
+  the seed lists are shape-checked. **Behavior change:** `worktree_seed = [1]` and an int plugin
+  seed entry are now rejected rather than silently `str()`-coerced.
 
-- **`init` no longer follows a config path that symlinks out of the project (#456).** The
-  profile/manifest guards are lexical and run at load, so a `skill_tree`, `hooks.config_path` or
-  plugin `[python] module` naming an ordinary project-relative directory passed all of them even
-  when that directory was a link out of the tree. `provision_worktree` already compared
-  resolved-vs-raw before writing; the `init` path reached mkdir/rmtree/write with no such check, and
-  `_copy_skills` supplied `_copy_traversable` neither containment root, so both of its legs were
-  inert there. Each now refuses after resolution — the plugin loader before `exec_module`, where a
-  slipped path is arbitrary code execution rather than a copy.
+- **`init` no longer follows a config path that leaves the project (#456).** The profile/manifest
+  guards are lexical, so a `skill_tree`, `hooks.config_path` or plugin `[python] module` naming an
+  ordinary project-relative directory passed them even when that directory linked out of the tree.
+  `provision_worktree` re-checked after resolution; `init` reached mkdir/rmtree/write with no such
+  check. Each now requires the target to resolve _strictly below_ the project — equality would
+  admit a link back to the root — and a refused skill tree fails the install instead of being
+  skipped past `init complete`.
 
 - **A wrongly-typed field in a profile or plugin TOML is reported, not crashed on.** `float()`,
   `int()` and `.items()` over TOML-legal values of the wrong type raised bare

--- a/src/bmad_loop/adapters/profile.py
+++ b/src/bmad_loop/adapters/profile.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 import regex
 
-from ..platform_util import has_parent_ref, is_absolute_path
+from ..platform_util import has_parent_ref, is_absolute_path, names_tree_root
 
 USAGE_PARSERS = {"claude-jsonl", "codex-rollout", "gemini-chat", "copilot-events", "none"}
 HOOK_DIALECTS = {
@@ -149,7 +149,11 @@ def _parse_profile(doc: dict, source: str) -> CLIProfile:
         events: dict[str, str] = {}
     else:
         config_path = str(hooks_d.get("config_path", ""))
-        if not config_path or is_absolute_path(config_path) or has_parent_ref(config_path):
+        if (
+            names_tree_root(config_path)
+            or is_absolute_path(config_path)
+            or has_parent_ref(config_path)
+        ):
             raise fail("hooks.config_path must be a project-relative path")
         events_d = hooks_d.get("events")
         if not isinstance(events_d, dict) or not events_d:
@@ -175,12 +179,16 @@ def _parse_profile(doc: dict, source: str) -> CLIProfile:
         raise fail(f"stop_without_result_nudges must be >= 0: got {stop_nudges}")
 
     skill_tree = str(doc.get("skill_tree", ".claude/skills"))
-    if not skill_tree or is_absolute_path(skill_tree) or has_parent_ref(skill_tree):
+    if names_tree_root(skill_tree) or is_absolute_path(skill_tree) or has_parent_ref(skill_tree):
         raise fail("skill_tree must be a project-relative path")
 
     seed_files = str_list("seed_files")
+    # `names_tree_root` subsumes the emptiness check it replaced. These entries feed
+    # provision_worktree's seed loop, where any spelling of the root ("", ".", "./",
+    # ".\") resolves src to the repo root and dst to the worktree — both pass the
+    # loop's containment checks, so the whole repo is copied in.
     for seed in seed_files:
-        if not seed or is_absolute_path(seed) or has_parent_ref(seed):
+        if names_tree_root(seed) or is_absolute_path(seed) or has_parent_ref(seed):
             raise fail(f"seed_files entries must be project-relative paths: got {seed!r}")
 
     env_fault_patterns = str_list("env_fault_patterns")

--- a/src/bmad_loop/adapters/profile.py
+++ b/src/bmad_loop/adapters/profile.py
@@ -223,7 +223,19 @@ def _load_toml(text: str, source: str) -> CLIProfile:
         doc = tomllib.loads(text)
     except tomllib.TOMLDecodeError as e:
         raise ProfileError(f"profile {source}: invalid TOML: {e}") from e
-    return _parse_profile(doc, source)
+    try:
+        return _parse_profile(doc, source)
+    except ProfileError:
+        raise
+    except (AttributeError, TypeError, ValueError) as e:
+        # A funnel, not per-field guards: `_parse_profile`'s raw conversions
+        # (`float()`, `int()`, `.items()`) raise bare conversion errors on
+        # TOML-legal values of the wrong type, and every consumer keys its
+        # fault handling on ProfileError — `validate`'s role loop reports an
+        # `adapter.profile` failure, `_require_base_skills` skips the one
+        # profile, `install` prints FAIL. A bare escape crashed `validate`
+        # before any document was printed.
+        raise ProfileError(f"profile {source}: malformed field value: {e}") from e
 
 
 def load_profiles(project: Path | None = None) -> dict[str, CLIProfile]:

--- a/src/bmad_loop/adapters/profile.py
+++ b/src/bmad_loop/adapters/profile.py
@@ -44,6 +44,19 @@ class ProfileError(Exception):
     pass
 
 
+# Every fault a raw coercion over a `tomllib` value can raise — the set is CLOSED,
+# not a list of the ones seen so far, which is what makes funnelling on it a funnel
+# rather than another round of enumeration. `tomllib` yields exactly nine types
+# (str, int, float, bool, datetime, date, time, list, dict) and all nine were run
+# through this module's coercions: `int()`/`float()` answer TypeError for the five
+# non-numerics, ValueError for a non-numeric str and for `nan`, and **OverflowError**
+# for `inf`/`-inf` (int) and for an int too large to be a float — `tomllib` accepts
+# arbitrary-precision integers, so that second one is reachable from a config file.
+# Iteration and `.items()` add TypeError and AttributeError and nothing new.
+# `plugins/manifest.py` funnels on the same set for the same reason.
+CONVERSION_FAULTS = (AttributeError, OverflowError, TypeError, ValueError)
+
+
 @dataclass(frozen=True)
 class HookSpec:
     dialect: str
@@ -226,8 +239,8 @@ def _load_toml(text: str, source: str) -> CLIProfile:
     try:
         return _parse_profile(doc, source)
     except ProfileError:
-        raise
-    except (AttributeError, TypeError, ValueError) as e:
+        raise  # intent: a domain error is never re-wrapped (it is not a CONVERSION_FAULT)
+    except CONVERSION_FAULTS as e:
         # A funnel, not per-field guards: `_parse_profile`'s raw conversions
         # (`float()`, `int()`, `.items()`) raise bare conversion errors on
         # TOML-legal values of the wrong type, and every consumer keys its

--- a/src/bmad_loop/data/plugins/unity/unity_seed_assets.py
+++ b/src/bmad_loop/data/plugins/unity/unity_seed_assets.py
@@ -70,6 +70,24 @@ def _has_parent_ref(value: str) -> bool:
     return ".." in PurePosixPath(value).parts or ".." in PureWindowsPath(value).parts
 
 
+def _names_tree_root(value: str) -> bool:
+    """True if ``value`` names the worktree rather than anything inside it
+    (mirrors ``bmad_loop.platform_util.names_tree_root``).
+
+    The third member of the family, and the one this script was missing. Win32
+    strips every trailing period and space from a path's final component, so
+    ``"..."`` names the worktree root there while both pure flavours read it as an
+    ordinary one-segment name. That mattered here: the caller `.strip()`s the env
+    var, which collapses the *space* spellings into ``"."`` and lets the existing
+    ``not rel.parts`` check catch them, but leaves the *dot* spellings intact —
+    and the asset-root probe below would then find the worktree itself, so the
+    payload landed in the worktree root instead of under ``Assets/``."""
+    if PurePosixPath(value) == PurePosixPath(".") or PureWindowsPath(value) == PureWindowsPath("."):
+        return True
+    parts = [part for part in value.replace("\\", "/").split("/") if part]
+    return bool(parts) and all(part.strip(" .") == "" and part != ".." for part in parts)
+
+
 def _truthy(value: str | None, default: bool) -> bool:
     if value is None or value.strip() == "":
         return default
@@ -166,10 +184,16 @@ def main() -> int:
 
     guard_dir = os.environ.get("BMAD_LOOP_UNITY_SCENE_GUARD_DIR", "").strip() or _DEFAULT_GUARD_DIR
     rel = Path(guard_dir)
-    # The install dir must stay inside the worktree: an absolute/drive-qualified
-    # path would make _install's relative_to() raise, and a ".." segment would
-    # let the copy escape the project tree.
-    if not rel.parts or _is_absolute(guard_dir) or _has_parent_ref(guard_dir):
+    # The install dir must stay inside the worktree AND name something in it: an
+    # absolute/drive-qualified path would make _install's relative_to() raise, a
+    # ".." segment would let the copy escape the project tree, and a root-naming
+    # spelling would scatter the payload across the worktree root itself.
+    if (
+        not rel.parts
+        or _names_tree_root(guard_dir)
+        or _is_absolute(guard_dir)
+        or _has_parent_ref(guard_dir)
+    ):
         print(f"unity_seed_assets: invalid scene guard dir {guard_dir!r}", file=sys.stderr)
         return 2
     target_dir = worktree / guard_dir

--- a/src/bmad_loop/install.py
+++ b/src/bmad_loop/install.py
@@ -1110,7 +1110,7 @@ def merge_hooks(config: dict, registrations: dict[str, str], dialect: str) -> tu
 
 
 def _confined_to(target: Path, root: Path) -> bool:
-    """True if ``target`` resolves inside ``root``.
+    """True if ``target`` resolves *strictly below* ``root``.
 
     The profile/manifest guards (``names_tree_root``/``is_absolute_path``/
     ``has_parent_ref``) are lexical and run at load, so they cannot see a *link*:
@@ -1119,9 +1119,18 @@ def _confined_to(target: Path, root: Path) -> bool:
     is the resolve-time backstop the worktree side already had inline
     (``worktree_flow`` compares resolved-vs-raw before writing); the ``init`` path
     reached mkdir/rmtree/write with no such check. Refuses on OSError rather than
-    degrading: a slot that cannot be inspected is not safe to write through."""
+    degrading: a slot that cannot be inspected is not safe to write through.
+
+    Strictly below, not merely inside, because ``is_relative_to`` is true for
+    equal paths — the same "a path is relative to itself" hole this guard family
+    exists to close in `provision_worktree`'s seed loop. `skill_tree = "skills"`
+    where `project/skills` links back to `project` resolves to the root itself, and
+    an equality-inclusive check would hand `_copy_skills` the project root: the
+    bundled skill dirs land at top level, and `--force-skills` `rmtree`s any root
+    directory whose name collides with one of them."""
     try:
-        return target.resolve().is_relative_to(root.resolve())
+        resolved, base = target.resolve(), root.resolve()
+        return resolved != base and resolved.is_relative_to(base)
     except (OSError, RuntimeError):
         return False
 
@@ -2418,9 +2427,13 @@ def _copy_skills(project: Path, trees: Sequence[str], force: bool) -> bool:
         # into `_copy_traversable`'s own guards on purpose: passing `worktree=`
         # would also force no-clobber and switch per-entry OSError to degrade,
         # and `init` must fail loudly on a write it cannot complete.
+        #
+        # Raises rather than skipping: a skipped tree leaves the install missing
+        # the skills every later session dispatches, and an `init` that prints
+        # `init complete` and exits 0 over that is an unattended-setup trap. Same
+        # severity as `_register_hooks`' refusal, which already fails the install.
         if not _confined_to(tree_dir, project):
-            print(f"FAIL: skill tree escapes the project, skipping: {tree_dir}")
-            continue
+            raise ProfileError(f"skill tree does not resolve inside the project: {tree_dir}")
         installed: list[str] = []
         skipped: list[str] = []
         for skill in MODULE_SKILLS:
@@ -2509,7 +2522,11 @@ def install_into(
     skills_skipped = False
     if skills:
         trees = list(dict.fromkeys(p.skill_tree for p in profiles))
-        skills_skipped = _copy_skills(project, trees, force_skills)
+        try:
+            skills_skipped = _copy_skills(project, trees, force_skills)
+        except ProfileError as e:
+            print(f"FAIL: {e}")
+            return 1
 
     # 4. policy template
     policy_path = bmad_loop_dir / "policy.toml"

--- a/src/bmad_loop/install.py
+++ b/src/bmad_loop/install.py
@@ -1109,11 +1109,31 @@ def merge_hooks(config: dict, registrations: dict[str, str], dialect: str) -> tu
     return config, changed
 
 
+def _confined_to(target: Path, root: Path) -> bool:
+    """True if ``target`` resolves inside ``root``.
+
+    The profile/manifest guards (``names_tree_root``/``is_absolute_path``/
+    ``has_parent_ref``) are lexical and run at load, so they cannot see a *link*:
+    a `skill_tree` or `hooks.config_path` naming a perfectly project-relative
+    directory that happens to be a symlink out of the tree passes all three. This
+    is the resolve-time backstop the worktree side already had inline
+    (``worktree_flow`` compares resolved-vs-raw before writing); the ``init`` path
+    reached mkdir/rmtree/write with no such check. Refuses on OSError rather than
+    degrading: a slot that cannot be inspected is not safe to write through."""
+    try:
+        return target.resolve().is_relative_to(root.resolve())
+    except (OSError, RuntimeError):
+        return False
+
+
 def _register_hooks(project: Path, profile: CLIProfile) -> int:
     if profile.hookless:
         print(f"  no hooks needed ({profile.name}): HTTP/SSE transport")
         return 0
     config_path = project / profile.hooks.config_path
+    if not _confined_to(config_path, project):
+        print(f"FAIL: hooks config_path escapes the project ({profile.name}): {config_path}")
+        return 1
     config_path.parent.mkdir(parents=True, exist_ok=True)
     config: dict = {}
     if config_path.is_file():
@@ -2391,6 +2411,16 @@ def _copy_skills(project: Path, trees: Sequence[str], force: bool) -> bool:
     skipped_any = False
     for tree in trees:
         tree_dir = project / tree
+        # This loop rmtree's under `force` and writes unconditionally, and its
+        # `_copy_traversable` call passes neither `worktree` nor `repo_root`, so
+        # both of that helper's containment legs are inert here by construction.
+        # The containment check therefore has to live at this level. Not folded
+        # into `_copy_traversable`'s own guards on purpose: passing `worktree=`
+        # would also force no-clobber and switch per-entry OSError to degrade,
+        # and `init` must fail loudly on a write it cannot complete.
+        if not _confined_to(tree_dir, project):
+            print(f"FAIL: skill tree escapes the project, skipping: {tree_dir}")
+            continue
         installed: list[str] = []
         skipped: list[str] = []
         for skill in MODULE_SKILLS:

--- a/src/bmad_loop/platform_util.py
+++ b/src/bmad_loop/platform_util.py
@@ -117,6 +117,28 @@ def has_parent_ref(value: str | Path) -> bool:
     return ".." in PurePosixPath(text).parts or ".." in PureWindowsPath(text).parts
 
 
+def names_tree_root(value: str | Path) -> bool:
+    """True if ``value`` names the tree it is relative to rather than anything
+    *inside* it: ``""``, ``"."``, ``"./"``, ``"./."`` all normalize to the root.
+
+    The third member of the "must be a path inside the project" family, and the
+    one a `not value` emptiness check misses. It exists because these guards feed
+    `provision_worktree`'s seed loop, where a root-naming entry resolves ``src``
+    to the repo root and ``dst`` to the worktree, both of which pass the loop's
+    ``is_relative_to`` containment checks — a path is relative to itself. Measured:
+    ``""`` and ``"."`` produce a byte-identical ``(src, raw, dst)`` triple there,
+    so a guard rejecting only the first is a guard against one spelling.
+
+    Both flavours are checked for the same reason :func:`is_absolute_path` checks
+    both: ``".\\"`` is a root ref Windows normalizes away and POSIX parsing keeps
+    as an ordinary one-segment name. Pair with the other two for a complete
+    "must stay inside the project, and must name something in it" guard."""
+    text = str(value)
+    return PurePosixPath(text) == PurePosixPath(".") or PureWindowsPath(text) == PureWindowsPath(
+        "."
+    )
+
+
 def _retry_on_sharing_violation(op: Callable[[], None]) -> None:
     """Run ``op``, retrying the transient Windows sharing violation a concurrent
     handle on the file triggers (WinError 5/32). Gated to win32 so a real POSIX

--- a/src/bmad_loop/platform_util.py
+++ b/src/bmad_loop/platform_util.py
@@ -132,11 +132,32 @@ def names_tree_root(value: str | Path) -> bool:
     Both flavours are checked for the same reason :func:`is_absolute_path` checks
     both: ``".\\"`` is a root ref Windows normalizes away and POSIX parsing keeps
     as an ordinary one-segment name. Pair with the other two for a complete
-    "must stay inside the project, and must name something in it" guard."""
+    "must stay inside the project, and must name something in it" guard.
+
+    The dot/space spellings are the same asymmetry one layer down. Win32 path
+    normalization strips *every* trailing period and space from a path's final
+    component, so ``". "``, ``".. "``, ``"..."`` and even ``"   "`` all name the
+    containing directory there, while both pure flavours keep them as ordinary
+    one-segment names (pathlib never applies that trim — only ``resolve()``, by
+    asking the OS, does). A component made solely of periods and spaces is
+    therefore root-naming, and that is the whole rule: ``"foo. "`` strips to
+    ``"foo"``, names a child, and is accepted.
+
+    ``".. "`` lands here rather than in :func:`has_parent_ref` because the trailing
+    space stops it matching the ``..`` relative component, so Win32 trims it to
+    empty instead of climbing — it names the root, not the parent. That reading is
+    Wine's conformance suite and Project Zero's write-up; Microsoft's own docs are
+    ambiguous on the trim-vs-relative-component ordering. Nothing rests on
+    resolving it: under the other reading ``".. "`` escapes the tree, and the
+    call sites that pair the two guards reject it either way. Plain ``".."`` is
+    unchanged and stays :func:`has_parent_ref`'s job."""
     text = str(value)
-    return PurePosixPath(text) == PurePosixPath(".") or PureWindowsPath(text) == PureWindowsPath(
-        "."
-    )
+    if PurePosixPath(text) == PurePosixPath(".") or PureWindowsPath(text) == PureWindowsPath("."):
+        return True
+    # `/` separates on both platforms, `\` only on Windows — split on both so a
+    # value is judged by the same components Win32 would see.
+    parts = [part for part in text.replace("\\", "/").split("/") if part]
+    return bool(parts) and all(part.strip(" .") == "" and part != ".." for part in parts)
 
 
 def _retry_on_sharing_violation(op: Callable[[], None]) -> None:

--- a/src/bmad_loop/plugins/manifest.py
+++ b/src/bmad_loop/plugins/manifest.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import tomllib
 from typing import Any
 
-from ..platform_util import has_parent_ref, is_absolute_path
+from ..platform_util import has_parent_ref, is_absolute_path, names_tree_root
 from .model import (
     SETTING_TYPES,
     WORKFLOW_ROLES,
@@ -31,8 +31,11 @@ from .model import (
 
 
 def _check_relative_paths(values: tuple[str, ...], label: str, fail) -> None:
+    # `names_tree_root` subsumes the emptiness check it replaced: "", ".", "./" and
+    # ".\" all name the tree rather than anything in it, and a seed entry that names
+    # the tree root makes provision_worktree copy the whole repo into the worktree.
     for value in values:
-        if not value or is_absolute_path(value) or has_parent_ref(value):
+        if names_tree_root(value) or is_absolute_path(value) or has_parent_ref(value):
             raise fail(f"{label} entries must be project-relative paths: got {value!r}")
 
 

--- a/src/bmad_loop/plugins/manifest.py
+++ b/src/bmad_loop/plugins/manifest.py
@@ -30,6 +30,20 @@ from .model import (
 )
 
 
+def _str_list(plugin_d: dict, key: str, fail) -> tuple[str, ...]:
+    # Shape before entries, the same rule the sibling seed sources apply to their
+    # own lists (policy.py `worktree_seed`, adapters/profile.py `str_list`): a
+    # bare string iterates into per-character entries that each pass the
+    # per-entry guard below, and a scalar raises a bare TypeError out of `loads`
+    # where every other malformed value here raises PluginError.
+    raw = plugin_d.get(key, ())
+    if isinstance(raw, (str, bytes)) or not isinstance(raw, (list, tuple)):
+        raise fail(f"[plugin] {key} must be a list of paths: got {raw!r}")
+    if not all(isinstance(s, str) for s in raw):
+        raise fail(f"[plugin] {key} entries must be strings: got {list(raw)!r}")
+    return tuple(raw)
+
+
 def _check_relative_paths(values: tuple[str, ...], label: str, fail) -> None:
     # `names_tree_root` subsumes the emptiness check it replaced: "", ".", "./" and
     # ".\" all name the tree rather than anything in it, and a seed entry that names
@@ -177,9 +191,9 @@ def parse_manifest(
     except (TypeError, ValueError):
         raise fail(f"[plugin] api_version must be an integer: got {raw_api!r}") from None
 
-    seed_files = tuple(str(s) for s in plugin_d.get("seed_files", ()))
+    seed_files = _str_list(plugin_d, "seed_files", fail)
     _check_relative_paths(seed_files, "seed_files", fail)
-    seed_globs = tuple(str(s) for s in plugin_d.get("seed_globs", ()))
+    seed_globs = _str_list(plugin_d, "seed_globs", fail)
     _check_relative_paths(seed_globs, "seed_globs", fail)
 
     return PluginManifest(

--- a/src/bmad_loop/plugins/manifest.py
+++ b/src/bmad_loop/plugins/manifest.py
@@ -172,7 +172,7 @@ def _parse_python(python_d: Any, fail) -> PythonSpec | None:
     module = str(python_d.get("module", "")).strip()
     if not module:
         raise fail("[python] requires a 'module'")
-    if is_absolute_path(module) or has_parent_ref(module):
+    if names_tree_root(module) or is_absolute_path(module) or has_parent_ref(module):
         raise fail(f"[python] module must be a plugin-relative path: got {module!r}")
     return PythonSpec(module=module, cls=str(python_d.get("class", "Plugin")) or "Plugin")
 

--- a/src/bmad_loop/plugins/manifest.py
+++ b/src/bmad_loop/plugins/manifest.py
@@ -221,4 +221,20 @@ def load_manifest(
         doc = tomllib.loads(text)
     except tomllib.TOMLDecodeError as e:
         raise PluginError(f"plugin {source}: invalid TOML: {e}") from e
-    return parse_manifest(doc, source, scripts_dir, origin)
+    try:
+        return parse_manifest(doc, source, scripts_dir, origin)
+    except PluginError:
+        raise
+    except (TypeError, ValueError) as e:
+        # A funnel, not per-field guards — the `_load_toml` arm of
+        # adapters/profile.py, same reason: `parse_manifest`'s raw conversions
+        # (`int()` on `priority` and a hook's `timeout_sec`, iteration over a
+        # setting's `options`) raise bare conversion errors on TOML-legal values
+        # of the wrong type, and every consumer keys its fault handling on
+        # PluginError — the TUI's settings pane reports it beside a PolicyError,
+        # and `settings_schema`/`PluginRegistry.build` reach it through
+        # `load_plugins`. A bare escape crashed `validate` before any document
+        # was printed. AttributeError is absent from the tuple deliberately: every
+        # `.get()`/`.items()` here is isinstance-guarded first, so it has no site
+        # to come from (profile.py's `.items()` on `env` does).
+        raise PluginError(f"plugin {source}: malformed field value: {e}") from e

--- a/src/bmad_loop/plugins/manifest.py
+++ b/src/bmad_loop/plugins/manifest.py
@@ -29,6 +29,14 @@ from .model import (
     WorkflowSpec,
 )
 
+# The CLOSED set of faults a raw coercion over a `tomllib` value can raise — see
+# `adapters/profile.py::CONVERSION_FAULTS` for the nine-type enumeration behind it
+# (the `inf`/`-inf` and oversized-int OverflowError rows are the ones a per-field
+# guard keeps missing). Restated here rather than imported: the plugin layer does
+# not otherwise depend on the adapter layer, and each module's own domain test
+# pins its copy.
+CONVERSION_FAULTS = (AttributeError, OverflowError, TypeError, ValueError)
+
 
 def _str_list(plugin_d: dict, key: str, fail) -> tuple[str, ...]:
     # Shape before entries, the same rule the sibling seed sources apply to their
@@ -188,7 +196,7 @@ def parse_manifest(
         raise fail("[plugin] 'api_version' is required")
     try:
         api_version = int(raw_api)
-    except (TypeError, ValueError):
+    except CONVERSION_FAULTS:
         raise fail(f"[plugin] api_version must be an integer: got {raw_api!r}") from None
 
     seed_files = _str_list(plugin_d, "seed_files", fail)
@@ -224,17 +232,17 @@ def load_manifest(
     try:
         return parse_manifest(doc, source, scripts_dir, origin)
     except PluginError:
-        raise
-    except (TypeError, ValueError) as e:
+        raise  # intent: a domain error is never re-wrapped (it is not a CONVERSION_FAULT)
+    except CONVERSION_FAULTS as e:
         # A funnel, not per-field guards — the `_load_toml` arm of
         # adapters/profile.py, same reason: `parse_manifest`'s raw conversions
-        # (`int()` on `priority` and a hook's `timeout_sec`, iteration over a
-        # setting's `options`) raise bare conversion errors on TOML-legal values
-        # of the wrong type, and every consumer keys its fault handling on
-        # PluginError — the TUI's settings pane reports it beside a PolicyError,
-        # and `settings_schema`/`PluginRegistry.build` reach it through
-        # `load_plugins`. A bare escape crashed `validate` before any document
-        # was printed. AttributeError is absent from the tuple deliberately: every
-        # `.get()`/`.items()` here is isinstance-guarded first, so it has no site
-        # to come from (profile.py's `.items()` on `env` does).
+        # (`int()` on `priority`, `api_version` and a hook's `timeout_sec`,
+        # iteration over a setting's `options`) raise bare conversion errors on
+        # TOML-legal values of the wrong type, and every consumer keys its fault
+        # handling on PluginError — the TUI's settings pane reports it beside a
+        # PolicyError, and `settings_schema`/`PluginRegistry.build` reach it
+        # through `load_plugins`. A bare escape crashed `validate` before any
+        # document was printed. The tuple is that module's CLOSED set for the
+        # `tomllib` value domain, shared so the two parsers cannot drift apart
+        # one exception type at a time.
         raise PluginError(f"plugin {source}: malformed field value: {e}") from e

--- a/src/bmad_loop/plugins/registry.py
+++ b/src/bmad_loop/plugins/registry.py
@@ -62,8 +62,11 @@ def _instantiate(manifest: PluginManifest, settings: dict) -> Plugin:
     # manifest load, but lexically: a project-relative name that is a symlink out of
     # the plugin resolves fine and would be exec'd. Re-check after resolution, since
     # what happens below is arbitrary code execution, not a copy.
+    # Strictly below, not merely inside: `is_relative_to` is true for equal paths,
+    # so a module resolving to the plugin dir itself would pass an inside-check.
     try:
-        contained = module_path.resolve().is_relative_to(scripts_dir.resolve())
+        resolved, base = module_path.resolve(), scripts_dir.resolve()
+        contained = resolved != base and resolved.is_relative_to(base)
     except (OSError, RuntimeError):
         contained = False
     if not contained:

--- a/src/bmad_loop/plugins/registry.py
+++ b/src/bmad_loop/plugins/registry.py
@@ -56,7 +56,18 @@ def _instantiate(manifest: PluginManifest, settings: dict) -> Plugin:
     ``exec_module``. Kept tiny so the registry's try/except wraps exactly the
     import + construct surface.
     """
-    module_path = Path(manifest.scripts_dir) / manifest.python.module  # type: ignore[union-attr]
+    scripts_dir = Path(manifest.scripts_dir)
+    module_path = scripts_dir / manifest.python.module  # type: ignore[union-attr]
+    # `_parse_python` rejects an absolute, parent-climbing or root-naming module at
+    # manifest load, but lexically: a project-relative name that is a symlink out of
+    # the plugin resolves fine and would be exec'd. Re-check after resolution, since
+    # what happens below is arbitrary code execution, not a copy.
+    try:
+        contained = module_path.resolve().is_relative_to(scripts_dir.resolve())
+    except (OSError, RuntimeError):
+        contained = False
+    if not contained:
+        raise ImportError(f"plugin module escapes its plugin directory: {module_path}")
     if not module_path.is_file():
         raise FileNotFoundError(f"plugin module not found: {module_path}")
     spec = importlib.util.spec_from_file_location(f"bmad_loop_plugin_{manifest.name}", module_path)

--- a/src/bmad_loop/policy.py
+++ b/src/bmad_loop/policy.py
@@ -19,7 +19,7 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
 
-from .platform_util import atomic_replace, has_parent_ref, is_absolute_path
+from .platform_util import atomic_replace, has_parent_ref, is_absolute_path, names_tree_root
 
 POLICY_FILE = Path(".bmad-loop") / "policy.toml"
 
@@ -944,6 +944,17 @@ def loads(text: str, plugin_schemas: dict[str, Any] | None = None) -> Policy:
         raise PolicyError(f"scm.preserve_keep must be an integer: got {preserve_keep!r}")
     if preserve_keep < 0:
         raise PolicyError(f"scm.preserve_keep must be >= 0: got {preserve_keep}")
+    # Shape before entries, because `tuple(str(s) for s in raw)` silently accepts
+    # things that are not a list of paths. Measured: `worktree_seed = ""` yields an
+    # empty tuple (the config reads as applied and seeds nothing), `= "foo"` yields
+    # ('f','o','o') — three bogus one-character entries that each pass the
+    # per-entry guard below — and `= 5` raises a bare TypeError out of `loads`,
+    # untyped, where every other malformed value here raises PolicyError.
+    raw_seed = scm_d.get("worktree_seed", ())
+    if isinstance(raw_seed, (str, bytes)) or not isinstance(raw_seed, (list, tuple)):
+        raise PolicyError(f"scm.worktree_seed must be a list of paths: got {raw_seed!r}")
+    if not all(isinstance(s, str) for s in raw_seed):
+        raise PolicyError(f"scm.worktree_seed entries must be strings: got {list(raw_seed)!r}")
     scm = ScmPolicy(
         isolation=str(scm_d.get("isolation", ScmPolicy.isolation)),
         branch_per=str(scm_d.get("branch_per", ScmPolicy.branch_per)),
@@ -965,7 +976,7 @@ def loads(text: str, plugin_schemas: dict[str, Any] | None = None) -> Policy:
         seed_adapter_defaults=bool(
             scm_d.get("seed_adapter_defaults", ScmPolicy.seed_adapter_defaults)
         ),
-        worktree_seed=tuple(str(s) for s in scm_d.get("worktree_seed", ())),
+        worktree_seed=tuple(raw_seed),
     )
     if scm.isolation not in ISOLATION_MODES:
         raise PolicyError(
@@ -987,13 +998,19 @@ def loads(text: str, plugin_schemas: dict[str, Any] | None = None) -> Policy:
     # All three feed one list into provision_worktree's seed loop, and this was the
     # only one arriving unvalidated.
     #
-    # The empty entry is why this is a guard rather than a tidy-up: `""` makes that
+    # A ROOT-NAMING entry is why this is a guard rather than a tidy-up: it makes that
     # loop resolve src to the repo ROOT and dst to the worktree, both of which pass
     # its `is_relative_to` containment checks — a path IS relative to itself — so it
     # copies the entire repo into the worktree, gitignored and untracked files
     # included. And because a worktree mounts UNDER the repo (.bmad-loop/runs/...),
     # that copy walks into its own destination: measured at 744 levels of nesting
     # before the path length failed, silently, since the seed copy suppresses errors.
+    #
+    # `names_tree_root` and not a `not seed` emptiness check, because "" is only one
+    # spelling of the root. Measured: "" and "." produce a byte-identical
+    # (src, raw, dst) triple in that loop, and a run seeded with ["."] copied an
+    # untracked secret.env in and self-recursed until the path length failed, with
+    # provision_worktree returning no skip at all.
     #
     # The "/" it then renders is INERT, not a blanket exclusion — git strips a bare
     # slash to a zero-length pattern that matches nothing (worktree_flow.py says the
@@ -1006,7 +1023,7 @@ def loads(text: str, plugin_schemas: dict[str, Any] | None = None) -> Policy:
     # because a silently-inert seed entry reads as applied configuration when it is
     # not.
     for seed in scm.worktree_seed:
-        if not seed or is_absolute_path(seed) or has_parent_ref(seed):
+        if names_tree_root(seed) or is_absolute_path(seed) or has_parent_ref(seed):
             raise PolicyError(
                 f"scm.worktree_seed entries must be project-relative paths: got {seed!r}"
             )

--- a/src/bmad_loop/policy.py
+++ b/src/bmad_loop/policy.py
@@ -19,7 +19,7 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
 
-from .platform_util import atomic_replace
+from .platform_util import atomic_replace, has_parent_ref, is_absolute_path
 
 POLICY_FILE = Path(".bmad-loop") / "policy.toml"
 
@@ -982,6 +982,34 @@ def loads(text: str, plugin_schemas: dict[str, Any] | None = None) -> Policy:
         )
     if scm.failed_diff_max_mb < 1:
         raise PolicyError(f"scm.failed_diff_max_mb must be >= 1: got {scm.failed_diff_max_mb}")
+    # The same rule the other two seed sources already apply to their own entries
+    # (adapters/profile.py `seed_files`, plugins/manifest.py `_check_relative_paths`).
+    # All three feed one list into provision_worktree's seed loop, and this was the
+    # only one arriving unvalidated.
+    #
+    # The empty entry is why this is a guard rather than a tidy-up: `""` makes that
+    # loop resolve src to the repo ROOT and dst to the worktree, both of which pass
+    # its `is_relative_to` containment checks — a path IS relative to itself — so it
+    # copies the entire repo into the worktree, gitignored and untracked files
+    # included. And because a worktree mounts UNDER the repo (.bmad-loop/runs/...),
+    # that copy walks into its own destination: measured at 744 levels of nesting
+    # before the path length failed, silently, since the seed copy suppresses errors.
+    #
+    # The "/" it then renders is INERT, not a blanket exclusion — git strips a bare
+    # slash to a zero-length pattern that matches nothing (worktree_flow.py says the
+    # same at the write side). That is what makes this worth guarding rather than
+    # shrugging at: none of the copied surplus is shielded, so the unit's
+    # `git add -A` stages the main checkout's untracked files into the story.
+    #
+    # Absolute and `..` entries are already contained by those same checks (silently
+    # skipped); they are rejected here for consistency with the sibling sources, and
+    # because a silently-inert seed entry reads as applied configuration when it is
+    # not.
+    for seed in scm.worktree_seed:
+        if not seed or is_absolute_path(seed) or has_parent_ref(seed):
+            raise PolicyError(
+                f"scm.worktree_seed entries must be project-relative paths: got {seed!r}"
+            )
     cleanup = CleanupPolicy(
         run_retention=int(cleanup_d.get("run_retention", CleanupPolicy.run_retention)),
         retention_days=int(cleanup_d.get("retention_days", CleanupPolicy.retention_days)),

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -525,6 +525,53 @@ def test_provision_worktree_does_not_clobber_existing_skill(tmp_path):
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX symlinks")
+def test_copy_skills_refuses_a_skill_tree_symlinked_out_of_the_project(tmp_path, capsys):
+    # The `init` counterpart of the provision_* symlink refusals below. The profile
+    # guards are lexical and run at load, so `skill_tree` naming an ordinary
+    # project-relative directory passes all three even when that directory is a link
+    # out of the tree; only resolution sees it. This loop rmtree's under `force`, and
+    # its `_copy_traversable` call supplies neither containment root, so nothing
+    # downstream would have caught it.
+    project, outside = tmp_path / "proj", tmp_path / "outside"
+    project.mkdir()
+    outside.mkdir()
+    (project / "skills").symlink_to(outside, target_is_directory=True)
+
+    assert install_mod._copy_skills(project, ("skills",), False) is False
+
+    assert list(outside.iterdir()) == []  # nothing written through the link
+    assert "escapes the project" in capsys.readouterr().out
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlinks")
+def test_copy_skills_still_installs_into_an_ordinary_tree(tmp_path):
+    # the containment check must not cost the normal path — ablation partner for
+    # the refusal above, which would otherwise pass if _copy_skills refused always
+    project = tmp_path / "proj"
+    project.mkdir()
+
+    assert install_mod._copy_skills(project, ("skills",), False) is False
+
+    for skill in MODULE_SKILLS:
+        assert (project / "skills" / skill / "SKILL.md").is_file()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlinks")
+def test_register_hooks_refuses_a_config_path_symlinked_out_of_the_project(tmp_path, capsys):
+    project, outside = tmp_path / "proj", tmp_path / "outside"
+    claude = get_profile("claude")
+    (project / Path(claude.hooks.config_path).parent).mkdir(parents=True)
+    outside.write_text('{"env":{"KEEP":"BYTE-IDENTICAL"}}\n', encoding="utf-8")
+    before = outside.read_bytes()
+    (project / claude.hooks.config_path).symlink_to(outside)
+
+    assert install_mod._register_hooks(project, claude) == 1
+
+    assert outside.read_bytes() == before  # the escape target is untouched
+    assert "escapes the project" in capsys.readouterr().out
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlinks")
 def test_provision_refuses_a_live_hook_config_symlink(tmp_path):
     wt, repo = tmp_path / "wt", tmp_path / "repo"
     claude = get_profile("claude")

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -23,7 +23,7 @@ from conftest import (
 
 import bmad_loop.install as install_mod
 from bmad_loop import verify
-from bmad_loop.adapters.profile import get_profile
+from bmad_loop.adapters.profile import ProfileError, get_profile
 from bmad_loop.install import (
     BASE_SKILLS,
     BMAD_DIR,
@@ -525,7 +525,7 @@ def test_provision_worktree_does_not_clobber_existing_skill(tmp_path):
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX symlinks")
-def test_copy_skills_refuses_a_skill_tree_symlinked_out_of_the_project(tmp_path, capsys):
+def test_copy_skills_refuses_a_skill_tree_symlinked_out_of_the_project(tmp_path):
     # The `init` counterpart of the provision_* symlink refusals below. The profile
     # guards are lexical and run at load, so `skill_tree` naming an ordinary
     # project-relative directory passes all three even when that directory is a link
@@ -537,10 +537,50 @@ def test_copy_skills_refuses_a_skill_tree_symlinked_out_of_the_project(tmp_path,
     outside.mkdir()
     (project / "skills").symlink_to(outside, target_is_directory=True)
 
-    assert install_mod._copy_skills(project, ("skills",), False) is False
+    with pytest.raises(ProfileError, match="does not resolve inside the project"):
+        install_mod._copy_skills(project, ("skills",), False)
 
     assert list(outside.iterdir()) == []  # nothing written through the link
-    assert "escapes the project" in capsys.readouterr().out
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlinks")
+def test_copy_skills_refuses_a_skill_tree_that_resolves_to_the_project_root(tmp_path):
+    # `is_relative_to` is true for equal paths, so an inside-check passes a tree that
+    # resolves to the project ITSELF — the same "a path is relative to itself" hole
+    # this guard family exists to close in the seed loop. Left unguarded, the bundled
+    # skill dirs land at top level and --force-skills rmtree's any root directory
+    # whose name collides with one of them.
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / "skills").symlink_to(project, target_is_directory=True)
+    decoy = project / MODULE_SKILLS[0]
+    decoy.mkdir()
+    (decoy / "PRECIOUS").write_text("KEEP", encoding="utf-8")
+
+    with pytest.raises(ProfileError, match="does not resolve inside the project"):
+        install_mod._copy_skills(project, ("skills",), True)  # force: the rmtree path
+
+    assert (decoy / "PRECIOUS").read_text() == "KEEP"  # never rmtree'd
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlinks")
+def test_init_fails_when_a_skill_tree_escapes_the_project(tmp_path, capsys):
+    # The refusal has to reach the exit code: a skipped tree leaves every later
+    # session without the skills it dispatches, and `init complete` + 0 over that is
+    # an unattended-setup trap.
+    claude = get_profile("claude")
+    # the escape target must sit outside the PROJECT, so the project cannot be
+    # tmp_path itself — a sibling under tmp_path would still resolve inside it
+    project, outside = tmp_path / "proj", tmp_path / "outside"
+    outside.mkdir()
+    (project / Path(claude.skill_tree).parent).mkdir(parents=True)
+    (project / claude.skill_tree).symlink_to(outside, target_is_directory=True)
+
+    assert install_into(project) == 1
+
+    out = capsys.readouterr().out
+    assert "does not resolve inside the project" in out
+    assert "init complete" not in out
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX symlinks")

--- a/tests/test_platform_util.py
+++ b/tests/test_platform_util.py
@@ -70,6 +70,22 @@ def test_has_parent_ref_ignores_non_segments(value):
     assert platform_util.has_parent_ref(value) is False
 
 
+@pytest.mark.parametrize("value", ["", ".", "./", ".//", "./.", ".\\"])
+def test_names_tree_root_catches_every_spelling_of_the_root(value):
+    # `""` is the spelling an emptiness check catches; the rest are why this exists.
+    # `.\` is the Windows-only one — POSIX parsing keeps it as a one-segment name,
+    # the same asymmetry `is_absolute_path` checks both flavors for.
+    assert platform_util.names_tree_root(value) is True
+
+
+@pytest.mark.parametrize("value", [".claude/skills", "a", "a/.", "./a", ".hidden", "..", "a/b"])
+def test_names_tree_root_accepts_anything_naming_a_child(value):
+    # `a/.` and `./a` normalize to a real child, so they name something inside the
+    # tree. `..` names the PARENT, which is `has_parent_ref`'s job, not this one —
+    # the guards are paired at every call site.
+    assert platform_util.names_tree_root(value) is False
+
+
 # ---------------------------------------------------------------- atomic_replace
 
 

--- a/tests/test_platform_util.py
+++ b/tests/test_platform_util.py
@@ -78,11 +78,57 @@ def test_names_tree_root_catches_every_spelling_of_the_root(value):
     assert platform_util.names_tree_root(value) is True
 
 
-@pytest.mark.parametrize("value", [".claude/skills", "a", "a/.", "./a", ".hidden", "..", "a/b"])
+@pytest.mark.parametrize(
+    "value",
+    [
+        ". ",  # Win32 trims the trailing space -> names the containing dir
+        ".  ",
+        ".. ",  # the space stops it matching `..`, so Win32 trims rather than climbs
+        "...",
+        "....",
+        "   ",  # no period at all, still trimmed to empty
+        ". .",
+        " . ",
+        "./ ",
+        ".\\ ",  # separator + a component that is nothing but a space
+    ],
+)
+def test_names_tree_root_catches_the_win32_trim_aliases(value):
+    # Win32 strips every trailing period and space from a path's final component,
+    # so each of these names the tree root there. Both pure pathlib flavours keep
+    # them as ordinary one-segment names, which is exactly why the lexical guard
+    # has to know the rule — `resolve()` would, but these are checked at load,
+    # long before any path is resolved. Parametrized apart from the `.`/`./` cases
+    # so restoring the pure-equality-only guard reddens these and only these.
+    assert platform_util.names_tree_root(value) is True
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        ".claude/skills",
+        "a",
+        "a/.",
+        "./a",
+        ".hidden",
+        "..",
+        "a/b",
+        "foo. ",  # strips to `foo` — names a CHILD, not the root
+        "foo ",
+        "a/. ",  # the trailing component is trimmed away, leaving `a`
+        ".claude/skills ",
+        "..hidden",
+        "a..b",
+        "../..",  # every component is dots, but these climb — has_parent_ref's job
+        "a/..",
+    ],
+)
 def test_names_tree_root_accepts_anything_naming_a_child(value):
     # `a/.` and `./a` normalize to a real child, so they name something inside the
     # tree. `..` names the PARENT, which is `has_parent_ref`'s job, not this one —
-    # the guards are paired at every call site.
+    # the guards are paired at every call site. The trailing-space entries are the
+    # boundary of the trim rule: a component only stops naming something once it is
+    # *nothing but* periods and spaces.
     assert platform_util.names_tree_root(value) is False
 
 

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -171,6 +171,12 @@ def test_full_manifest_parses(tmp_path):
         # absolute seed path
         ('[plugin]\nname = "e"\napi_version = 1\nseed_files = ["/etc/passwd"]\n', "seed_files"),
         ('[plugin]\nname = "e"\napi_version = 1\nseed_globs = ["/abs/*"]\n', "seed_globs"),
+        # root-naming seed path — "" is only one spelling. These feed the same
+        # provision_worktree seed loop, where a root ref copies the whole repo into
+        # the worktree and the copy then recurses into its own destination.
+        ('[plugin]\nname = "e"\napi_version = 1\nseed_files = ["."]\n', "seed_files"),
+        ('[plugin]\nname = "e"\napi_version = 1\nseed_files = ["./"]\n', "seed_files"),
+        ('[plugin]\nname = "e"\napi_version = 1\nseed_globs = ["."]\n', "seed_globs"),
         # absolute python module path
         ('[plugin]\nname = "e"\napi_version = 1\n[python]\nmodule = "/x.py"\n', "plugin-relative"),
         # hook with no cmd

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -152,6 +152,11 @@ def test_full_manifest_parses(tmp_path):
         ("[plugin]\napi_version = 1\n", "name"),  # missing name
         ('[plugin]\nname = "e"\n', "api_version"),  # missing api_version
         ('[plugin]\nname = "e"\napi_version = "x"\n', "api_version must be an integer"),
+        # `inf` reaches api_version's own guard as OverflowError. The load_manifest
+        # funnel would catch it either way, so this row is what keeps the field's
+        # specific message (rather than the funnel's generic one) — ablate the
+        # guard's tuple back to (TypeError, ValueError) and only this row reddens.
+        ('[plugin]\nname = "e"\napi_version = inf\n', "api_version must be an integer"),
         # duplicate setting key
         (
             '[plugin]\nname = "e"\napi_version = 1\n'
@@ -274,18 +279,64 @@ def test_seed_list_shapes_rejected(key, value, match):
         "priority = [1]",  # int() -> TypeError
         '[hooks.pre_session]\ncmd = "true"\ntimeout_sec = "x"',  # int() -> ValueError
         '[[settings]]\nkey = "k"\ntype = "select"\noptions = 5',  # iteration -> TypeError
+        "priority = inf",  # int() -> OverflowError
+        "priority = -inf",  # int() -> OverflowError
+        "priority = nan",  # int() -> ValueError
+        '[hooks.pre_session]\ncmd = "true"\ntimeout_sec = inf',  # int() -> OverflowError
     ],
 )
 def test_malformed_field_values_raise_plugin_error(tail):
     """TOML-legal values of the wrong TYPE hit raw conversions (`int()`, and
     iteration over a setting's `options`) that `api_version`'s own guard shows
     were only ever handled one field at a time. The `load_manifest` funnel turns
-    those bare ValueError/TypeError escapes into PluginError, which is what every
-    consumer's fault handling keys on. Ablation: drop the funnel arm and these
-    four raise the bare exception instead."""
+    those bare escapes into PluginError, which is what every consumer's fault
+    handling keys on.
+
+    `inf` is the row that shows why the funnel must be the CLOSED set rather than
+    the types seen so far: `int(float('inf'))` raises OverflowError, a sibling of
+    neither ValueError nor TypeError, so the first version of this funnel let it
+    through. Ablation: drop the funnel arm and every row raises the bare exception;
+    drop OverflowError alone and exactly the three `inf` rows do."""
     body = f'[plugin]\nname = "e"\napi_version = 1\n{tail}\n'
     with pytest.raises(PluginError, match="malformed field value"):
         load_manifest(body, "e/plugin.toml", "e")
+
+
+# every type `tomllib` can yield, plus the numeric spellings that are legal TOML
+# and hostile to a raw coercion
+TOML_VALUE_DOMAIN = [
+    '"x"',
+    "1",
+    "1.5",
+    "true",
+    "1979-05-27T07:32:00Z",
+    "1979-05-27",
+    "07:32:00",
+    "[1]",
+    "{ k = 1 }",
+    "inf",
+    "-inf",
+    "nan",
+    "9" * 400,  # tomllib keeps arbitrary precision; float() of this overflows
+]
+
+
+@pytest.mark.parametrize("value", TOML_VALUE_DOMAIN)
+def test_every_toml_value_type_parses_or_raises_plugin_error(value):
+    """The closure pin behind `CONVERSION_FAULTS`, and the reason that tuple is a
+    funnel rather than one more round of enumeration: a manifest field can hold
+    any of the nine types `tomllib` yields, and the contract is that each either
+    parses or raises the DOMAIN error — never a bare conversion fault.
+
+    This is what a per-type exception list cannot promise: the last two review
+    rounds each added a type after a bot found a spelling nobody had tried. A new
+    coercion that raises something outside the set reddens this without anyone
+    having to think of the spelling first."""
+    body = f'[plugin]\nname = "e"\napi_version = 1\npriority = {value}\n'
+    try:
+        load_manifest(body, "e/plugin.toml", "e")
+    except PluginError:
+        pass
 
 
 def test_registry_orders_by_priority(tmp_path):

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -185,6 +185,13 @@ def test_full_manifest_parses(tmp_path):
         ('[plugin]\nname = "e"\napi_version = 1\nseed_globs = ["."]\n', "seed_globs"),
         # absolute python module path
         ('[plugin]\nname = "e"\napi_version = 1\n[python]\nmodule = "/x.py"\n', "plugin-relative"),
+        # root-naming python module path. The value is `.strip()`ed before the guard,
+        # so the trailing-space spellings arrive as "." — but the trailing-DOT ones
+        # arrive intact, and Win32 trims those to the plugin dir just the same. What
+        # gets exec'd matters more than what gets copied, hence the whole family.
+        ('[plugin]\nname = "e"\napi_version = 1\n[python]\nmodule = "."\n', "plugin-relative"),
+        ('[plugin]\nname = "e"\napi_version = 1\n[python]\nmodule = "..."\n', "plugin-relative"),
+        ('[plugin]\nname = "e"\napi_version = 1\n[python]\nmodule = ". ."\n', "plugin-relative"),
         # hook with no cmd
         (
             '[plugin]\nname = "e"\napi_version = 1\n[hooks.pre_run]\nblocking = true\n',

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -267,6 +267,27 @@ def test_seed_list_shapes_rejected(key, value, match):
         load_manifest(body, "e/plugin.toml", "e")
 
 
+@pytest.mark.parametrize(
+    "tail",
+    [
+        'priority = "x"',  # int() -> ValueError
+        "priority = [1]",  # int() -> TypeError
+        '[hooks.pre_session]\ncmd = "true"\ntimeout_sec = "x"',  # int() -> ValueError
+        '[[settings]]\nkey = "k"\ntype = "select"\noptions = 5',  # iteration -> TypeError
+    ],
+)
+def test_malformed_field_values_raise_plugin_error(tail):
+    """TOML-legal values of the wrong TYPE hit raw conversions (`int()`, and
+    iteration over a setting's `options`) that `api_version`'s own guard shows
+    were only ever handled one field at a time. The `load_manifest` funnel turns
+    those bare ValueError/TypeError escapes into PluginError, which is what every
+    consumer's fault handling keys on. Ablation: drop the funnel arm and these
+    four raise the bare exception instead."""
+    body = f'[plugin]\nname = "e"\napi_version = 1\n{tail}\n'
+    with pytest.raises(PluginError, match="malformed field value"):
+        load_manifest(body, "e/plugin.toml", "e")
+
+
 def test_registry_orders_by_priority(tmp_path):
     write_plugin(tmp_path, "hi", '[plugin]\nname = "hi"\napi_version = 1\npriority = 10\n')
     write_plugin(tmp_path, "lo", '[plugin]\nname = "lo"\napi_version = 1\npriority = -5\n')

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -21,6 +21,7 @@ from bmad_loop.plugins import (
     load_plugins,
 )
 from bmad_loop.plugins.loader import USER_PLUGINS_REL
+from bmad_loop.plugins.manifest import load_manifest
 
 # --------------------------------------------------------------- helpers
 
@@ -243,6 +244,27 @@ def test_discover_order_is_builtin_then_project(tmp_path):
     # every builtin precedes every project plugin (entry-point seam is empty)
     assert sources == sorted(sources, key=lambda s: 0 if s == "builtin" else 1)
     assert "builtin" in sources and sources[-1] == "project"
+
+
+@pytest.mark.parametrize("key", ["seed_files", "seed_globs"])
+@pytest.mark.parametrize(
+    ("value", "match"),
+    [
+        ('""', "must be a list of paths"),
+        ('"foo"', "must be a list of paths"),
+        ("5", "must be a list of paths"),
+        ("[1]", "entries must be strings"),
+    ],
+)
+def test_seed_list_shapes_rejected(key, value, match):
+    """Shape before entries, mirroring the sibling seed sources (policy.py
+    `worktree_seed`, profile `str_list`): a bare string iterates into
+    per-character entries that each pass the per-entry path guard, and a scalar
+    used to leak a raw TypeError out of `loads` where every other malformed
+    value raises PluginError."""
+    body = f'[plugin]\nname = "e"\napi_version = 1\n{key} = {value}\n'
+    with pytest.raises(PluginError, match=match):
+        load_manifest(body, "e/plugin.toml", "e")
 
 
 def test_registry_orders_by_priority(tmp_path):

--- a/tests/test_plugin_trust.py
+++ b/tests/test_plugin_trust.py
@@ -10,6 +10,7 @@ misbehaving in-process plugin is isolated instead of crashing the run.
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -186,6 +187,31 @@ def test_import_exception_disables_instance_run_survives(tmp_path):
     reg = PluginRegistry.build(tmp_path, policy=enable("badimport"), journal=journal)
     lp = reg.get("badimport")
     assert lp.instance is None and lp.disabled
+    assert "plugin-error" in journal.kinds()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlinks")
+def test_python_module_symlinked_out_of_the_plugin_is_never_executed(tmp_path):
+    # `_parse_python` rejects an absolute, parent-climbing or root-naming module
+    # lexically, at manifest load. A perfectly ordinary relative name that happens
+    # to be a LINK out of the plugin dir passes all three and used to reach
+    # exec_module — the one consumer where a slipped path is arbitrary code
+    # execution rather than a copy, so it re-checks after resolution.
+    pdir = write_py_plugin(tmp_path, "escapee")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    stray = outside / "evil.py"
+    stray.write_text(PY_MODULE.format(cls="Plugin"))
+    (pdir / "hooks.py").unlink()
+    (pdir / "hooks.py").symlink_to(stray)
+
+    journal = FakeJournal()
+    reg = PluginRegistry.build(tmp_path, policy=enable("escapee"), journal=journal)
+    lp = reg.get("escapee")
+
+    assert lp.instance is None and lp.disabled  # isolated, like any load failure
+    # the smoking gun: the linked module's import-time side effect never happened
+    assert not (pdir / "IMPORTED").exists()
     assert "plugin-error" in journal.kinds()
 
 

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -636,6 +636,10 @@ def test_scm_worktree_seed_settings(tmp_path):
     "entry",
     [
         "",  # the harmful one — see below
+        ".",  # …and the SAME harm, one spelling later
+        "./",
+        "./.",
+        ".\\",  # a root ref only Windows parsing normalizes away
         "/etc/passwd",  # POSIX-absolute
         "C:\\secrets",  # Windows drive-absolute (rejected on POSIX too)
         "../../etc",  # climbs out without being absolute
@@ -646,16 +650,55 @@ def test_scm_worktree_seed_rejects_non_project_relative_entries(tmp_path, entry)
     provision_worktree that arrived unvalidated — profiles and plugin manifests
     both already apply this rule to their own entries.
 
-    The empty entry is the one that does damage rather than merely no-op: it makes
-    the seed loop resolve src to the repo ROOT and dst to the worktree, both of
-    which pass its containment checks, so the whole repo is copied in — and since a
-    worktree mounts under the repo, that copy recurses into itself until the path
+    A ROOT-NAMING entry is the one that does damage rather than merely no-op: it
+    makes the seed loop resolve src to the repo ROOT and dst to the worktree, both
+    of which pass its containment checks, so the whole repo is copied in — and since
+    a worktree mounts under the repo, that copy recurses into itself until the path
     length fails. The "/" it renders is inert (git strips a bare slash to a pattern
-    matching nothing), so none of the surplus is even shielded from `git add -A`."""
+    matching nothing), so none of the surplus is even shielded from `git add -A`.
+
+    `""` is only ONE spelling of the root, which is why the guard is
+    `names_tree_root` and not an emptiness check. Measured: `""` and `"."` produce a
+    byte-identical (src, raw, dst) triple in that loop, and a real run seeded with
+    `["."]` copied an untracked `secret.env` into the worktree and self-recursed 127
+    levels — with `provision_worktree` reporting no skipped entry at all.
+
+    Ablation: restore `not seed` in place of `names_tree_root(seed)` and the four
+    dot spellings fail while `""` keeps passing — which is what makes them worth
+    parametrizing separately."""
     p = tmp_path / "policy.toml"
     p.write_text(f"[scm]\nworktree_seed = [{entry!r}]\n".replace("'", '"'))
 
     with pytest.raises(policy.PolicyError, match="worktree_seed entries must be project-relative"):
+        policy.load(p)
+
+
+@pytest.mark.parametrize(
+    ("value", "match"),
+    [
+        ('""', "must be a list of paths"),  # iterates to an EMPTY tuple: silently inert
+        ('"foo"', "must be a list of paths"),  # iterates to ('f','o','o')
+        ("5", "must be a list of paths"),  # raised a bare TypeError out of loads()
+        ("[1]", "entries must be strings"),  # str()'d into the path "1"
+    ],
+)
+def test_scm_worktree_seed_rejects_value_shapes_that_are_not_a_list_of_paths(
+    tmp_path, value, match
+):
+    """The per-entry guard runs over whatever `tuple(str(s) for s in raw)` produced,
+    and that coercion accepts things a list of paths never is. A scalar string is
+    the trap: TOML permits it, it iterates CHARACTER-WISE, and every character then
+    passes the per-entry rule — so `worktree_seed = "foo"` seeded three
+    one-character paths while reading as applied configuration. A scalar int did not
+    even reach a PolicyError; it raised TypeError out of `loads`, untyped, where
+    every other malformed value in this file escalates as PolicyError.
+
+    Ablation: drop the shape check and all four cases pass (three silently, the int
+    as a TypeError rather than the PolicyError this asserts)."""
+    p = tmp_path / "policy.toml"
+    p.write_text(f"[scm]\nworktree_seed = {value}\n")
+
+    with pytest.raises(policy.PolicyError, match=match):
         policy.load(p)
 
 

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -632,6 +632,43 @@ def test_scm_worktree_seed_settings(tmp_path):
     assert pol.scm.worktree_seed == (".mcp.json", ".envrc")
 
 
+@pytest.mark.parametrize(
+    "entry",
+    [
+        "",  # the harmful one — see below
+        "/etc/passwd",  # POSIX-absolute
+        "C:\\secrets",  # Windows drive-absolute (rejected on POSIX too)
+        "../../etc",  # climbs out without being absolute
+    ],
+)
+def test_scm_worktree_seed_rejects_non_project_relative_entries(tmp_path, entry):
+    """`worktree_seed` was the only one of the three seed sources feeding
+    provision_worktree that arrived unvalidated — profiles and plugin manifests
+    both already apply this rule to their own entries.
+
+    The empty entry is the one that does damage rather than merely no-op: it makes
+    the seed loop resolve src to the repo ROOT and dst to the worktree, both of
+    which pass its containment checks, so the whole repo is copied in — and since a
+    worktree mounts under the repo, that copy recurses into itself until the path
+    length fails. The "/" it renders is inert (git strips a bare slash to a pattern
+    matching nothing), so none of the surplus is even shielded from `git add -A`."""
+    p = tmp_path / "policy.toml"
+    p.write_text(f"[scm]\nworktree_seed = [{entry!r}]\n".replace("'", '"'))
+
+    with pytest.raises(policy.PolicyError, match="worktree_seed entries must be project-relative"):
+        policy.load(p)
+
+
+def test_scm_worktree_seed_rejects_a_bad_entry_beside_good_ones(tmp_path):
+    """Every entry is checked, not just the first: a valid leading entry must not
+    let a later empty one through."""
+    p = tmp_path / "policy.toml"
+    p.write_text('[scm]\nworktree_seed = [".mcp.json", "", ".envrc"]\n')
+
+    with pytest.raises(policy.PolicyError, match="got ''"):
+        policy.load(p)
+
+
 def test_scm_override(tmp_path):
     p = tmp_path / "policy.toml"
     p.write_text(

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -231,6 +231,29 @@ def test_user_profile_overlay(tmp_path):
             ),
             "seed_files",
         ),
+        # A root-naming entry is the harmful one, and `""` is only one spelling of
+        # it: these feed provision_worktree's seed loop, where any of them resolves
+        # src to the repo root and dst to the worktree — both pass its containment
+        # checks, so the whole repo is copied in and the copy recurses into itself.
+        (
+            MINIMAL_PROFILE.replace("[hooks]", 'seed_files = ["."]\n[hooks]'),
+            "seed_files",
+        ),
+        (
+            MINIMAL_PROFILE.replace("[hooks]", 'seed_files = ["./"]\n[hooks]'),
+            "seed_files",
+        ),
+        (
+            MINIMAL_PROFILE.replace("[hooks]", 'skill_tree = "."\n[hooks]'),
+            "skill_tree",
+        ),
+        (
+            MINIMAL_PROFILE.replace(
+                'config_path = ".mycli/settings.json"',
+                'config_path = "."',
+            ),
+            "relative",
+        ),
         # an env_fault_patterns entry that is not a valid regex fails fast at parse
         (
             MINIMAL_PROFILE.replace(

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -318,6 +318,19 @@ def test_user_profile_overlay(tmp_path):
             MINIMAL_PROFILE.replace("[hooks]", 'env = "invalid"\n[hooks]'),
             "malformed field value",
         ),
+        # `inf` and an oversized int are legal TOML and raise OverflowError, a
+        # sibling of neither ValueError nor TypeError — the rows that show why
+        # the funnel has to be the CLOSED set for the tomllib domain rather than
+        # the types seen so far. Ablation: drop OverflowError from
+        # CONVERSION_FAULTS and exactly these two raise the bare exception.
+        (
+            MINIMAL_PROFILE.replace("[hooks]", "stop_without_result_nudges = inf\n[hooks]"),
+            "malformed field value",
+        ),
+        (
+            MINIMAL_PROFILE.replace("[hooks]", f"usage_grace_s = {'9' * 400}\n[hooks]"),
+            "malformed field value",
+        ),
         # real dialects still hard-require config_path and events
         (
             MINIMAL_PROFILE.replace('config_path = ".mycli/settings.json"', ""),
@@ -342,3 +355,46 @@ def test_invalid_profiles_rejected(tmp_path, mutation, match):
     (profiles_dir / "bad.toml").write_text(mutation)
     with pytest.raises(ProfileError, match=match):
         load_profiles(tmp_path)
+
+
+# every type `tomllib` can yield, plus the numeric spellings that are legal TOML
+# and hostile to a raw coercion
+TOML_VALUE_DOMAIN = [
+    '"x"',
+    "1",
+    "1.5",
+    "true",
+    "1979-05-27T07:32:00Z",
+    "1979-05-27",
+    "07:32:00",
+    "[1]",
+    "{ k = 1 }",
+    "inf",
+    "-inf",
+    "nan",
+    "9" * 400,  # tomllib keeps arbitrary precision; float() of this overflows
+]
+
+
+@pytest.mark.parametrize("value", TOML_VALUE_DOMAIN)
+@pytest.mark.parametrize("key", ["usage_grace_s", "stop_without_result_nudges"])
+def test_every_toml_value_type_parses_or_raises_profile_error(tmp_path, key, value):
+    """The closure pin behind `CONVERSION_FAULTS`: a profile field can hold any of
+    the nine types `tomllib` yields, and the contract is that each either parses or
+    raises the DOMAIN error — never a bare conversion fault out of a `float()`,
+    `int()` or `.items()`.
+
+    Both a float knob and an int knob, because they fault differently: `inf` is a
+    fine float and an OverflowError for `int()`, while a 400-digit integer is a
+    fine int and an OverflowError for `float()`. A per-type exception list cannot
+    promise this; two review rounds each added one type after a bot found a
+    spelling nobody had tried."""
+    profiles_dir = tmp_path / ".bmad-loop" / "profiles"
+    profiles_dir.mkdir(parents=True)
+    (profiles_dir / "probe.toml").write_text(
+        MINIMAL_PROFILE.replace("[hooks]", f"{key} = {value}\n[hooks]")
+    )
+    try:
+        load_profiles(tmp_path)
+    except ProfileError:
+        pass

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -297,6 +297,27 @@ def test_user_profile_overlay(tmp_path):
             MINIMAL_PROFILE.replace("[hooks]", "stop_without_result_nudges = -2\n[hooks]"),
             "stop_without_result_nudges",
         ),
+        # TOML-legal values of the wrong TYPE hit raw conversions (`float()`,
+        # `int()`, `.items()`) — the `_load_toml` funnel turns those bare
+        # ValueError/TypeError/AttributeError escapes into ProfileError, which
+        # is what every consumer's fault handling keys on. Ablation: drop the
+        # funnel arm and these four raise the bare exception instead.
+        (
+            MINIMAL_PROFILE.replace("[hooks]", 'usage_grace_s = "invalid"\n[hooks]'),
+            "malformed field value",
+        ),
+        (
+            MINIMAL_PROFILE.replace("[hooks]", "usage_grace_s = [1]\n[hooks]"),
+            "malformed field value",
+        ),
+        (
+            MINIMAL_PROFILE.replace("[hooks]", 'stop_without_result_nudges = "x"\n[hooks]'),
+            "malformed field value",
+        ),
+        (
+            MINIMAL_PROFILE.replace("[hooks]", 'env = "invalid"\n[hooks]'),
+            "malformed field value",
+        ),
         # real dialects still hard-require config_path and events
         (
             MINIMAL_PROFILE.replace('config_path = ".mycli/settings.json"', ""),

--- a/tests/test_unity_scene_guard.py
+++ b/tests/test_unity_scene_guard.py
@@ -200,6 +200,22 @@ def test_seed_rejects_parent_traversal_guard_dir(tmp_path, monkeypatch):
     assert not (tmp_path / "escaped").exists()  # no write outside the worktree
 
 
+def test_seed_rejects_root_naming_guard_dir(tmp_path, monkeypatch):
+    mod = _load_seeder()
+    worktree = tmp_path / "wt"
+    (worktree / "Assets").mkdir(parents=True)
+    # `main()` `.strip()`s the env var, so the trailing-SPACE spellings collapse to
+    # "." and the pre-existing `not rel.parts` arm already caught them. These are
+    # the ones that survive that strip: on Windows each names the worktree itself,
+    # and the asset-root probe below the guard would then find the worktree (a real
+    # directory) and pass, scattering the payload across the worktree root.
+    for evil in ("...", "....", ". .", ".\\"):
+        _set_env(monkeypatch, worktree, guard_dir=evil)
+        assert mod.main() == 2, evil
+    assert not (worktree / mod._GUARD_CS).exists()  # payload never hit the root
+    assert not (worktree / "BmadLoop").exists()
+
+
 def test_seed_rejects_windows_flavored_escapes_on_any_platform(tmp_path, monkeypatch):
     mod = _load_seeder()
     (tmp_path / "Assets").mkdir()


### PR DESCRIPTION
Closes #456.

Recovers six fixes that lived on `feat/384-validate-exclude-pollution` only because that
is where the session was. They fix code on `main` today, were never part of PR #386's
feature, and died with it when it was closed unmerged. The branch survives at `86be5dd`.

Nothing here touches the dead detector. Every hunk referencing a branch-only symbol
(`legacy_exclude_pollution`, `discovered_profiles`, `discovered_manifests`) was stripped,
including three prose references inside comments that would otherwise have shipped naming
functions that do not exist — those comments now name the real `main`-side consumers.

## What lands

| commit | fix |
|---|---|
| `6baf6d8` | `policy.loads` validates `scm.worktree_seed` shape + entries |
| `b5ec152` | new `platform_util.names_tree_root` + 4 call sites |
| `b9148ce` | `manifest._str_list` gates `seed_files`/`seed_globs` |
| `9a5404a` | `profile._load_toml` funnels conversion faults → `ProfileError` |
| `7d41ec7` | `manifest.load_manifest` funnels → `PluginError` |
| `656d2f3` | `CONVERSION_FAULTS` incl. `OverflowError`, in both parsers |

### The seed guards (#456)

Three sources feed one seed list into `provision_worktree`'s copy loop. A root-naming entry
makes that loop resolve `src` to the repo **root** and `dst` to the worktree — both pass its
`is_relative_to` containment checks, because a path is relative to itself — so it copies the
whole project in, gitignored and untracked files included, then walks into its own
destination (measured: 744 levels for `""`, 127 for `"."`, both silent).

`""` was only one spelling. `""`, `"."`, `"./"`, `"./."` and `".\"` all name the tree root;
`""` and `"."` produce a byte-identical `(src, raw, dst)` triple in that loop. The emptiness
check becomes `names_tree_root`, the third member of the
`is_absolute_path`/`has_parent_ref` family, applied at all four sites — strictly a widening.

### The conversion funnels

`float()`, `int()` and `.items()` over TOML-legal values of the wrong type raise bare
`ValueError`/`TypeError`/`AttributeError`, and `inf` or an oversized integer (tomllib keeps
arbitrary precision) raises `OverflowError`. Every consumer keys fault handling on
`ProfileError`/`PluginError`, so those escaped to `main`'s bare-except and printed one
`error:` line naming neither the file nor the key. One funnel at each load boundary, over a
`CONVERSION_FAULTS` set closed on the nine types `tomllib` can yield rather than on the ones
seen so far.

**This makes #474's premise true.** #474 currently carries a correction saying all three
user-authored TOML parsers are uncovered — verified accurate on `main` today. With these
two funnels in, #474 narrows to `policy.toml` alone, which is what its title already says.

## Review round: the Win32 root aliases

Codex flagged that the new guard misses Windows trailing-space aliases. The premise is
correct and is fixed here; validating it also turned up a live bug it did not name.

| commit | fix |
|---|---|
| `7868500` | `names_tree_root` rejects every dot/space spelling of the root |
| `362a8de` | `[python] module` gets the root guard + containment before `exec_module` |
| `464311b` | `init`'s skill-tree and hook-config writes are confined to the project |
| `8c04443` | the Unity seeder's hand-copied guard clone gets the missing mirror |

Win32 strips **every** trailing period and space from a path's final component, so `". "`,
`".. "`, `"..."` and `"   "` all name the containing directory there, while both pure
pathlib flavours keep them as ordinary one-segment names. A component made solely of
periods and spaces is now root-naming; `"foo. "` strips to `"foo"`, names a child, and is
still accepted.

**The reviewer's stated consequence does not hold at `worktree_seed`.** That loop compares
the *unresolved* `raw` against the resolved `dst` (`worktree_flow.py:422`, `:456`), and any
aliasing makes those differ, so such an entry lands in the reported `skipped` list rather
than reaching the copy. `resolve()` either collapses the spelling to the root — the guard
catches it — or keeps it — raw≠resolved catches it. Stated plainly because it is the harm
the helper's own docstring claims to prevent.

**The exposure was at the call sites without that comparison:**

- **`init`** — `_register_hooks` and `_copy_skills` reach `mkdir`/`rmtree`/`write_text` with
  no resolve-time check, and `_copy_skills` passes `_copy_traversable` neither containment
  root, so both of that helper's legs are inert there by construction.
  `provision_worktree` has the check; `init` never did. Not fixed by supplying `worktree=`,
  which would also force no-clobber and switch per-entry `OSError` to degrade — `init` must
  fail loudly on a write it cannot complete.
- **`[python] module`** — only two of the three predicates, and no containment recheck
  before `exec_module`. Arbitrary code execution rather than a copy, so it re-checks after
  resolution.
- **Unity's `scene_guard_dir`** — a live bug. `unity_seed_assets.py` is stdlib-only and
  hand-copies `is_absolute_path`/`has_parent_ref`, so a core-side fix cannot reach it, and
  it never had a `names_tree_root` mirror. `main()` `.strip()`s the env var, collapsing the
  *space* spellings into `"."` for the existing `not rel.parts` arm but leaving the *dot*
  spellings intact. On Windows those name the worktree itself, the asset-root probe then
  finds a real directory and passes, and the payload scatters across the worktree root
  instead of landing under `Assets/`.

`".. "` lands in `names_tree_root` rather than `has_parent_ref`: the trailing space stops it
matching the `..` relative component, so Win32 trims it to empty and it names the containing
directory, not the parent (Wine's conformance suite and Project Zero; Microsoft's docs are
ambiguous on the trim-vs-relative-component ordering). Nothing rests on that — under the
other reading it escapes the tree, and the paired guards reject it either way.

Reserved device names (`NUL`, `CON`) still pass all three predicates, and three smaller
lexical-check gaps remain. All predate this PR; filed as #480 rather than folded into a
recovery branch.

## Deliberate behavior changes

Both were silent `str()` coercions, now rejections:

- `[scm] worktree_seed = [1]` → `PolicyError: scm.worktree_seed entries must be strings`
- an int entry in a plugin manifest's `seed_files`/`seed_globs` →
  `PluginError: [plugin] seed_files entries must be strings`

Called out in the CHANGELOG under **Behavior change:**.

## Second review round

Codex and CodeRabbit each filed findings on the first round's fix; all were accepted.

| commit | fix |
|---|---|
| `0738bfc` | `_confined_to` requires strictly-below containment; a refused skill tree fails `init` |
| `732b6d5` | CHANGELOG entries trimmed to the house baseline |

**The containment helper had the very hole this PR is about.** `is_relative_to` is true for
equal paths, so `skill_tree = "skills"` where `project/skills` links back to `project`
resolved to the root itself and passed — the same "a path is relative to itself" trap the
seed loop has, reintroduced in the helper written to prevent it. `_copy_skills` would then
have been handed the project root, landing the bundled skill dirs at top level and, under
`--force-skills`, `rmtree`ing any root directory whose name collides with one of them.
Containment is now `resolved != base and resolved.is_relative_to(base)`.

**A refused skill tree now fails the install.** It printed and continued, so `install_into`
still reached `init complete` and exit 0 with the skills missing — an unattended-setup trap,
and inconsistent with `_register_hooks`' refusal, which already failed the install. It raises
`ProfileError`, caught at the `install_into` boundary like the profile faults above it.

The plugin loader's pre-`exec_module` check got the same strictness. There it changes only
which error is raised — a module resolving to the plugin dir is a directory, so `is_file()`
already refused it — so it is consistency rather than a second fix, and claims no ablation
lane on that basis.

## Verification

- `uv run pytest -q -n auto` — 4396 passed, 24 skipped
- `uv run pyright` — 0 errors, 0 warnings
- `trunk check --all` — 242 files, no issues

**Ablations: 20/20 RED**, all re-run against the rebased tree rather than inherited from the
pre-rebase branch. Every gate was deleted and the suite re-run, scored off pytest's exit code
(a grep-based harness has rotted here before), with the harness refusing any lane whose
mutation did not apply. No lane reddened a test outside its own reach.

| lane | ablation |
|---|---|
| A | `policy` entry guard → `not seed` |
| B | `policy` `worktree_seed` shape guard removed |
| C–E | `profile` `seed_files` / `skill_tree` / `hooks.config_path` → `not <x>` |
| F | `manifest._check_relative_paths` → `not value` |
| G | `manifest._str_list` → `tuple(str(s) for s in …)` |
| H, I | each conversion funnel arm removed |
| J, K | `OverflowError` dropped from each `CONVERSION_FAULTS` |
| L | `names_tree_root` forced to `False` |
| M | `names_tree_root`'s dot/space arm removed |
| N | `manifest` `[python] module` root guard removed |
| O | registry `exec_module` containment removed |
| P | `_register_hooks` containment removed |
| Q | `_copy_skills` containment removed |
| R | unity `_names_tree_root` removed from the guard condition |
| S | `_confined_to` equality readmitted |
| T | `_copy_skills` raise → print-and-continue |

The four dot spellings are parametrized separately from `""` for this reason: restoring
`not seed` fails them while `""` keeps passing. Lane M's reds are disjoint from lane L's, and
lane S reddens only the resolves-to-root test.

## Rebase

Rebased onto `main` after #478 merged. The only conflict was `CHANGELOG.md`, where both
branches added entries at the head of `### Fixed`; both sides are kept. CI is green on all
nine legs including both Windows ones — the Actions outage noted when this PR was opened has
cleared.
