### PR TITLE
fix(recovery): bound the preserve-ref probe and refuse to reuse an occupied name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,14 @@ whose seams had diverged enough that several ports needed a different fix, and t
 
 ### Fixed
 
+- **A re-armed escalation no longer overwrites the previous attempt's dirty snapshot (#349).**
+  `refs/attempt-preserve-dirty/*` names were keyed on `task.attempt`, which `rearm_escalation`
+  resets to 0, so a post-resolve re-drive rolling back against the same baseline recomputed the
+  earlier rollback's refname and destroyed the only copy of that attempt's work. Probe for a free
+  name instead of trusting the counter, suffixing `-r2`, `-r3`, … The scan is bounded; exhausting
+  it refuses (`attempt-worktree-preserve-failed`, then the usual pause) rather than reusing an
+  occupied name. Prune the namespace or lower `scm.preserve_keep` if it ever fires.
+
 - **The auto-sweep child refuses config a session rewrote under the run (#461).** `policy.toml` and
   `profiles/*.toml` sit in the agent-writable workspace and reach host code execution — the
   `[verify] commands` run with `shell=True`, the resolved profile plus `adapter.extra_args` decide

--- a/src/bmad_loop/recovery_flow.py
+++ b/src/bmad_loop/recovery_flow.py
@@ -455,17 +455,33 @@ class RecoveryFlow:
         # namespace is small" into an enforced invariant, and exhausting it raises
         # rather than reusing the last candidate: falling through to an occupied
         # name is the precise data loss this probe exists to prevent (#349).
+        #
+        # The probe is check-then-write, not atomic: `snapshot_worktree` finishes on a
+        # plain two-arg `update-ref`, which overwrites whatever is there rather than
+        # failing if the name were taken in between. Safe here because each name has
+        # exactly one possible writer, on two independent grounds — the control loop
+        # is sequential (nothing in this path threads, so one run never has two
+        # rollbacks in flight), and the name is keyed on `run_id`, so separate runs
+        # address disjoint namespaces. Only two processes driving the SAME run could
+        # collide, and they would already be racing on run state, worktrees and mux
+        # sessions; the remedy for that is run-level exclusion, not a compare-and-swap
+        # on this one ref.
         base_ref = f"refs/attempt-preserve-dirty/{slug}-{baseline[:8]}-{task.attempt}"
         ref = base_ref
         serial = 2
         try:
             while verify.ref_exists(workspace.root, ref):
                 if serial > PRESERVE_REF_PROBE_LIMIT:
+                    # Remedy has to hold at BOTH ends of the preserve_keep range:
+                    # "lower it" is impossible at 0, which is precisely the setting
+                    # (pruning disabled) that lets this namespace grow far enough to
+                    # exhaust the probe in the first place.
                     raise verify.PreserveRefExhaustedError(
                         f"no free snapshot refname for {base_ref}: "
                         f"{PRESERVE_REF_PROBE_LIMIT} candidates through -r{serial - 1} "
-                        f"are all taken (prune refs/attempt-preserve-dirty/* or lower "
-                        f"scm.preserve_keep)"
+                        f"are all taken (prune refs/attempt-preserve-dirty/*, or set "
+                        f"scm.preserve_keep to a positive value below that limit — "
+                        f"0 disables pruning entirely)"
                     )
                 ref = f"{base_ref}-r{serial}"
                 serial += 1

--- a/src/bmad_loop/recovery_flow.py
+++ b/src/bmad_loop/recovery_flow.py
@@ -31,6 +31,16 @@ if TYPE_CHECKING:
     from .workspace import Workspace
 
 
+# How many candidate `refs/attempt-preserve-dirty/*` names one rollback may probe
+# before giving up (the base name plus -r2..-r100). Deliberately not a policy
+# field: it is a runaway backstop, not a tuning knob — `scm.preserve_keep`
+# (default 20) already prunes this namespace at every run start, so needing even
+# a dozen candidates for ONE {slug}-{baseline}-{attempt} triple means something
+# upstream is wrong. The cost of the bound is one git spawn per candidate on a
+# path that only runs while a crashed attempt is being rolled back.
+PRESERVE_REF_PROBE_LIMIT = 100
+
+
 class RecoveryFlow:
     """Roll back or pause a stopped/abandoned attempt, parking any work it did on
     named recovery refs before the reset.
@@ -438,11 +448,25 @@ class RecoveryFlow:
         # Uncaught it would crash the rollback here — the one thing this handler
         # exists to prevent — so a probe that cannot run degrades into the same
         # "preservation is observation" path as a snapshot that cannot be written.
+        # The scan is BOUNDED: it terminates on its own (the ref set is finite and
+        # `serial` only climbs), but termination is not a bound — the iteration
+        # count is whatever the namespace happens to hold, one git spawn apiece, in
+        # the middle of a crash-recovery path. PROBE_LIMIT turns "trust the
+        # namespace is small" into an enforced invariant, and exhausting it raises
+        # rather than reusing the last candidate: falling through to an occupied
+        # name is the precise data loss this probe exists to prevent (#349).
         base_ref = f"refs/attempt-preserve-dirty/{slug}-{baseline[:8]}-{task.attempt}"
         ref = base_ref
         serial = 2
         try:
             while verify.ref_exists(workspace.root, ref):
+                if serial > PRESERVE_REF_PROBE_LIMIT:
+                    raise verify.PreserveRefExhaustedError(
+                        f"no free snapshot refname for {base_ref}: "
+                        f"{PRESERVE_REF_PROBE_LIMIT} candidates through -r{serial - 1} "
+                        f"are all taken (prune refs/attempt-preserve-dirty/* or lower "
+                        f"scm.preserve_keep)"
+                    )
                 ref = f"{base_ref}-r{serial}"
                 serial += 1
             parked = verify.snapshot_worktree(

--- a/src/bmad_loop/verify.py
+++ b/src/bmad_loop/verify.py
@@ -788,6 +788,17 @@ def snapshot_worktree(
     return ref_name
 
 
+class PreserveRefExhaustedError(GitError):
+    """Every candidate snapshot refname in a probe's bounded range was already
+    taken. A GitError so the preservation handlers that already guard
+    ``(GitError, OSError)`` degrade instead of crashing; a distinct type so the
+    caller can tell "the namespace is full" from "git said no" — the two want
+    opposite remedies (prune/raise ``scm.preserve_keep`` vs. fix the repo).
+
+    Raised rather than falling through to the last candidate on purpose: reusing
+    an occupied name is the exact data loss the probe exists to prevent (#349)."""
+
+
 def ref_exists(repo: Path, refname: str) -> bool:
     """Whether ``refname`` — a FULL refname, e.g. ``refs/attempt-preserve-dirty/…``
     — currently exists. Sibling of :func:`branch_exists`, which prepends

--- a/src/bmad_loop/verify.py
+++ b/src/bmad_loop/verify.py
@@ -793,7 +793,10 @@ class PreserveRefExhaustedError(GitError):
     taken. A GitError so the preservation handlers that already guard
     ``(GitError, OSError)`` degrade instead of crashing; a distinct type so the
     caller can tell "the namespace is full" from "git said no" — the two want
-    opposite remedies (prune/raise ``scm.preserve_keep`` vs. fix the repo).
+    different remedies (prune the namespace, or re-enable pruning by setting
+    ``scm.preserve_keep`` to a positive value, vs. fix the repo). Note the
+    remedy is *not* "lower ``preserve_keep``": 0 means never prune, so the
+    setting most likely to exhaust a probe is the one that cannot go lower.
 
     Raised rather than falling through to the last candidate on purpose: reusing
     an occupied name is the exact data loss the probe exists to prevent (#349)."""

--- a/tests/test_recovery_flow.py
+++ b/tests/test_recovery_flow.py
@@ -18,7 +18,7 @@ from bmad_loop import verify
 from bmad_loop.gates import ATTENTION_FILE
 from bmad_loop.model import Phase, StoryTask
 from bmad_loop.policy import GatesPolicy, LimitsPolicy, NotifyPolicy, Policy, ScmPolicy
-from bmad_loop.recovery_flow import RecoveryFlow
+from bmad_loop.recovery_flow import PRESERVE_REF_PROBE_LIMIT, RecoveryFlow
 from bmad_loop.verify import GitError, rev_parse_head
 from bmad_loop.workspace import Workspace
 
@@ -735,6 +735,57 @@ def test_ref_probe_git_fault_degrades_like_a_failed_snapshot(project, monkeypatc
 
     entry = flow.journal.fields("attempt-worktree-preserve-failed")
     assert "command not found" in entry["error"]
+    assert (repo / "src.txt").read_text() == "uncommitted work\n"  # work not reset away
+
+
+def test_ref_probe_is_bounded_and_refuses_to_reuse_an_occupied_name(project, monkeypatch):
+    """The probe terminates on its own — the ref set is finite and the serial only
+    climbs — but terminating is not the same as being bounded: without a cap the
+    iteration count is whatever the namespace happens to hold, one git spawn each,
+    inside a crash-recovery path. `PRESERVE_REF_PROBE_LIMIT` bounds the scan, and
+    exhausting it must RAISE rather than fall through to the last candidate;
+    reusing an occupied name is the exact data loss the probe exists to prevent
+    (#349). Exhaustion is a preservation fault like any other, so it degrades into
+    the typed pause instead of crashing the rollback.
+
+    `ref_exists` is answered True for a few calls PAST the limit, so removing the
+    cap makes this fail on the missing pause rather than hanging the suite.
+
+    Ablation target: delete the `serial > PRESERVE_REF_PROBE_LIMIT` raise and the
+    probe walks past the bound to a free name, the snapshot succeeds, and the
+    `pytest.raises(_Pause)` fails."""
+    repo = project.project
+    ws = Workspace.default(project)
+    flow = _make_flow(workspace=ws, policy=_policy(rollback_on_failure=True))
+    task = _task(repo)
+    (repo / "src.txt").write_text("uncommitted work\n")
+
+    probed: list[str] = []
+
+    def _occupied(_repo, refname: str) -> bool:
+        probed.append(refname)
+        return len(probed) <= PRESERVE_REF_PROBE_LIMIT + 5
+
+    snapshots: list[str] = []
+
+    def _snapshot(_repo, refname, **_k):
+        snapshots.append(refname)
+        return refname
+
+    monkeypatch.setattr(verify, "ref_exists", _occupied)
+    monkeypatch.setattr(verify, "snapshot_worktree", _snapshot)
+
+    with pytest.raises(_Pause):  # the typed pause, not a raw error and not a hang
+        flow.rollback_or_pause(task)
+
+    # The bound is the assertion: the base name plus -r2..-r<limit>, then stop.
+    assert len(probed) == PRESERVE_REF_PROBE_LIMIT
+    assert probed[-1].endswith(f"-r{PRESERVE_REF_PROBE_LIMIT}")
+    assert not snapshots  # never wrote over any of the names it found occupied
+
+    entry = flow.journal.fields("attempt-worktree-preserve-failed")
+    assert "no free snapshot refname" in entry["error"]  # names the exhaustion
+    assert "scm.preserve_keep" in entry["error"]  # and the operator's remedy
     assert (repo / "src.txt").read_text() == "uncommitted work\n"  # work not reset away
 
 


### PR DESCRIPTION
Follow-up hardening on the preserve-ref probe that landed in #353. Not a regression in that PR — the data-loss fix is sound and stays as written; this closes the one gap the review flagged and merged over.

## The gap

`recovery_flow.py` probed for a free `refs/attempt-preserve-dirty/*` name with an uncapped loop:

```python
while verify.ref_exists(workspace.root, ref):
    ref = f"{base_ref}-r{serial}"
    serial += 1
```

That **terminates** — `serial` only climbs and the ref set is finite — but terminating is not the same as being **bounded**. The iteration count is whatever the namespace happens to hold, one git spawn apiece, on a path that only runs while a crashed attempt is being rolled back. `scm.preserve_keep` (default 20) prunes the namespace at run start, so it is short in practice and unbounded at `preserve_keep = 0` (never prune).

## The fix

Cap the scan at `PRESERVE_REF_PROBE_LIMIT` (100: the base name plus `-r2`..`-r100`) and **raise** on exhaustion rather than falling through to the last candidate — reusing an occupied name is the precise data loss #349 fixed.

The new `verify.PreserveRefExhaustedError` subclasses `GitError`, so the existing `except (verify.GitError, OSError)` at `recovery_flow.py:451` degrades it into the same journal-and-decide path as a snapshot that cannot be written. Preservation is observation: exhaustion must not crash the rollback. A distinct type so a caller can tell "the namespace is full" from "git said no" — those want opposite remedies — mirroring why `GitSpawnError` is its own type (`verify.py:79`).

Deliberately a module constant, not a policy field: it is a runaway backstop, not a tuning knob, and `scm.preserve_keep` already governs the namespace.

## What I did not change

- **The degradation path.** I checked rather than assumed: `GitSpawnError(GitError)` at `verify.py:79` means the handler already catches spawn and timeout faults. Correct as merged.
- **`ref_exists` folding "missing ref" and "malformed name" into `rc != 0 → absent`.** The names are built from `safe_ref_segment(run_id)` + hex + an int, so a malformed one is effectively unreachable, and if it happened the subsequent `update-ref` fails loudly into the same handler. Documented honestly in its own docstring; no change warranted.

## Verification

`tests/test_recovery_flow.py::test_ref_probe_is_bounded_and_refuses_to_reuse_an_occupied_name` answers `ref_exists` True for a few calls **past** the limit, then False. That shape matters: with the cap deleted the probe walks on to a free name and the test fails on the missing pause, instead of hanging the suite. It pins the exact bound (`len(probed) == PRESERVE_REF_PROBE_LIMIT`), asserts `snapshot_worktree` is never reached, and asserts the dirty work is not reset away.

Ablation performed per the repo rule — cap deleted, test failed with `DID NOT RAISE _Pause`, restored from the commit.

Gates: `uv run pytest -q -n auto` 4514 passed / 26 skipped · `uv run pyright` 0 errors · `trunk check` no issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dirty worktree recovery snapshots now use collision-safe names, adding revision suffixes when needed.
  * Recovery stops safely after 100 occupied snapshot names instead of risking reuse or indefinite probing.
  * When no safe name is available, recovery pauses, records the failure and remediation, and leaves the working tree unchanged.

* **Documentation**
  * Added changelog coverage for collision-safe snapshot naming and exhaustion handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->