### PR TITLE
fix(sweep): integrity-pin the agent-writable host-exec config across the auto-sweep re-read (#461 point 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,7 +158,9 @@ whose seams had diverged enough that several ports needed a different fix, and t
   the launch argv and env, and `[plugins] enabled` gates in-process Python import. A run freezes its
   policy at launch, but the auto-triggered child sweep re-reads both from disk; it is now pinned to
   a launch-time digest of those fields and refuses on a mismatch (`sweep-auto-failed` + notify, the
-  parent run continues). `resume` re-baselines and warns with the changed categories instead of
+  parent run continues). The config is read once and frozen, so the gate hashes the same bytes the
+  child launches from rather than a second read a background writer can swap in between.
+  `resume` re-baselines and warns with the changed categories instead of
   refusing. The digest is field-scoped, so live-editing `[limits]` mid-run still works. Plugins are
   pinned by allowlist name only: swapping the module behind an already-enabled plugin, and
   folder-dropping a declarative plugin whose shell hooks need no allowlist entry, are both still

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,7 +162,7 @@ whose seams had diverged enough that several ports needed a different fix, and t
   refusing. The digest is field-scoped, so live-editing `[limits]` mid-run still works. Plugins are
   pinned by allowlist name only: swapping the module behind an already-enabled plugin, and
   folder-dropping a declarative plugin whose shell hooks need no allowlist entry, are both still
