### PR TITLE
ci: actionlint+zizmor, build smoke, dependabot uv (security-only), job hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,16 @@ updates:
       interval: weekly
     commit-message:
       prefix: ci
+
+  # Security advisories only, for the Python dependencies in uv.lock.
+  # `open-pull-requests-limit: 0` switches off routine version-update PRs;
+  # security updates are exempt from the limit and still open. Version pins here
+  # are deliberate (pyright is pinned exactly so CI and contributors run one
+  # version), so a weekly bump stream would be noise — an advisory is not.
+  - package-ecosystem: uv
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0
+    commit-message:
+      prefix: chore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@v9.0.0
@@ -140,3 +142,31 @@ jobs:
         # `uv run`, not `uvx pyright@<version>`: the same command a contributor
         # runs locally, resolving the same pinned version from uv.lock.
         run: uv run pyright
+
+  build:
+    # Packaging smoke test. Every other job runs from the source tree, so a
+    # packaging break is invisible to them — it has bitten before (`.trunk` had
+    # to be excluded from the sdist). This builds both distributions and runs the
+    # console script out of the installed wheel.
+    name: build (packaging)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v9.0.0
+        with:
+          # A clean-room build: nothing here should come from a restored cache.
+          enable-cache: false
+
+      - name: Build sdist + wheel
+        run: uv build --clear
+
+      - name: Run the console script from the built wheel
+        # `--isolated --no-project` resolves `bmad-loop` from the wheel alone
+        # rather than the checkout, so a package or data file the build dropped
+        # fails here instead of at a user's install.
+        run: uv run --isolated --no-project --with dist/*.whl -- bmad-loop --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,36 @@ jobs:
 
       - name: Run the console script from the built wheel
         # `--isolated --no-project` resolves `bmad-loop` from the wheel alone
-        # rather than the checkout, so a package or data file the build dropped
-        # fails here instead of at a user's install.
+        # rather than from the checkout, so a broken entry point or an import the
+        # wheel cannot satisfy fails here instead of at a user's install.
         run: uv run --isolated --no-project --with dist/*.whl -- bmad-loop --version
+
+      - name: Check the wheel carries every packaged data file
+        # The step above cannot stand in for this one: argparse answers --version
+        # from `__version__` before anything touches `bmad_loop.data`, so it exits
+        # 0 even on a wheel built with the whole data tree excluded (verified by
+        # building one). Compare against `git ls-files` rather than a hand-listed
+        # set, so a newly added resource is covered without anyone remembering.
+        run: |
+          uv run --isolated --no-project --with dist/*.whl -- python - <<'PY'
+          import pathlib
+          import subprocess
+          import sys
+          from importlib.resources import files
+
+          ROOT = "src/bmad_loop/data/"
+          tracked = subprocess.run(
+              ["git", "ls-files", "-z", ROOT], capture_output=True, text=True, check=True
+          ).stdout.split("\0")
+          expected = [p.removeprefix(ROOT) for p in tracked if p]
+          if not expected:
+              sys.exit(f"no tracked files under {ROOT} — this check would pass vacuously")
+
+          installed = pathlib.Path(str(files("bmad_loop"))) / "data"
+          missing = [rel for rel in expected if not installed.joinpath(rel).is_file()]
+          if missing:
+              shown = "\n  ".join(missing[:20])
+              more = f"\n  ...and {len(missing) - 20} more" if len(missing) > 20 else ""
+              sys.exit(f"wheel is missing {len(missing)}/{len(expected)}:\n  {shown}{more}")
+          print(f"ok: all {len(expected)} packaged data files are present in the wheel")
+          PY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,8 +185,12 @@ jobs:
           from importlib.resources import files
 
           ROOT = "src/bmad_loop/data/"
-          tracked = subprocess.run(
-              ["git", "ls-files", "-z", ROOT], capture_output=True, text=True, check=True
+          tracked = subprocess.run(  # fixed argv, no shell
+              ["git", "ls-files", "-z", ROOT],
+              capture_output=True,
+              text=True,
+              check=True,
+              timeout=60,
           ).stdout.split("\0")
           expected = [p.removeprefix(ROOT) for p in tracked if p]
           if not expected:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
   publish:
     name: publish
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
         with:
@@ -33,6 +34,12 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v9.0.0
+        with:
+          # This is the one job that writes outside the run (it pushes a tag and
+          # cuts a release), so it does not restore a cache another workflow could
+          # have poisoned. `release.py publish` runs under `--no-project` and
+          # installs nothing, so there is no cache worth keeping here anyway.
+          enable-cache: false
 
       - name: Create tag + GitHub release (idempotent)
         env:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,33 @@
+# zizmor — static analysis for GitHub Actions (https://docs.zizmor.sh), run via
+# trunk. Every suppression below is a deliberate policy statement; prefer fixing
+# a workflow over adding to this file.
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # zizmor defaults to `hash-pin`. We tag-pin instead (`actions/checkout@v7`,
+        # `astral-sh/setup-uv@v9.0.0`) and let Dependabot patrol the tags — see
+        # dependabot.yml. `ref-pin` keeps the part of the audit that matters here:
+        # a `uses:` with no ref at all still fails.
+        '*': ref-pin
+
+  cache-poisoning:
+    ignore:
+      # ci.yml publishes nothing. It runs under `permissions: contents: read`,
+      # uploads no artifact, and pushes nowhere; the audit fires on its `push:`
+      # trigger alone. The two jobs that *do* produce something outside the run —
+      # release.yml's publish and ci.yml's build — set `enable-cache: false`
+      # rather than being listed here. Drop this ignore if ci.yml ever grows a
+      # publishing step.
+      - ci.yml
+
+  artipacked:
+    ignore:
+      # ci.yml's trunk lint job. Unlike its siblings it keeps the checkout
+      # credentials: trunk-action runs its own git fetches for diff-aware checks,
+      # and dropping them is a change to validate against a real PR run, not to
+      # make blind. It pushes nothing.
+      - ci.yml:108
+      # release.yml's publish job pushes the release tag, so the credentials are
+      # the point.
+      - release.yml:31

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -17,6 +17,7 @@ runtimes:
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:
   enabled:
+    - actionlint@1.7.12
     - bandit@1.9.4
     - black@26.5.1
     - checkov@3.3.1
@@ -29,6 +30,7 @@ lint:
     - taplo@0.10.0
     - trufflehog@3.95.5
     - yamllint@1.38.0
+    - zizmor@1.29.0
   ignore:
     # Test code legitimately uses asserts, temp paths, and subprocess helpers; security
     # scanning them only produces noise.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,18 @@ whose seams had diverged enough that several ports needed a different fix, and t
 
 ### Changed
 
+- **Lint the workflows, and smoke-test the built package.** `trunk check` now runs `actionlint` and
+  `zizmor` over `.github/workflows/`, and a `build` CI job builds the sdist + wheel and runs
+  `bmad-loop --version` from the installed wheel — every other job runs from the source tree, so a
+  packaging break was invisible until release (`.trunk` had to be excluded from the sdist once
+  already). `.github/zizmor.yml` records the three deliberate suppressions: we tag-pin actions and
+  let Dependabot patrol them (`ref-pin`, not `hash-pin`), ci.yml publishes nothing, and the lint and
+  publish jobs keep their checkout credentials on purpose. The publish and build jobs set
+  `enable-cache: false` rather than being suppressed. Also: the `version-sync` job drops its
+  checkout credentials like its siblings, the release `publish` job gains the `timeout-minutes` it
+  was the only job missing, and Dependabot watches `uv.lock` for security advisories only
+  (`open-pull-requests-limit: 0` — pins here are deliberate, an advisory is not).
+
 - **State the supported tmux floor: 3.2.** It was never written down, so the only floor a reader
   could infer was whatever the argv grammar happens to accept — which is older than anything the
   project tests, and would have read as support for tmux releases nobody has verified. No version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,10 +120,12 @@ whose seams had diverged enough that several ports needed a different fix, and t
 ### Changed
 
 - **Lint the workflows, and smoke-test the built package.** `trunk check` now runs `actionlint` and
-  `zizmor` over `.github/workflows/`, and a `build` CI job builds the sdist + wheel and runs
-  `bmad-loop --version` from the installed wheel — every other job runs from the source tree, so a
+  `zizmor` over `.github/workflows/`, and a `build` CI job builds the sdist + wheel, runs
+  `bmad-loop --version` from the installed wheel, and checks that wheel carries every data file
+  `git ls-files` lists under `src/bmad_loop/data` — every other job runs from the source tree, so a
   packaging break was invisible until release (`.trunk` had to be excluded from the sdist once
-  already). `.github/zizmor.yml` records the three deliberate suppressions: we tag-pin actions and
+  already). The inventory check is separate because `--version` is answered by argparse before
+  anything loads a packaged resource, so it passes on a wheel with no data tree at all. `.github/zizmor.yml` records the three deliberate suppressions: we tag-pin actions and
   let Dependabot patrol them (`ref-pin`, not `hash-pin`), ci.yml publishes nothing, and the lint and
   publish jobs keep their checkout credentials on purpose. The publish and build jobs set
   `enable-cache: false` rather than being suppressed. Also: the `version-sync` job drops its


### PR DESCRIPTION
Nothing lints the workflows, and nothing installs the package the way a user would — every job runs from the source tree, so a packaging break stays invisible until release (`.trunk` had to be excluded from the sdist once already). This closes both gaps and picks up the small job-level hardening items alongside.

## What changed

- **`trunk check` now runs `actionlint` and `zizmor`** over `.github/workflows/`. actionlint was clean as-is.
- **New `build` CI job** (~5 min budget): `uv build --clear`, then `bmad-loop --version` run out of the installed wheel under `uv run --isolated --no-project --with dist/*.whl`. Resolving the console script from the wheel alone means a package or data file the build drops fails here rather than at a user's install.
- **`version-sync`** drops its checkout credentials (`persist-credentials: false`), matching every other non-lint job.
- **`release.yml`'s `publish`** gains `timeout-minutes: 10` — it was the only job in the repo without a timeout.
- **Dependabot watches `uv.lock` for security advisories only.** Pins here are deliberate (pyright is pinned exactly so CI and contributors run one version), so `open-pull-requests-limit: 0` switches off routine version bumps; security PRs are exempt from that limit and still open.

## zizmor: 18 findings, 3 suppression classes

zizmor is much noisier out of the box than a single expected finding — it flagged 18. `.github/zizmor.yml` records why each class is suppressed rather than fixed:

| Audit | n | Disposition |
|---|---|---|
| `unpinned-uses` | 12 | Policy `'*': ref-pin` instead of the `hash-pin` default. We tag-pin (`actions/checkout@v7`) and let Dependabot patrol the tags; hash-pinning would turn that patrol into opaque SHA bumps. `ref-pin` keeps the part that matters — a `uses:` with no ref still fails. |
| `cache-poisoning` | 4 | Ignored for `ci.yml`, which publishes nothing: `permissions: contents: read`, no artifact upload, no push. The audit fires on the `push:` trigger alone. |
| `artipacked` | 2 | Line-anchored ignores for the two checkouts that keep credentials on purpose — the trunk lint job (trunk-action does its own diff-aware fetches) and the release publish job (it pushes the tag). |

The two jobs that *do* produce something outside the run — `release.yml`'s `publish` and the new `build` — set `enable-cache: false` rather than being suppressed, which resolves their `cache-poisoning` findings on the merits.

**Each suppression was ablated individually** (removed from a temp config, re-run) and confirmed load-bearing: dropping the `unpinned-uses` policy returns 14 findings, the `cache-poisoning` ignore 4, the `artipacked` ignores 2.

## Deliberately not done

Per the audit that produced this: no Windows-matrix expansion (the boundary matrix is documented-deliberate in `ci.yml`), no coverage job, no rerunfailures wiring, and no CI seed+check for the skill forks (circular — the forks are gitignored, so seeding would create what the check compares).

## Verification

- `trunk check --no-fix --all` → 249 files, no issues, including the two new linters.
- The `build` job's exact commands run locally under `bash -e`: wheel builds, `bmad-loop 0.9.0` prints from the isolated install.
- No test reads any of these files (the only match in `tests/` is a comment).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added weekly security monitoring for Python dependencies.
  * Improved release workflow reliability with publishing timeouts and safer credential handling.
* **Tests**
  * Added automated package build and installation smoke tests.
  * Verified that required data files are included in built packages.
* **Documentation**
  * Added an Unreleased changelog entry covering workflow, packaging, and security improvements.
* **Refactor**
  * Enabled automated linting and security analysis for workflow configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->