### PR TITLE
fix(#461): symlink-safe hook relay event write + validate stats the relay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,16 +152,18 @@ whose seams had diverged enough that several ports needed a different fix, and t
 
 ### Fixed
 
-- **The hook relay refuses a symlinked `events/` dir, and `validate` stats the relay (#461).** The
-  relay's event write followed a symlink — `os.makedirs(exist_ok=True)` `isdir()`-checks through a
-  link — so a driven session, which can write inside the run dir, could redirect the orchestrator's
-  control-plane event stream and stall the run to `session_timeout_min`. The write now refuses a
-  symlinked events dir before creating it (the whole defense on Windows), anchors the create+replace
-  to an `O_NOFOLLOW` dir_fd where the platform supports it, creates `O_EXCL` at `0o600` (was 0644),
-  and degrades to a no-op on any `OSError` rather than failing the session. Separately, validate's
-  `hooks.registered` was a substring match on the hook config that never touched the script it
-  points at, so a deleted `.bmad-loop/` (branch switch) read as green while every hook event
-  no-opped; a new `hooks.relay-present` finding stats the relay and says `run bmad-loop init`.
+- **The hook relay refuses a redirected `events/` dir, and `validate` stats the relay (#461).** The
+  relay's event write followed a symlink — or, on Windows, a directory junction, which
+  `os.path.islink` reports False for and which `mklink /J` creates without elevation — so a driven
+  session could redirect the orchestrator's control-plane event stream and stall the run to
+  `session_timeout_min`. The write now refuses a redirected events dir before creating it, anchors
+  the create+replace to an `O_NOFOLLOW` dir_fd where the platform supports it, creates `O_EXCL` at
+  `0o600`, writes the payload in full (a short `os.write` would publish truncated JSON, which
+  `SignalWatcher` drops permanently), and degrades to a no-op on `OSError` rather than failing the
+  session. Separately, `hooks.registered` was a substring match on the hook config that never
+  touched the script it points at, so a deleted `.bmad-loop/` (branch switch) read green while every
+  hook event no-opped; a new `hooks.relay-present` finding stats the relay and says
+  `run bmad-loop init`.
 
 - **Dispatched sessions are told the sprint board is orchestrator-owned (#437).** The board advances
   at dev-verify time but the story commits only after the review loop, so a session dispatched in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,17 @@ whose seams had diverged enough that several ports needed a different fix, and t
 
 ### Fixed
 
+- **The hook relay refuses a symlinked `events/` dir, and `validate` stats the relay (#461).** The
+  relay's event write followed a symlink — `os.makedirs(exist_ok=True)` `isdir()`-checks through a
+  link — so a driven session, which can write inside the run dir, could redirect the orchestrator's
+  control-plane event stream and stall the run to `session_timeout_min`. The write now refuses a
+  symlinked events dir before creating it (the whole defense on Windows), anchors the create+replace
+  to an `O_NOFOLLOW` dir_fd where the platform supports it, creates `O_EXCL` at `0o600` (was 0644),
+  and degrades to a no-op on any `OSError` rather than failing the session. Separately, validate's
+  `hooks.registered` was a substring match on the hook config that never touched the script it
+  points at, so a deleted `.bmad-loop/` (branch switch) read as green while every hook event
+  no-opped; a new `hooks.relay-present` finding stats the relay and says `run bmad-loop init`.
+
 - **Dispatched sessions are told the sprint board is orchestrator-owned (#437).** The board advances
   at dev-verify time but the story commits only after the review loop, so a session dispatched in
   between opens on an uncommitted, unattributed `sprint-status.yaml` change — one review reverted it

--- a/src/bmad_loop/checks.py
+++ b/src/bmad_loop/checks.py
@@ -60,6 +60,7 @@ VALIDATE_CHECKS: frozenset[str] = frozenset(
         "git.render-tracked",
         "hooks.config-parse",
         "hooks.registered",
+        "hooks.relay-present",
         "mux.backend",
         "mux.preflight",
         "mux.backends-detected",

--- a/src/bmad_loop/cli.py
+++ b/src/bmad_loop/cli.py
@@ -356,6 +356,7 @@ def cmd_validate(args: argparse.Namespace) -> int:
         else:
             report.fail("adapter.binary", f"{tool} not found on PATH", {"binary": tool})
 
+    any_hooks_registered = False
     for profile in profiles:
         if profile.hookless:
             report.ok(
@@ -394,6 +395,7 @@ def cmd_validate(args: argparse.Namespace) -> int:
                     {"profile": profile.name, "config_path": str(hook_config)},
                 )
         if hooks_ok:
+            any_hooks_registered = True
             report.ok(
                 "hooks.registered",
                 f"bmad-loop hooks registered for {profile.name}",
@@ -405,6 +407,35 @@ def cmd_validate(args: argparse.Namespace) -> int:
                 f"bmad-loop hooks not registered for {profile.name} — "
                 f"run `bmad-loop init --cli {profile.name}`",
                 {"profile": profile.name, "config_path": str(hook_config)},
+            )
+
+    # #461: `hooks.registered` above is a substring match on the config JSON — it
+    # never touches the artifact the registered command points AT. A branch switch
+    # (or a deleted .bmad-loop/) leaves the registration green while every hook
+    # event is a silent no-op and the run stalls to session_timeout_min, so stat
+    # the relay itself. Outside the per-profile loop on purpose: the relay is one
+    # shared artifact, and per-profile reporting would print the same line N times.
+    # A distinct id, not a repurposed `hooks.registered` — the two answer different
+    # questions and an operator needs to see which one failed.
+    #
+    # COUPLING (#461 Phase 2): Phase 2 moves the relay to
+    # `<abs-python> -m bmad_loop.hookrelay` and retires HOOK_SCRIPT_REL. It must
+    # RETARGET this check to stat the registered interpreter (`hooks.interpreter`),
+    # not drop it — the stall it guards against survives the move.
+    if any_hooks_registered:
+        relay = project / install.HOOK_SCRIPT_REL
+        if relay.is_file():
+            report.ok(
+                "hooks.relay-present",
+                f"hook relay script present: {relay}",
+                {"path": str(relay)},
+            )
+        else:
+            report.fail(
+                "hooks.relay-present",
+                f"hooks are registered but the relay script {relay} is missing — "
+                f"run `bmad-loop init`",
+                {"path": str(relay)},
             )
 
     # opencode config-file model ids are "provider/model" (see the opencode_http docstring);

--- a/src/bmad_loop/cli.py
+++ b/src/bmad_loop/cli.py
@@ -424,17 +424,39 @@ def cmd_validate(args: argparse.Namespace) -> int:
     # not drop it — the stall it guards against survives the move.
     if any_hooks_registered:
         relay = project / install.HOOK_SCRIPT_REL
-        if relay.is_file():
-            report.ok(
-                "hooks.relay-present",
-                f"hook relay script present: {relay}",
-                {"path": str(relay)},
-            )
-        else:
+        # Existence is not enough: `is_file()` stays True for a mode-000 file, and
+        # the registered command is `<interpreter> <relay> <Event>`, which has to
+        # READ the script — an unreadable relay exits 2 ("can't open file") and the
+        # run stalls exactly as if the relay were gone, which is the blind spot
+        # this whole check exists to remove. `os.access` uses the REAL uid/gid,
+        # which is what the operator's own `bmad-loop` invocation runs as, and it
+        # stays correct under root (who can read a 000 file) where a mode-bit test
+        # would false-fail. On Windows `chmod` can only toggle the read-only flag,
+        # so this arm is POSIX-effective and never makes the Windows path stricter.
+        if not relay.is_file():
             report.fail(
                 "hooks.relay-present",
                 f"hooks are registered but the relay script {relay} is missing — "
                 f"run `bmad-loop init`",
+                {"path": str(relay)},
+            )
+        elif not os.access(relay, os.R_OK):
+            # Deliberately NOT "run `bmad-loop init`": install_into writes this path
+            # with write_text(), which needs write access to the same file, so init
+            # raises PermissionError instead of repairing it. Sending the operator
+            # to a command that also fails is worse than saying nothing.
+            report.fail(
+                "hooks.relay-present",
+                f"hooks are registered but the relay script {relay} is not readable — "
+                f"the registered hook command cannot run it, so every hook event "
+                f"no-ops. Restore read permission (`chmod u+r`) or delete it and "
+                f"re-run `bmad-loop init`",
+                {"path": str(relay)},
+            )
+        else:
+            report.ok(
+                "hooks.relay-present",
+                f"hook relay script present: {relay}",
                 {"path": str(relay)},
             )
 

--- a/src/bmad_loop/data/bmad_loop_hook.py
+++ b/src/bmad_loop/data/bmad_loop_hook.py
@@ -17,8 +17,24 @@ normal interactive sessions are unaffected.
 
 import json
 import os
+import stat
 import sys
 import time
+
+# Windows reparse tags that make a directory entry REDIRECT somewhere else,
+# compared against os.lstat().st_reparse_tag (Windows, 3.8+). Deliberately not
+# os.path.isjunction(), which is 3.12+ — this relay runs under whatever
+# interpreter the host has, not under the orchestrator's. Deliberately not "any
+# reparse tag" either: cloud placeholders (OneDrive) and dedup stubs are reparse
+# points too, and refusing those would stall a legitimate run. Empty on POSIX.
+_LINK_REPARSE_TAGS = tuple(
+    tag
+    for tag in (
+        getattr(stat, "IO_REPARSE_TAG_SYMLINK", None),
+        getattr(stat, "IO_REPARSE_TAG_MOUNT_POINT", None),
+    )
+    if tag is not None
+)
 
 
 def _first_workspace(payload):
@@ -28,26 +44,64 @@ def _first_workspace(payload):
     return None
 
 
+def _is_link_like(path):
+    """True when `path` redirects elsewhere: a POSIX symlink, or a Windows
+    symlink OR DIRECTORY JUNCTION.
+
+    `os.path.islink()` is False for a junction — junctions are a distinct
+    reparse kind, which is why `os.path.isjunction()` exists at all. On Windows
+    the junction is the arm that matters: `mklink /J` needs no elevation, while
+    a directory symlink needs SeCreateSymbolicLinkPrivilege or Developer Mode —
+    so the unprivileged attack is exactly the one `islink()` misses.
+    """
+    if os.path.islink(path):
+        return True
+    try:
+        return getattr(os.lstat(path), "st_reparse_tag", 0) in _LINK_REPARSE_TAGS
+    except OSError:
+        return False
+
+
+def _write_all(fd, data):
+    """Write every byte of `data` to `fd`.
+
+    `os.write()` may write FEWER bytes than asked and simply return the count. A
+    truncated event file is not merely retried, it is lost: `SignalWatcher.poll`
+    adds a filename to its consumed set BEFORE parsing it (signals.py), so
+    malformed JSON is skipped and never re-read — the session's Stop signal is
+    gone for good and the run waits out `session_timeout_min`. The buffered
+    `open()` this replaced looped internally; the raw fd needed for
+    O_NOFOLLOW/dir_fd does not, so loop here.
+    """
+    view = memoryview(data)
+    while view:
+        written = os.write(fd, view)
+        if written <= 0:  # not observed in practice; a spinning hook is worse
+            raise OSError("short write to the event file")
+        view = view[written:]
+
+
 def _write_event(events_dir, name, event):
-    """Write one event file into `events_dir`, refusing to follow a symlink.
+    """Write one event file into `events_dir`, refusing to follow a redirect.
 
     The events dir is the orchestrator's control plane. A driven session has
     write access to the project, so it could plant `<run_dir>/events` as a
-    symlink and redirect (or swallow) the completion signal — stalling the run
-    to `session_timeout_min` instead of completing. `os.makedirs(exist_ok=True)`
-    `isdir()`-checks THROUGH a link, so the refusal has to come before it; that
-    refusal works on every platform and is the whole defense on Windows, where
-    O_NOFOLLOW/O_DIRECTORY do not exist and `os.supports_dir_fd` is empty.
+    symlink (or, on Windows, a junction) and redirect — or swallow — the
+    completion signal, stalling the run to `session_timeout_min` instead of
+    completing. `os.makedirs(exist_ok=True)` `isdir()`-checks THROUGH such a
+    link, so the refusal has to come before it; that refusal works on every
+    platform and is the whole defense on Windows, where O_NOFOLLOW/O_DIRECTORY
+    do not exist and `os.supports_dir_fd` is empty.
 
     Where the platform has them, the create+replace is additionally anchored to
     a dir_fd opened O_NOFOLLOW, which closes the window between the check and
-    the write. Mode is 0o600 (narrowed from the umask-derived 0644 an ordinary
+    the write. Mode is 0o600 (narrowed from the umask-derived mode an ordinary
     `open()` produced): only the operator running the loop reads these.
 
     Raises OSError on any refusal or failure; the caller degrades to a no-op.
     """
-    if os.path.islink(events_dir):
-        raise OSError(f"refusing to write events into a symlinked directory: {events_dir}")
+    if _is_link_like(events_dir):
+        raise OSError(f"refusing to write events into a redirected directory: {events_dir}")
     os.makedirs(events_dir, exist_ok=True)
     data = json.dumps(event).encode("utf-8")
     tmp = name + ".tmp"
@@ -66,7 +120,7 @@ def _write_event(events_dir, name, event):
         try:
             fd = os.open(tmp, create, 0o600, dir_fd=dir_fd)
             try:
-                os.write(fd, data)
+                _write_all(fd, data)
             finally:
                 os.close(fd)
             os.rename(tmp, name, src_dir_fd=dir_fd, dst_dir_fd=dir_fd)
@@ -76,7 +130,7 @@ def _write_event(events_dir, name, event):
     tmp_path = os.path.join(events_dir, tmp)
     fd = os.open(tmp_path, create, 0o600)
     try:
-        os.write(fd, data)
+        _write_all(fd, data)
     finally:
         os.close(fd)
     os.replace(tmp_path, os.path.join(events_dir, name))

--- a/src/bmad_loop/data/bmad_loop_hook.py
+++ b/src/bmad_loop/data/bmad_loop_hook.py
@@ -28,6 +28,60 @@ def _first_workspace(payload):
     return None
 
 
+def _write_event(events_dir, name, event):
+    """Write one event file into `events_dir`, refusing to follow a symlink.
+
+    The events dir is the orchestrator's control plane. A driven session has
+    write access to the project, so it could plant `<run_dir>/events` as a
+    symlink and redirect (or swallow) the completion signal — stalling the run
+    to `session_timeout_min` instead of completing. `os.makedirs(exist_ok=True)`
+    `isdir()`-checks THROUGH a link, so the refusal has to come before it; that
+    refusal works on every platform and is the whole defense on Windows, where
+    O_NOFOLLOW/O_DIRECTORY do not exist and `os.supports_dir_fd` is empty.
+
+    Where the platform has them, the create+replace is additionally anchored to
+    a dir_fd opened O_NOFOLLOW, which closes the window between the check and
+    the write. Mode is 0o600 (narrowed from the umask-derived 0644 an ordinary
+    `open()` produced): only the operator running the loop reads these.
+
+    Raises OSError on any refusal or failure; the caller degrades to a no-op.
+    """
+    if os.path.islink(events_dir):
+        raise OSError(f"refusing to write events into a symlinked directory: {events_dir}")
+    os.makedirs(events_dir, exist_ok=True)
+    data = json.dumps(event).encode("utf-8")
+    tmp = name + ".tmp"
+    o_nofollow = getattr(os, "O_NOFOLLOW", 0)
+    o_directory = getattr(os, "O_DIRECTORY", 0)
+    # O_BINARY is a no-op flag on POSIX; on Windows it stops the fd from
+    # newline-translating what os.write() puts through it.
+    create = os.O_WRONLY | os.O_CREAT | os.O_EXCL | o_nofollow | getattr(os, "O_BINARY", 0)
+    # Probe os.rename, not os.replace: CPython omits os.replace from
+    # supports_dir_fd on Linux even though it accepts src_dir_fd/dst_dir_fd, so
+    # probing it would leave this whole branch dead everywhere. This branch is
+    # POSIX-only by construction, and there rename(2) IS the atomic-replace
+    # primitive os.replace wraps — probe the function actually called.
+    if o_nofollow and o_directory and {os.open, os.rename} <= os.supports_dir_fd:
+        dir_fd = os.open(events_dir, os.O_RDONLY | o_directory | o_nofollow)
+        try:
+            fd = os.open(tmp, create, 0o600, dir_fd=dir_fd)
+            try:
+                os.write(fd, data)
+            finally:
+                os.close(fd)
+            os.rename(tmp, name, src_dir_fd=dir_fd, dst_dir_fd=dir_fd)
+        finally:
+            os.close(dir_fd)
+        return
+    tmp_path = os.path.join(events_dir, tmp)
+    fd = os.open(tmp_path, create, 0o600)
+    try:
+        os.write(fd, data)
+    finally:
+        os.close(fd)
+    os.replace(tmp_path, os.path.join(events_dir, name))
+
+
 def main() -> int:
     run_dir = os.environ.get("BMAD_LOOP_RUN_DIR")
     task_id = os.environ.get("BMAD_LOOP_TASK_ID")
@@ -59,13 +113,13 @@ def main() -> int:
         # agy sends no cwd — it sends workspacePaths, a list of workspace roots.
         "cwd": payload.get("cwd") or _first_workspace(payload),
     }
-    events_dir = os.path.join(run_dir, "events")
-    os.makedirs(events_dir, exist_ok=True)
-    final = os.path.join(events_dir, f"{ts}-{task_id}-{event_name}.json")
-    tmp = final + ".tmp"
-    with open(tmp, "w", encoding="utf-8") as f:
-        json.dump(event, f)
-    os.replace(tmp, final)
+    try:
+        _write_event(os.path.join(run_dir, "events"), f"{ts}-{task_id}-{event_name}.json", event)
+    except OSError:
+        # A hostile or broken events dir must degrade to the orchestrator's
+        # normal session_timeout_min path, never surface as a hook failure that
+        # fails the CLI window (mirrors bmad_loop_probe_hook.py's write wrap).
+        return 0
     return 0
 
 

--- a/src/bmad_loop/data/bmad_loop_hook.py
+++ b/src/bmad_loop/data/bmad_loop_hook.py
@@ -100,9 +100,16 @@ def _write_event(events_dir, name, event):
     re-resolves the path and the check-to-write window stays open there. It is
     NARROWED, not closed: the redirect check runs again after the payload is
     written and before it is published, so a swap still in place is refused and
-    the temp file removed. A swap-and-restore inside the window remains
-    undetectable from stdlib Python (#494), and degrades to the same timeout the
-    run would have hit anyway.
+    the temp file removed. Two windows stay open on that path (#494), both
+    measured: a swap-and-restore around the create is undetectable from stdlib
+    Python, and a swap landing after the second check leaves the path-based
+    publish unable to find the temp file it wrote — it either raises or renames
+    a file the attacker planted inside the attacker's own directory. Neither
+    redirects the payload, and both end where a refusal ends: no event, so the
+    run waits out session_timeout_min. That is the same outcome an attacker gets
+    for free by leaving a redirect in place, which is refused without any race —
+    winning the race buys no capability, which is why the residual is accepted
+    rather than chased into ctypes/NtCreateFile inside a stdlib-only relay.
 
     Mode is 0o600 (narrowed from the umask-derived mode an ordinary `open()`
     produced): only the operator running the loop reads these.

--- a/src/bmad_loop/data/bmad_loop_hook.py
+++ b/src/bmad_loop/data/bmad_loop_hook.py
@@ -89,14 +89,23 @@ def _write_event(events_dir, name, event):
     symlink (or, on Windows, a junction) and redirect — or swallow — the
     completion signal, stalling the run to `session_timeout_min` instead of
     completing. `os.makedirs(exist_ok=True)` `isdir()`-checks THROUGH such a
-    link, so the refusal has to come before it; that refusal works on every
-    platform and is the whole defense on Windows, where O_NOFOLLOW/O_DIRECTORY
-    do not exist and `os.supports_dir_fd` is empty.
+    link, so the refusal has to come before it. That refusal works on every
+    platform.
 
-    Where the platform has them, the create+replace is additionally anchored to
-    a dir_fd opened O_NOFOLLOW, which closes the window between the check and
-    the write. Mode is 0o600 (narrowed from the umask-derived mode an ordinary
-    `open()` produced): only the operator running the loop reads these.
+    Where the platform has them, the create+replace is anchored to a dir_fd
+    opened O_NOFOLLOW: every later operation goes through that fd, so a swap
+    after the check cannot reach the write. Windows has neither
+    O_NOFOLLOW/O_DIRECTORY nor a handle-relative open (`os.supports_dir_fd` is
+    empty — dir_fd is implemented with the POSIX `*at` calls), so its fallback
+    re-resolves the path and the check-to-write window stays open there. It is
+    NARROWED, not closed: the redirect check runs again after the payload is
+    written and before it is published, so a swap still in place is refused and
+    the temp file removed. A swap-and-restore inside the window remains
+    undetectable from stdlib Python (#494), and degrades to the same timeout the
+    run would have hit anyway.
+
+    Mode is 0o600 (narrowed from the umask-derived mode an ordinary `open()`
+    produced): only the operator running the loop reads these.
 
     Raises OSError on any refusal or failure; the caller degrades to a no-op.
     """
@@ -127,12 +136,24 @@ def _write_event(events_dir, name, event):
         finally:
             os.close(dir_fd)
         return
+    # Fallback (Windows): no dir_fd to anchor to, so the create below re-resolves
+    # events_dir by path. A swap into a junction between the check above and this
+    # create would have put the temp file inside the attacker's directory. Check
+    # again before publishing, so a swap that is still in place is refused rather
+    # than followed — the realistic shape, since a junction has to persist to
+    # capture the events the attacker is after.
     tmp_path = os.path.join(events_dir, tmp)
     fd = os.open(tmp_path, create, 0o600)
     try:
         _write_all(fd, data)
     finally:
         os.close(fd)
+    if _is_link_like(events_dir):
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise OSError(f"events directory was redirected mid-write: {events_dir}")
     os.replace(tmp_path, os.path.join(events_dir, name))
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3901,6 +3901,35 @@ def test_validate_stories_mode_reports_missing_manifest(project, capsys):
     assert "sprint status" not in text
 
 
+def test_validate_flags_registered_hooks_with_missing_relay_script(project, capsys):
+    """#461 papercut: `hooks.registered` is a substring match on the hook config —
+    it stays green after the relay script itself is gone (branch switch, deleted
+    `.bmad-loop/`), while every hook event silently no-ops and the run stalls to
+    session_timeout_min. A distinct finding stats the artifact.
+
+    Ablation guard: deleting the `hooks.relay-present` block in cmd_validate makes
+    this FAIL on the first assertion."""
+    from bmad_loop import install as install_mod
+
+    install_bmad_config(project)
+    _write_policy(project.project)
+    assert cli.main(["init", "--project", str(project.project), "--no-skills"]) == 0
+    args = argparse.Namespace(project=str(project.project), spec=None)
+
+    cli.cmd_validate(args)
+    assert "hook relay script present" in _validate_output(capsys)
+
+    (project.project / install_mod.HOOK_SCRIPT_REL).unlink()
+
+    cli.cmd_validate(args)
+    text = _validate_output(capsys)
+    # The registration check is untouched — it still reads green, which is exactly
+    # the blind spot the new finding covers.
+    assert "hooks registered" in text
+    assert "relay script" in text and "missing" in text
+    assert "bmad-loop init" in text
+
+
 def test_validate_sprint_mode_still_gates_on_sprint_status(project, capsys):
     """Item 8 regression: the default (sprint) mode still requires sprint-status."""
     install_bmad_config(project)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@
 import argparse
 import io
 import json
+import os
 import sys
 
 import pytest
@@ -3928,6 +3929,49 @@ def test_validate_flags_registered_hooks_with_missing_relay_script(project, caps
     assert "hooks registered" in text
     assert "relay script" in text and "missing" in text
     assert "bmad-loop init" in text
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Windows chmod only toggles the read-only flag")
+@pytest.mark.skipif(
+    os.geteuid() == 0 if hasattr(os, "geteuid") else False, reason="root reads a 000 file"
+)
+def test_validate_flags_registered_hooks_with_an_unreadable_relay_script(project, capsys):
+    """A relay that exists but cannot be READ is the same stall as a missing one:
+    the registered command is `<interpreter> <relay> <Event>`, which exits 2
+    ("can't open file") and never writes the event, so the run waits out
+    session_timeout_min. `Path.is_file()` is True for a mode-000 file, so
+    existence alone left that green — the blind spot this check exists to remove.
+
+    The remediation differs from the missing case and is asserted here: `init`
+    writes the relay with `write_text()`, which needs write access to the same
+    file, so it raises PermissionError rather than repairing it.
+
+    Ablation guard: dropping the `os.access` branch makes this FAIL — validate
+    reports the relay present."""
+    from bmad_loop import install as install_mod
+
+    install_bmad_config(project)
+    _write_policy(project.project)
+    assert cli.main(["init", "--project", str(project.project), "--no-skills"]) == 0
+    args = argparse.Namespace(project=str(project.project), spec=None)
+
+    relay = project.project / install_mod.HOOK_SCRIPT_REL
+    cli.cmd_validate(args)
+    assert "hook relay script present" in _validate_output(capsys)
+
+    relay.chmod(0o000)
+    # The premise, asserted rather than assumed: existence still reads True, which
+    # is the whole reason readability needs its own check.
+    assert relay.is_file() and not os.access(relay, os.R_OK)
+
+    cli.cmd_validate(args)
+    text = _validate_output(capsys)
+    assert "hooks registered" in text  # registration is untouched, still green
+    assert "relay script" in text and "not readable" in text
+    # It must NOT tell the operator to run a command that also fails.
+    assert "chmod" in text
+
+    relay.chmod(0o644)  # so the sandbox tears down cleanly
 
 
 def test_validate_sprint_mode_still_gates_on_sprint_status(project, capsys):

--- a/tests/test_hook_script.py
+++ b/tests/test_hook_script.py
@@ -176,6 +176,35 @@ def test_is_link_like_refuses_a_reparse_tagged_dir(tmp_path, monkeypatch):
     assert relay._is_link_like(plain) is True
 
 
+def test_fallback_refuses_a_redirect_that_appears_mid_write(tmp_path, monkeypatch):
+    """The Windows fallback has no dir_fd to anchor to, so it re-resolves
+    `events_dir` by path and a swap between the check and the create lands the
+    temp file in the attacker's directory. The post-write re-check catches a
+    swap that is still in place. Driven here with the dir_fd branch disabled,
+    because on POSIX that branch is always taken and the fallback would ship
+    unexercised.
+
+    Ablation guard: deleting the post-write `_is_link_like` block makes this
+    fail — the event gets published instead of refused."""
+    relay = _relay_module()
+    events = tmp_path / "events"
+    calls = []
+    real = relay._is_link_like
+
+    def swapped_after_the_check(path):
+        calls.append(path)
+        return len(calls) > 1 and real(path) is False  # clean at check, dirty after
+
+    monkeypatch.setattr(os, "supports_dir_fd", frozenset())  # force the fallback
+    monkeypatch.setattr(relay, "_is_link_like", swapped_after_the_check)
+
+    with pytest.raises(OSError, match="redirected mid-write"):
+        relay._write_event(str(events), "1-t1-Stop.json", {"event": "Stop", "task_id": "t1"})
+
+    assert len(calls) == 2  # the check ran on both sides of the write
+    assert list(events.iterdir()) == []  # nothing published, no .tmp left behind
+
+
 @pytest.mark.skipif(os.name != "nt", reason="directory junctions are Windows-only")
 def test_junctioned_events_dir_writes_nothing_and_exits_zero(tmp_path):
     """The Windows half of the symlink test — Windows CI is its only oracle, a

--- a/tests/test_hook_script.py
+++ b/tests/test_hook_script.py
@@ -205,6 +205,91 @@ def test_fallback_refuses_a_redirect_that_appears_mid_write(tmp_path, monkeypatc
     assert list(events.iterdir()) == []  # nothing published, no .tmp left behind
 
 
+@pytest.mark.skipif(os.name == "nt", reason="dir_fd is implemented with the POSIX *at() calls")
+def test_the_anchored_branch_is_actually_taken_on_posix(tmp_path, monkeypatch):
+    """The capability probe must resolve to True where the capability exists, or
+    the TOCTOU-closing layer ships dead while every other test stays green — the
+    `islink` refusal covers the same cases, so nothing else would redden.
+
+    This is not hypothetical: `os.replace` is NOT in `os.supports_dir_fd` on
+    Linux (only `os.rename` is) even though it accepts src_dir_fd/dst_dir_fd, so
+    probing `os.replace` — the function the code used to call — made the branch
+    unreachable on every platform. Observe the anchoring behaviorally rather
+    than re-deriving the probe, so editing the probe reddens this.
+
+    Ablation guard: change the probe to `os.replace` (or drop the branch) and
+    this fails; no other test notices."""
+    relay = _relay_module()
+    real_open, real_supports = os.open, os.supports_dir_fd
+    # The premise, asserted rather than assumed: were a future CPython to drop
+    # rename from the set, the branch would go dead and this says so directly.
+    assert {real_open, os.rename} <= real_supports
+    anchored = []
+
+    def spy(path, flags, mode=0o777, *, dir_fd=None):
+        anchored.append(dir_fd)
+        if dir_fd is None:
+            return real_open(path, flags, mode)
+        return real_open(path, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr(os, "open", spy)
+    # The probe tests os.open by IDENTITY, so the spy has to be in the capability
+    # set too or the probe answers False and this measures the fallback instead
+    # of the branch it exists to pin — which is how it first went red.
+    monkeypatch.setattr(os, "supports_dir_fd", real_supports | {spy})
+    relay._write_event(str(tmp_path / "events"), "1-t1-Stop.json", {"event": "Stop"})
+    monkeypatch.undo()
+
+    assert any(fd is not None for fd in anchored), "the create was never anchored to a dir_fd"
+
+
+@pytest.mark.parametrize("forced_fallback", [False, True])
+def test_a_short_os_write_still_publishes_the_whole_payload(tmp_path, monkeypatch, forced_fallback):
+    """`os.write` may write FEWER bytes than asked and just return the count. The
+    buffered `open()` this replaced looped internally; the raw fd needed for
+    O_NOFOLLOW/dir_fd does not. A truncated event file is not retried but LOST:
+    `SignalWatcher.poll` adds a name to `_consumed` before parsing it, so
+    malformed JSON is skipped and never re-read — the Stop signal is gone and the
+    run waits out `session_timeout_min`.
+
+    Both branches are driven: the loop is shared, but the fallback is the only
+    path Windows takes and POSIX would otherwise never exercise it.
+
+    Ablation guard: collapsing `_write_all` back to a single `os.write` makes
+    this fail. Nothing else in the suite catches that — a real `os.write`
+    returns the full count, so the normal-path tests pass either way."""
+    relay = _relay_module()
+    events = tmp_path / "events"
+    real_write = os.write
+
+    def a_byte_at_a_time(fd, data):
+        return real_write(fd, bytes(data)[:1])  # a legal short write
+
+    if forced_fallback:
+        monkeypatch.setattr(os, "supports_dir_fd", frozenset())
+    event = {"event": "Stop", "task_id": "t1", "session_id": "s" * 300}
+    monkeypatch.setattr(os, "write", a_byte_at_a_time)
+    relay._write_event(str(events), "1-t1-Stop.json", event)
+    monkeypatch.undo()
+
+    published = list(events.glob("*.json"))
+    assert len(published) == 1
+    assert json.loads(published[0].read_text()) == event
+    assert list(events.glob("*.tmp")) == []
+
+
+def test_a_zero_length_write_raises_instead_of_spinning(tmp_path, monkeypatch):
+    """`_write_all` loops on short writes, so a descriptor that always accepts 0
+    bytes would spin forever. Refuse instead: the caller degrades to a no-op and
+    the run takes the timeout path, which beats a hook process that never exits.
+
+    Ablation guard: dropping the `written <= 0` arm hangs this test."""
+    relay = _relay_module()
+    monkeypatch.setattr(os, "write", lambda fd, data: 0)
+    with pytest.raises(OSError, match="short write"):
+        relay._write_event(str(tmp_path / "events"), "1-t1-Stop.json", {"event": "Stop"})
+
+
 @pytest.mark.skipif(os.name != "nt", reason="directory junctions are Windows-only")
 def test_junctioned_events_dir_writes_nothing_and_exits_zero(tmp_path):
     """The Windows half of the symlink test — Windows CI is its only oracle, a

--- a/tests/test_hook_script.py
+++ b/tests/test_hook_script.py
@@ -1,9 +1,13 @@
 """The hook relay script runs as a real subprocess, like Claude Code runs it."""
 
 import json
+import os
+import stat
 import subprocess
 import sys
 from pathlib import Path
+
+import pytest
 
 SCRIPT = Path(__file__).parent.parent / "src" / "bmad_loop" / "data" / "bmad_loop_hook.py"
 
@@ -103,6 +107,38 @@ def test_tolerates_garbage_stdin(tmp_path):
     files = list((tmp_path / "events").glob("*.json"))
     assert len(files) == 1
     assert json.loads(files[0].read_text())["session_id"] is None
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlinks")
+def test_symlinked_events_dir_writes_nothing_and_exits_zero(tmp_path):
+    """#461 (Low): a driven session can write inside the run dir, so it can plant
+    `events/` as a symlink and redirect the orchestrator's control-plane event
+    stream — swallowing the Stop signal and stalling the run to timeout. The relay
+    must refuse the link and degrade to a no-op, never write through it."""
+    target = tmp_path / "attacker"
+    target.mkdir()
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    (run_dir / "events").symlink_to(target, target_is_directory=True)
+
+    env = {"BMAD_LOOP_RUN_DIR": str(run_dir), "BMAD_LOOP_TASK_ID": "t1"}
+    proc = run_hook("Stop", env, {"session_id": "s1"})
+
+    assert proc.returncode == 0
+    assert list(target.iterdir()) == []
+    assert list((run_dir / "events").iterdir()) == []
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX file modes")
+def test_event_file_mode_is_0600(tmp_path):
+    """Event files carry the orchestrator's control plane; nothing but the
+    operator running the loop needs to read them (narrowed from the umask-derived
+    0644 a plain `open()` produced)."""
+    env = {"BMAD_LOOP_RUN_DIR": str(tmp_path), "BMAD_LOOP_TASK_ID": "t1"}
+    proc = run_hook("Stop", env, {"session_id": "s1"})
+    assert proc.returncode == 0
+    written = next((tmp_path / "events").glob("*.json"))
+    assert stat.S_IMODE(written.stat().st_mode) == 0o600
 
 
 def test_installed_copy_matches_source(tmp_path):

--- a/tests/test_hook_script.py
+++ b/tests/test_hook_script.py
@@ -1,5 +1,6 @@
 """The hook relay script runs as a real subprocess, like Claude Code runs it."""
 
+import importlib.util
 import json
 import os
 import stat
@@ -10,6 +11,18 @@ from pathlib import Path
 import pytest
 
 SCRIPT = Path(__file__).parent.parent / "src" / "bmad_loop" / "data" / "bmad_loop_hook.py"
+
+
+def _relay_module():
+    """Import the relay by path. It ships as package DATA, not an importable
+    module (init copies it into the workspace), so the behavioral tests below
+    drive it as a subprocess — but the reparse-tag branch of `_is_link_like` is
+    reachable only on Windows, and shipping it unexercised is how a capability
+    check silently becomes dead code."""
+    spec = importlib.util.spec_from_file_location("_bmad_loop_hook_under_test", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def run_hook(event: str, env: dict, payload) -> subprocess.CompletedProcess:
@@ -127,6 +140,69 @@ def test_symlinked_events_dir_writes_nothing_and_exits_zero(tmp_path):
     assert proc.returncode == 0
     assert list(target.iterdir()) == []
     assert list((run_dir / "events").iterdir()) == []
+
+
+class _ReparseStat:
+    """Stand-in for the os.lstat() result of a Windows junction: a DIRECTORY
+    mode (which is why os.path.islink() answers False) carrying a reparse tag."""
+
+    st_mode = stat.S_IFDIR | 0o755
+    st_reparse_tag = 0xA0000003  # IO_REPARSE_TAG_MOUNT_POINT
+
+
+def test_is_link_like_refuses_a_reparse_tagged_dir(tmp_path, monkeypatch):
+    """A Windows directory junction is a reparse point but NOT a symlink, so
+    `os.path.islink` is False for it while `os.makedirs`/`os.open` follow it —
+    and `mklink /J` needs no elevation, unlike a directory symlink, so it is the
+    cheaper attack. The refusal keys on the reparse tag instead. That branch is
+    reachable only on Windows; drive its logic here so it is not shipped
+    unexercised (the `stat.IO_REPARSE_TAG_*` constants do not exist on POSIX,
+    hence the substituted tuple).
+
+    Ablation guard: dropping the `st_reparse_tag` arm of `_is_link_like` makes
+    the last assertion fail."""
+    relay = _relay_module()
+    plain = tmp_path / "events"
+    plain.mkdir()
+    assert relay._is_link_like(plain) is False
+
+    real_lstat = os.lstat
+    monkeypatch.setattr(relay, "_LINK_REPARSE_TAGS", (_ReparseStat.st_reparse_tag,))
+    monkeypatch.setattr(
+        os,
+        "lstat",
+        lambda p, *a, **k: _ReparseStat() if str(p) == str(plain) else real_lstat(p),
+    )
+    assert relay._is_link_like(plain) is True
+
+
+@pytest.mark.skipif(os.name != "nt", reason="directory junctions are Windows-only")
+def test_junctioned_events_dir_writes_nothing_and_exits_zero(tmp_path):
+    """The Windows half of the symlink test — Windows CI is its only oracle, a
+    junction cannot be created on POSIX."""
+    # If either tag constant were misnamed the tuple is empty and the refusal
+    # silently never fires. Assert it directly rather than inferring from below.
+    assert _relay_module()._LINK_REPARSE_TAGS
+
+    target = tmp_path / "attacker"
+    target.mkdir()
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    subprocess.run(
+        ["cmd", "/c", "mklink", "/J", str(run_dir / "events"), str(target)],
+        check=True,
+        capture_output=True,
+    )
+    # The premise, asserted rather than assumed: were a future CPython to start
+    # reporting junctions as links, this says so directly instead of going green
+    # for the wrong reason.
+    assert os.path.islink(run_dir / "events") is False
+
+    env = {"BMAD_LOOP_RUN_DIR": str(run_dir), "BMAD_LOOP_TASK_ID": "t1"}
+    proc = run_hook("Stop", env, {"session_id": "s1"})
+
+    assert proc.returncode == 0
+    assert list(target.iterdir()) == []
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX file modes")


### PR DESCRIPTION
Phase 1 of the #461 hardening program: the two small, independently-mergeable
items — the relay's symlink-following event write (the issue's **Low**
sub-issue) and `validate`'s never-stat-the-relay **papercut**. Closes nothing:
#461's core (Medium) item is Phase 2, the adjacent config surface is Phase 3.

## Fix A — refuse a redirected `events/` dir (`data/bmad_loop_hook.py`)

`os.makedirs(events_dir, exist_ok=True)` `isdir()`-checks *through* a symlink, so
a driven session — which has write access to the run dir — could plant
`<run_dir>/events` as a link and redirect (or swallow) the orchestrator's
control-plane event stream. Since sessions complete **only** on a Stop event or
window death, a swallowed Stop stalls the run to `session_timeout_min`.

The write now goes through `_write_event`, layered:

1. **Redirect refusal before `makedirs`** — `os.path.islink()`, **plus** an
   `os.lstat().st_reparse_tag` check against `IO_REPARSE_TAG_SYMLINK`/`MOUNT_POINT`.
   `islink()` is False for a Windows **directory junction**, and `mklink /J` needs
   no elevation while a directory symlink needs `SeCreateSymbolicLinkPrivilege` —
   so the junction is the *cheap* attack and it is exactly the one `islink()`
   misses. Deliberately not "any reparse tag": OneDrive placeholders and dedup
   stubs are reparse points too, and refusing those would stall a legitimate run.
2. **dir_fd anchoring where available** — `O_RDONLY|O_DIRECTORY|O_NOFOLLOW` dir_fd,
   `O_WRONLY|O_CREAT|O_EXCL|O_NOFOLLOW` create, dir_fd-anchored rename. Closes the
   check-to-write TOCTOU window on POSIX.
3. **A post-write redirect re-check on the fallback path** — Windows has no dir_fd
   to anchor to, so the create re-resolves by path; the check runs again before
   publication, so a redirect swapped in and left in place is refused and the temp
   file removed.
4. **A complete write** — `os.write` may return a short count, and a truncated
   event file is *lost*, not retried: `SignalWatcher.poll` adds a filename to
   `_consumed` **before** parsing it, so malformed JSON is skipped forever and the
   run waits out its timeout. The buffered `open()` this replaced looped
   internally; a raw fd does not, so `_write_all` loops (and refuses a
   non-positive return rather than spinning).
5. **mode `0o600`**, narrowed from the umask-derived mode a plain `open()` gave.
6. **`OSError → return 0`** at the call site — a hostile or broken events dir must
   degrade to the normal timeout path, never fail the CLI window (mirrors
   `bmad_loop_probe_hook.py`'s write wrap).

Still stdlib-only; capability guarded with `getattr(os, "O_NOFOLLOW", 0)`.

**Residual, filed as #494 rather than hidden:** the Windows fallback re-resolves
`events_dir` by path, so two narrow windows stay open there. Both were
*measured*, not assumed — a swap-and-restore around the create, and a swap
landing after the post-write check. Neither redirects the payload (the publish
step's source is the temp file in the *real* directory), and both end where a
refusal ends: no event, run waits out `session_timeout_min`. That is the same
outcome an attacker gets for free by leaving a redirect in place and being
refused deterministically — **winning either race buys no capability**. Closing
them properly needs `ctypes`/`NtCreateFile` inside a relay that is stdlib-only by
contract, where a bug stops hook delivery on Windows and stalls every run: the
exact harm being defended against. Re-verified against current docs (3.14.7 and
the 3.16.0a0 dev tree): `dir_fd` is the POSIX `*at()` calls, `O_NOFOLLOW`/
`O_DIRECTORY` are Unix-only, and `os` exposes no Windows handle-relative
create/rename.

### One deliberate deviation from the plan

The plan specified probing `{os.open, os.replace} <= os.supports_dir_fd`. **That
probe is False on Linux** — CPython registers only `os.rename` in
`supports_dir_fd`, even though `os.replace` accepts `src_dir_fd`/`dst_dir_fd` and
works (verified both ways). Shipping it verbatim would have left layer 2 dead
code on *every* platform, with the tests still green because layer 1 covers the
same case. This PR probes and calls `os.rename`: the branch is POSIX-only by
construction, and there `rename(2)` *is* the atomic-replace primitive `os.replace`
wraps. The reason is a comment in the code, and a test now pins it (see below).

## Fix B — `validate` stats the relay (`cli.py`, `checks.py`)

`hooks.registered` is a substring match on the hook config JSON; it never touches
the artifact the command points at. A branch switch or a deleted `.bmad-loop/`
reads green while every hook event no-ops. New distinct finding
`hooks.relay-present` (registered in `VALIDATE_CHECKS`), emitted **after** the
per-profile loop because the relay is one shared artifact, gated on any profile
actually having hooks registered. `hooks.registered` keeps its exact semantics.

The predicate is existence **and readability**: `Path.is_file()` stays True for a
mode-`000` file, and the registered `<interpreter> <relay> <Event>` command has to
*read* the script — an unreadable relay exits 2 (`can't open file`) and stalls the
run exactly as if it were gone. `os.access` rather than a mode-bit test, because it
uses the real uid/gid the operator's own invocation runs as and stays correct under
root; on Windows `chmod` only toggles the read-only flag, so the arm is
POSIX-effective and never makes that path stricter.

The two failures carry **separate remediations**, because the missing case's advice
is actively wrong for the other: `install_into` writes the relay with
`write_text()`, which needs write access to the same file, so `bmad-loop init`
raises `PermissionError` instead of repairing an unreadable relay. Missing → run
`init`; unreadable → `chmod u+r`, or delete and re-init.

**Coupling, called out in the code:** Phase 2 retires `HOOK_SCRIPT_REL` and must
*retarget* this check to the registered interpreter (`hooks.interpreter`), not
drop it — the stall it guards against survives the relay move.

## Ablation matrix — graded two-sided

Each lane must **pass unablated and fail ablated**. A one-sided "did it redden?"
driver scored a *broken* test as a working lane earlier in this PR, so both sides
are reported:

| Lane | Target test | Verdict |
| --- | --- | --- |
| pre-write redirect refusal removed | symlink | vacuous — layer 2 covers it (see below) |
| pre-check removed + fallback forced | symlink | vacuous — layer 3 covers it |
| **both** redirect layers removed + fallback forced | symlink | **PROVEN** |
| reparse-tag arm removed | junction logic | **PROVEN** |
| post-write re-check removed | mid-write redirect | **PROVEN** |
| `0o600` → `0o644`, both call sites | mode | **PROVEN** |
| `0o600` → `0o644`, dir_fd site only | mode | **PROVEN** |
| `_write_all` → single `os.write` | short write | **PROVEN** |
| `written <= 0` anti-spin arm removed | zero-length write | **PROVEN** (hangs) |
| capability probe → `os.replace` | anchored branch | **PROVEN** |
| anchored branch forced off | anchored branch | **PROVEN** |
| `hooks.relay-present` block removed | validate | **PROVEN** |
| readability (`os.access`) arm removed | unreadable relay | **PROVEN** |
| readability weakened to `elif False:` | unreadable relay | **PROVEN** |
| missing-relay arm removed (block restructured to `if/elif/else`) | missing relay | **PROVEN** |

13/15 proven. The two vacuous lanes are **defense-in-depth, verified rather than
assumed**: with the pre-check removed,
`os.open(events_dir, O_RDONLY|O_DIRECTORY|O_NOFOLLOW)` independently refuses a
symlink (`NotADirectoryError`), and the post-write check covers the other. The
all-layers-off lane reddens, which is what proves the test measures the guards at
all.

Two layers were shipping **untested** and are now pinned, because an ablation
would have removed either with the suite still green: `_write_all`'s loop (a real
`os.write` returns the full count, so nothing noticed) and the dir_fd capability
probe (nothing observed that the anchored branch was taken, so "fixing" the probe
back to `os.replace` would re-kill layer 2, green).

`tests/test_portability_guard.py` green with **no** new allowlist entry (none of
the six scanned construct kinds appear in the new code).

## Verification

`uv run pytest -q -n auto` → 4475 passed, 26 skipped · `uv run pyright` → 0 errors
· `trunk check` (no path filter) → no issues.

The Windows lane is the sole oracle for the fallback path, so its counts are
diffed per commit rather than read as a bare green: `4d92239` = 4382 passed/114
skipped → `9933b11` = 4385/115, i.e. the three cross-platform additions in the
*passed* column and the POSIX-only one *skipped*.

## Review rounds

Codex ran every round and produced 4 findings; CodeRabbit produced 2 (both
self-marked addressed in `ecb4685`); Greptile is credit-exhausted on this account
and never reviewed. Disposition, each answered in its own thread:

- **Windows junctions bypass `islink`** — valid, fixed (layer 1's reparse arm).
- **Short `os.write` publishes truncated JSON** — valid, fixed (`_write_all`), and
  now tested.
- **Check-to-write race on the fallback** — valid, narrowed (layer 3), residual
  documented and filed as #494.
- **Anchor the publish to the checked directory** — premise valid, harm refuted by
  measurement, remedy unreachable from a stdlib-only relay. See the residual
  paragraph above.
- **An unreadable relay validates as present** — valid, fixed. Its *remedy* needed
  correcting: the suggested "report a problem" is right, but `bmad-loop init`
  cannot repair an unreadable relay, so the two cases now carry different
  remediations.

Refs #461.

