### PR TITLE
test(worktree): pin #392's teardown-residue arc end to end

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -253,8 +253,40 @@ def make_validate_document(findings, *, stories_on: bool = False, spec_folder: s
     return documents.validate_document(report, stories_on, spec_folder)
 
 
+@pytest.fixture(scope="session", autouse=True)
+def _isolate_ambient_git_ignores(tmp_path_factory: pytest.TempPathFactory):
+    """Shadow the two ignore sources git reads from OUTSIDE the repo, for every test.
+
+    Developer boxes routinely carry `.claude/` or `.codex/` in a global gitignore —
+    ignoring your AI tooling everywhere is the obvious thing to do — and without this
+    the shield tests silently measure that instead of the shield. The failure is not
+    only a red: a global `.codex/` makes `git add -A` skip the hook config, so the
+    file the test believes it TRACKED is untracked, the tracked-file filter is never
+    reached, and `ls-files -ci --exclude-standard` answers "" because an untracked
+    file is not tracked-and-ignored. The test passes having exercised nothing.
+
+    Two sources, and both are needed: `core.excludesFile` from `~/.gitconfig`
+    (suppressed by pointing GIT_CONFIG_GLOBAL at a file that does not exist), and its
+    documented fallback `$XDG_CONFIG_HOME/git/ignore`, which still applies once the
+    key is unset. Session-scoped so `_project_template`'s own `add -A` is covered too.
+
+    `GIT_CONFIG_NOSYSTEM` is deliberately NOT set, for the reason
+    `test_shield_falls_back_to_home_when_xdg_is_relative` records: it would suppress
+    Git-for-Windows' system `core.autocrlf` and make unrelated tracked files read as
+    modified. A system-level excludes file therefore stays reachable — tests that
+    depend on a path really being tracked assert that as a precondition."""
+    env = tmp_path_factory.mktemp("git-env")
+    mp = pytest.MonkeyPatch()
+    mp.setenv("GIT_CONFIG_GLOBAL", str(env / "no-such-gitconfig"))
+    mp.setenv("XDG_CONFIG_HOME", str(env / "xdg"))
+    yield
+    mp.undo()
+
+
 @pytest.fixture(scope="session")
-def _project_template(tmp_path_factory: pytest.TempPathFactory) -> Path:
+def _project_template(
+    tmp_path_factory: pytest.TempPathFactory, _isolate_ambient_git_ignores: None
+) -> Path:
     """Master sandbox repo, built once per xdist worker. NEVER hand this path to
     a test — a mutation would poison every later test in the worker; tests get
     disposable copies via `project`. (Do not chmod it read-only either: copytree

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -2448,6 +2448,58 @@ def test_shield_tracked_hook_config_is_not_excluded(project, tmp_path):
     assert git(repo, "ls-files", "-ci", "--exclude-standard") == ""
 
 
+def test_shield_tracked_hook_config_leaves_no_residue_after_teardown(project, tmp_path):
+    """#392's fourth ask, end to end: track the hook config, provision, run the
+    reporter's probe in BOTH checkouts, tear the worktree down, and prove nothing the
+    shield wrote outlived it. Their report was one arc — the exclusion appeared during
+    provisioning and survived deleting the run — and no single test walked it.
+
+    codex is the faithful fixture. `.codex/hooks.json` is its `config_path` and is NOT
+    one of its `seed_files`, which is the reporter's exact shape; claude's `config_path`
+    doubles as a seed file (the coincidence #471 reports), so it cannot express it.
+
+    Complements `test_shield_dies_with_the_worktree`, which pins the same lifetime from
+    #384's angle — plain fixture, no tracked file, no `-ci` probe."""
+    repo = project.project
+    codex = get_profile("codex")
+    hook_rel = codex.hooks.config_path
+    # The preconditions that make this the reporter's case rather than claude's.
+    assert not codex.hookless and hook_rel
+    assert hook_rel not in codex.seed_files
+    (repo / hook_rel).parent.mkdir(parents=True, exist_ok=True)
+    (repo / hook_rel).write_text('{"hooks": {}}\n', encoding="utf-8")
+    git(repo, "add", "-A")
+    git(repo, "commit", "-q", "-m", "track the hook config")
+    wt = tmp_path / "wt"
+    verify.worktree_add(repo, wt, "feat", "main")
+    shared = repo / ".git" / "info" / "exclude"
+    before = shared.read_bytes()
+
+    provision_worktree(wt, [codex], repo)
+
+    private = _wt_private_exclude(wt)
+    assert private.is_file()  # the shield really ran: there is something to outlive
+    gitdir = private.parent.parent
+    assert git(wt, "ls-files", "-ci", "--exclude-standard") == ""
+    assert git(repo, "ls-files", "-ci", "--exclude-standard") == ""
+
+    # `force`: provisioning's hook step writes the now-tracked config, so the
+    # worktree is dirty and a bare remove would refuse.
+    verify.worktree_remove(repo, wt, force=True)
+
+    assert not private.exists()
+    assert not gitdir.exists()
+    assert shared.read_bytes() == before
+    # The residue the reporter cleaned up by hand would answer here. Defense in depth
+    # rather than an independent pin, and knowing which is which matters: no single
+    # ablation reddens this line alone, because every ignore source the main checkout
+    # can see after teardown is equally visible BEFORE it, so the probes above fail
+    # first. What it adds over the byte comparison is reach — a residue that is not
+    # the shared exclude's bytes (a `.gitignore` left in the tree, a surviving
+    # `core.excludesFile`) answers here and nowhere else in this test.
+    assert git(repo, "ls-files", "-ci", "--exclude-standard") == ""
+
+
 def test_shield_tracked_skill_tree_keeps_its_pattern(project, tmp_path):
     """The other half of the same predicate, and the reason it is not simply "never
     exclude a tracked path": a tracked DIRECTORY's pattern measurably DOES hide new

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -2470,6 +2470,13 @@ def test_shield_tracked_hook_config_leaves_no_residue_after_teardown(project, tm
     (repo / hook_rel).write_text('{"hooks": {}}\n', encoding="utf-8")
     git(repo, "add", "-A")
     git(repo, "commit", "-q", "-m", "track the hook config")
+    # The fixture's own precondition, asserted rather than assumed: an ambient ignore
+    # matching `.codex/` would make `add -A` skip this file, and every assertion below
+    # would then pass on an UNTRACKED path having exercised nothing — `-ci` reports
+    # tracked-and-ignored, so it answers "" for a file git never took. `conftest`
+    # shadows the two out-of-repo ignore sources; this catches the third (a system
+    # excludes file, which cannot be suppressed without breaking Windows autocrlf).
+    assert verify.path_tracked_file(repo, hook_rel)
     wt = tmp_path / "wt"
     verify.worktree_add(repo, wt, "feat", "main")
     shared = repo / ".git" / "info" / "exclude"

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -2477,6 +2477,11 @@ def test_shield_tracked_hook_config_leaves_no_residue_after_teardown(project, tm
 
     provision_worktree(wt, [codex], repo)
 
+    # Checked HERE as well as after teardown, and the pair is not redundant: a shared
+    # write that teardown happens to remove would satisfy the post-teardown comparison
+    # alone. #384's harm is the window while the operator's checkout and every sibling
+    # worktree are live, which is this line, not only what survives the run.
+    assert shared.read_bytes() == before
     private = _wt_private_exclude(wt)
     assert private.is_file()  # the shield really ran: there is something to outlive
     gitdir = private.parent.parent


### PR DESCRIPTION
The one leg of #392's requested regression test that was never written.

The reporter asked for four things, and their fourth — *"deletes the run/worktree and verifies no exclude residue remains"* — had no test in their scenario. `test_shield_dies_with_the_worktree` pins the same lifetime from #384's angle, but with a plain fixture and no `ls-files -ci` probe, so nothing walked their arc in one piece: track the hook config → provision → probe **both** checkouts → tear down → prove no residue.

## Fixture

**codex**, not claude. `.codex/hooks.json` is codex's `config_path` and is **not** one of its `seed_files` — the reporter's exact shape. claude's `config_path` (`.claude/settings.json`) doubles as a seed file, which is the coincidence #471 reports, so claude cannot express it. Asserted as a precondition in the test so a profile change cannot quietly make it stop biting.

## Ablations, run singly

| ablation | reddens |
|---|---|
| drop the tracked-file filter (`_drop_inert_tracked_file_patterns`) | the in-worktree probe returns `.codex/hooks.json` — the reporter's path verbatim |
| point the shield write at the common dir | `assert private.is_file()`, so the guard is not vacuous |
| write the patterns to **both** excludes | `shared.read_bytes() == before`, so the residue comparison is live |

The post-teardown probe is **defense in depth, not an independent pin**, and the comment at the line says so rather than leaving a reader to assume otherwise: no single ablation reddens it alone, because every ignore source the main checkout can see after teardown is equally visible before it, so the earlier probes fail first. What it adds over the byte comparison is reach — a residue that is not the shared exclude's bytes (a `.gitignore` left in the tree, a surviving `core.excludesFile`) answers there and nowhere else in this test.

## Scope

Test-only. No behavior change, so no CHANGELOG entry — the behavior shipped in #385 (scope + lifetime) and #478 (the tracked-file filter).

Suite 4446 green, 25 skipped. pyright clean, `trunk check` clean.

## Issues

Covers the last untested ask in #392. The tracked-**directory** half of that report stays a documented non-fix and is tracked separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for cleaning up tracked hook configuration.
  * Verified worktree removal fully clears private configuration and ignore state.
  * Confirmed shared exclude settings remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->