### PR TITLE
test: dedup sweep — consolidate duplicated mcp-agent-id test, cross-link adapter parity blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,17 @@ whose seams had diverged enough that several ports needed a different fix, and t
   traceback dumped after any partial `--json` stdout; it is now a clean exit, so a Python caller's
   `subprocess.returncode` shows `130` rather than `-2`. A Ctrl+C _during_ a run is unchanged.
 
+- **Dedup the test suite; drop `engine._setup_mcp_agent_id`.** An AST sweep over all 69 test files
+  (name collisions plus normalized-body hashes) found one true duplicate:
+  `test_setup_mcp_agent_id_mapping` existed in both `test_engine_plugin.py` and
+  `test_worktree_flow.py`, the latter asserting a subset. The superset now lives once, beside the
+  function it covers, and `engine.py`'s `_setup_mcp_agent_id` re-export — carried solely for the
+  deleted import — goes with it. The adapter timeout (#157) and token-budget (#158) blocks in
+  `test_generic_tmux.py` now state their contract parity with the identically named
+  `test_opencode_http.py` tests, which already pointed back: a behavior change lands in both or
+  records the divergence. Every other collision the sweep surfaced was adjudicated deliberate
+  (disjoint `parametrize` sets, or one body run against two different shipped scripts).
+
 ### Removed
 
 - **The `bmad-auto` → `bmad-loop` rename compatibility is gone.** The rename shipped in 0.8.0 and no

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -62,7 +62,6 @@ from .sprintstatus import next_actionable, parse_selector
 from .statemachine import advance
 from .workspace import UnitWorkspace, Workspace, discard_worktree, open_unit_workspace
 from .worktree_flow import WorktreeFlow
-from .worktree_flow import _setup_mcp_agent_id as _setup_mcp_agent_id  # re-export for tests
 
 if TYPE_CHECKING:
     # Type-only: the worktree-provisioning helpers speak in CLI profiles.

--- a/tests/test_engine_plugin.py
+++ b/tests/test_engine_plugin.py
@@ -27,7 +27,7 @@ import time
 import pytest
 from conftest import write_script_launcher
 
-from bmad_loop.engine import Engine, _setup_mcp_agent_id
+from bmad_loop.engine import Engine
 from bmad_loop.plugins import HookContext, PluginError, get_plugin, load_plugins
 from bmad_loop.plugins.model import PluginManifest
 from bmad_loop.policy import NotifyPolicy, PluginsPolicy, Policy, ScmPolicy
@@ -695,15 +695,10 @@ def test_engine_rejects_invalid_coupling_at_construction(project):
 
 
 # ------------------------------------ per_worktree MCP agent routing (feeds ctx.agents)
-
-
-def test_setup_mcp_agent_id_mapping():
-    # only claude carries the "-code" suffix; everything else passes through
-    assert _setup_mcp_agent_id("claude") == "claude-code"
-    assert _setup_mcp_agent_id("codex") == "codex"
-    assert _setup_mcp_agent_id("gemini") == "gemini"
-    assert _setup_mcp_agent_id("cursor") == "cursor"
-    assert _setup_mcp_agent_id("some-custom-profile") == "some-custom-profile"
+#
+# The profile -> agent-id mapping itself is covered in tests/test_worktree_flow.py,
+# next to the _setup_mcp_agent_id definition; what is under test here is the
+# routing that carries that id into ctx.agents.
 
 
 class _FakeProfile:

--- a/tests/test_generic_tmux.py
+++ b/tests/test_generic_tmux.py
@@ -1544,6 +1544,10 @@ def test_capped_session_still_completes_when_marker_lands_late(tmp_path, monkeyp
 # a session-lifecycle.jsonl line, a wall-clock co-bound fires through a frozen
 # monotonic clock (but may never EXTEND the deadline), and each tick tops up a
 # throttled heartbeat.json whose staleness diagnoses a frozen orchestrator.
+#
+# Contract parity: test_opencode_http.py holds identically named tests over the
+# HTTP transport. A behavior change here must land in both or record the
+# divergence.
 
 
 def _timeout_clock_adapter(tmp_path, monkeypatch):
@@ -1693,6 +1697,10 @@ def test_lifecycle_and_heartbeat_write_failure_is_swallowed(tmp_path):
 # artifact under a live window. Driven with a scripted watcher, a steerable
 # clock (ticks advance past HEARTBEAT_INTERVAL_S to cross the throttle), and a
 # real claude-jsonl transcript file.
+#
+# Contract parity: test_opencode_http.py holds identically named tests over the
+# HTTP transport. A behavior change here must land in both or record the
+# divergence.
 
 
 def _write_claude_transcript(path: Path, input_tokens: int) -> None:

--- a/tests/test_worktree_flow.py
+++ b/tests/test_worktree_flow.py
@@ -439,5 +439,9 @@ def test_provision_worktree_reexported_from_install():
 
 
 def test_setup_mcp_agent_id_mapping():
+    # only claude carries the "-code" suffix; everything else passes through
     assert _setup_mcp_agent_id("claude") == "claude-code"
     assert _setup_mcp_agent_id("codex") == "codex"
+    assert _setup_mcp_agent_id("gemini") == "gemini"
+    assert _setup_mcp_agent_id("cursor") == "cursor"
+    assert _setup_mcp_agent_id("some-custom-profile") == "some-custom-profile"


### PR DESCRIPTION
## What

An exhaustive AST dedup sweep over the test suite, landing the one consolidation it confirmed.

A scratchpad script AST-parsed all 69 `tests/test_*.py` (3671 test functions), extracting each test's name and a normalized-body SHA — docstrings and comments stripped, `ast.unparse`-canonicalized so formatting differences collapse — then reported cross-file name collisions, identical body hashes, and near-identical bodies (token-set Jaccard, re-scored with order-sensitive `difflib`).

## The one true duplicate

`test_setup_mcp_agent_id_mapping` existed twice:

| | asserts |
|---|---|
| `tests/test_engine_plugin.py:700` | 5 (claude, codex, gemini, cursor, custom) |
| `tests/test_worktree_flow.py:441` | 2 (claude, codex) — a strict subset |

Both called the same function, `worktree_flow._setup_mcp_agent_id`.

- The 5-assert superset now lives once, in `test_worktree_flow.py`, beside the function it covers.
- The `test_engine_plugin.py` copy is deleted; its section header keeps a pointer to where the mapping is now covered, since the surrounding section still tests the *routing* that carries the id into `ctx.agents`.
- `src/bmad_loop/engine.py` carried `from .worktree_flow import _setup_mcp_agent_id as _setup_mcp_agent_id  # re-export for tests` **solely** for that deleted import. Re-grepped after removal: zero consumers across `src/`, `tests/`, `scripts/`, `docs/`; no `__all__` in `engine.py`; no star-imports or `getattr` access. Deleted.

Net test-function count: **3671 → 3670**, exactly the expected −1.

## Cross-link

`test_opencode_http.py`'s `#157` and `#158` section headers already pointed back at the generic adapter ("Mirrors the generic-adapter guard/coverage on the HTTP transport"), but the link was one-way. Both headers in `test_generic_tmux.py` now state the contract parity, so a behavior change lands in both or records the divergence.

## Everything else the sweep surfaced was adjudicated deliberate

Each new hit got a read-only adjudication pass. **Zero** returned `true-duplicate`, so no deletions beyond the one above.

**All 6 identical-body groups are shared assertion harnesses under disjoint `@pytest.mark.parametrize` sets** — the parametrize args *are* the test input, so identical bodies are expected:

- `test_policy.py` ×2 — `must_be_positive` (`0`, `-1`) hits the range guard at `policy.py:828`; `rejects_non_integers` (`"true"`, `"2.5"`, `'"2M"'`) hits the *type* guard at `policy.py:745`. Two independent raise sites that regress separately.
- `test_psmux_backend.py` — 14 ASCII quoting/chain-splitter shapes vs 3 Unicode-whitespace shapes; the latter is the only input reaching the `c.isspace() and c != " "` clause, and `"with space nb"` specifically pins that the whitespace ban fires *before* the spaced/double-quote branch.
- `test_platform_util.py` — 6 pure-equality root spellings vs 10 win32 trailing-dot/space aliases; disjoint, and each pins a different branch of `names_tree_root`. The test's own comment says the split exists so a revert reddens "these and only these."
- `test_env_fault_patterns.py` — `BAIT` (108 lines, never reaches the pattern anchor) vs `ANCHOR_REACHING_BAIT` (9 lines, built to clear the anchor and pressure the rest of the regex). A third test exists purely to keep the anchor corpus non-vacuous.

**Cross-file, different names, identical body:** `test_hook_script.py::test_noop_without_env` vs `test_probe_hook.py::test_noop_without_capture_dir`. Each file defines its own module-level `SCRIPT` constant, so the identical bodies exec two *different* shipped scripts (`bmad_loop_hook.py` gated on `BMAD_LOOP_RUN_DIR`/`BMAD_LOOP_TASK_ID`; `bmad_loop_probe_hook.py` gated on `BMAD_LOOP_PROBE_CAPTURE_DIR`) — the same rationale the prior audit applied to the same-named trio across these two files.

**Near-identical bodies: zero cross-file pairs.** All 108 pairs above Jaccard 0.90 are intra-file siblings differing in inputs; the 21 above `difflib` 0.98 are adjacent parametrize-style variants (e.g. `test_devcontract.py`'s fence-quoting cases, `test_tui_data.py`'s SGR-marker splits).

The 12 previously-adjudicated cross-file name collisions were skipped as instructed and are unchanged; the sweep re-derived exactly those 12 plus the mcp one, so the name-collision surface is now fully accounted for.

## Verification

- `uv run pytest -q -n auto` — **4983 passed, 39 skipped, 5 xfailed**
- `uv run pyright` — **0 errors, 0 warnings, 0 informations**
- `trunk check --no-fix` — **No issues** (5 modified files)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected agent profile mapping behavior, including custom profiles and the special Claude mapping.
  * Removed an obsolete private engine export.

* **Tests**
  * Consolidated duplicate agent-mapping coverage.
  * Added parity checks for timeout and token-budget behavior across integrations.

* **Documentation**
  * Updated the changelog with test coverage and behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->