### PR TITLE
test(platform_util): pin resolve() semantics without a live UNC provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,11 @@ whose seams had diverged enough that several ports needed a different fix, and t
   environment-fault pause. Diagnosis only: routing is unchanged and a retry re-creates the
   session.
 
+- **Stop a #332 resolve guard from flaking on the Windows runner (#529).** Test-only; no runtime
+  change. Resolving a real `\\wsl$\...` path tied the guard to the runner's WSL provider, which
+  answers `ERROR_NETNAME_DELETED` (64) when registered but not serving — a code CPython's non-strict
+  resolution does not tolerate. The syscall is stubbed instead, covering both `realpath` branches.
+
 - **A native-Windows install driven from a WSL shell now says so (#332).** WSL appends the Windows
   `PATH` to its own, so a bash prompt can reach a Windows-installed `bmad-loop`: that interpreter
   reports `win32`, takes the psmux platform default, and never sees the distro's tmux — while

--- a/tests/test_platform_util.py
+++ b/tests/test_platform_util.py
@@ -7,6 +7,7 @@ the legacy ``platform_util`` entry points still delegate, plus the real
 
 from __future__ import annotations
 
+import ntpath
 import os
 import stat
 import subprocess
@@ -188,25 +189,87 @@ def test_is_wsl_unc_path_is_platform_blind(monkeypatch):
 
 @pytest.mark.skipif(sys.platform != "win32", reason="UNC resolution is a Windows behavior")
 @pytest.mark.parametrize(
-    "spelling",
+    "spelling,expected",
     [
-        "\\\\wsl.localhost\\{d}\\home",
-        "\\\\wsl$\\{d}\\home",
-        "//wsl.localhost/{d}/home",
+        ("\\\\wsl.localhost\\{d}\\home", "\\\\wsl.localhost\\{d}\\home"),
+        ("\\\\wsl$\\{d}\\home", "\\\\wsl$\\{d}\\home"),
+        ("//wsl.localhost/{d}/home", "\\\\wsl.localhost\\{d}\\home"),
         # resolve() must keep, not strip, an extended prefix the input carried —
         # the premise the predicate's fold rests on; if a future CPython starts
         # stripping it, the fold goes dead and only this row notices
-        "\\\\?\\UNC\\wsl.localhost\\{d}\\home",
+        ("\\\\?\\UNC\\wsl.localhost\\{d}\\home", "\\\\?\\UNC\\wsl.localhost\\{d}\\home"),
     ],
 )
-def test_is_wsl_unc_path_survives_the_resolve_the_caller_applies(spelling):
+def test_is_wsl_unc_path_survives_the_resolve_the_caller_applies(spelling, expected, monkeypatch):
     """The one shape production actually sees. `cli._project` hands the preflight a
     `Path(...).resolve()`, and every other test here passes an unresolved literal — so
     a `Path.resolve()` semantics change (it has moved across 3.6/3.8/3.13) could
     normalize the bridge prefix away and silently disable the whole #332 check with
-    this file still green. The distro need not exist: resolution is non-strict."""
-    raw = spelling.format(d="Ubuntu-24.04")
-    assert platform_util.is_wsl_unc_path(Path(raw).resolve()) is True
+    this file still green.
+
+    This row pins `realpath`'s *lexical* walk — the branch taken when the syscall
+    cannot answer — so the syscall wrapper is stubbed rather than aimed at a live
+    provider. It raises ERROR_BAD_NET_NAME (67), which is on CPython's non-strict
+    allow-list, so `realpath` degrades instead of failing. That is what the earlier
+    "the distro need not exist" premise assumed it always got, and #529 is what
+    happens when it does not: a registered-but-not-serving `wsl$` provider answers
+    ERROR_NETNAME_DELETED (64), which is *off* that list, so `resolve()` raises and a
+    semantics guard flakes on network state. The other branch — what a *serving*
+    distro makes `realpath` do — is pinned by the sibling test below; keep both, they
+    reach the same string by different routes."""
+    calls: list[str] = []
+
+    def unreachable_provider(path):
+        calls.append(path)
+        # Only the 4th arg (winerror) matters: an OSError escaping this test means 67
+        # left ntpath's non-strict allow-list and the premise below needs re-measuring.
+        raise OSError(0, "stubbed: 67 must stay on ntpath's non-strict allow-list", None, 67)
+
+    def no_symlink(_path):
+        raise OSError(0, "stubbed: nothing to dereference", None, 67)
+
+    monkeypatch.setattr(ntpath, "_getfinalpathname", unreachable_provider)
+    # the lexical walk also tries to read the path as a symlink; stub that too so the
+    # row touches no provider at all, on a runner with WSL or without
+    monkeypatch.setattr(ntpath, "_nt_readlink", no_symlink)
+
+    resolved = Path(spelling.format(d="Ubuntu-24.04")).resolve()
+    # Ablation guard: a future pathlib that stops routing resolve() through ntpath would
+    # leave the stub unused and everything below would pass while pinning nothing. The
+    # second half is what proves the *lexical walk* ran and not just the opening call:
+    # measured 3.11-3.14, it asks 3 times and the last ask is the parent, having climbed.
+    assert len(calls) > 1 and calls[-1] != calls[0], "resolve() no longer walks the path in ntpath"
+    assert str(resolved) == expected.format(d="Ubuntu-24.04")
+    assert platform_util.is_wsl_unc_path(resolved) is True
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="UNC resolution is a Windows behavior")
+@pytest.mark.parametrize("host", ["wsl.localhost", "wsl$"])
+def test_is_wsl_unc_path_survives_the_resolve_a_serving_distro_takes(host, monkeypatch):
+    """The other branch of the same `resolve()`, and the one production runs on the
+    hosts #332 exists for. Measured on Win11/WSL2 with the distro serving: the syscall
+    *succeeds* and hands `realpath` the extended form, which `realpath` then strips
+    back down because it added that prefix itself — an add/strip decision the sibling
+    test's lexical walk never reaches. Stubbing the syscall's *return value* covers it
+    with no provider; a live row would only reinstate the #529 flake."""
+    plain = f"\\\\{host}\\Ubuntu-24.04\\home"
+    calls: list[str] = []
+
+    def serving_provider(path):
+        calls.append(path)
+        return f"\\\\?\\UNC\\{host}\\Ubuntu-24.04\\home"
+
+    monkeypatch.setattr(ntpath, "_getfinalpathname", serving_provider)
+
+    resolved = Path(plain).resolve()
+    # Same ablation guard, and it is what makes this row non-vacuous: on a host with a
+    # live distro an unstubbed resolve() returns `plain` too, so without proof the stub
+    # answered, both asserts below would pass on the environment rather than the code.
+    # Two asks, measured 3.11-3.14: the input, then the prefix-stripped candidate
+    # realpath re-verifies before returning it — that verify *is* the strip decision.
+    assert calls == [plain, plain], "realpath no longer verifies the prefix it strips"
+    assert str(resolved) == plain
+    assert platform_util.is_wsl_unc_path(resolved) is True
 
 
 # ---------------------------------------------------------------- atomic_replace


### PR DESCRIPTION
Closes #529

## Root cause, measured

`ntpath._getfinalpathname_nonstrict` re-raises any winerror outside its allow-list `1, 2, 3, 5, 21, 32, 50, 53, 65, 67, 87, 123, 161, 1920, 1921`. `ERROR_NETNAME_DELETED` (64) is not on it, so `Path.resolve()` propagates instead of degrading — the test's "the distro need not exist: resolution is non-strict" premise only ever held for the allow-listed codes. A registered-but-not-serving bridge provider answers 64, so a guard over *string* semantics hung on network state.

## The fix

Keep the real `Path.resolve()` — it is the subject of the guard — but stub the syscall wrapper so it cannot reach a provider:

- **Lexical branch** (`test_..._survives_the_resolve_the_caller_applies`): the stub raises the allow-listed `ERROR_BAD_NET_NAME` (67), which is the condition the old premise assumed it always got. Each row now asserts the **exact** resolved string instead of a prefix match, so a normalization change that dropped the tail can no longer pass.
- **Serving branch** (`test_..._survives_the_resolve_a_serving_distro_takes`, new): review caught that this is the branch production actually runs on a WSL host. Traced on Win11/WSL2: the syscall **succeeds** and returns `\?\UNC\<host>\...`, which `realpath` strips back down because it added that prefix itself. Nothing covered it. Stubbing the syscall's *return value* pins the add/strip decision with no provider.

Stubbed and live resolves return byte-identical strings for all four spellings — but by different branches, so one never covered the other.

## Non-vacuity

Both rows prove the stub was used before trusting the result: the lexical row that the walk climbed to the parent (3 asks, last one the parent), the serving row that `realpath` re-verified the stripped candidate (exactly 2 asks). Without that second guard, a host with a live distro would pass the serving row on the environment rather than on the code.

Ablations run, not assumed: a stub answering with another share, and a second answer defeating the strip check, each redden the row they guard; uninstalling the stub trips the liveness assert.

## Rejected alternatives

- `pytest.skip` on `OSError` — lets the guard silently stop running on exactly the runners that flake.
- Swap `resolve()` for `os.path.abspath` — identical output here, but skips the prefix-strip branch, so it stops pinning what production does.
- A live row gated on "is a distro serving" — TOCTOU: the gate can pass and `resolve()` still answer 64, reinstating this flake.
- Stubbing `_findfirstfile` — reachable only for winerror 1/5/32/50/87/1920/1921, never 67.

## Verification

`pytest tests/test_platform_util.py`: 280 passed, 8 skipped. `trunk check` clean. Branch behaviour and syscall-argument traces measured on CPython 3.11.11, 3.12.9, 3.13.2 and 3.14.6 — the full Windows CI matrix.

## Out of scope, filed separately

`cli._project` is a bare `Path(args.project).resolve()`, so on the same host every command dies with `error: [WinError 64] ...` instead of the `host.win32-on-wsl-path` warning that would explain the mis-picked interpreter. Pre-existing, and it needs its own decision (degrade to `Path.absolute()`, or fail with a typed message) plus a blast-radius pass over every consumer of `project`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded Windows WSL UNC path resolution coverage.
  * Added checks for unresolved and serving network-provider scenarios.
  * Improved test reliability by simulating filesystem behavior instead of relying on environment-specific WSL state.
  * Verified path traversal, extended UNC formatting, syscall ordering, and final path recognition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->