-  uncaught (#496).
+  uncaught (#496, #497).
 
 - **The hook relay refuses a redirected `events/` dir, and `validate` stats the relay (#461).** The
   relay's event write followed a symlink — or, on Windows, a directory junction, which

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,7 +160,9 @@ whose seams had diverged enough that several ports needed a different fix, and t
   a launch-time digest of those fields and refuses on a mismatch (`sweep-auto-failed` + notify, the
   parent run continues). `resume` re-baselines and warns with the changed categories instead of
   refusing. The digest is field-scoped, so live-editing `[limits]` mid-run still works. Plugins are
-  pinned by name only — swapping the module behind an already-enabled plugin is not yet caught.
+  pinned by allowlist name only: swapping the module behind an already-enabled plugin, and
+  folder-dropping a declarative plugin whose shell hooks need no allowlist entry, are both still
+  uncaught (#496).
 
 - **The hook relay refuses a redirected `events/` dir, and `validate` stats the relay (#461).** The
   relay's event write followed a symlink — or, on Windows, a directory junction, which

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,14 +153,14 @@ whose seams had diverged enough that several ports needed a different fix, and t
 ### Fixed
 
 - **The auto-sweep child refuses config a session rewrote under the run (#461).** `policy.toml` and
-  `profiles/*.toml` sit in the agent-writable workspace, and both reach host code execution: the
-  `[verify] commands` run with `shell=True`, the resolved profile supplies the launch `binary`, and
-  `[plugins] enabled` gates in-process Python import. A run freezes its policy at launch, but the
-  auto-triggered child sweep re-reads both from disk — the one mid-run config change no human
-  initiates. It is now pinned to a launch-time digest of exactly those fields and refuses on a
-  mismatch (`sweep-auto-failed` + notify; the parent run is unaffected). Human-present paths stay
-  trusted: `resume` re-baselines and only warns, naming the changed categories, never the values.
-  The digest is field-scoped, so live-editing `[limits]` mid-run still works.
+  `profiles/*.toml` sit in the agent-writable workspace and reach host code execution — the
+  `[verify] commands` run with `shell=True`, the resolved profile plus `adapter.extra_args` decide
+  the launch argv and env, and `[plugins] enabled` gates in-process Python import. A run freezes its
+  policy at launch, but the auto-triggered child sweep re-reads both from disk; it is now pinned to
+  a launch-time digest of those fields and refuses on a mismatch (`sweep-auto-failed` + notify, the
+  parent run continues). `resume` re-baselines and warns with the changed categories instead of
+  refusing. The digest is field-scoped, so live-editing `[limits]` mid-run still works. Plugins are
+  pinned by name only — swapping the module behind an already-enabled plugin is not yet caught.
 
 - **The hook relay refuses a redirected `events/` dir, and `validate` stats the relay (#461).** The
   relay's event write followed a symlink — or, on Windows, a directory junction, which

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,16 @@ whose seams had diverged enough that several ports needed a different fix, and t
 
 ### Fixed
 
+- **The auto-sweep child refuses config a session rewrote under the run (#461).** `policy.toml` and
+  `profiles/*.toml` sit in the agent-writable workspace, and both reach host code execution: the
+  `[verify] commands` run with `shell=True`, the resolved profile supplies the launch `binary`, and
+  `[plugins] enabled` gates in-process Python import. A run freezes its policy at launch, but the
+  auto-triggered child sweep re-reads both from disk — the one mid-run config change no human
+  initiates. It is now pinned to a launch-time digest of exactly those fields and refuses on a
+  mismatch (`sweep-auto-failed` + notify; the parent run is unaffected). Human-present paths stay
+  trusted: `resume` re-baselines and only warns, naming the changed categories, never the values.
+  The digest is field-scoped, so live-editing `[limits]` mid-run still works.
+
 - **The hook relay refuses a redirected `events/` dir, and `validate` stats the relay (#461).** The
   relay's event write followed a symlink — or, on Windows, a directory junction, which
   `os.path.islink` reports False for and which `mklink /J` creates without elevation — so a driven

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,7 +155,8 @@ whose seams had diverged enough that several ports needed a different fix, and t
 - **The auto-sweep child refuses config a session rewrote under the run (#461).** `policy.toml` and
   `profiles/*.toml` sit in the agent-writable workspace and reach host code execution — the
   `[verify] commands` run with `shell=True`, the resolved profile plus `adapter.extra_args` decide
-  the launch argv and env, and `[plugins] enabled` gates in-process Python import. A run freezes its
+  the launch argv and env, `hooks.dialect` decides which argv builder runs at all, and
+  `[plugins] enabled` gates in-process Python import. A run freezes its
   policy at launch, but the auto-triggered child sweep re-reads both from disk; it is now pinned to
   a launch-time digest of those fields and refuses on a mismatch (`sweep-auto-failed` + notify, the
   parent run continues). The config is read once and frozen, so the gate hashes the same bytes the

--- a/src/bmad_loop/cli.py
+++ b/src/bmad_loop/cli.py
@@ -1558,6 +1558,16 @@ def _resume_paused_run(project: Path, run_dir: Path) -> int:
     # the operator was away, and `resume` is the moment they can still look.
     # Deliberately no --allow-config-change flag: a refuse-by-default gate here
     # would break resume-to-fix-a-setting, which is a supported workflow.
+    #
+    # ADVISORY, not a control, and the asymmetry with the gate is deliberate. The
+    # auto-sweep refusal in `_sweep_factory` baselines off a digest threaded in
+    # MEMORY from launch (see cmd_run/the compose_resume call below), which a
+    # session cannot reach. This comparison baselines off `state.trusted_config_digest`,
+    # which round-trips through <project>/.bmad-loop/runs/<id>/state.json — inside
+    # the same agent-writable tree the digest exists to police. A session that
+    # rewrites policy.toml can blank or re-stamp that field and silence the warning
+    # (blank suffices: the bool() guard reads "" as no prior pin). It catches the
+    # incidental change, not a deliberate one. Tracked in #498.
     security_config_changed = bool(state.trusted_config_digest) and (
         new_digest != state.trusted_config_digest
     )

--- a/src/bmad_loop/cli.py
+++ b/src/bmad_loop/cli.py
@@ -192,7 +192,7 @@ def _reject_isolation_conflict(paths: bmadconfig.ProjectPaths, pol) -> int | Non
     return 1
 
 
-def _trusted_config_digest(pol, project: Path) -> str:
+def _trusted_config_digest(pol, project: Path, *, profiles=None) -> str:
     """The launch-time integrity baseline the auto-sweep child is held to (#461
     point 4). Thin wrapper over :func:`runsetup.config_digest` for the two
     human-initiated entrypoints that stamp one (`cmd_run`, `_resume_paused_run`)
@@ -203,11 +203,15 @@ def _trusted_config_digest(pol, project: Path) -> str:
     `make_adapters` renders that as `error: unknown CLI profile ...` and exits 1,
     so re-raise it in the same shape rather than letting a `ProfileError`
     traceback escape a misconfigured `run`. The child-sweep gate deliberately does
-    NOT go through here — there a raise is the point."""
+    NOT go through here — there a raise is the point.
+
+    `profiles` forwards an already-resolved `runsetup.resolve_profiles` mapping,
+    so the stamped pin is taken from the same resolution the caller gated on and
+    the adapters are built from — never a fresh read."""
     from .adapters.profile import ProfileError
 
     try:
-        return runsetup.config_digest(pol, project)
+        return runsetup.config_digest(pol, project, profiles=profiles)
     except ProfileError as e:
         raise SystemExit(f"error: {e}") from e
 
@@ -1375,11 +1379,17 @@ def _start_sweep(
     max_cycles: int | None = None,
     trigger: str,
     run_id: str | None = None,
+    profiles=None,
 ) -> int:
     # The composition (run dir + state + pid + sweep.json + adapters + engine)
     # lives in runsetup; this stays compose -> render. SweepEngine and
     # _make_adapters are handed in from this module's namespace so the test suite's
     # `monkeypatch.setattr(cli, "SweepEngine"/"_make_adapters", ...)` still applies.
+    #
+    # `profiles` is the auto-sweep gate's frozen resolution (#461 point 4) — it
+    # both stamps the pin and builds the adapters, so neither re-reads
+    # profiles/*.toml after the gate compared it. `cmd_sweep` passes None: a human
+    # started that one, so a fresh read is the point.
     composed = runsetup.compose_sweep(
         project=project,
         paths=paths,
@@ -1393,7 +1403,8 @@ def _start_sweep(
         trigger=trigger,
         make_adapters=_make_adapters,
         sweep_engine_cls=SweepEngine,
-        trusted_config_digest=_trusted_config_digest(pol, project),
+        trusted_config_digest=_trusted_config_digest(pol, project, profiles=profiles),
+        profiles=profiles,
     )
     print(f"sweep {composed.run_id} starting (attach: bmad-loop attach)")
     summary = composed.engine.run()
@@ -1408,25 +1419,36 @@ def _sweep_factory(project: Path, paths: bmadconfig.ProjectPaths, trusted_digest
     ``trusted_digest`` is the caller's launch-time :func:`runsetup.config_digest`
     — the integrity pin for the config this factory re-reads from disk below.
     Required, with no default: an omitted baseline would silently disable the
-    refusal, which is the failure mode a security gate can least afford."""
+    refusal, which is the failure mode a security gate can least afford. The
+    re-read happens once and is frozen, so the gate validates the bytes the child
+    actually launches from rather than a separate read of the same files."""
 
     def factory(trigger: str) -> None:
         pol = policy_mod.load(_policy_path(project))
+        # Read the agent-writable config EXACTLY ONCE, here, and run the child off
+        # these two objects: `pol` and `profiles` are threaded through the gate
+        # below, the pin `_start_sweep` stamps, and `make_adapters`. Before this
+        # the gate hashed its own `get_profile` read while the adapters took a
+        # later one, so a session that leaves a background writer alternating a
+        # benign and a hostile profiles/*.toml only had to land the benign copy on
+        # the digest's read — and losing a round costs it nothing, since the
+        # refusal is swallowed by `_maybe_auto_sweep` and the next trigger deals
+        # again. Freezing the read is the fix; narrowing the window is not.
+        profiles = runsetup.resolve_profiles(pol, project)
         # #461 point 4. This reload is the ONE path where a mid-run rewrite of the
         # agent-writable config reaches host code execution with no human
         # initiating the change: the driven sessions can write policy.toml and
-        # profiles/*.toml, and this factory re-reads both (here, and through
-        # make_adapters -> get_profile) on a trigger the engine raised, not an
-        # operator. The parent loop is already safe — it froze its Policy at launch
-        # — and the two documented human-present mid-run edits (the TUI live-edit,
-        # resume-to-fix-a-setting) stay trusted; resume only warns. So refuse here
-        # and only here.
+        # profiles/*.toml, and this factory re-reads both on a trigger the engine
+        # raised, not an operator. The parent loop is already safe — it froze its
+        # Policy at launch — and the two documented human-present mid-run edits
+        # (the TUI live-edit, resume-to-fix-a-setting) stay trusted; resume only
+        # warns. So refuse here and only here.
         #
         # ABLATION GUARDS: deleting this block must fail
         # test_auto_sweep_refuses_a_rewritten_verify_command,
         # test_auto_sweep_refuses_a_rewritten_profile_binary, and
         # test_auto_sweep_refuses_a_widened_plugin_allowlist in tests/test_cli.py.
-        if runsetup.config_digest(pol, project) != trusted_digest:
+        if runsetup.config_digest(pol, project, profiles=profiles) != trusted_digest:
             raise RuntimeError(
                 "policy.toml/profiles changed under a running loop before an auto-sweep"
                 " — refusing the child sweep; no human initiated this config change."
@@ -1452,6 +1474,7 @@ def _sweep_factory(project: Path, paths: bmadconfig.ProjectPaths, trusted_digest
             decisions_only=False,
             max_bundles=None,
             trigger=trigger,
+            profiles=profiles,
         )
 
     return factory

--- a/src/bmad_loop/cli.py
+++ b/src/bmad_loop/cli.py
@@ -192,6 +192,43 @@ def _reject_isolation_conflict(paths: bmadconfig.ProjectPaths, pol) -> int | Non
     return 1
 
 
+def _launch_profiles(pol, project: Path) -> dict[str, CLIProfile]:
+    """Resolve a run's profiles ONCE, for the two human-initiated entrypoints that
+    stamp an integrity baseline (`cmd_run`, `_resume_paused_run`).
+
+    The stamp and the adapters must describe the SAME bytes. Each used to read
+    `profiles/*.toml` on its own — the digest via `config_digest`, the adapters via
+    `make_adapters` — so a write landing between them stamped a baseline for config
+    the run never launched.
+
+    This is NOT the child gate's check-then-use, and must not be read as one: there
+    is no comparison here. At launch the on-disk config IS the trust anchor, so an
+    adversary who can write in that gap could equally have written BEFORE it and
+    been blessed outright, with no timing at all — the race grants no capability.
+    The defect runs the other way, toward over-refusal. This pin is the one
+    baseline a session cannot reach (`_sweep_factory` holds every later auto-sweep
+    to it from MEMORY, unlike resume's disk-backed advisory), so a pin describing
+    bytes the run did not launch makes those children refuse the config the parent
+    has been running all along. `engine._maybe_auto_sweep` appends the trigger to
+    `sweeps_triggered` BEFORE calling the factory and returns early on an
+    already-recorded one, so that refusal burns the trigger for the life of the run
+    — it is not retried, not even across a resume.
+
+    `cmd_sweep` deliberately keeps its fresh read: a human started it, and the pin
+    it stamps gates no child.
+
+    Same `ProfileError` -> `SystemExit` contract as `_trusted_config_digest`, for
+    the same reason — resolving here happens a few frames EARLIER than
+    `make_adapters` used to, and a misconfigured `[adapter] name` must still exit 1
+    as `error: unknown CLI profile ...` rather than escape as a traceback."""
+    from .adapters.profile import ProfileError
+
+    try:
+        return runsetup.resolve_profiles(pol, project)
+    except ProfileError as e:
+        raise SystemExit(f"error: {e}") from e
+
+
 def _trusted_config_digest(pol, project: Path, *, profiles=None) -> str:
     """The launch-time integrity baseline the auto-sweep child is held to (#461
     point 4). Thin wrapper over :func:`runsetup.config_digest` for the two
@@ -1201,7 +1238,15 @@ def cmd_run(args: argparse.Namespace) -> int:
     # The launch baseline for the auto-sweep child's config re-read (#461 point 4).
     # Taken ONCE, from the same `pol` the engine is about to freeze, and used for
     # both the factory's gate and the RunState stamp so the two cannot disagree.
-    trusted_digest = _trusted_config_digest(pol, project)
+    #
+    # `profiles` is resolved once here for the same reason and carried into
+    # compose_run: the digest and `make_adapters` each used to read
+    # profiles/*.toml separately, so the stamped baseline could describe bytes
+    # this run never launched — and every later auto-sweep is held to that
+    # baseline. See `_launch_profiles` for why this is an over-refusal fix and
+    # not the child gate's check-then-use.
+    profiles = _launch_profiles(pol, project)
+    trusted_digest = _trusted_config_digest(pol, project, profiles=profiles)
 
     # The composition (run dir + state + pid + adapters + engine) lives in
     # runsetup; cmd_run stays parse -> compose -> render. Engine/StoriesEngine and
@@ -1222,6 +1267,7 @@ def cmd_run(args: argparse.Namespace) -> int:
         engine_cls=Engine,
         stories_engine_cls=StoriesEngine,
         trusted_config_digest=trusted_digest,
+        profiles=profiles,
     )
     print(f"run {composed.run_id} starting (attach: bmad-loop attach)")
     summary = composed.engine.run()
@@ -1572,7 +1618,12 @@ def _resume_paused_run(project: Path, run_dir: Path) -> int:
     # diagnose scrubs unknown fields with scrub_json, NOT the key-aware
     # _scrub_policy that reduces adapter.env and plugins.settings.
     new_snapshot = pol.to_dict()
-    new_digest = _trusted_config_digest(pol, project)
+    # Resolved once and carried into compose_resume below, so the re-stamped pin
+    # describes the bytes this resumed process actually launches (see
+    # `_launch_profiles`). A resume mints the same in-memory baseline `cmd_run`
+    # does — `_sweep_factory(..., new_digest)` — so the same reasoning applies.
+    profiles = _launch_profiles(pol, project)
+    new_digest = _trusted_config_digest(pol, project, profiles=profiles)
     # #461 point 4, human-present half. A resume IS a deliberate human choice, so
     # the on-disk config is re-blessed (new_digest is re-stamped below) and the run
     # proceeds — the auto-sweep child is the only path that refuses. But the issue's
@@ -1677,6 +1728,7 @@ def _resume_paused_run(project: Path, run_dir: Path) -> int:
         engine_cls=Engine,
         stories_engine_cls=StoriesEngine,
         sweep_engine_cls=SweepEngine,
+        profiles=profiles,
     )
     summary = composed.engine.run()
     print(summary.render())

--- a/src/bmad_loop/cli.py
+++ b/src/bmad_loop/cli.py
@@ -192,6 +192,26 @@ def _reject_isolation_conflict(paths: bmadconfig.ProjectPaths, pol) -> int | Non
     return 1
 
 
+def _trusted_config_digest(pol, project: Path) -> str:
+    """The launch-time integrity baseline the auto-sweep child is held to (#461
+    point 4). Thin wrapper over :func:`runsetup.config_digest` for the two
+    human-initiated entrypoints that stamp one (`cmd_run`, `_resume_paused_run`)
+    plus `_start_sweep`.
+
+    Its only job is the error contract: `config_digest` resolves profiles, so an
+    unknown `[adapter] name` now fails a few frames EARLIER than it used to.
+    `make_adapters` renders that as `error: unknown CLI profile ...` and exits 1,
+    so re-raise it in the same shape rather than letting a `ProfileError`
+    traceback escape a misconfigured `run`. The child-sweep gate deliberately does
+    NOT go through here — there a raise is the point."""
+    from .adapters.profile import ProfileError
+
+    try:
+        return runsetup.config_digest(pol, project)
+    except ProfileError as e:
+        raise SystemExit(f"error: {e}") from e
+
+
 def _reconcile_stale(project: Path, paths: bmadconfig.ProjectPaths, pol) -> None:
     """Tear down worktrees leaked by a prior run that stopped mid-flight, before
     starting a new run/sweep — the clean-finish GC never reached them. Gated on
@@ -1174,6 +1194,11 @@ def cmd_run(args: argparse.Namespace) -> int:
 
     _reconcile_stale(project, paths, pol)
 
+    # The launch baseline for the auto-sweep child's config re-read (#461 point 4).
+    # Taken ONCE, from the same `pol` the engine is about to freeze, and used for
+    # both the factory's gate and the RunState stamp so the two cannot disagree.
+    trusted_digest = _trusted_config_digest(pol, project)
+
     # The composition (run dir + state + pid + adapters + engine) lives in
     # runsetup; cmd_run stays parse -> compose -> render. Engine/StoriesEngine and
     # _make_adapters are handed in from this module's namespace so the test suite's
@@ -1188,10 +1213,11 @@ def cmd_run(args: argparse.Namespace) -> int:
         max_stories=args.max_stories,
         stories_on=stories_on,
         spec_folder=spec_folder,
-        sweep_factory=_sweep_factory(project, paths),
+        sweep_factory=_sweep_factory(project, paths, trusted_digest),
         make_adapters=_make_adapters,
         engine_cls=Engine,
         stories_engine_cls=StoriesEngine,
+        trusted_config_digest=trusted_digest,
     )
     print(f"run {composed.run_id} starting (attach: bmad-loop attach)")
     summary = composed.engine.run()
@@ -1367,6 +1393,7 @@ def _start_sweep(
         trigger=trigger,
         make_adapters=_make_adapters,
         sweep_engine_cls=SweepEngine,
+        trusted_config_digest=_trusted_config_digest(pol, project),
     )
     print(f"sweep {composed.run_id} starting (attach: bmad-loop attach)")
     summary = composed.engine.run()
@@ -1374,12 +1401,37 @@ def _start_sweep(
     return 0
 
 
-def _sweep_factory(project: Path, paths: bmadconfig.ProjectPaths):
+def _sweep_factory(project: Path, paths: bmadconfig.ProjectPaths, trusted_digest: str):
     """Child-sweep launcher injected into story-run engines. Auto-triggered
-    sweeps are unattended: never prompt, never run decision bundles."""
+    sweeps are unattended: never prompt, never run decision bundles.
+
+    ``trusted_digest`` is the caller's launch-time :func:`runsetup.config_digest`
+    — the integrity pin for the config this factory re-reads from disk below.
+    Required, with no default: an omitted baseline would silently disable the
+    refusal, which is the failure mode a security gate can least afford."""
 
     def factory(trigger: str) -> None:
         pol = policy_mod.load(_policy_path(project))
+        # #461 point 4. This reload is the ONE path where a mid-run rewrite of the
+        # agent-writable config reaches host code execution with no human
+        # initiating the change: the driven sessions can write policy.toml and
+        # profiles/*.toml, and this factory re-reads both (here, and through
+        # make_adapters -> get_profile) on a trigger the engine raised, not an
+        # operator. The parent loop is already safe — it froze its Policy at launch
+        # — and the two documented human-present mid-run edits (the TUI live-edit,
+        # resume-to-fix-a-setting) stay trusted; resume only warns. So refuse here
+        # and only here.
+        #
+        # ABLATION GUARDS: deleting this block must fail
+        # test_auto_sweep_refuses_a_rewritten_verify_command,
+        # test_auto_sweep_refuses_a_rewritten_profile_binary, and
+        # test_auto_sweep_refuses_a_widened_plugin_allowlist in tests/test_cli.py.
+        if runsetup.config_digest(pol, project) != trusted_digest:
+            raise RuntimeError(
+                "policy.toml/profiles changed under a running loop before an auto-sweep"
+                " — refusing the child sweep; no human initiated this config change."
+                " Run `bmad-loop sweep` yourself to proceed under the new config."
+            )
         # Raise rather than return the rc the other three sites return. By the time
         # the engine calls this it has already latched the trigger and journaled
         # `sweep-auto-trigger`, and it reads a plain return as success — so a bare
@@ -1497,7 +1549,22 @@ def _resume_paused_run(project: Path, run_dir: Path) -> int:
     # diagnose scrubs unknown fields with scrub_json, NOT the key-aware
     # _scrub_policy that reduces adapter.env and plugins.settings.
     new_snapshot = pol.to_dict()
+    new_digest = _trusted_config_digest(pol, project)
+    # #461 point 4, human-present half. A resume IS a deliberate human choice, so
+    # the on-disk config is re-blessed (new_digest is re-stamped below) and the run
+    # proceeds — the auto-sweep child is the only path that refuses. But the issue's
+    # real complaint is that the change is SILENT, so say it out loud: a session may
+    # have rewritten the verify commands / launch binary / plugin allowlist while
+    # the operator was away, and `resume` is the moment they can still look.
+    # Deliberately no --allow-config-change flag: a refuse-by-default gate here
+    # would break resume-to-fix-a-setting, which is a supported workflow.
+    security_config_changed = bool(state.trusted_config_digest) and (
+        new_digest != state.trusted_config_digest
+    )
     fields: dict[str, object] = {
+        # Scalars only, per the note above: a bool records THAT the pinned surface
+        # moved without journaling a command, a binary path or a plugin name.
+        "security_config_changed": security_config_changed,
         "was_paused": state.paused_reason,
         "cache_read_weight": pol.limits.cache_read_weight,
         # Compare JSON-normalized, the way save_state persists it: to_dict()
@@ -1512,6 +1579,19 @@ def _resume_paused_run(project: Path, run_dir: Path) -> int:
     if prior_weight != pol.limits.cache_read_weight:
         fields["cache_read_weight_was"] = prior_weight
     journal.append("run-resume", **fields)
+    if security_config_changed:
+        # STATIC category names — the ones config_digest covers. A single sha256
+        # cannot say which of them moved, and naming the actual old/new values is
+        # exactly what this must not do (the mutation is attacker-controlled text
+        # headed for an operator's terminal).
+        print(
+            f"warning: run {run_dir.name}: the host-exec config pinned at launch has"
+            " changed — one or more of: verify commands, launch binary/args/env,"
+            " plugin allowlist. Resuming trusts the config now on disk; re-read"
+            " .bmad-loop/policy.toml and .bmad-loop/profiles/ first if you did not"
+            " make that edit.",
+            file=sys.stderr,
+        )
     # Re-stamp: the snapshot must describe the policy THIS process enforces, for
     # its whole lifetime (Policy is loaded once here and frozen — the engine never
     # re-reads policy.toml). Enforcement already reads the reloaded `pol` (the
@@ -1524,6 +1604,12 @@ def _resume_paused_run(project: Path, run_dir: Path) -> int:
     # a policy edit mid-run cannot switch a live run's mode or scope. The snapshot
     # can therefore disagree with those fields; that is correct, not a bug.
     state.policy_snapshot = new_snapshot
+    # Re-baseline the integrity pin for the same reason and at the same moment: a
+    # human typed `resume`, which re-blesses the config on disk, and the engine
+    # this process is about to arm re-reads it from there. Leaving the launch
+    # digest would make every auto-sweep after a legitimate resume-to-fix-a-setting
+    # refuse — and would make the warning above fire forever, on every later resume.
+    state.trusted_config_digest = new_digest
     state.clear_pause()
     # A resume is fresh user intent: discard any graceful-stop request left over from
     # a prior stopped-gracefully run so the re-armed engine does not consume it at the
@@ -1553,7 +1639,7 @@ def _resume_paused_run(project: Path, run_dir: Path) -> int:
         state=state,
         policy=pol,
         journal=journal,
-        sweep_factory=_sweep_factory(project, paths),
+        sweep_factory=_sweep_factory(project, paths, new_digest),
         make_adapters=_make_adapters,
         engine_cls=Engine,
         stories_engine_cls=StoriesEngine,

--- a/src/bmad_loop/model.py
+++ b/src/bmad_loop/model.py
@@ -464,6 +464,14 @@ class RunState:
     project: str
     started_at: str
     policy_snapshot: dict[str, Any] = field(default_factory=dict)
+    # runsetup.config_digest over the agent-writable config that reaches HOST code
+    # execution — verify commands, the resolved launch binary/args/env, the plugin
+    # allowlist (#461 point 4). Stamped at launch and re-stamped on resume, beside
+    # policy_snapshot. The auto-sweep gate compares against its own closure
+    # baseline, not this; the field is the audit record plus the baseline `resume`
+    # warns off. Empty on runs persisted before the field existed, which is why the
+    # resume compare is guarded on it being non-empty — no prior pin, no warning.
+    trusted_config_digest: str = ""
     current_epic: int | None = None
     # the run's story scope + cap, as passed on the launching CLI (`--epic`,
     # `--story`, `--max-stories`). Persisted so `resume` rebuilds the Engine with
@@ -551,6 +559,7 @@ class RunState:
             "project": self.project,
             "started_at": self.started_at,
             "policy_snapshot": self.policy_snapshot,
+            "trusted_config_digest": self.trusted_config_digest,
             "current_epic": self.current_epic,
             "epic_filter": self.epic_filter,
             "story_filter": self.story_filter,
@@ -579,6 +588,7 @@ class RunState:
             project=d["project"],
             started_at=d["started_at"],
             policy_snapshot=d.get("policy_snapshot", {}),
+            trusted_config_digest=str(d.get("trusted_config_digest", "")),
             current_epic=d.get("current_epic"),
             epic_filter=d.get("epic_filter"),
             story_filter=d.get("story_filter"),

--- a/src/bmad_loop/runsetup.py
+++ b/src/bmad_loop/runsetup.py
@@ -148,9 +148,12 @@ def config_digest(
       ``interactive_env`` and every token there traces back to one of
       ``binary`` / ``launch_args`` / ``bypass_args`` / ``model_flag`` /
       ``prompt_template`` / ``env`` on the *resolved* profile, or to
-      ``extra_args`` on the resolved adapter. The opencode-http ``_serve_argv``
-      reads the same two sources; its ``_session_env`` adds one *generated*
-      variable on top of them, which the ``skill_tree`` bullet below accounts for.
+      ``extra_args`` on the resolved adapter. The opencode-http builder reads a
+      strict SUBSET of those — ``_serve_argv`` takes ``binary`` and the adapter's
+      ``extra_args`` and nothing else, and ``_session_env`` layers
+      ``profile.env`` plus one *generated* variable, which the ``skill_tree``
+      bullet below accounts for. See the union paragraph on why the subset does
+      not narrow what is hashed.
     * ``hookless`` — the transport, because it decides *which of those two argv
       builders runs at all*. See the paragraph below on why a hard-coded token is
       not the same thing as a safe one.
@@ -186,6 +189,25 @@ def config_digest(
     is a literal, and the argv is still attacker-controlled — walking the consumer
     means asking what the *launched program* does with a token, not only where the
     token came from.
+
+    The payload is the UNION of those fields across transports, not the subset
+    the role's builder actually reads, and that costs a known false positive:
+    ``adapter.extra_args`` REPLACES ``bypass_args`` rather than extending it, so
+    for a role that sets it the hashed ``bypass_args`` is dead, and rewriting the
+    dead field alone moves this digest without moving one token of the launched
+    argv. Under ``hookless``, ``bypass_args`` / ``launch_args`` / ``model_flag``
+    are dead the same way. Hashing the effective projection instead means
+    restating two builders' precedence rules inside the control that polices
+    them, where drift is silent and lands in the UNDER-covering direction — the
+    failure this function has already made four times by reasoning from one
+    builder. Over-coverage fails the other way, loudly: ``sweep-auto-failed`` +
+    notify, with the message naming ``bmad-loop sweep`` as the human-present path.
+    Not free (the refusal burns the trigger for the life of the run, #501), but it
+    needs a writer, and nothing under ``src/`` writes ``.bmad-loop/profiles/*.toml``
+    at all — that overlay is hand-authored, and the TUI settings screen writes
+    ``policy.toml`` (``extra_args`` included). So a dead-field rewrite arriving
+    mid-run is a config change nobody automated made under a running loop, which
+    is the condition this gate reports rather than a false alarm to suppress.
 
     Deliberately EXCLUDED:
 

--- a/src/bmad_loop/runsetup.py
+++ b/src/bmad_loop/runsetup.py
@@ -151,6 +151,9 @@ def config_digest(
       ``extra_args`` on the resolved adapter. The opencode-http ``_serve_argv``
       reads the same two sources; its ``_session_env`` adds one *generated*
       variable on top of them, which the ``skill_tree`` bullet below accounts for.
+    * ``hookless`` — the transport, because it decides *which of those two argv
+      builders runs at all*. See the paragraph below on why a hard-coded token is
+      not the same thing as a safe one.
 
     Three of those are easy to lose, and each was lost in an earlier cut of this
     function — which is why the rule above is stated rather than the list.
@@ -167,6 +170,23 @@ def config_digest(
     ``shlex.quote``\\ s it, which bounds it to ONE token — no word-splitting — but
     one token is enough for the ``--opt=value`` form.
 
+    ``hookless`` was the fourth, and it was excluded here on a reading that turned
+    out to be wrong, so the correction is worth keeping: *a hard-coded argv token
+    is not the same thing as a safe one.* Flipping ``hooks.dialect`` to ``"none"``
+    does not add a token — it swaps the whole builder, dropping ``launch_args``,
+    the prompt and the ``bypass_args`` fallback and putting the literal ``"serve"``
+    at argv[1], which ``_spawn_server`` then runs with ``cwd`` at the workspace
+    root. To a CLI that is a subcommand and a bad one dies in the health poll. To
+    an *interpreter* — a profile whose ``binary`` is ``python``/``sh``/``node``
+    with the real program in ``launch_args``, which nothing forbids — argv[1] is a
+    **script path resolved against the agent-writable tree**, and the exec happens
+    before the health poll it fails (three times: ``SPAWN_ATTEMPTS``). ``binary``
+    being pinned does not save it: the attacker inherits whichever binary the
+    project configured and only has to write a file named ``serve``. So the token
+    is a literal, and the argv is still attacker-controlled — walking the consumer
+    means asking what the *launched program* does with a token, not only where the
+    token came from.
+
     Deliberately EXCLUDED:
 
     * ``hooks.config_path`` — the relay is issue #461's points 1-3, hardened on
@@ -174,18 +194,6 @@ def config_digest(
     * ``adapter.model`` — it cannot introduce an argv token, only fill the value
       slot behind ``model_flag``, which IS pinned here. Pinning it would refuse an
       auto-sweep after a human's mid-run model change in the TUI.
-    * ``hooks.dialect`` (and so the ``hookless`` property derived from it) — it
-      selects the *transport*, not the launch surface. Flipping it moves
-      ``make_adapters`` between the multiplexer adapter and the HTTP/SSE one, but
-      ``opencode_http._serve_argv`` builds its argv from the same pinned
-      ``binary`` and ``extra_args`` plus tokens hard-coded in Python, so the flip
-      introduces no program and no flag. It is NOT env-neutral — ``_session_env``
-      layers the pinned ``profile.env`` and then adds ``OPENCODE_CONFIG_CONTENT``,
-      generated JSON carrying ``skill_tree`` and the model, both excluded below
-      and above on their own merits. What the flip can do is exec the pinned
-      ``binary`` in ``serve`` mode: a CLI that does not speak it dies in the
-      health poll, stranding the run — a denial the config writer already has by
-      simply breaking this digest.
     * ``skill_tree`` — the one profile field reaching a launched session's env
       without passing through argv. For a hookless role ``_config_content`` plants
       ``cwd/skill_tree`` in that ``OPENCODE_CONFIG_CONTENT`` as ``skills.paths``,
@@ -270,6 +278,11 @@ def config_digest(
             # template formatted, and it need not reference {prompt} at all.
             "prompt_template": prof.prompt_template,
             "env": dict(prof.env),
+            # The transport, because it rewrites the argv WHOLESALE rather than
+            # adding a token: hookless drops launch_args/prompt/bypass_args and
+            # substitutes `serve --port … --print-logs`, whose literal "serve" an
+            # interpreter binary reads as a cwd-relative script path.
+            "hookless": prof.hookless,
             # None (inherit profile.bypass_args) is NOT the same state as () (an
             # explicit override to no flags at all); json.dumps keeps them apart.
             "extra_args": None if cfg.extra_args is None else list(cfg.extra_args),

--- a/src/bmad_loop/runsetup.py
+++ b/src/bmad_loop/runsetup.py
@@ -149,7 +149,8 @@ def config_digest(
       ``binary`` / ``launch_args`` / ``bypass_args`` / ``model_flag`` /
       ``prompt_template`` / ``env`` on the *resolved* profile, or to
       ``extra_args`` on the resolved adapter. The opencode-http ``_serve_argv``
-      reads the same two sources.
+      reads the same two sources; its ``_session_env`` adds one *generated*
+      variable on top of them, which the ``skill_tree`` bullet below accounts for.
 
     Three of those are easy to lose, and each was lost in an earlier cut of this
     function — which is why the rule above is stated rather than the list.
@@ -177,11 +178,31 @@ def config_digest(
       selects the *transport*, not the launch surface. Flipping it moves
       ``make_adapters`` between the multiplexer adapter and the HTTP/SSE one, but
       ``opencode_http._serve_argv`` builds its argv from the same pinned
-      ``binary`` and ``extra_args`` plus tokens hard-coded in Python, and
-      ``_session_env`` layers the same pinned ``profile.env``: no attacker-chosen
-      token, program, or variable enters through the flip. What it can do is
-      strand a run on a transport its CLI does not speak, which is a denial the
-      config writer already has by simply breaking this digest.
+      ``binary`` and ``extra_args`` plus tokens hard-coded in Python, so the flip
+      introduces no program and no flag. It is NOT env-neutral — ``_session_env``
+      layers the pinned ``profile.env`` and then adds ``OPENCODE_CONFIG_CONTENT``,
+      generated JSON carrying ``skill_tree`` and the model, both excluded below
+      and above on their own merits. What the flip can do is exec the pinned
+      ``binary`` in ``serve`` mode: a CLI that does not speak it dies in the
+      health poll, stranding the run — a denial the config writer already has by
+      simply breaking this digest.
+    * ``skill_tree`` — the one profile field reaching a launched session's env
+      without passing through argv. For a hookless role ``_config_content`` plants
+      ``cwd/skill_tree`` in that ``OPENCODE_CONFIG_CONTENT`` as ``skills.paths``,
+      so a rewritten tree points the unattended child sweep at instructions of the
+      writer's choosing. Excluded because the pointer is not the door — the
+      content is, and the content is writable in place. Nothing hashes or reseeds
+      a skill: ``_copy_skills`` skips an existing skill dir absent
+      ``--force-skills`` and both ``provision_worktree`` seeds are per-file
+      no-clobber (pinned by
+      ``test_provision_worktree_does_not_clobber_existing_skill``), while the
+      sweep's triage session runs at ``workspace.root`` — the main checkout, never
+      a unit worktree, since ``sweep.py`` swaps the workspace only around bundle
+      execution. So editing ``.claude/skills/bmad-loop-sweep/SKILL.md`` in place
+      reaches the same child with no config change at all, and therefore no digest
+      to move; pinning the redirect would close the costlier of two routes to one
+      door. Skill-content integrity is a real question and not one a config hash
+      can answer.
     * ``usage_parser`` — and with it the rest of the token-budget surface. It
       selects a read-only tally over a transcript the orchestrator opens anyway
       and decides no program, flag, or variable. Rewriting it to ``"none"`` DOES

--- a/src/bmad_loop/runsetup.py
+++ b/src/bmad_loop/runsetup.py
@@ -182,6 +182,20 @@ def config_digest(
       token, program, or variable enters through the flip. What it can do is
       strand a run on a transport its CLI does not speak, which is a denial the
       config writer already has by simply breaking this digest.
+    * ``usage_parser`` — and with it the rest of the token-budget surface. It
+      selects a read-only tally over a transcript the orchestrator opens anyway
+      and decides no program, flag, or variable. Rewriting it to ``"none"`` DOES
+      make the mid-session guard inert (``tokens.read_usage`` returns None for
+      anything it does not recognize, so ``_sample_weighted_usage`` never trips
+      and the session drops out of accounting) — but the guard's own controls are
+      ``limits.session_budget_mode`` / ``max_tokens_per_session`` /
+      ``cache_read_weight``, which sit in the ``[limits]`` excluded above and
+      which the child sweep re-reads fresh from disk. ``session_budget_mode =
+      "off"`` silences the guard in one line and more completely (it never
+      samples at all), so pinning the parser bolts a side door in a wall whose
+      main door is held open on purpose. Admitting it also widens the rule from
+      the launch surface to the launch surface *plus safety knobs*, which is
+      ``[limits]`` — the whole-file hash the second paragraph exists to reject.
     * ``[plugins.<name>]`` settings — an enabled plugin's resolved settings do
       reach exec (``bus.py`` exports each as ``BMAD_LOOP_SETTING_*`` into a
       ``shell=True`` hook, and the Unity plugin turns one into an ``--editor-path``

--- a/src/bmad_loop/runsetup.py
+++ b/src/bmad_loop/runsetup.py
@@ -16,6 +16,8 @@ frontend (or a test) can compose a run directly:
 * :func:`compose_resume` — rebuilds the engine for a paused/interrupted run
   (``cmd_resume`` and ``resolve``'s re-arm), selecting the sweep/stories/plain
   variant from persisted run state.
+* :func:`config_digest` — the integrity pin over the agent-writable config that
+  reaches host code execution (issue #461 point 4).
 
 The engine class and the adapter factory are *injected* into :func:`compose_run`
 rather than referenced here directly: ``cli`` resolves ``Engine`` /
@@ -28,6 +30,7 @@ so those seams stay importable and monkeypatchable from ``cli``.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import sys
 import time
@@ -58,6 +61,58 @@ if TYPE_CHECKING:
 # actually builds them) and re-exported as ``cli.ROLES``, which `cmd_validate`
 # and the test suite resolve.
 ROLES = ("dev", "review", "triage")
+
+
+def config_digest(policy: Policy, project: Path) -> str:
+    """sha256 over the agent-writable config that reaches **host** code execution.
+
+    The driven sessions can write anywhere under the project tree, including
+    ``.bmad-loop/policy.toml`` and ``.bmad-loop/profiles/*.toml`` — so a session
+    can rewrite the commands ``verify`` runs (``shell=True``), the ``binary`` a
+    later session is launched from, or the ``[plugins] enabled`` allowlist that
+    gates in-process Python import (issue #461 point 4). A run freezes its
+    ``Policy`` at launch, so the parent loop is already pinned; this digest exists
+    for the one path that re-reads config mid-run with **no human present** — the
+    auto-triggered child sweep in ``cli._sweep_factory``.
+
+    Field-scoped on purpose. A whole-file hash would also fire on the benign
+    ``[limits]`` live-edits #189 documents as supported, so this covers exactly
+    the exec-reachable surface:
+
+    * ``verify.commands`` — order-preserved; they run in sequence.
+    * ``sorted(plugins.enabled)`` — set semantics, so order is not meaningful.
+    * each :data:`ROLES` profile's ``binary`` / ``launch_args`` / ``bypass_args`` /
+      ``env``, *resolved* through ``get_profile``. ``binary`` lives in
+      ``profiles/*.toml`` and never appears in ``policy_snapshot``, so a
+      snapshot-only compare cannot see it change at all.
+
+    Deliberately EXCLUDES ``hooks.config_path``: the relay is issue #461's points
+    1-3, hardened on its own track, and folding it in here would make the sweep
+    gate fire on an ordinary ``bmad-loop init`` re-registration.
+
+    Tuples are normalized to lists before ``json.dumps(sort_keys=True)`` for the
+    same reason ``cli._resume_paused_run``'s ``policy_changed`` compare does it:
+    the live policy carries TUPLES where a persisted round-trip yields lists, and
+    a raw compare then reports "changed" every single time. ``ProfileError``
+    propagates — an unresolvable profile already aborts at :func:`make_adapters`.
+    """
+    from .adapters.profile import get_profile
+
+    profiles: dict[str, dict[str, object]] = {}
+    for role in ROLES:
+        prof = get_profile(policy.adapter.resolved(role).name, project)
+        profiles[role] = {
+            "binary": prof.binary,
+            "launch_args": list(prof.launch_args),
+            "bypass_args": list(prof.bypass_args),
+            "env": dict(prof.env),
+        }
+    payload = {
+        "verify_commands": list(policy.verify.commands),
+        "plugins_enabled": sorted(policy.plugins.enabled),
+        "profiles": profiles,
+    }
+    return hashlib.sha256(json.dumps(payload, sort_keys=True).encode("utf-8")).hexdigest()
 
 
 def make_adapters(project: Path, run_dir: Path, policy) -> dict[str, CodingCLIAdapter]:
@@ -299,17 +354,24 @@ def build_run_state(
     max_stories: int | None,
     stories_on: bool,
     spec_folder: str,
+    trusted_config_digest: str = "",
 ) -> RunState:
     """Assemble the launch-time :class:`RunState` for a fresh run.
 
     ``policy_snapshot`` freezes ``policy`` at launch so every later display reads
     the weights the run actually launched under; ``source`` / ``spec_folder``
-    record which queue the run dispatches (a stories manifest vs sprint-status)."""
+    record which queue the run dispatches (a stories manifest vs sprint-status).
+
+    ``trusted_config_digest`` is passed in rather than derived from ``policy`` +
+    ``project`` here so the value stamped on the run is the same string the caller
+    handed the sweep factory — and so a broken profile still aborts where it always
+    did (``make_adapters``'s ``SystemExit``), not from inside this constructor."""
     return RunState(
         run_id=run_id,
         project=str(project),
         started_at=time.strftime("%Y-%m-%dT%H:%M:%S"),
         policy_snapshot=policy.to_dict(),
+        trusted_config_digest=trusted_config_digest,
         epic_filter=epic_filter,
         story_filter=story_filter,
         max_stories=max_stories,
@@ -350,6 +412,7 @@ def compose_run(
     make_adapters: Callable[[Path, Path, Policy], dict[str, CodingCLIAdapter]],
     engine_cls: type[Engine],
     stories_engine_cls: type[StoriesEngine],
+    trusted_config_digest: str = "",
 ) -> ComposedRun:
     """Stand up a run: allocate the run dir, persist state + pid, build the
     adapters, and wire the engine — everything ``cmd_run`` did inline between its
@@ -371,6 +434,7 @@ def compose_run(
         max_stories=max_stories,
         stories_on=stories_on,
         spec_folder=spec_folder,
+        trusted_config_digest=trusted_config_digest,
     )
     save_state(run_dir, state)
     runs.write_pid(run_dir)
@@ -418,6 +482,7 @@ def compose_sweep(
     trigger: str,
     make_adapters: Callable[[Path, Path, Policy], dict[str, CodingCLIAdapter]],
     sweep_engine_cls: type[SweepEngine],
+    trusted_config_digest: str = "",
 ) -> ComposedRun:
     """Stand up a sweep run: allocate the run dir, persist state + pid, record the
     sweep options, build the adapters, and wire the ``SweepEngine`` — everything
@@ -436,6 +501,7 @@ def compose_sweep(
         project=str(project),
         started_at=time.strftime("%Y-%m-%dT%H:%M:%S"),
         policy_snapshot=policy.to_dict(),
+        trusted_config_digest=trusted_config_digest,
         run_type="sweep",
     )
     save_state(run_dir, state)

--- a/src/bmad_loop/runsetup.py
+++ b/src/bmad_loop/runsetup.py
@@ -81,14 +81,40 @@ def config_digest(policy: Policy, project: Path) -> str:
 
     * ``verify.commands`` — order-preserved; they run in sequence.
     * ``sorted(plugins.enabled)`` — set semantics, so order is not meaningful.
-    * each :data:`ROLES` profile's ``binary`` / ``launch_args`` / ``bypass_args`` /
-      ``env``, *resolved* through ``get_profile``. ``binary`` lives in
-      ``profiles/*.toml`` and never appears in ``policy_snapshot``, so a
-      snapshot-only compare cannot see it change at all.
+    * per :data:`ROLES`, every field that decides **which program runs and with
+      what flags and environment**. That rule, not a hand-picked list, is what
+      keeps this complete: walk ``GenericAdapter.interactive_argv`` and
+      ``interactive_env`` and every token there traces back to one of
+      ``binary`` / ``launch_args`` / ``bypass_args`` / ``model_flag`` / ``env``
+      on the *resolved* profile, or to ``extra_args`` on the resolved adapter.
+      The opencode-http ``_serve_argv`` reads the same two sources.
 
-    Deliberately EXCLUDES ``hooks.config_path``: the relay is issue #461's points
-    1-3, hardened on its own track, and folding it in here would make the sweep
-    gate fire on an ordinary ``bmad-loop init`` re-registration.
+    Two of those are easy to lose, and both were lost in the first cut of this
+    function: ``binary`` (and its siblings) live in ``profiles/*.toml`` and never
+    appear in ``policy_snapshot``, so a snapshot-only compare is blind to them;
+    and ``adapter.extra_args`` *replaces* ``profile.bypass_args`` when set — it is
+    the field that carries ``--permission-mode bypassPermissions`` — so hashing
+    the profile default alone leaves the flags actually launched unpinned. ``None``
+    there means "fall back to the profile", a different state from ``()``, and the
+    two are kept apart.
+
+    Deliberately EXCLUDED:
+
+    * ``hooks.config_path`` — the relay is issue #461's points 1-3, hardened on
+      its own track; folding it in would fire on an ordinary ``bmad-loop init``.
+    * ``adapter.model`` and ``prompt_template`` — neither can introduce an argv
+      token. ``model`` only ever fills the value slot behind ``model_flag``, which
+      IS pinned here, and ``prompt_template`` fills the prompt payload, which is
+      data for the driven LLM rather than for the host. Pinning them would refuse
+      an auto-sweep after a human's mid-run model change in the TUI.
+
+    Known gap, tracked separately: this pins the plugin allowlist by NAME only. A
+    project-origin ``.bmad-loop/plugins/<name>/`` overrides a same-named builtin
+    (``plugins/loader.py`` overlay precedence) and ``trust.require_enabled`` gates
+    on the name, so a session can swap the module behind an *already* enabled
+    plugin without moving this digest. Adding a plugin is caught; changing what an
+    enabled one runs is not. Closing that is a plugin-trust-model change rather
+    than a wider hash, so it does not belong here.
 
     Tuples are normalized to lists before ``json.dumps(sort_keys=True)`` for the
     same reason ``cli._resume_paused_run``'s ``policy_changed`` compare does it:
@@ -98,19 +124,24 @@ def config_digest(policy: Policy, project: Path) -> str:
     """
     from .adapters.profile import get_profile
 
-    profiles: dict[str, dict[str, object]] = {}
+    launch: dict[str, dict[str, object]] = {}
     for role in ROLES:
-        prof = get_profile(policy.adapter.resolved(role).name, project)
-        profiles[role] = {
+        cfg = policy.adapter.resolved(role)
+        prof = get_profile(cfg.name, project)
+        launch[role] = {
             "binary": prof.binary,
             "launch_args": list(prof.launch_args),
             "bypass_args": list(prof.bypass_args),
+            "model_flag": prof.model_flag,
             "env": dict(prof.env),
+            # None (inherit profile.bypass_args) is NOT the same state as () (an
+            # explicit override to no flags at all); json.dumps keeps them apart.
+            "extra_args": None if cfg.extra_args is None else list(cfg.extra_args),
         }
     payload = {
         "verify_commands": list(policy.verify.commands),
         "plugins_enabled": sorted(policy.plugins.enabled),
-        "profiles": profiles,
+        "profiles": launch,
     }
     return hashlib.sha256(json.dumps(payload, sort_keys=True).encode("utf-8")).hexdigest()
 
@@ -354,7 +385,7 @@ def build_run_state(
     max_stories: int | None,
     stories_on: bool,
     spec_folder: str,
-    trusted_config_digest: str = "",
+    trusted_config_digest: str,
 ) -> RunState:
     """Assemble the launch-time :class:`RunState` for a fresh run.
 
@@ -412,7 +443,7 @@ def compose_run(
     make_adapters: Callable[[Path, Path, Policy], dict[str, CodingCLIAdapter]],
     engine_cls: type[Engine],
     stories_engine_cls: type[StoriesEngine],
-    trusted_config_digest: str = "",
+    trusted_config_digest: str,
 ) -> ComposedRun:
     """Stand up a run: allocate the run dir, persist state + pid, build the
     adapters, and wire the engine — everything ``cmd_run`` did inline between its
@@ -482,7 +513,7 @@ def compose_sweep(
     trigger: str,
     make_adapters: Callable[[Path, Path, Policy], dict[str, CodingCLIAdapter]],
     sweep_engine_cls: type[SweepEngine],
-    trusted_config_digest: str = "",
+    trusted_config_digest: str,
 ) -> ComposedRun:
     """Stand up a sweep run: allocate the run dir, persist state + pid, record the
     sweep options, build the adapters, and wire the ``SweepEngine`` — everything

--- a/src/bmad_loop/runsetup.py
+++ b/src/bmad_loop/runsetup.py
@@ -120,8 +120,8 @@ def config_digest(policy: Policy, project: Path) -> str:
       are inside an *already-enabled* plugin's blast radius — the trust boundary
       the gap below is about — rather than a way past the allowlist.
 
-    Known gaps, tracked separately (#496). This pins the plugin allowlist by NAME
-    only, and the allowlist is not the whole plugin exec surface:
+    Known gaps, tracked separately (#496, #497). This pins the plugin allowlist by
+    NAME only, and the allowlist is not the whole plugin exec surface:
 
     * A project-origin ``.bmad-loop/plugins/<name>/`` overrides a same-named
       builtin (``plugins/loader.py`` overlay precedence) and

--- a/src/bmad_loop/runsetup.py
+++ b/src/bmad_loop/runsetup.py
@@ -97,6 +97,14 @@ def resolve_profiles(policy: Policy, project: Path) -> dict[str, CLIProfile]:
     again — so "narrow window" is not a defense. Resolving once and threading the
     result removes the second read rather than shrinking the window.
 
+    ``cmd_run`` and ``_resume_paused_run`` thread it too, for a DIFFERENT reason —
+    they stamp a baseline rather than compare against one, and at launch the
+    on-disk config is the trust anchor, so no race there grants an attacker
+    anything a plain pre-launch write does not. What the second read cost them was
+    accuracy: the pin they mint is what every later auto-sweep is held to, so a pin
+    over bytes the run did not launch makes those children refuse the config the
+    parent has been running all along. See ``cli._launch_profiles``.
+
     The policy half needs no equivalent: ``cli._sweep_factory`` already loads
     ``policy.toml`` once and passes that one frozen ``Policy`` to both the gate
     and the composition. Profiles were the only surface read twice.
@@ -205,10 +213,13 @@ def config_digest(
     propagates — an unresolvable profile already aborts at :func:`make_adapters`.
 
     ``profiles`` is an already-resolved mapping from :func:`resolve_profiles`.
-    Pass it wherever the digest gates something that then *runs* under the same
-    config, so the bytes hashed here are the bytes launched rather than a second
-    read of a file the sessions can rewrite in between; omit it to resolve fresh.
-    """
+    Pass it wherever the digest gates — or becomes the baseline for — something
+    that then *runs* under the same config, so the bytes hashed here are the bytes
+    launched rather than a second read of a file the sessions can rewrite in
+    between. Both halves of that rule have a caller: ``cli._sweep_factory`` gates,
+    ``cmd_run``/``_resume_paused_run`` baseline. Omit it to resolve fresh, which
+    ``cmd_sweep`` does deliberately — a human started that one, and the pin it
+    stamps gates no child."""
     profiles = profiles if profiles is not None else resolve_profiles(policy, project)
 
     launch: dict[str, dict[str, object]] = {}
@@ -543,14 +554,20 @@ def compose_run(
     stories_on: bool,
     spec_folder: str,
     sweep_factory: Callable[[str], None],
-    make_adapters: Callable[[Path, Path, Policy], dict[str, CodingCLIAdapter]],
+    make_adapters: MakeAdapters,
     engine_cls: type[Engine],
     stories_engine_cls: type[StoriesEngine],
     trusted_config_digest: str,
+    profiles: dict[str, CLIProfile] | None = None,
 ) -> ComposedRun:
     """Stand up a run: allocate the run dir, persist state + pid, build the
     adapters, and wire the engine — everything ``cmd_run`` did inline between its
     preflight gates and ``engine.run()``.
+
+    ``profiles`` carries ``cmd_run``'s single :func:`resolve_profiles` resolution —
+    the same one ``trusted_config_digest`` was computed from — so the stamped
+    baseline describes the bytes these adapters are built from rather than a second
+    read of an agent-writable file (#461 point 4). ``None`` resolves fresh.
 
     ``make_adapters`` and the engine classes are injected (rather than imported
     here) so ``cli`` supplies its own module-level names — keeping the test
@@ -572,7 +589,7 @@ def compose_run(
     )
     save_state(run_dir, state)
     runs.write_pid(run_dir)
-    adapters = make_adapters(project, run_dir, policy)
+    adapters = make_adapters(project, run_dir, policy, profiles=profiles)
     journal.append(
         "run-start",
         run_id=run_id,
@@ -690,10 +707,11 @@ def compose_resume(
     policy: Policy,
     journal: Journal,
     sweep_factory: Callable[[str], None],
-    make_adapters: Callable[[Path, Path, Policy], dict[str, CodingCLIAdapter]],
+    make_adapters: MakeAdapters,
     engine_cls: type[Engine],
     stories_engine_cls: type[StoriesEngine],
     sweep_engine_cls: type[SweepEngine],
+    profiles: dict[str, CLIProfile] | None = None,
 ) -> ComposedRun:
     """Rebuild the engine for a paused/interrupted run and return it ready to
     :meth:`run` — the adapter build + engine selection ``cli._resume_paused_run``
@@ -707,11 +725,17 @@ def compose_resume(
     otherwise ``source`` picks ``StoriesEngine`` vs ``Engine``, restoring the
     launching scope + cap so a resumed ``--epic N`` run keeps its filter. The engine
     classes and ``make_adapters`` are injected so ``cli``'s ``monkeypatch.setattr``
-    seams bite."""
+    seams bite.
+
+    ``profiles`` carries the caller's single :func:`resolve_profiles` resolution —
+    the one the re-stamped ``state.trusted_config_digest`` was computed from — so
+    the new baseline describes the bytes these adapters are built from rather than
+    a second read of an agent-writable file (#461 point 4). ``None`` resolves
+    fresh."""
     # drop any stale agent session so the run spins up a fresh one (a stopped or
     # interrupted run can leave a lingering bmad-loop-<id> session behind).
     runs.kill_session(run_dir.name)
-    adapters = make_adapters(project, run_dir, policy)
+    adapters = make_adapters(project, run_dir, policy, profiles=profiles)
     if state.run_type == "sweep":
         opts_path = run_dir / "sweep.json"
         try:

--- a/src/bmad_loop/runsetup.py
+++ b/src/bmad_loop/runsetup.py
@@ -189,6 +189,37 @@ def config_digest(
 
     Deliberately EXCLUDED:
 
+    * The *bytes* behind ``binary``/``launch_args`` — this pins the launch
+      target's SPELLING, not its content. A project-local target (``binary`` a
+      path into the tree, or ``python`` with the program in ``launch_args``) can
+      be rewritten in place with no config field moving. The gap is real and
+      unguarded: ``profile.py`` requires only a non-empty ``binary`` string, while
+      the three sibling path fields (``hooks.config_path``, ``skill_tree``,
+      ``seed_files``) all reject absolute and parent refs.
+
+      NOT excluded on "the parent execs it too" — that defence is false for the
+      ``triage`` role. Base ``Engine`` wires only dev+review; ``sweep.py`` holds
+      the only ``adapters["triage"]`` assignment and the only two ``role="triage"``
+      dispatches, so a ``[adapter.triage]`` profile override's target is exec'd by
+      a sweep and by nothing else. ``sweep.auto = "run-end"`` and worktree
+      isolation give two more shapes where the child is the uniquely exposed one.
+
+      Excluded because a hash cannot identify the target. Which ``launch_args``
+      token names a file is undecidable (``-i`` vs ``tools/agent.py``);
+      digest-time resolution is not the tmux shell's; and one indirection defeats
+      it — this repo's own ``write_script_launcher`` is a stub that execs an
+      interpreter on a sidecar, so hashing the stub misses the payload. Nor is
+      the target ours to pin: it is normally a third-party CLI that self-updates,
+      and a mid-run update would move a content hash and burn the auto-sweep
+      trigger for the life of the run (``_maybe_auto_sweep`` records the trigger
+      BEFORE calling the factory, and early-returns on it forever after).
+      Confinement is the instrument, not hashing — and as a ``validate`` warning
+      rather than a refusal, since "resolves inside the project" does not decide
+      it either: under an active project venv ``which("python")`` IS
+      ``<project>/.venv/bin/python``, and this repo's own zero-token E2E gate
+      configures ``binary`` at ``<sandbox>/.bmad-loop/fake-cli.sh``. Tracked as
+      #500, to land with #499's fix option 3; unreachable on stock config (all six
+      shipped profiles are bare PATH names).
     * ``hooks.config_path`` — the relay is issue #461's points 1-3, hardened on
       its own track; folding it in would fire on an ordinary ``bmad-loop init``.
     * ``adapter.model`` — it cannot introduce an argv token, only fill the value
@@ -199,18 +230,30 @@ def config_digest(
       ``cwd/skill_tree`` in that ``OPENCODE_CONFIG_CONTENT`` as ``skills.paths``,
       so a rewritten tree points the unattended child sweep at instructions of the
       writer's choosing. Excluded because the pointer is not the door — the
-      content is, and the content is writable in place. Nothing hashes or reseeds
-      a skill: ``_copy_skills`` skips an existing skill dir absent
-      ``--force-skills`` and both ``provision_worktree`` seeds are per-file
-      no-clobber (pinned by
-      ``test_provision_worktree_does_not_clobber_existing_skill``), while the
-      sweep's triage session runs at ``workspace.root`` — the main checkout, never
-      a unit worktree, since ``sweep.py`` swaps the workspace only around bundle
-      execution. So editing ``.claude/skills/bmad-loop-sweep/SKILL.md`` in place
-      reaches the same child with no config change at all, and therefore no digest
-      to move; pinning the redirect would close the costlier of two routes to one
-      door. Skill-content integrity is a real question and not one a config hash
-      can answer.
+      content is, and the content is reachable with no config change at all, so
+      there is no digest to move either way. The triage session that consumes
+      ``bmad-loop-sweep`` runs at ``workspace.root`` — the main checkout, never a
+      unit worktree, since ``sweep.py`` swaps the workspace only around bundle
+      execution — and a driven session can write that copy: worktrees mount under
+      ``.bmad-loop/runs/`` INSIDE the main checkout, and nothing confines a
+      session's writes to its cwd (this docstring's opening premise). Nothing
+      hashes or reseeds a skill in place: ``_copy_skills`` skips an existing skill
+      dir absent ``--force-skills``.
+
+      Be precise about the worktree case, because the obvious reading is wrong:
+      under ``isolation = "worktree"`` a session editing the skill tree *in its
+      own worktree* does NOT reach that child. A gitignored tree is absent from a
+      fresh ``git worktree add`` checkout, so ``provision_worktree`` seeds it from
+      the WHEEL (``resources.files("bmad_loop.data")``) — the per-file no-clobber
+      that ``test_provision_worktree_does_not_clobber_existing_skill`` pins only
+      preserves a file the destination already has, which is the *tracked*
+      skill-tree case that test's own docstring names. The two copies then never
+      share bytes: the worktree-local exclude blocks staging and ``git merge``
+      moves only tracked content. The route above (absolute path into the main
+      checkout) is what carries this bullet, not in-worktree editing.
+
+      Skill-content integrity is a real question and not one a config hash can
+      answer.
     * ``usage_parser`` — and with it the rest of the token-budget surface. It
       selects a read-only tally over a transcript the orchestrator opens anyway
       and decides no program, flag, or variable. Rewriting it to ``"none"`` DOES

--- a/src/bmad_loop/runsetup.py
+++ b/src/bmad_loop/runsetup.py
@@ -36,7 +36,7 @@ import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 
 from . import bmadconfig
 from . import policy as policy_mod
@@ -51,10 +51,28 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from .adapters.base import CodingCLIAdapter
+    from .adapters.profile import CLIProfile
     from .engine import Engine
     from .policy import Policy
     from .stories_engine import StoriesEngine
     from .sweep import SweepEngine
+
+    class MakeAdapters(Protocol):
+        """Call shape of :func:`make_adapters`, which ``compose_*`` takes injected.
+
+        Spelled as a Protocol rather than a ``Callable`` alias only so the
+        keyword-only ``profiles`` freeze below is part of the injected contract:
+        a frontend that supplies its own factory has to accept the pre-resolved
+        profiles, or silently re-read them from disk."""
+
+        def __call__(
+            self,
+            project: Path,
+            run_dir: Path,
+            policy: Policy,
+            *,
+            profiles: dict[str, CLIProfile] | None = None,
+        ) -> dict[str, CodingCLIAdapter]: ...
 
 
 # The three adapter roles a run wires. Defined here (the composition layer that
@@ -63,7 +81,42 @@ if TYPE_CHECKING:
 ROLES = ("dev", "review", "triage")
 
 
-def config_digest(policy: Policy, project: Path) -> str:
+def resolve_profiles(policy: Policy, project: Path) -> dict[str, CLIProfile]:
+    """Resolve every role's :class:`CLIProfile` from disk **once**, as a mapping
+    the caller can then hand to both :func:`config_digest` and
+    :func:`make_adapters` so the two agree on the same bytes.
+
+    This exists for the child-sweep gate (#461 point 4). ``config_digest`` and
+    ``make_adapters`` each used to call ``get_profile`` on their own, which made
+    the gate a check-then-use over two *separate* reads of an agent-writable
+    file: a session that leaves a background writer flipping
+    ``.bmad-loop/profiles/*.toml`` between a benign and a hostile copy needs only
+    the digest's read to catch the benign one and the adapter's read to catch the
+    other. That race is cheap to retry — a lost round raises `sweep-auto-failed`,
+    which `_maybe_auto_sweep` swallows, and the next auto-sweep trigger deals
+    again — so "narrow window" is not a defense. Resolving once and threading the
+    result removes the second read rather than shrinking the window.
+
+    The policy half needs no equivalent: ``cli._sweep_factory`` already loads
+    ``policy.toml`` once and passes that one frozen ``Policy`` to both the gate
+    and the composition. Profiles were the only surface read twice.
+
+    Deduplicated by profile name, so the common single-CLI policy touches disk
+    once rather than three times. ``ProfileError`` propagates.
+    """
+    from .adapters.profile import get_profile
+
+    by_name: dict[str, CLIProfile] = {}
+    for role in ROLES:
+        name = policy.adapter.resolved(role).name
+        if name not in by_name:
+            by_name[name] = get_profile(name, project)
+    return {role: by_name[policy.adapter.resolved(role).name] for role in ROLES}
+
+
+def config_digest(
+    policy: Policy, project: Path, *, profiles: dict[str, CLIProfile] | None = None
+) -> str:
     """sha256 over the agent-writable config that reaches **host** code execution.
 
     The driven sessions can write anywhere under the project tree, including
@@ -112,6 +165,15 @@ def config_digest(policy: Policy, project: Path) -> str:
     * ``adapter.model`` — it cannot introduce an argv token, only fill the value
       slot behind ``model_flag``, which IS pinned here. Pinning it would refuse an
       auto-sweep after a human's mid-run model change in the TUI.
+    * ``hooks.dialect`` (and so the ``hookless`` property derived from it) — it
+      selects the *transport*, not the launch surface. Flipping it moves
+      ``make_adapters`` between the multiplexer adapter and the HTTP/SSE one, but
+      ``opencode_http._serve_argv`` builds its argv from the same pinned
+      ``binary`` and ``extra_args`` plus tokens hard-coded in Python, and
+      ``_session_env`` layers the same pinned ``profile.env``: no attacker-chosen
+      token, program, or variable enters through the flip. What it can do is
+      strand a run on a transport its CLI does not speak, which is a denial the
+      config writer already has by simply breaking this digest.
     * ``[plugins.<name>]`` settings — an enabled plugin's resolved settings do
       reach exec (``bus.py`` exports each as ``BMAD_LOOP_SETTING_*`` into a
       ``shell=True`` hook, and the Unity plugin turns one into an ``--editor-path``
@@ -141,13 +203,18 @@ def config_digest(policy: Policy, project: Path) -> str:
     the live policy carries TUPLES where a persisted round-trip yields lists, and
     a raw compare then reports "changed" every single time. ``ProfileError``
     propagates — an unresolvable profile already aborts at :func:`make_adapters`.
+
+    ``profiles`` is an already-resolved mapping from :func:`resolve_profiles`.
+    Pass it wherever the digest gates something that then *runs* under the same
+    config, so the bytes hashed here are the bytes launched rather than a second
+    read of a file the sessions can rewrite in between; omit it to resolve fresh.
     """
-    from .adapters.profile import get_profile
+    profiles = profiles if profiles is not None else resolve_profiles(policy, project)
 
     launch: dict[str, dict[str, object]] = {}
     for role in ROLES:
         cfg = policy.adapter.resolved(role)
-        prof = get_profile(cfg.name, project)
+        prof = profiles[role]
         launch[role] = {
             "binary": prof.binary,
             "launch_args": list(prof.launch_args),
@@ -169,7 +236,17 @@ def config_digest(policy: Policy, project: Path) -> str:
     return hashlib.sha256(json.dumps(payload, sort_keys=True).encode("utf-8")).hexdigest()
 
 
-def make_adapters(project: Path, run_dir: Path, policy) -> dict[str, CodingCLIAdapter]:
+def make_adapters(
+    project: Path,
+    run_dir: Path,
+    policy,
+    *,
+    profiles: dict[str, CLIProfile] | None = None,
+) -> dict[str, CodingCLIAdapter]:
+    """Build the per-role adapters. ``profiles`` is an already-resolved mapping
+    from :func:`resolve_profiles`; when given, no profile is re-read from disk, so
+    a caller that gated on :func:`config_digest` launches the *same* bytes it
+    validated (#461 point 4). Omitted, each role resolves fresh as before."""
     from .adapters.generic import GenericAdapter, GenericDevAdapter
     from .adapters.multiplexer import fold_version, get_multiplexer, mux_usable
     from .adapters.profile import ProfileError, get_profile
@@ -192,10 +269,13 @@ def make_adapters(project: Path, run_dir: Path, policy) -> dict[str, CodingCLIAd
         synthesizes = role in ("dev", "review") and policy.dev.skill == "bmad-dev-auto"
         key = (cfg, synthesizes)
         if key not in by_cfg:
-            try:
-                profile = get_profile(cfg.name, project)
-            except ProfileError as e:
-                raise SystemExit(f"error: {e}") from e
+            if profiles is not None:
+                profile = profiles[role]
+            else:
+                try:
+                    profile = get_profile(cfg.name, project)
+                except ProfileError as e:
+                    raise SystemExit(f"error: {e}") from e
             if profile.hookless:
                 # Hookless profiles (opencode-http) are driven over HTTP/SSE —
                 # the tmux adapters below cannot host them.
@@ -534,13 +614,19 @@ def compose_sweep(
     repeat: bool | None,
     max_cycles: int | None,
     trigger: str,
-    make_adapters: Callable[[Path, Path, Policy], dict[str, CodingCLIAdapter]],
+    make_adapters: MakeAdapters,
     sweep_engine_cls: type[SweepEngine],
     trusted_config_digest: str,
+    profiles: dict[str, CLIProfile] | None = None,
 ) -> ComposedRun:
     """Stand up a sweep run: allocate the run dir, persist state + pid, record the
     sweep options, build the adapters, and wire the ``SweepEngine`` — everything
     ``cli._start_sweep`` did inline before ``engine.run()``.
+
+    ``profiles`` carries an already-resolved :func:`resolve_profiles` mapping down
+    to ``make_adapters``. The child-sweep factory passes the same one it gated on,
+    so the adapters are built from the validated bytes instead of a fresh read of
+    an agent-writable file (#461 point 4); ``cmd_sweep`` (human-present) omits it.
 
     ``sweep.json`` freezes the launch options so a resume rebuilds the same sweep
     (see :func:`compose_resume`). ``make_adapters`` and ``sweep_engine_cls`` are
@@ -575,7 +661,7 @@ def compose_sweep(
     sweep_tmp = sweep_path.with_suffix(".json.tmp")
     sweep_tmp.write_text(json.dumps(options, indent=2), encoding="utf-8")
     atomic_replace(sweep_tmp, sweep_path)
-    adapters = make_adapters(project, run_dir, policy)
+    adapters = make_adapters(project, run_dir, policy, profiles=profiles)
     journal.append("run-start", run_id=run_id, run_type="sweep", trigger=trigger)
     engine: Engine = sweep_engine_cls(
         paths=paths,

--- a/src/bmad_loop/runsetup.py
+++ b/src/bmad_loop/runsetup.py
@@ -85,36 +85,56 @@ def config_digest(policy: Policy, project: Path) -> str:
       what flags and environment**. That rule, not a hand-picked list, is what
       keeps this complete: walk ``GenericAdapter.interactive_argv`` and
       ``interactive_env`` and every token there traces back to one of
-      ``binary`` / ``launch_args`` / ``bypass_args`` / ``model_flag`` / ``env``
-      on the *resolved* profile, or to ``extra_args`` on the resolved adapter.
-      The opencode-http ``_serve_argv`` reads the same two sources.
+      ``binary`` / ``launch_args`` / ``bypass_args`` / ``model_flag`` /
+      ``prompt_template`` / ``env`` on the *resolved* profile, or to
+      ``extra_args`` on the resolved adapter. The opencode-http ``_serve_argv``
+      reads the same two sources.
 
-    Two of those are easy to lose, and both were lost in the first cut of this
-    function: ``binary`` (and its siblings) live in ``profiles/*.toml`` and never
-    appear in ``policy_snapshot``, so a snapshot-only compare is blind to them;
-    and ``adapter.extra_args`` *replaces* ``profile.bypass_args`` when set — it is
-    the field that carries ``--permission-mode bypassPermissions`` — so hashing
-    the profile default alone leaves the flags actually launched unpinned. ``None``
+    Three of those are easy to lose, and each was lost in an earlier cut of this
+    function — which is why the rule above is stated rather than the list.
+    ``binary`` (and its siblings) live in ``profiles/*.toml`` and never appear in
+    ``policy_snapshot``, so a snapshot-only compare is blind to them.
+    ``adapter.extra_args`` *replaces* ``profile.bypass_args`` when set — it is the
+    field that carries ``--permission-mode bypassPermissions`` — so hashing the
+    profile default alone leaves the flags actually launched unpinned; ``None``
     there means "fall back to the profile", a different state from ``()``, and the
-    two are kept apart.
+    two are kept apart. And ``prompt_template`` reads like prompt *payload* but is
+    not: ``interactive_argv`` places ``render_prompt(spec.prompt)`` in the argv
+    list, and the template need not contain ``{prompt}`` at all, so a rewritten
+    template is a verbatim attacker-chosen argv token. ``build_command``
+    ``shlex.quote``\\ s it, which bounds it to ONE token — no word-splitting — but
+    one token is enough for the ``--opt=value`` form.
 
     Deliberately EXCLUDED:
 
     * ``hooks.config_path`` — the relay is issue #461's points 1-3, hardened on
       its own track; folding it in would fire on an ordinary ``bmad-loop init``.
-    * ``adapter.model`` and ``prompt_template`` — neither can introduce an argv
-      token. ``model`` only ever fills the value slot behind ``model_flag``, which
-      IS pinned here, and ``prompt_template`` fills the prompt payload, which is
-      data for the driven LLM rather than for the host. Pinning them would refuse
-      an auto-sweep after a human's mid-run model change in the TUI.
+    * ``adapter.model`` — it cannot introduce an argv token, only fill the value
+      slot behind ``model_flag``, which IS pinned here. Pinning it would refuse an
+      auto-sweep after a human's mid-run model change in the TUI.
+    * ``[plugins.<name>]`` settings — an enabled plugin's resolved settings do
+      reach exec (``bus.py`` exports each as ``BMAD_LOOP_SETTING_*`` into a
+      ``shell=True`` hook, and the Unity plugin turns one into an ``--editor-path``
+      argv token), but the TUI settings screen writes those same tables, so
+      pinning them would refuse an auto-sweep after a supported human edit. They
+      are inside an *already-enabled* plugin's blast radius — the trust boundary
+      the gap below is about — rather than a way past the allowlist.
 
-    Known gap, tracked separately: this pins the plugin allowlist by NAME only. A
-    project-origin ``.bmad-loop/plugins/<name>/`` overrides a same-named builtin
-    (``plugins/loader.py`` overlay precedence) and ``trust.require_enabled`` gates
-    on the name, so a session can swap the module behind an *already* enabled
-    plugin without moving this digest. Adding a plugin is caught; changing what an
-    enabled one runs is not. Closing that is a plugin-trust-model change rather
-    than a wider hash, so it does not belong here.
+    Known gaps, tracked separately (#496). This pins the plugin allowlist by NAME
+    only, and the allowlist is not the whole plugin exec surface:
+
+    * A project-origin ``.bmad-loop/plugins/<name>/`` overrides a same-named
+      builtin (``plugins/loader.py`` overlay precedence) and
+      ``trust.require_enabled`` gates on the name, so a session can swap the module
+      behind an *already* enabled plugin without moving this digest.
+    * Adding a plugin is caught only for one that declares ``[python]``. A
+      *declarative* manifest (no ``[python]``) loads on folder-drop by design
+      (``plugins/trust.py``) and ``registry.hooks_for`` hands its ``[hooks.<stage>]
+      cmd`` to the bus, which runs it with ``shell=True`` — with no ``enabled``
+      entry, and from a directory this digest never reads.
+
+    Closing either is a plugin-trust-model change rather than a wider hash, so
+    neither belongs here.
 
     Tuples are normalized to lists before ``json.dumps(sort_keys=True)`` for the
     same reason ``cli._resume_paused_run``'s ``policy_changed`` compare does it:
@@ -133,6 +153,9 @@ def config_digest(policy: Policy, project: Path) -> str:
             "launch_args": list(prof.launch_args),
             "bypass_args": list(prof.bypass_args),
             "model_flag": prof.model_flag,
+            # An argv element, not prompt payload: render_prompt returns this
+            # template formatted, and it need not reference {prompt} at all.
+            "prompt_template": prof.prompt_template,
             "env": dict(prof.env),
             # None (inherit profile.bypass_args) is NOT the same state as () (an
             # explicit override to no flags at all); json.dumps keeps them apart.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6526,6 +6526,134 @@ def test_auto_sweep_launches_the_profile_bytes_the_gate_validated(project, monke
     assert captured["state"].trusted_config_digest == pin
 
 
+def test_run_pins_the_profile_bytes_it_launches(project, monkeypatch):
+    """`cmd_run` STAMPS the baseline every later auto-sweep is held to. It used to
+    hash one read of profiles/*.toml and build its adapters from a second, so a
+    write landing between them pinned config this run never launched.
+
+    Deliberately NOT a security test — there is no attack here to refuse. At launch
+    the on-disk config IS the trust anchor, so a writer who can land in that gap
+    could just as well have written before it and been blessed with no timing at
+    all. The harm is over-refusal: the pin is the one baseline a session cannot
+    reach (`_sweep_factory` holds children to it from memory), so a pin over
+    unlaunched bytes makes those children refuse the config the parent is running —
+    and `engine._maybe_auto_sweep` records the trigger BEFORE calling the factory,
+    so the refusal burns it for the life of the run.
+
+    Asserts the invariant, not the plumbing: the stamp and the adapter agree.
+
+    The writer fires from inside `resolve_profiles`' own return — the instant a
+    read completes — rather than from `config_digest`'s, so BOTH threads are
+    load-bearing. Swapping at the digest boundary would leave the stamp assert
+    vacuous: disk is still honest when the baseline is taken, so the pin comes out
+    right whether or not it was handed the resolution.
+
+    ABLATION, both lanes bite: drop `profiles=` from `compose_run` and the adapter
+    assert fails (it re-reads the swapped overlay); drop it from
+    `_trusted_config_digest` and the stamp assert fails (the digest re-resolves
+    after the swap and pins config the run never launched)."""
+    from conftest import git, install_base_skills
+
+    from bmad_loop.adapters import profile as profile_mod
+
+    monkeypatch.setattr(mux_mod, "_usable", lambda mux: True)
+    install_bmad_config(project)
+    install_base_skills(project)
+    _write_policy(project.project, PIN_POLICY)
+    _pin_profile(project)
+    write_sprint(project, {"1-1-a": "ready-for-dev"})
+    git(project.project, "add", "-A")
+    git(project.project, "commit", "-q", "-m", "setup")
+    pin = _config_pin(project)
+
+    real_resolve = runsetup.resolve_profiles
+
+    def resolve_then_swap(*a, **kw):
+        resolved = real_resolve(*a, **kw)
+        # A concurrent writer wakes the instant a read of the overlay completes.
+        _pin_profile(project, PIN_PROFILE.replace('binary = "mycli"', 'binary = "rogue-cli"'))
+        return resolved
+
+    monkeypatch.setattr(runsetup, "resolve_profiles", resolve_then_swap)
+
+    captured: dict = {}
+
+    class _Recorder:
+        """Stands in for Engine: records what compose_run wired, drives nothing."""
+
+        def __init__(self, **kw):
+            captured.update(kw)
+
+        def run(self):
+            return types.SimpleNamespace(render=lambda: "")
+
+    monkeypatch.setattr(cli, "Engine", _Recorder)
+
+    assert cli.main(["run", "--project", str(project.project)]) == 0
+
+    assert (
+        profile_mod.get_profile("mycli", project.project).binary == "rogue-cli"
+    ), "the swap must actually have landed on disk, or this test proves nothing"
+    assert captured["adapter"].profile.binary == "mycli"
+    assert captured["state"].trusted_config_digest == pin
+
+
+def test_resume_pins_the_profile_bytes_it_launches(project, monkeypatch):
+    """The twin of `test_run_pins_the_profile_bytes_it_launches`, on the other
+    entrypoint that mints this baseline. A resume RE-stamps
+    `state.trusted_config_digest` and arms `_sweep_factory(..., new_digest)`, so
+    the children of a resumed run are held to a pin this function produced — the
+    same read-twice defect lands here, and fixing only `cmd_run` would leave one of
+    two identical call sites open.
+
+    ABLATION: drop `profiles=` from `_trusted_config_digest` or `compose_resume`
+    in `_resume_paused_run` and the matching assert fails."""
+    from conftest import install_base_skills
+
+    from bmad_loop import runs
+    from bmad_loop.adapters import profile as profile_mod
+
+    monkeypatch.setattr(mux_mod, "_usable", lambda mux: True)
+    install_bmad_config(project)
+    install_base_skills(project)
+    write_sprint(project, {"1-1-a": "ready-for-dev"})
+    _write_policy(project.project, PIN_POLICY)
+    _pin_profile(project)
+    pin = _config_pin(project)
+    run_dir = _make_run_with_state(
+        project.project,
+        "20990101-000000-beef",
+        paused_reason="escalation",
+        paused_stage="escalation",
+    )
+
+    real_resolve = runsetup.resolve_profiles
+
+    def resolve_then_swap(*a, **kw):
+        resolved = real_resolve(*a, **kw)
+        _pin_profile(project, PIN_PROFILE.replace('binary = "mycli"', 'binary = "rogue-cli"'))
+        return resolved
+
+    monkeypatch.setattr(runsetup, "resolve_profiles", resolve_then_swap)
+    monkeypatch.setattr(runs, "kill_session", lambda rid: None)
+
+    captured: dict = {}
+
+    class _Recorder(_StubEngine):
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(cli, "Engine", _Recorder)
+
+    assert cli._resume_paused_run(project.project, run_dir) == 0
+
+    assert (
+        profile_mod.get_profile("mycli", project.project).binary == "rogue-cli"
+    ), "the swap must actually have landed on disk, or this test proves nothing"
+    assert captured["adapter"].profile.binary == "mycli"
+    assert captured["state"].trusted_config_digest == pin
+
+
 def test_dry_run_banner_names_the_isolation_refusal_first(project, capsys):
     """The preview keeps rc 0 and still renders the schedule, but the banner has to
     name every refusal the dry-run's early return skips past — and in the order the

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,6 +26,7 @@ from conftest import (
 
 from bmad_loop import cli
 from bmad_loop import policy as policy_mod
+from bmad_loop import runsetup
 from bmad_loop.adapters import multiplexer as mux_mod
 
 STORIES_SPEC_FOLDER = "_bmad-output/epic-1"
@@ -60,6 +61,14 @@ def _write_policy(project, text=DUAL_CLIENT_POLICY) -> None:
     bmad_loop_dir = project / ".bmad-loop"
     bmad_loop_dir.mkdir(parents=True, exist_ok=True)
     (bmad_loop_dir / "policy.toml").write_text(text)
+
+
+def _config_pin(project) -> str:
+    """The host-exec config digest for a sandbox project as it stands — the launch
+    baseline `cmd_run` / `_resume_paused_run` pin (#461 point 4)."""
+    return runsetup.config_digest(
+        policy_mod.load(project.project / ".bmad-loop" / "policy.toml"), project.project
+    )
 
 
 def test_init_registers_hooks_for_all_policy_profiles(tmp_path):
@@ -3141,6 +3150,56 @@ def test_resume_under_an_unchanged_policy_reports_no_change(project, monkeypatch
     entry = _resume_entries(run_dir)[-1]
     assert entry["policy_changed"] is False
     assert "cache_read_weight_was" not in entry  # unchanged -> omitted
+
+
+def test_resume_warns_when_the_pinned_host_exec_config_changed(project, monkeypatch, capsys):
+    """#461 point 4, human-present half. A session may have rewritten the verify
+    commands while the operator was away; `resume` is the moment they can still
+    look, so the change stops being silent. It stays a WARNING — a human typed
+    `resume`, and refusing here would break resume-to-fix-a-setting."""
+    from bmad_loop.journal import load_state
+
+    run_dir = _paused_run_for_resume(project, monkeypatch)
+    monkeypatch.setattr(cli, "Engine", _StubEngine)
+    # First resume stamps the pin (the run predates the field, so it has none).
+    assert cli._resume_paused_run(project.project, run_dir) == 0
+    assert _resume_entry(run_dir)["security_config_changed"] is False
+    pinned = load_state(run_dir).trusted_config_digest
+    assert pinned  # the launch/resume baseline is persisted, not just in memory
+    capsys.readouterr()
+
+    _write_policy(project.project, RESUME_POLICY.replace('["true"]', '["touch pwned"]'))
+    assert cli._resume_paused_run(project.project, run_dir) == 0
+
+    assert _resume_entries(run_dir)[-1]["security_config_changed"] is True
+    err = capsys.readouterr().err
+    assert "host-exec config pinned at launch has changed" in err
+    # STATIC category names only — never the command that was substituted in.
+    assert "verify commands" in err and "plugin allowlist" in err
+    assert "touch pwned" not in err
+    # ...and the resume re-blesses it, so the next one is quiet again.
+    assert load_state(run_dir).trusted_config_digest != pinned
+
+
+def test_resume_under_an_unchanged_host_exec_config_reports_no_security_change(
+    project, monkeypatch, capsys
+):
+    """The false-positive guard, and the reason the pin is a field-scoped digest:
+    a `[limits]` edit is a policy change (#189 supports it mid-run) but not a
+    host-exec one, so `policy_changed` fires and `security_config_changed` must
+    not — otherwise the warning cries wolf on every supported live-edit."""
+    run_dir = _paused_run_for_resume(project, monkeypatch)
+    monkeypatch.setattr(cli, "Engine", _StubEngine)
+    assert cli._resume_paused_run(project.project, run_dir) == 0
+    capsys.readouterr()
+
+    _write_policy(project.project, RESUME_POLICY.replace("0.5", "0.25"))
+    assert cli._resume_paused_run(project.project, run_dir) == 0
+
+    entry = _resume_entries(run_dir)[-1]
+    assert entry["policy_changed"] is True  # the edit IS a policy change...
+    assert entry["security_config_changed"] is False  # ...but not a host-exec one
+    assert "host-exec config" not in capsys.readouterr().err
 
 
 def test_resume_discards_stale_graceful_stop_request(project, monkeypatch, capsys):
@@ -6275,10 +6334,131 @@ def test_auto_sweep_refuses_worktree_isolation_under_a_repo_root_override(projec
     started = []
     monkeypatch.setattr(cli, "_start_sweep", lambda *a, **kw: started.append(kw) or 0)
 
-    factory = cli._sweep_factory(project.project, bmadconfig.load_paths(project.project))
+    # Hand it a MATCHING config digest so the #461 gate (which sits ahead of the
+    # isolation check) stays quiet and this test still measures the isolation
+    # refusal — otherwise it would pass off the wrong RuntimeError.
+    factory = cli._sweep_factory(
+        project.project,
+        bmadconfig.load_paths(project.project),
+        _config_pin(project),
+    )
     with pytest.raises(RuntimeError, match=REFUSAL):
         factory("epic-boundary")
     assert started == []
+
+
+# --- #461 point 4: the auto-sweep child's config re-read is integrity-pinned ---
+
+# A project whose whole host-exec surface is expressible: the verify command the
+# parent would shell out, and a profile overlay carrying the launch `binary`. Both
+# live under the project tree, so a driven session can rewrite either one.
+PIN_POLICY = """\
+[adapter]
+name = "mycli"
+
+[verify]
+commands = ["true"]
+"""
+
+PIN_PROFILE = """\
+name = "mycli"
+binary = "mycli"
+bypass_args = ["--yes"]
+
+[hooks]
+dialect = "claude-settings-json"
+config_path = ".mycli/settings.json"
+events = { SessionStart = "SessionStart", Stop = "Stop" }
+"""
+
+DIGEST_REFUSAL = "changed under a running loop before an auto-sweep"
+
+
+def _pin_profile(project, text=PIN_PROFILE) -> None:
+    profiles = project.project / ".bmad-loop" / "profiles"
+    profiles.mkdir(parents=True, exist_ok=True)
+    (profiles / "mycli.toml").write_text(text, encoding="utf-8")
+
+
+def _pinned_sweep_factory(project, monkeypatch, *, policy_text=PIN_POLICY):
+    """A child-sweep factory pinned to the config as it stands right now — the
+    launch baseline `cmd_run` hands it. Anything a test writes AFTER this returns
+    is exactly the mid-run rewrite #461 point 4 describes: no human asked for it,
+    and the factory re-reads both files off disk on the engine's next trigger."""
+    from bmad_loop import bmadconfig
+
+    install_bmad_config(project)
+    _write_policy(project.project, policy_text)
+    _pin_profile(project)
+    write_sprint(project, {"1-1-a": "ready-for-dev"})
+    started = []
+    monkeypatch.setattr(cli, "_start_sweep", lambda *a, **kw: started.append(kw) or 0)
+    factory = cli._sweep_factory(
+        project.project, bmadconfig.load_paths(project.project), _config_pin(project)
+    )
+    return factory, started
+
+
+def test_auto_sweep_refuses_a_rewritten_verify_command(project, monkeypatch):
+    """`[verify] commands` runs with shell=True on the HOST, outside any session's
+    sandbox — and policy.toml sits in the workspace every driven session can write.
+    The parent loop froze its Policy at launch, so this factory's fresh reload is
+    the one path where that rewrite reaches execution with no human in the loop."""
+    factory, started = _pinned_sweep_factory(project, monkeypatch)
+    _write_policy(project.project, PIN_POLICY.replace('["true"]', '["touch pwned"]'))
+
+    with pytest.raises(RuntimeError, match=DIGEST_REFUSAL):
+        factory("epic-boundary")
+    assert started == []
+
+
+def test_auto_sweep_refuses_a_rewritten_profile_binary(project, monkeypatch):
+    """The case a `policy_snapshot`-only compare provably cannot catch: `binary`
+    is read from profiles/*.toml through get_profile and never appears in the
+    snapshot at all. This is why config_digest resolves profiles rather than
+    hashing the policy dict."""
+    factory, started = _pinned_sweep_factory(project, monkeypatch)
+    _pin_profile(project, PIN_PROFILE.replace('binary = "mycli"', 'binary = "rogue-cli"'))
+
+    with pytest.raises(RuntimeError, match=DIGEST_REFUSAL):
+        factory("epic-boundary")
+    assert started == []
+
+
+def test_auto_sweep_refuses_a_widened_plugin_allowlist(project, monkeypatch):
+    """`[plugins] enabled` is the trust gate for in-process Python import
+    (plugins/trust.py) — adding a name to it mid-run is a straight path from a
+    workspace write to code running inside the orchestrator itself."""
+    factory, started = _pinned_sweep_factory(project, monkeypatch)
+    _write_policy(project.project, PIN_POLICY + '\n[plugins]\nenabled = ["rogue"]\n')
+
+    with pytest.raises(RuntimeError, match=DIGEST_REFUSAL):
+        factory("epic-boundary")
+    assert started == []
+
+
+def test_auto_sweep_proceeds_after_a_benign_limits_edit(project, monkeypatch):
+    """Why the digest is field-scoped and not a whole-file hash. #189 documents
+    live-editing `[limits]` under a running loop as supported; a file hash would
+    refuse every auto-sweep after one, turning a correctness feature into a
+    regression. Nothing in `[limits]` reaches host exec, so nothing here fires."""
+    factory, started = _pinned_sweep_factory(project, monkeypatch)
+    _write_policy(project.project, PIN_POLICY + "\n[limits]\ncache_read_weight = 0.5\n")
+
+    factory("epic-boundary")  # no raise
+
+    assert len(started) == 1
+
+
+def test_auto_sweep_proceeds_when_the_pinned_config_is_untouched(project, monkeypatch):
+    """The gate's own null case — and the one that would catch a digest that is
+    unstable across two reads of an unchanged tree, which would refuse every
+    auto-sweep in the product."""
+    factory, started = _pinned_sweep_factory(project, monkeypatch)
+
+    factory("epic-boundary")  # no raise
+
+    assert len(started) == 1
 
 
 def test_dry_run_banner_names_the_isolation_refusal_first(project, capsys):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ import io
 import json
 import os
 import sys
+import types
 
 import pytest
 import yaml
@@ -6463,6 +6464,66 @@ def test_auto_sweep_proceeds_when_the_pinned_config_is_untouched(project, monkey
     factory("epic-boundary")  # no raise
 
     assert len(started) == 1
+
+
+def test_auto_sweep_launches_the_profile_bytes_the_gate_validated(project, monkeypatch):
+    """The gate is worth only as much as the read it protects: hashing one read of
+    profiles/*.toml and then launching from a *later* one is check-then-use over a
+    file the driven sessions can write. A session that leaves a background writer
+    behind swaps the overlay the instant the compare succeeds — modelled here by
+    flipping it from inside `config_digest`'s own return — and the window is not a
+    defense, because a lost round only raises `sweep-auto-failed`, which
+    `_maybe_auto_sweep` swallows before the next trigger deals again.
+
+    So `_sweep_factory` resolves the profiles ONCE and threads that mapping through
+    the gate, the pin it stamps, and `make_adapters`. Both assertions below are the
+    harm, not the plumbing: the adapter must carry the validated `binary`, and the
+    child must not re-baseline itself onto the swapped config.
+
+    ABLATION: drop `profiles=` from either `runsetup.make_adapters` or
+    `_trusted_config_digest` in `_start_sweep` and the matching assert fails."""
+    from bmad_loop import bmadconfig
+    from bmad_loop.adapters import profile as profile_mod
+
+    monkeypatch.setattr(mux_mod, "_usable", lambda mux: True)
+    install_bmad_config(project)
+    _write_policy(project.project, PIN_POLICY)
+    _pin_profile(project)
+    write_sprint(project, {"1-1-a": "ready-for-dev"})
+    pin = _config_pin(project)
+
+    real_digest = runsetup.config_digest
+
+    def digest_then_swap(*a, **kw):
+        digest = real_digest(*a, **kw)
+        # The writer wakes the moment the comparison has its answer.
+        _pin_profile(project, PIN_PROFILE.replace('binary = "mycli"', 'binary = "rogue-cli"'))
+        return digest
+
+    monkeypatch.setattr(runsetup, "config_digest", digest_then_swap)
+
+    captured: dict = {}
+
+    class _Recorder:
+        """Stands in for SweepEngine: records what compose_sweep wired, drives
+        nothing. `_start_sweep` renders the summary, so run() answers one."""
+
+        def __init__(self, **kw):
+            captured.update(kw)
+
+        def run(self):
+            return types.SimpleNamespace(render=lambda: "")
+
+    monkeypatch.setattr(cli, "SweepEngine", _Recorder)
+
+    factory = cli._sweep_factory(project.project, bmadconfig.load_paths(project.project), pin)
+    factory("epic-boundary")  # the gate saw the honest bytes and passed
+
+    assert (
+        profile_mod.get_profile("mycli", project.project).binary == "rogue-cli"
+    ), "the swap must actually have landed on disk, or this test proves nothing"
+    assert captured["adapter"].profile.binary == "mycli"
+    assert captured["state"].trusted_config_digest == pin
 
 
 def test_dry_run_banner_names_the_isolation_refusal_first(project, capsys):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -66,8 +66,12 @@ def _write_policy(project, text=DUAL_CLIENT_POLICY) -> None:
 def _config_pin(project) -> str:
     """The host-exec config digest for a sandbox project as it stands — the launch
     baseline `cmd_run` / `_resume_paused_run` pin (#461 point 4)."""
+    # Resolve the path the way the production baseline does. Hardcoding it would
+    # silently hand `policy_mod.load` a missing file (which returns all defaults)
+    # if that layout ever moved, turning every gate test below into a confusing
+    # digest mismatch instead of a pointer at the path.
     return runsetup.config_digest(
-        policy_mod.load(project.project / ".bmad-loop" / "policy.toml"), project.project
+        policy_mod.load(cli._policy_path(project.project)), project.project
     )
 
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -6986,6 +6986,40 @@ def test_auto_sweep_failure_does_not_pause_parent(project):
     assert "sweep-auto-failed" in journal and "child sweep blew up" in journal
 
 
+def test_auto_sweep_config_digest_refusal_journals_and_spares_the_parent(project):
+    """#461 point 4, end to end through the REAL factory rather than a stand-in
+    exploder: the config-integrity gate's raise has to land on the same
+    `sweep-auto-failed` + notify path every other child-sweep failure takes, and
+    the parent story loop has to finish anyway.
+
+    Pinning it here rather than trusting the exploder test above is the point —
+    that one proves `_maybe_auto_sweep` catches *something*; this proves the gate
+    raises (rather than returning quietly, which the engine would record as
+    `sweep-auto-finished`: a child sweep that ran when none was ever launched)."""
+    from bmad_loop import cli
+
+    write_sprint(project, {"1-1-a": "ready-for-dev"})
+    policy = Policy(gates=GatesPolicy(mode="none"), notify=QUIET, sweep=SweepPolicy(auto="run-end"))
+    # A baseline no on-disk config can match — the shape of "a session rewrote
+    # policy.toml/profiles between launch and this trigger".
+    factory = cli._sweep_factory(project.project, project, "not-the-launch-digest")
+
+    engine, _ = make_engine(
+        project,
+        [dev_effect(project, "1-1-a"), review_effect(project, "1-1-a", clean=True)],
+        policy=policy,
+        sweep_factory=factory,
+    )
+    summary = engine.run()
+
+    assert summary.done == 1 and not summary.paused
+    assert engine.state.finished
+    journal = (engine.run_dir / "journal.jsonl").read_text()
+    assert "sweep-auto-failed" in journal
+    assert "changed under a running loop before an auto-sweep" in journal
+    assert "sweep-auto-finished" not in journal
+
+
 def test_no_auto_sweep_by_default(project):
     write_sprint(project, {"1-1-a": "ready-for-dev"})
     calls = []

--- a/tests/test_runsetup.py
+++ b/tests/test_runsetup.py
@@ -124,6 +124,15 @@ def test_digest_preserves_verify_command_order(pinned):
         pytest.param(
             'binary = "mycli"', 'model_flag = "--exec"\nbinary = "mycli"', id="model_flag"
         ),
+        # prompt_template reads like prompt payload but is an argv ELEMENT:
+        # interactive_argv places render_prompt(spec.prompt) in the list, and the
+        # template need not reference {prompt} at all. shlex.quote bounds it to one
+        # token, which is still enough for the --opt=value form.
+        pytest.param(
+            'binary = "mycli"',
+            'prompt_template = "--mcp-config=/tmp/evil.json"\nbinary = "mycli"',
+            id="prompt_template",
+        ),
     ],
 )
 def test_digest_moves_on_any_resolved_profile_launch_field(pinned, old, new):
@@ -163,18 +172,12 @@ def test_digest_separates_absent_extra_args_from_an_empty_override(pinned):
     assert inherit != explicit_none
 
 
-def test_digest_ignores_the_model_and_prompt_template(pinned):
-    """The documented exclusions, pinned so they stay deliberate. Neither can
-    introduce an argv token: `model` only fills the value slot behind `model_flag`
-    (itself pinned above), and `prompt_template` fills the prompt payload — data
-    for the driven LLM, not for the host. Including them would refuse an
-    auto-sweep after an operator's mid-run model change in the TUI."""
-    before = _digest(pinned)
-    assert _digest(pinned, _with_adapter_key('model = "some-other-model"')) == before
-    _rewrite_profile(
-        pinned, 'binary = "mycli"', 'prompt_template = "GO: {prompt}"\nbinary = "mycli"'
-    )
-    assert _digest(pinned) == before
+def test_digest_ignores_the_adapter_model(pinned):
+    """The documented exclusion, pinned so it stays deliberate. `model` cannot
+    introduce an argv token — it only fills the value slot behind `model_flag`,
+    which IS pinned above — and including it would refuse an auto-sweep after an
+    operator's mid-run model change in the TUI."""
+    assert _digest(pinned, _with_adapter_key('model = "some-other-model"')) == _digest(pinned)
 
 
 def test_digest_moves_on_a_widened_plugin_allowlist(pinned):

--- a/tests/test_runsetup.py
+++ b/tests/test_runsetup.py
@@ -180,6 +180,27 @@ def test_digest_ignores_the_adapter_model(pinned):
     assert _digest(pinned, _with_adapter_key('model = "some-other-model"')) == _digest(pinned)
 
 
+def test_digest_moves_when_the_transport_flips_to_hookless(pinned):
+    """`hooks.dialect = "none"` swaps the argv BUILDER, not a token in it:
+    `make_adapters` routes to the HTTP adapter, whose `_serve_argv` drops
+    `launch_args`, the prompt and the `bypass_args` fallback and puts the literal
+    "serve" at argv[1] — run with `cwd` at the workspace root. Against an
+    interpreter `binary` (python/sh/node, the real program in `launch_args` —
+    nothing forbids that shape) argv[1] is a script path resolved out of the tree
+    every driven session can write, and the spawn precedes the health poll it
+    fails. Pinning `binary` does not cover it, because the attacker inherits the
+    binary rather than choosing it. None of the hook fields deleted here are
+    hashed (see the `config_path` exclusion above), so only the transport moves."""
+    before = _digest(pinned)
+    _rewrite_profile(
+        pinned,
+        'dialect = "claude-settings-json"\nconfig_path = ".mycli/settings.json"\n'
+        'events = { SessionStart = "SessionStart", Stop = "Stop" }',
+        'dialect = "none"',
+    )
+    assert _digest(pinned) != before
+
+
 def test_digest_covers_a_profile_overlay_that_did_not_exist_at_launch(tmp_path):
     """The create path, which is where two shipped tools got this exact class wrong:
     a protection that covers an EXISTING config file but not a MISSING one (Cursor
@@ -207,8 +228,13 @@ def test_digest_covers_a_profile_overlay_that_did_not_exist_at_launch(tmp_path):
     )
     assert _digest(tmp_path, policy_text) == at_launch
 
+    # Hooked, matching the builtin's transport, so the mover here is the launch
+    # surface itself rather than the `hookless` flip covered by its own test.
     (profiles / "claude.toml").write_text(
-        'name = "claude"\nbinary = "rogue-cli"\n\n[hooks]\ndialect = "none"\n', encoding="utf-8"
+        'name = "claude"\nbinary = "rogue-cli"\n\n[hooks]\n'
+        'dialect = "claude-settings-json"\nconfig_path = ".claude/settings.json"\n'
+        'events = { SessionStart = "SessionStart", Stop = "Stop" }\n',
+        encoding="utf-8",
     )
     assert _digest(tmp_path, policy_text) != at_launch
 

--- a/tests/test_runsetup.py
+++ b/tests/test_runsetup.py
@@ -1,0 +1,172 @@
+"""Run-composition layer — chiefly `config_digest`, the integrity pin over the
+agent-writable config that reaches HOST code execution (issue #461 point 4).
+
+The digest's whole job is to be exact in two directions at once: it must move for
+every field that reaches exec, and hold still for everything else. A digest that
+under-covers lets a mid-run rewrite through the auto-sweep gate; one that
+over-covers refuses every auto-sweep after a `[limits]` live-edit #189 documents
+as supported. Both halves are pinned below.
+"""
+
+import dataclasses
+
+import pytest
+
+from bmad_loop import policy as policy_mod
+from bmad_loop import runsetup
+from bmad_loop.adapters.profile import ProfileError
+
+# A profile overlay carrying the whole launch surface the digest covers. It lives
+# under .bmad-loop/profiles/, inside the tree every driven session can write.
+PROFILE = """\
+name = "mycli"
+binary = "mycli"
+launch_args = ["-i"]
+bypass_args = ["--yes"]
+env = { FOO = "bar" }
+
+[hooks]
+dialect = "claude-settings-json"
+config_path = ".mycli/settings.json"
+events = { SessionStart = "SessionStart", Stop = "Stop" }
+"""
+
+POLICY = """\
+[adapter]
+name = "mycli"
+
+[verify]
+commands = ["ruff check .", "pytest -q"]
+"""
+
+PROFILE_REL = ".bmad-loop/profiles/mycli.toml"
+
+
+@pytest.fixture
+def pinned(tmp_path):
+    """A project whose entire host-exec surface is expressible on disk: a policy
+    naming the verify commands, and a profile overlay carrying the launch
+    binary/args/env."""
+    profiles = tmp_path / ".bmad-loop" / "profiles"
+    profiles.mkdir(parents=True)
+    (profiles / "mycli.toml").write_text(PROFILE, encoding="utf-8")
+    return tmp_path
+
+
+def _digest(project, policy_text=POLICY) -> str:
+    return runsetup.config_digest(policy_mod.loads(policy_text), project)
+
+
+def _rewrite_profile(project, old, new) -> None:
+    """The mid-run profile rewrite a driven session can perform."""
+    assert old in PROFILE, f"fixture drift: {old!r} no longer in PROFILE"
+    (project / PROFILE_REL).write_text(PROFILE.replace(old, new), encoding="utf-8")
+
+
+def test_digest_is_a_stable_sha256_over_an_unchanged_tree(pinned):
+    """The null case, and the one that matters most in production: an unstable
+    digest would refuse every auto-sweep in the product, not just a tampered one."""
+    first = _digest(pinned)
+    assert len(first) == 64 and int(first, 16) >= 0  # sha256 hex
+    assert _digest(pinned) == first
+
+
+def test_digest_ignores_a_benign_limits_edit(pinned):
+    """Why this is field-scoped rather than a whole-file hash. #189 documents
+    live-editing `[limits]` under a running loop as supported; a file hash would
+    turn every such edit into a refused auto-sweep."""
+    assert _digest(pinned, POLICY + "\n[limits]\ncache_read_weight = 0.5\n") == _digest(pinned)
+
+
+def test_digest_ignores_the_hook_config_path(pinned):
+    """Deliberate exclusion: the relay is issue #461's points 1-3 and is hardened
+    on its own track. Folding it in would make the auto-sweep gate refuse after an
+    ordinary `bmad-loop init` re-registration, which is not an attack."""
+    before = _digest(pinned)
+    _rewrite_profile(pinned, 'config_path = ".mycli/settings.json"', 'config_path = ".x/s.json"')
+    assert _digest(pinned) == before
+
+
+def test_digest_moves_on_a_rewritten_verify_command(pinned):
+    """`[verify] commands` runs with shell=True on the host (verify.py), outside
+    any session's sandbox."""
+    assert _digest(pinned, POLICY.replace("pytest -q", "touch pwned")) != _digest(pinned)
+
+
+def test_digest_preserves_verify_command_order(pinned):
+    """They run in sequence, so a reorder is a different execution — a canonical
+    that sorted them would let one be silently resequenced."""
+    swapped = POLICY.replace('["ruff check .", "pytest -q"]', '["pytest -q", "ruff check ."]')
+    assert _digest(pinned, swapped) != _digest(pinned)
+
+
+@pytest.mark.parametrize(
+    "old,new",
+    [
+        pytest.param('binary = "mycli"', 'binary = "rogue-cli"', id="binary"),
+        pytest.param('launch_args = ["-i"]', 'launch_args = ["-i", "--evil"]', id="launch_args"),
+        pytest.param('bypass_args = ["--yes"]', 'bypass_args = ["--all"]', id="bypass_args"),
+        pytest.param('env = { FOO = "bar" }', 'env = { FOO = "evil" }', id="env"),
+    ],
+)
+def test_digest_moves_on_any_resolved_profile_launch_field(pinned, old, new):
+    """The launch surface issue #461 names, and the reason the digest RESOLVES
+    profiles instead of hashing `policy_snapshot`: not one of these fields appears
+    in the snapshot, so a snapshot-only compare is blind to all four. Parametrized
+    so a field quietly dropped from the canonical fails on its own row."""
+    before = _digest(pinned)
+    _rewrite_profile(pinned, old, new)
+    assert _digest(pinned) != before
+
+
+def test_digest_moves_on_a_widened_plugin_allowlist(pinned):
+    """`[plugins] enabled` gates in-process Python import (plugins/trust.py) —
+    a straight path from a workspace write to code inside the orchestrator."""
+    assert _digest(pinned, POLICY + '\n[plugins]\nenabled = ["rogue"]\n') != _digest(pinned)
+
+
+def test_digest_is_insensitive_to_plugin_allowlist_order(pinned):
+    """`enabled` is a trust SET; listing the same two names the other way round is
+    not a config change and must not refuse an auto-sweep."""
+    both = POLICY + '\n[plugins]\nenabled = ["alpha", "beta"]\n'
+    reordered = POLICY + '\n[plugins]\nenabled = ["beta", "alpha"]\n'
+    assert _digest(pinned, both) == _digest(pinned, reordered)
+
+
+def test_digest_is_invariant_to_tuple_vs_list_shapes(pinned):
+    """The false-"changed" trap `cli._resume_paused_run`'s policy compare already
+    documents: these fields are TUPLES on a live Policy and lists on anything that
+    round-tripped through JSON. The canonical normalizes both to lists before
+    hashing, so a digest can never move for shape alone — which would refuse every
+    auto-sweep while looking exactly like a real tamper."""
+    pol = policy_mod.loads(POLICY + '\n[plugins]\nenabled = ["alpha", "beta"]\n')
+    assert isinstance(pol.verify.commands, tuple) and isinstance(pol.plugins.enabled, tuple)
+    listy = dataclasses.replace(
+        pol,
+        verify=dataclasses.replace(pol.verify, commands=list(pol.verify.commands)),
+        plugins=dataclasses.replace(pol.plugins, enabled=list(pol.plugins.enabled)),
+    )
+
+    assert runsetup.config_digest(listy, pinned) == runsetup.config_digest(pol, pinned)
+
+
+def test_digest_covers_every_adapter_role(pinned):
+    """A per-stage override points a role at a different profile, so hashing only
+    the base adapter would leave the review and triage launch surfaces unpinned."""
+    before = _digest(pinned)
+    (pinned / ".bmad-loop" / "profiles" / "other.toml").write_text(
+        PROFILE.replace('name = "mycli"', 'name = "other"').replace(
+            'binary = "mycli"', 'binary = "other"'
+        ),
+        encoding="utf-8",
+    )
+    for role in runsetup.ROLES:
+        assert _digest(pinned, POLICY + f'\n[adapter.{role}]\nname = "other"\n') != before
+
+
+def test_digest_raises_on_an_unresolvable_profile(pinned):
+    """ProfileError propagates by design: an unknown `[adapter] name` already
+    aborts the run at make_adapters, so the digest must not paper over one by
+    hashing a hole where the launch surface should be."""
+    with pytest.raises(ProfileError):
+        _digest(pinned, '[adapter]\nname = "no-such-cli"\n')

--- a/tests/test_runsetup.py
+++ b/tests/test_runsetup.py
@@ -46,7 +46,13 @@ PROFILE_REL = ".bmad-loop/profiles/mycli.toml"
 def pinned(tmp_path):
     """A project whose entire host-exec surface is expressible on disk: a policy
     naming the verify commands, and a profile overlay carrying the launch
-    binary/args/env."""
+    binary/args/env.
+
+    Deliberately `tmp_path` rather than the `project` conftest sandbox: this is a
+    pure-core unit test of `config_digest`, which reads only `.bmad-loop/`. It
+    needs no git repo, no BMAD artifact dirs and no sprint board, so the sandbox's
+    per-test copytree would buy nothing. The end-to-end gate behavior is tested on
+    the real sandbox in tests/test_cli.py."""
     profiles = tmp_path / ".bmad-loop" / "profiles"
     profiles.mkdir(parents=True)
     (profiles / "mycli.toml").write_text(PROFILE, encoding="utf-8")
@@ -55,6 +61,12 @@ def pinned(tmp_path):
 
 def _digest(project, policy_text=POLICY) -> str:
     return runsetup.config_digest(policy_mod.loads(policy_text), project)
+
+
+def _with_adapter_key(line: str) -> str:
+    """POLICY with one more key inside its EXISTING `[adapter]` table — appending a
+    second `[adapter]` header is a TOML redeclaration error, not an override."""
+    return POLICY.replace('name = "mycli"', f'name = "mycli"\n{line}', 1)
 
 
 def _rewrite_profile(project, old, new) -> None:
@@ -107,6 +119,11 @@ def test_digest_preserves_verify_command_order(pinned):
         pytest.param('launch_args = ["-i"]', 'launch_args = ["-i", "--evil"]', id="launch_args"),
         pytest.param('bypass_args = ["--yes"]', 'bypass_args = ["--all"]', id="bypass_args"),
         pytest.param('env = { FOO = "bar" }', 'env = { FOO = "evil" }', id="env"),
+        # model_flag is an argv FLAG, not a value: an overlay that turns "--model"
+        # into some other option changes what the CLI does with the model string.
+        pytest.param(
+            'binary = "mycli"', 'model_flag = "--exec"\nbinary = "mycli"', id="model_flag"
+        ),
     ],
 )
 def test_digest_moves_on_any_resolved_profile_launch_field(pinned, old, new):
@@ -117,6 +134,47 @@ def test_digest_moves_on_any_resolved_profile_launch_field(pinned, old, new):
     before = _digest(pinned)
     _rewrite_profile(pinned, old, new)
     assert _digest(pinned) != before
+
+
+def test_digest_moves_on_rewritten_adapter_extra_args(pinned):
+    """`extra_args` is the field that carries `--permission-mode bypassPermissions`,
+    and `GenericAdapter.interactive_argv` prefers it over `profile.bypass_args`
+    whenever it is set — so hashing the profile default alone leaves the flags the
+    host CLI is actually launched with unpinned. It lives in policy.toml, which
+    every driven session can write."""
+    assert _digest(pinned, _with_adapter_key('extra_args = ["--yolo"]')) != _digest(pinned)
+
+
+@pytest.mark.parametrize("role", ["dev", "review", "triage"])
+def test_digest_moves_on_rewritten_per_stage_extra_args(pinned, role):
+    """Per-stage `[adapter.<role>] extra_args` overrides the base for that role
+    only, so a digest reading just the base would miss a rewrite aimed at one
+    stage — and the review stage is the one that runs after the dev work lands."""
+    staged = POLICY + f'\n[adapter.{role}]\nextra_args = ["--yolo"]\n'
+    assert _digest(pinned, staged) != _digest(pinned)
+
+
+def test_digest_separates_absent_extra_args_from_an_empty_override(pinned):
+    """`None` means "fall back to profile.bypass_args"; `[]` means "launch with no
+    flags at all". Two different command lines, so they must not collide — a
+    canonical that coerced None to [] would let one be swapped for the other."""
+    inherit = _digest(pinned)  # extra_args absent entirely
+    explicit_none = _digest(pinned, _with_adapter_key("extra_args = []"))
+    assert inherit != explicit_none
+
+
+def test_digest_ignores_the_model_and_prompt_template(pinned):
+    """The documented exclusions, pinned so they stay deliberate. Neither can
+    introduce an argv token: `model` only fills the value slot behind `model_flag`
+    (itself pinned above), and `prompt_template` fills the prompt payload — data
+    for the driven LLM, not for the host. Including them would refuse an
+    auto-sweep after an operator's mid-run model change in the TUI."""
+    before = _digest(pinned)
+    assert _digest(pinned, _with_adapter_key('model = "some-other-model"')) == before
+    _rewrite_profile(
+        pinned, 'binary = "mycli"', 'prompt_template = "GO: {prompt}"\nbinary = "mycli"'
+    )
+    assert _digest(pinned) == before
 
 
 def test_digest_moves_on_a_widened_plugin_allowlist(pinned):

--- a/tests/test_runsetup.py
+++ b/tests/test_runsetup.py
@@ -180,6 +180,39 @@ def test_digest_ignores_the_adapter_model(pinned):
     assert _digest(pinned, _with_adapter_key('model = "some-other-model"')) == _digest(pinned)
 
 
+def test_digest_covers_a_profile_overlay_that_did_not_exist_at_launch(tmp_path):
+    """The create path, which is where two shipped tools got this exact class wrong:
+    a protection that covers an EXISTING config file but not a MISSING one (Cursor
+    CVE-2025-54135, "editing a dotfile requires approval but creating a new one
+    doesn't"; Claude Code CVE-2026-25725, settings.json unprotected while absent, so
+    the agent creates it and injects SessionStart hooks).
+
+    This digest is structurally immune because it resolves through `get_profile`
+    rather than hashing whatever files happen to be on disk: with no overlay the
+    launch baseline covers the BUILTIN profile's fields, so a session creating
+    `.bmad-loop/profiles/<name>.toml` mid-run changes the resolved binary and moves
+    the digest. A refactor to "hash the profile files that exist" would pass every
+    other test in this file and silently reintroduce the CVE shape."""
+    (tmp_path / ".bmad-loop").mkdir(parents=True)
+    policy_text = '[adapter]\nname = "claude"\n\n[verify]\ncommands = ["pytest -q"]\n'
+    at_launch = _digest(tmp_path, policy_text)  # no overlay: resolves the builtin
+
+    profiles = tmp_path / ".bmad-loop" / "profiles"
+    profiles.mkdir(parents=True)
+    # First the non-vacuity half: an overlay for a name this run does not resolve
+    # must NOT move the digest. Without this, the assertion below would also pass
+    # for a digest that merely reacted to a file appearing.
+    (profiles / "unused.toml").write_text(
+        'name = "unused"\nbinary = "whatever"\n\n[hooks]\ndialect = "none"\n', encoding="utf-8"
+    )
+    assert _digest(tmp_path, policy_text) == at_launch
+
+    (profiles / "claude.toml").write_text(
+        'name = "claude"\nbinary = "rogue-cli"\n\n[hooks]\ndialect = "none"\n', encoding="utf-8"
+    )
+    assert _digest(tmp_path, policy_text) != at_launch
+
+
 def test_digest_moves_on_a_widened_plugin_allowlist(pinned):
     """`[plugins] enabled` gates in-process Python import (plugins/trust.py) —
     a straight path from a workspace write to code inside the orchestrator."""


### PR DESCRIPTION
Phase 3 of the #461 hardening plan, closing the issue's **point 4** (adjacent blast radius). Independent of Phases 1 (merged, #493) and 2 — disjoint file set.

## The hole

`policy.toml` and `profiles/*.toml` live in `.bmad-loop/`, inside the workspace every driven session can write. Three of their fields reach code execution on the **host**, outside any session's sandbox:

| Field | Reaches |
| --- | --- |
| `[verify] commands` | `shell=True` in `verify.py` |
| resolved profile `binary` / `launch_args` / `bypass_args` / `model_flag` / `env` | the process the next session is launched as |
| resolved `adapter.extra_args` (base and per-stage) | the same argv — and it *replaces* `bypass_args` when set |
| `[plugins] enabled` | in-process Python import (`plugins/trust.py`) |

The parent story loop is already safe: `Engine.policy` is frozen at launch. The **one** path that re-reads all of this mid-run is `cli._sweep_factory` — the auto-triggered child sweep reloads `policy.toml` and re-resolves profiles through `make_adapters` → `get_profile`, on a trigger the *engine* raised. No human initiated that config change, and nobody is watching.

## The fix

**`runsetup.config_digest(policy, project)`** — sha256 over a field-scoped canonical of exactly the surface above: `verify.commands` (order-preserved — they run in sequence), `sorted(plugins.enabled)` (set semantics), and per role every field that decides *which program runs and with what flags and environment* — `binary`/`launch_args`/`bypass_args`/`model_flag`/`env` off the resolved profile plus `extra_args` off the resolved adapter. Tuples → lists + `json.dumps(sort_keys=True)` before hashing. Stating the rule rather than a hand-picked list is what makes the coverage reviewable — see the reviewer round below, which is exactly what the rule was missing.

**The gate** — `_sweep_factory` takes a `trusted_digest` and refuses on mismatch, immediately after the fresh policy load and before the isolation check. The raise lands on the existing `sweep-auto-failed` + `gates.notify` path; `_maybe_auto_sweep` swallows it, so the parent run is unaffected. The parameter is **required, with no default** — an omitted baseline would silently disable the refusal, which is the failure mode a security gate can least afford.

**Human-present paths stay trusted.** `resume` re-baselines the pin and only *warns*, so the change stops being silent without breaking resume-to-fix-a-setting. `RunState.trusted_config_digest` persists the pin for audit + the resume compare; re-stamped beside `policy_snapshot`.

No `--allow-config-change` flag, no `core.toml` change — `trusted_config_digest` is `RunState`, not `Policy`, so the settings-schema sync test is untouched.

## Review risks, answered

- **"This violates the repo's 'a deliberate human choice is trusted' doctrine."** It's the inverse: the auto-sweep child re-read is the one config change with *no* human choice at the moment it happens. The two documented mid-run edits — TUI live-edit and resume-to-fix-a-setting — are both human-present and stay trusted; resume warns and proceeds.
- **"A whole-file hash would be simpler."** It false-positives on the benign `[limits]` live-edit #189 documents as supported, turning a correctness feature into a refused auto-sweep. `test_auto_sweep_proceeds_after_a_benign_limits_edit` + `test_digest_ignores_a_benign_limits_edit` are that guard — the field scope is correctness here, not minimalism.
- **"Why resolve profiles instead of hashing `policy_snapshot`?"** `binary` lives in `profiles/*.toml` and never appears in the snapshot at all — a snapshot-only compare is blind to the entire launch surface. `test_auto_sweep_refuses_a_rewritten_profile_binary` fails against snapshot-only, and `test_digest_moves_on_any_resolved_profile_launch_field` covers all four fields on their own parametrized rows.
- **"The session already has bypass exec, so what does this buy?"** The same weighting the issue itself applies: this closes the **unattended, human-absent** escalation from a session's workspace write to the *orchestrator's* host exec context — after a clean review, and reaching into otherwise-restricted or sandboxed sessions.
- **`hooks.config_path` is deliberately excluded.** That's the relay surface (#461 points 1-3, Phase 1/2). Folding it in would make the sweep gate refuse after an ordinary `bmad-loop init` re-registration.

## Tests

`tests/test_runsetup.py` (new — flat `tests/` mirrors src by name) pins `config_digest` in both directions: stability over an unchanged tree, `[limits]` and `hooks.config_path` held still, and movement on rewritten verify commands, verify-command reorder, each of the four profile launch fields, and a widened plugin allowlist. Plus the two false-"changed" traps — allowlist order-insensitivity and tuple-vs-list shape invariance — and `ProfileError` propagation.

`tests/test_cli.py` mirrors the existing factory-refusal (`6186`) and resume-journal (`3081`) patterns: three refusals (verify command / profile binary / plugin allowlist), two proceed cases (benign `[limits]`, untouched config), and the resume warning true/false including "the warning names static categories, never the substituted command".

`tests/test_engine.py` drives the **real** factory to prove the raise reaches `sweep-auto-failed` and never `sweep-auto-finished`.

### Ablation (mandatory, run)

Deleting the `if … != trusted_digest: raise` block against the **whole** suite: `4 failed, 4493 passed` — exactly the three refusal tests plus the engine wiring test. Nothing else reddened; both *proceed* tests correctly stayed green (they guard against over-refusal, so they pass with or without the gate). Two further ablations on the resume half: forcing `security_config_changed = False`, and deleting the `state.trusted_config_digest = new_digest` re-stamp — each fails `test_resume_warns_when_the_pinned_host_exec_config_changed` alone. Restored after each; full suite green.

`uv run pytest -q -n auto` → 4497 passed, 26 skipped. `uv run pyright` → 0 errors. `trunk check` → no issues.

## Out of scope (follow-ups)

- **Relocating** `policy.toml`/profiles outside the workspace — a config-contract change; the maintainer chose integrity-pinning over relocation.
- **Plugin implementations are trusted by name, not by content — filed as #496.** The digest pins `sorted(plugins.enabled)`, which catches a session *adding* a plugin. It does not catch a session swapping the module behind an *already* enabled one: `plugins/loader.py` gives project-origin `.bmad-loop/plugins/<name>/` the highest overlay precedence over a same-named builtin, and `trust.require_enabled` gates on the name. Recorded in the `config_digest` docstring and the CHANGELOG so the pin is not read as stronger than it is. Closing it is a plugin-trust-model decision (refuse workspace-origin `[python]` plugins, or content-pin them at enable time), not a wider hash.
- **Ungated data-only plugin shell hooks — now filed as #497, and wider than it looked when this list was written.** `registry._resolve` returns early for a manifest with no `[python]` *before* the trust check, so `hooks_for`/`HookBus.emit` hand a folder-dropped manifest's `[hooks.<stage>] cmd` to `_run_subprocess(..., shell=True)` with **no allowlist entry at all**. Reproduced on a stock project (`enabled = ()`): digest unmoved, plugin `trusted=True`, hook returned for dispatch. Strictly wider than #496, which needs an already-enabled `[python]` plugin. Closing it is the same trust-model call: gate declarative hooks on `enabled` (at least for project-origin manifests), or trust folder-drop by origin.
- **The resume config-change warning is advisory, not a gate — filed as #498.** The child gate's baseline is threaded in memory from launch and never read back from disk, but the resume comparison baselines off `state.trusted_config_digest`, which round-trips through `.bmad-loop/runs/<id>/state.json` inside the same agent-writable tree the digest polices. Blanking that field silences the warning.
- **`_serve_argv`'s cwd-relative `"serve"` literal — filed as #499.** The launch-time half of the transport finding: against an interpreter `binary`, argv[1] is a script path resolved against the workspace, exec'd three times before the health poll. The mid-run half is closed by pinning `hookless`; a config digest structurally cannot reach the launch-time half, since at launch the on-disk config *is* the trust anchor.
- **The pin covers the launch target's spelling, not its bytes — filed as #500.** `binary`/`launch_args` are hashed as strings; a project-local target stays rewritable in place with no config field moving. Not dismissible as "the parent execs it too" — base `Engine` never wires the `triage` role, so a `[adapter.triage]` override's target is exec'd by sweeps alone. Excluded from the hash because the target is not identifiable from argv (which token is a file is undecidable, one indirection defeats it) and is normally a self-updating third-party CLI, whose update would burn the auto-sweep trigger permanently. Confinement as a `validate` warning is the instrument; lands with #499's fix option 3.

Refs #461 (point 4).


---

## Reviewer round 1 (addressed in `ebcda75`)

**CodeRabbit and Codex independently landed on the same real gap, and they were right.** The first cut hashed `profile.bypass_args` but not `policy.adapter.resolved(role).extra_args` — and `GenericAdapter.interactive_argv` *prefers* `extra_args` whenever it is set, falling back to `bypass_args` only when it is `None`. `extra_args` is the field that carries `--permission-mode bypassPermissions` (policy.py's own comment says so), and opencode-http's `_serve_argv` reads it too. So a session rewriting `[adapter] extra_args` changed the launched command line while the digest held still. Fixed, with base and all three per-stage overrides covered.

Walking the rest of `interactive_argv`/`interactive_env` for siblings turned up one neither bot flagged: **`profile.model_flag`**, an argv *flag* rather than a value, also unpinned. Now covered. That is what prompted replacing the hand-picked field list in the docstring with the rule the list derives from.

`None` (inherit the profile) is now kept distinct from `()` (an explicit override to no flags) — two different command lines that must not collide.

**Codex's second P1 — plugin implementations pinned by name only — is also correct, and is now #496.** It refutes a claim this PR inherited from the phase plan ("Phase 3's digest closes the in-proc-Python exec path via `plugins.enabled`"). It does not: the allowlist is satisfied by the name while the bytes behind it are swappable. The claim is corrected here, in the `config_digest` docstring and in the CHANGELOG rather than papered over. It is a pre-existing hole this PR narrows around but does not open.

Also taken from the review: `trusted_config_digest` is now required (no `""` default) on `build_run_state`/`compose_run`/`compose_sweep`, for the same reason it is required on `_sweep_factory` — an omitted baseline persists an empty pin, which the resume compare reads as "no prior pin, no warning". `RunState` keeps its `""` default for runs persisted before the field existed. The `tmp_path` fixture in `test_runsetup.py` now states *why* it is not the `project` sandbox (pure-core unit; `config_digest` reads only `.bmad-loop/`), and the CHANGELOG entry is tightened.

Not taken: ast-grep's "use jsonify instead of `json.dumps`" is a Flask rule and does not apply to a hash canonical.

### New ablations

`model_flag` removed from the canonical → only `test_digest_moves_on_any_resolved_profile_launch_field[model_flag]` fails. `extra_args` removed → 5 targeted failures (base, `[dev]`/`[review]`/`[triage]`, and the `None`-vs-`[]` distinction). Restored, full suite green: **4504 passed, 26 skipped**; `pyright` 0 errors; `trunk check` clean.

## Reviewer round 2 (`b049133`) — the stated rule earning its keep

Replacing the hand-picked field list with a *rule* was round 1's real fix, so I re-walked `interactive_argv`/`interactive_env` against that rule rather than against the diff. It found a third unpinned argv field, and this one the docstring had **explicitly and wrongly excluded** — with a test pinning the wrong claim.

**`profile.prompt_template` is an argv element, not prompt payload.** `interactive_argv` places `render_prompt(spec.prompt)` directly in the argv list, and `render_prompt` returns `self.prompt_template.format(...)` — the template need not reference `{prompt}` at all. So a session rewriting *only* `prompt_template` in `profiles/*.toml` adds a verbatim attacker-chosen argv token while every other hashed launch field holds still. `build_command` `shlex.quote`s it, which bounds it to one token — no word-splitting — but one token is enough for the `--opt=value` form, `--mcp-config=...` being the obvious one. Now pinned; `test_digest_ignores_the_model_and_prompt_template` is split, and `adapter.model` keeps its exclusion on the reason that actually holds (it fills the value slot behind the already-pinned `model_flag`, and the TUI live-edits it).

**Two claims corrected rather than papered over.** "Neither can introduce an argv token" was false for `prompt_template`. And "Adding a plugin is caught" is true only of plugins declaring `[python]` — see #497 above. Both the docstring and the CHANGELOG now scope what the pin catches to what it actually catches.

**`[plugins.<name>]` settings are now a documented exclusion, not an omission.** They do reach exec — `bus.py` exports each as `BMAD_LOOP_SETTING_*` into the `shell=True` hook env, and the Unity plugin turns one into an `--editor-path` argv token — but the TUI settings screen writes those same tables, so pinning them would refuse an auto-sweep after a supported human edit. They sit inside an already-trusted plugin's blast radius, which is #496/#497's boundary rather than this digest's.

Ablation: dropping `prompt_template` from the canonical fails exactly `test_digest_moves_on_any_resolved_profile_launch_field[prompt_template]` against the whole suite — `1 failed, 4504 passed`. Restored by re-edit and verified with an empty `git diff`, not by `git checkout`. Suite after: **4505 passed, 26 skipped**; `pyright` 0 errors; `trunk check` clean.

### On current external guidance

Checked against the [OWASP Top 10 for Agentic Applications 2026](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/) (published 2025-12-09), the current published taxonomy for this class. The closest categories are ASI05 Unexpected Code Execution and ASI04 Agentic Supply Chain Vulnerabilities; ASI02 Tool Misuse covers parameter pollution and tool-chain manipulation. Notably the framework does **not** yet name the specific shape here — an agent with write access to the config that determines its own successors' launch surface — and offers no competing mitigation, so nothing in it argues against the field-scoped pin. Recorded as context, not as authority.



## Reviewer round 3 (`3d23a30`) — the gate was check-then-use

**Codex found the gate protecting the wrong read, and it is the most serious finding of the three rounds** — not a missing field this time, but a defect in the gate's own construction. `_sweep_factory` hashed one read of `profiles/*.toml` and then launched from later ones: `config_digest` resolved profiles per role, `_start_sweep`'s `_trusted_config_digest` resolved them again, and `compose_sweep` -> `make_adapters` -> `get_profile` once more. Seven reads of an agent-writable file, one comparison. A session that leaves a background writer alternating a benign and a hostile overlay only has to land the benign copy on the digest's read.

The severity turns on a detail this PR already documents: a lost round costs the attacker nothing. The refusal raises, `_maybe_auto_sweep` swallows it as `sweep-auto-failed`, and the parent loop continues to the next trigger. Failure is free and repeatable, so "narrow window" is not a defense and shrinking it would not have been a fix.

`runsetup.resolve_profiles(policy, project)` now reads each distinct profile once, and that mapping is threaded through all three consumers — the gate's `config_digest`, the pin `_start_sweep` stamps, and `make_adapters`. The policy half needed nothing: `_sweep_factory` already loads `policy.toml` once and passes that one frozen `Policy` everywhere, so profiles were the only surface read twice. `make_adapters`/`compose_sweep` take the mapping keyword-only (`None` = resolve fresh), so human-present `cmd_sweep` is unchanged; `compose_sweep`'s injected factory parameter is now a `Protocol` so an out-of-tree frontend must accept the freeze rather than silently re-read.

**A second bug of the same shape came out with it.** `_start_sweep` recomputed the pin from its own fresh read, so a child launched after a swap would have persisted the *attacker's* config as its own trusted baseline — the gate blessing what it was built to refuse.

**CodeRabbit's `hookless` / profile-name finding is not taken**, and the walk is in the docstring's exclusion list rather than in a reply, since this is the second review to probe that boundary. The dispatch flip is real; the consequence is not. `opencode_http._serve_argv` builds `[binary, "serve", "--port", ..., *extra_args]` — both variables already pinned, every other token a literal — and `_session_env` layers the same pinned `profile.env`. The flip hands an already-pinned program a Python-controlled argv, so no attacker-chosen token enters; what it can do is strand a run on a transport its CLI does not speak, which is the same denial breaking the digest already gives. The profile *name* is transitively covered: a name change that matters moves a hashed launch field, and one that does not reaches only worktree seeding, transcript parsing, hook-config writing (#461 pts 1-3), and pane-log classification. `env_fault_patterns` was the one worth chasing — an agent-written catastrophic regex is a plausible orchestrator hang — but `_env_fault_evidence` already matches under a timeout and declines on `TimeoutError`.

No test pins that exclusion, deliberately: this PR has already had a test pin a false exclusion claim once (`prompt_template`), and an exclusion test is exactly what would fight a future change making `hooks.dialect` exec-relevant.

### New ablations

`test_auto_sweep_launches_the_profile_bytes_the_gate_validated` swaps the overlay from inside `config_digest`'s own return — the writer waking the instant the comparison has its answer — and asserts the harm, not the plumbing, in both halves. Ablated singly: dropping `profiles=` from `compose_sweep`'s `make_adapters` call gives `assert 'rogue-cli' == 'mycli'` (Codex's finding reproduced end to end); dropping it from `_trusted_config_digest` in `_start_sweep` makes the stamped pin diverge from the launch baseline. A third assert pins non-vacuity — the swap must actually have landed on disk, or every other assertion passes trivially. Restored by re-edit between the two and verified with an empty `git diff`.

`uv run pytest -q -n auto` -> **4507 passed, 26 skipped**; `uv run pyright` -> 0 errors; `trunk check` -> no issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added launch-time configuration protection for runs and automatic sweeps.
  * Automatic sweeps now detect changes to execution policies, profiles, plugins, or commands.
  * Resuming a run re-baselines configuration and warns about relevant changes.
  * Limits-only changes remain live without triggering warnings.

* **Bug Fixes**
  * Prevented automatic sweeps from running with changed execution settings while allowing the parent run to continue.
  * Added notifications and activity records when an automatic sweep is blocked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

