### PR TITLE
fix(cli+config): degrade at the front door, refuse typed at config load, when the OS cannot canonicalize the project root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,12 +241,19 @@ whose seams had diverged enough that several ports needed a different fix, and t
   allow-list, so `Path.resolve()` fails outright. `cli._project` runs before dispatch, so every
   subcommand died at the backstop with `error: [WinError 64] ...`, `diagnose` and `validate`
   included: the `host.win32-on-wsl-path` warning naming the fault was unreachable on the only
-  hosts it is for. `_project` and `bmadconfig.load_paths` now degrade to `Path.absolute()` with
-  one note on stderr, so those commands run and report. Deliberately bounded to the entry
-  chokepoint: the paths that need a canonical answer — `runs.project_tag`, worktree provisioning,
-  `verify` — still raise, so a `run` fails loud rather than tagging one project two ways.
-  `..` is kept rather than collapsed; folding it lexically names a different directory across a
-  symlink, and this value is persisted as `state.project` and reused as a repo root and a cwd.
+  hosts it is for. `cli._project` now degrades to `Path.absolute()` with one note on stderr — it
+  runs pre-dispatch, where no handler can catch anything — so those commands run and report.
+  `bmadconfig.load_paths` refuses instead, with a typed `BmadConfigError`: every artifact path is
+  compared against the canonical root, so a degraded root beside any canonically spelled member —
+  a resolved child, or an absolute path written canonically in config.yaml — mis-files an in-tree
+  artifact dir as external and sends a worktree-isolated run's writes into the original checkout.
+  Every caller already catches the typed error; `validate` records the `bmad-config` failure and
+  still reaches the platform preflight. Configured artifact strings keep a per-member degrade: one
+  that refuses beside a canonical root is on some other share and genuinely is outside the tree.
+  The paths that need a canonical answer downstream — `runs.project_tag`, worktree provisioning,
+  `verify` — still raise, so nothing tags one project two ways. `..` is kept rather than
+  collapsed; folding it lexically names a different directory across a symlink, and this value is
+  persisted as `state.project` and reused as a repo root and a cwd.
 
 - **The last two bare git spawns route through the `_run_git` chokepoint, and a guard now
   enforces the invariant (#390).** An undecodable byte in a commit subject crashed the TUI's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -248,8 +248,10 @@ whose seams had diverged enough that several ports needed a different fix, and t
   a resolved child, or an absolute path written canonically in config.yaml — mis-files an in-tree
   artifact dir as external and sends a worktree-isolated run's writes into the original checkout.
   Every caller already catches the typed error; `validate` records the `bmad-config` failure and
-  still reaches the platform preflight. Configured artifact strings keep a per-member degrade: one
-  that refuses beside a canonical root is on some other share and genuinely is outside the tree.
+  still reaches the platform preflight. Configured artifact strings refuse on the same terms: a
+  spelling the OS cannot canonicalize has an unknowable location — it can sit lexically inside
+  the project while an in-tree junction carries it to a dead share outside — so classifying it by
+  its spelling is a guess that can redirect a worktree-isolated run's writes.
   The paths that need a canonical answer downstream — `runs.project_tag`, worktree provisioning,
   `verify` — still raise, so nothing tags one project two ways. `..` is kept rather than
   collapsed; folding it lexically names a different directory across a symlink, and this value is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -235,6 +235,19 @@ whose seams had diverged enough that several ports needed a different fix, and t
 
 ### Fixed
 
+- **A project path the OS refuses to canonicalize no longer kills every command (#552).** On a
+  Windows host whose WSL UNC provider is registered but not serving, resolving
+  `\\wsl$\<distro>\...` raises `ERROR_NETNAME_DELETED` (WinError 64) — off CPython's non-strict
+  allow-list, so `Path.resolve()` fails outright. `cli._project` runs before dispatch, so every
+  subcommand died at the backstop with `error: [WinError 64] ...`, `diagnose` and `validate`
+  included: the `host.win32-on-wsl-path` warning naming the fault was unreachable on the only
+  hosts it is for. `_project` and `bmadconfig.load_paths` now degrade to `Path.absolute()` with
+  one note on stderr, so those commands run and report. Deliberately bounded to the entry
+  chokepoint: the paths that need a canonical answer — `runs.project_tag`, worktree provisioning,
+  `verify` — still raise, so a `run` fails loud rather than tagging one project two ways.
+  `..` is kept rather than collapsed; folding it lexically names a different directory across a
+  symlink, and this value is persisted as `state.project` and reused as a repo root and a cwd.
+
 - **The last two bare git spawns route through the `_run_git` chokepoint, and a guard now
   enforces the invariant (#390).** An undecodable byte in a commit subject crashed the TUI's
   story-checkpoint modal: the bare spawn decoded strictly, and `UnicodeDecodeError` slipped both

--- a/src/bmad_loop/bmadconfig.py
+++ b/src/bmad_loop/bmadconfig.py
@@ -134,6 +134,22 @@ def worktree_isolation_conflict(paths: ProjectPaths, isolation: str) -> str | No
     )
 
 
+def _canonical(expanded: Path, label: str) -> Path:
+    """Canonicalize-or-raise, the shared boundary for every ProjectPaths member.
+    `label` names what refused in the operator's terms — a configured string is
+    reported with its raw spelling, the default output folder as the default —
+    so the message never calls a path "configured" that nobody configured."""
+    try:
+        return expanded.resolve()
+    except (OSError, RuntimeError) as e:
+        raise BmadConfigError(
+            f"cannot canonicalize the {label} ({expanded}): {e} — "
+            "whether it lies inside or outside the project tree cannot be determined, "
+            "so no run can safely proceed. Run `bmad-loop validate` for what this "
+            "host is doing."
+        ) from e
+
+
 def _resolve(raw: str, project: Path) -> Path:
     """Expand `{project-root}` and canonicalize, or raise typed. A config string can
     name a UNC share of its own, independent of `--project`, so it refuses on the same
@@ -145,15 +161,7 @@ def _resolve(raw: str, project: Path) -> Path:
     sends a worktree-isolated run's artifact writes into a worktree-local directory
     instead of the configured destination. No member enters a snapshot unresolved."""
     expanded = Path(raw.replace("{project-root}", str(project)))
-    try:
-        return expanded.resolve()
-    except (OSError, RuntimeError) as e:
-        raise BmadConfigError(
-            f"cannot canonicalize the configured path {raw!r} ({expanded}): {e} — "
-            "whether it lies inside or outside the project tree cannot be determined, "
-            "so no run can safely proceed. Run `bmad-loop validate` for what this "
-            "host is doing."
-        ) from e
+    return _canonical(expanded, f"configured path {raw!r}")
 
 
 def load_paths(project: Path) -> ProjectPaths:
@@ -207,7 +215,7 @@ def load_paths(project: Path) -> ProjectPaths:
         # the default branch is a bare join off the (canonical) root and takes the
         # same canonicalize-or-raise treatment as a configured string: an in-tree
         # junction under the default name misclassifies exactly like a configured one.
-        else _resolve(str(project / "_bmad-output"), project)
+        else _canonical(project / "_bmad-output", "default output folder")
     )
     return ProjectPaths(
         project=project,

--- a/src/bmad_loop/bmadconfig.py
+++ b/src/bmad_loop/bmadconfig.py
@@ -102,16 +102,24 @@ def worktree_isolation_conflict(paths: ProjectPaths, isolation: str) -> str | No
     hand-built :class:`ProjectPaths` (tests) need not have."""
     if isolation != "worktree":
         return None
+    # The default config — no `repo_root` key, so `__post_init__` makes the two the
+    # same object — is settled here, before anything asks the OS. That is not just an
+    # optimization: the two calls below are independent, so a *transient*
+    # canonicalization failure between them (the guard catches every OSError, not only
+    # a persistent WinError 64) could have one side degrade to lexical while the other
+    # succeeds and canonicalizes, making one path unequal to itself and refusing an
+    # ordinary isolated run with the #414 text. Comparing raw first means the common
+    # shape cannot reach that window at all.
+    if paths.repo_root == paths.project:
+        return None
     # Same degrade as `load_paths` (#552): this gate runs in `cmd_validate` *before*
     # the platform preflight, so a raise here is the #332 finding going unreachable
-    # again for anyone on `isolation = "worktree"`. Both sides take the same
-    # treatment, so a host that cannot canonicalize compares lexical to lexical.
-    # What that costs, stated rather than hidden: on such a host the two spellings
-    # the test below pins (`p/../p` vs `p`) no longer fold together, so an override
-    # that merely respells the project directory would be refused with the #414 text
-    # — a wrong message, where the alternative is no message and no command at all.
-    # The default config never reaches it: with no `repo_root` key the two sides are
-    # the same object.
+    # again for anyone on `isolation = "worktree"`. Both sides take the same treatment,
+    # so a host that cannot canonicalize compares lexical to lexical. What that costs,
+    # stated rather than hidden: on such a host the two spellings the test above pins
+    # (`p/../p` vs `p`) no longer fold together, so a `repo_root` override that merely
+    # respells the project directory would be refused — a wrong message, where the
+    # alternative is no message and no command at all.
     if resolve_or_lexical(paths.repo_root) == resolve_or_lexical(paths.project):
         return None
     return (

--- a/src/bmad_loop/bmadconfig.py
+++ b/src/bmad_loop/bmadconfig.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 import yaml
 
+from .platform_util import resolve_or_lexical
+
 
 class BmadConfigError(Exception):
     pass
@@ -100,7 +102,17 @@ def worktree_isolation_conflict(paths: ProjectPaths, isolation: str) -> str | No
     hand-built :class:`ProjectPaths` (tests) need not have."""
     if isolation != "worktree":
         return None
-    if paths.repo_root.resolve() == paths.project.resolve():
+    # Same degrade as `load_paths` (#552): this gate runs in `cmd_validate` *before*
+    # the platform preflight, so a raise here is the #332 finding going unreachable
+    # again for anyone on `isolation = "worktree"`. Both sides take the same
+    # treatment, so a host that cannot canonicalize compares lexical to lexical.
+    # What that costs, stated rather than hidden: on such a host the two spellings
+    # the test below pins (`p/../p` vs `p`) no longer fold together, so an override
+    # that merely respells the project directory would be refused with the #414 text
+    # — a wrong message, where the alternative is no message and no command at all.
+    # The default config never reaches it: with no `repo_root` key the two sides are
+    # the same object.
+    if resolve_or_lexical(paths.repo_root) == resolve_or_lexical(paths.project):
         return None
     return (
         'isolation = "worktree" is not supported when repo_root differs from the project '
@@ -113,11 +125,19 @@ def worktree_isolation_conflict(paths: ProjectPaths, isolation: str) -> str | No
 
 
 def _resolve(raw: str, project: Path) -> Path:
-    return Path(raw.replace("{project-root}", str(project))).resolve()
+    """Expand `{project-root}` and canonicalize. A config string can name a UNC share
+    of its own, independent of `--project`, so it degrades on the same terms — see
+    `platform_util.resolve_or_lexical` (#552)."""
+    return resolve_or_lexical(raw.replace("{project-root}", str(project)))
 
 
 def load_paths(project: Path) -> ProjectPaths:
-    project = project.resolve()
+    # Degrades rather than raises when the OS cannot canonicalize (#552). `_project`
+    # already ran this, so on a host that refuses it the argument arriving here is
+    # the lexical form and a bare `.resolve()` would raise a second time — taking out
+    # `validate`, which loads paths before it reaches the finding that explains the
+    # host. See `platform_util.resolve_or_lexical` for the bounds of the degrade.
+    project = resolve_or_lexical(project)
     config_path = project / "_bmad" / "bmm" / "config.yaml"
     if not config_path.is_file():
         raise BmadConfigError(f"BMAD config not found: {config_path} (is BMAD installed here?)")
@@ -147,6 +167,6 @@ def load_paths(project: Path) -> ProjectPaths:
         project=project,
         implementation_artifacts=_resolve(str(impl), project),
         planning_artifacts=_resolve(str(plan), project),
-        output_folder=output_folder.resolve(),
+        output_folder=resolve_or_lexical(output_folder),
         repo_root=repo_root,
     )

--- a/src/bmad_loop/bmadconfig.py
+++ b/src/bmad_loop/bmadconfig.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import yaml
 
-from .platform_util import resolve_or_lexical, try_resolve
+from .platform_util import resolve_or_lexical
 
 
 class BmadConfigError(Exception):
@@ -112,14 +112,16 @@ def worktree_isolation_conflict(paths: ProjectPaths, isolation: str) -> str | No
     # shape cannot reach that window at all.
     if paths.repo_root == paths.project:
         return None
-    # Same degrade as `load_paths` (#552): this gate runs in `cmd_validate` *before*
+    # Degrades rather than raises (#552): this gate runs in `cmd_validate` *before*
     # the platform preflight, so a raise here is the #332 finding going unreachable
-    # again for anyone on `isolation = "worktree"`. Both sides take the same treatment,
-    # so a host that cannot canonicalize compares lexical to lexical. What that costs,
-    # stated rather than hidden: on such a host the two spellings the test above pins
-    # (`p/../p` vs `p`) no longer fold together, so a `repo_root` override that merely
-    # respells the project directory would be refused — a wrong message, where the
-    # alternative is no message and no command at all.
+    # again for anyone on `isolation = "worktree"`. A ProjectPaths built by
+    # `load_paths` arrives with both sides canonical (it raises otherwise), so the
+    # degrade below covers only hand-built instances and a share flapping between
+    # the load and this gate. Both sides take the same treatment, so a host that
+    # cannot canonicalize compares lexical to lexical; the cost, stated rather than
+    # hidden: two spellings that only canonicalization folds together (`p/../p` vs
+    # `p`) would be refused with a wrong message, where the alternative is no
+    # message and no command at all.
     if resolve_or_lexical(paths.repo_root) == resolve_or_lexical(paths.project):
         return None
     return (
@@ -132,35 +134,38 @@ def worktree_isolation_conflict(paths: ProjectPaths, isolation: str) -> str | No
     )
 
 
-def _resolve(raw: str, project: Path, *, canonical: bool) -> Path:
+def _resolve(raw: str, project: Path) -> Path:
     """Expand `{project-root}` and canonicalize. A config string can name a UNC share
     of its own, independent of `--project`, so it degrades on the same terms — see
-    `platform_util.resolve_or_lexical` (#552).
-
-    `canonical` says whether the project root itself canonicalized. When it did not,
-    this one does not even try: consistency across the returned ProjectPaths matters
-    more than canonicality of any single member, because `rebased` decides "is this
-    artifact dir inside the project" with `relative_to`, and a lexical project paired
-    with a canonical artifact path answers *no* either side of a symlink. That files an
-    in-tree artifact dir as externally configured, and a worktree-isolated run then
-    writes into the original checkout. The asymmetry only runs one way: a canonical
-    root paired with an artifact path that degrades is fine, because such a path is on
-    some other share and genuinely *is* outside the tree."""
+    `platform_util.resolve_or_lexical` (#552). The degrade is safe *here* because
+    `load_paths` guarantees `project` canonicalized before any config string is
+    resolved: a member that refuses is on some other share and genuinely *is* outside
+    the tree, which is exactly how `rebased`'s `relative_to` will file it."""
     expanded = Path(raw.replace("{project-root}", str(project)))
-    return resolve_or_lexical(expanded) if canonical else expanded.absolute()
+    return resolve_or_lexical(expanded)
 
 
 def load_paths(project: Path) -> ProjectPaths:
-    # Degrades rather than raises when the OS cannot canonicalize (#552). `_project`
-    # already ran this, so on a host that refuses it the argument arriving here is
-    # the lexical form and a bare `.resolve()` would raise a second time — taking out
-    # `validate`, which loads paths before it reaches the finding that explains the
-    # host. `try_resolve` rather than `resolve_or_lexical` because the *fact* of the
-    # refusal has to reach `_resolve` below; see its docstring for what a
-    # half-canonical ProjectPaths costs.
-    resolved = try_resolve(project)
-    canonical = resolved is not None
-    project = Path(project).absolute() if resolved is None else resolved
+    # The root must canonicalize or there is no consistent ProjectPaths to hand back
+    # (#552). Every member is compared against `project` — `rebased` decides "is this
+    # artifact dir inside the tree" with `relative_to` — so a lexical root next to a
+    # canonically spelled member (a resolved child, or an absolute path written
+    # canonically in config.yaml) sits on the far side of a symlink from it, files an
+    # in-tree artifact dir as external, and a worktree-isolated run then writes into
+    # the original checkout. Degrading here reopened that split once per review round;
+    # a typed raise closes every route at once, and it costs the diagnostic commands
+    # nothing: every caller already catches BmadConfigError — `cmd_validate` records
+    # the failure and still reaches the platform preflight that names the host — and
+    # `diagnose` never loads paths at all. Only `cli._project` still degrades: it runs
+    # pre-dispatch, where there is no handler to catch anything.
+    try:
+        project = Path(project).resolve()
+    except (OSError, RuntimeError) as e:
+        raise BmadConfigError(
+            f"cannot canonicalize the project root {project}: {e} — artifact paths "
+            "are derived from the canonical root, so no run can safely proceed. "
+            "Run `bmad-loop validate` for what this host is doing."
+        ) from e
     config_path = project / "_bmad" / "bmm" / "config.yaml"
     if not config_path.is_file():
         raise BmadConfigError(f"BMAD config not found: {config_path} (is BMAD installed here?)")
@@ -183,21 +188,19 @@ def load_paths(project: Path) -> ProjectPaths:
             f"{config_path} missing implementation_artifacts/planning_artifacts keys"
         )
     repo_root_raw = doc.get("repo_root")
-    repo_root = (
-        _resolve(str(repo_root_raw), project, canonical=canonical) if repo_root_raw else project
-    )
+    repo_root = _resolve(str(repo_root_raw), project) if repo_root_raw else project
     out_raw = doc.get("output_folder")
     output_folder = (
-        _resolve(str(out_raw), project, canonical=canonical)
+        _resolve(str(out_raw), project)
         if out_raw
-        else (project / "_bmad-output")
+        # the default branch is a bare join off the (canonical) root and takes the
+        # same per-member degrade as a configured string would.
+        else resolve_or_lexical(project / "_bmad-output")
     )
     return ProjectPaths(
         project=project,
-        implementation_artifacts=_resolve(str(impl), project, canonical=canonical),
-        planning_artifacts=_resolve(str(plan), project, canonical=canonical),
-        # already routed through `_resolve` when configured; the default branch is a
-        # bare join off `project` and needs the same one-spelling treatment.
-        output_folder=resolve_or_lexical(output_folder) if canonical else output_folder.absolute(),
+        implementation_artifacts=_resolve(str(impl), project),
+        planning_artifacts=_resolve(str(plan), project),
+        output_folder=output_folder,
         repo_root=repo_root,
     )

--- a/src/bmad_loop/bmadconfig.py
+++ b/src/bmad_loop/bmadconfig.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import yaml
 
-from .platform_util import resolve_or_lexical
+from .platform_util import resolve_or_lexical, try_resolve
 
 
 class BmadConfigError(Exception):
@@ -132,11 +132,22 @@ def worktree_isolation_conflict(paths: ProjectPaths, isolation: str) -> str | No
     )
 
 
-def _resolve(raw: str, project: Path) -> Path:
+def _resolve(raw: str, project: Path, *, canonical: bool) -> Path:
     """Expand `{project-root}` and canonicalize. A config string can name a UNC share
     of its own, independent of `--project`, so it degrades on the same terms — see
-    `platform_util.resolve_or_lexical` (#552)."""
-    return resolve_or_lexical(raw.replace("{project-root}", str(project)))
+    `platform_util.resolve_or_lexical` (#552).
+
+    `canonical` says whether the project root itself canonicalized. When it did not,
+    this one does not even try: consistency across the returned ProjectPaths matters
+    more than canonicality of any single member, because `rebased` decides "is this
+    artifact dir inside the project" with `relative_to`, and a lexical project paired
+    with a canonical artifact path answers *no* either side of a symlink. That files an
+    in-tree artifact dir as externally configured, and a worktree-isolated run then
+    writes into the original checkout. The asymmetry only runs one way: a canonical
+    root paired with an artifact path that degrades is fine, because such a path is on
+    some other share and genuinely *is* outside the tree."""
+    expanded = Path(raw.replace("{project-root}", str(project)))
+    return resolve_or_lexical(expanded) if canonical else expanded.absolute()
 
 
 def load_paths(project: Path) -> ProjectPaths:
@@ -144,8 +155,12 @@ def load_paths(project: Path) -> ProjectPaths:
     # already ran this, so on a host that refuses it the argument arriving here is
     # the lexical form and a bare `.resolve()` would raise a second time — taking out
     # `validate`, which loads paths before it reaches the finding that explains the
-    # host. See `platform_util.resolve_or_lexical` for the bounds of the degrade.
-    project = resolve_or_lexical(project)
+    # host. `try_resolve` rather than `resolve_or_lexical` because the *fact* of the
+    # refusal has to reach `_resolve` below; see its docstring for what a
+    # half-canonical ProjectPaths costs.
+    resolved = try_resolve(project)
+    canonical = resolved is not None
+    project = Path(project).absolute() if resolved is None else resolved
     config_path = project / "_bmad" / "bmm" / "config.yaml"
     if not config_path.is_file():
         raise BmadConfigError(f"BMAD config not found: {config_path} (is BMAD installed here?)")
@@ -168,13 +183,21 @@ def load_paths(project: Path) -> ProjectPaths:
             f"{config_path} missing implementation_artifacts/planning_artifacts keys"
         )
     repo_root_raw = doc.get("repo_root")
-    repo_root = _resolve(str(repo_root_raw), project) if repo_root_raw else project
+    repo_root = (
+        _resolve(str(repo_root_raw), project, canonical=canonical) if repo_root_raw else project
+    )
     out_raw = doc.get("output_folder")
-    output_folder = _resolve(str(out_raw), project) if out_raw else (project / "_bmad-output")
+    output_folder = (
+        _resolve(str(out_raw), project, canonical=canonical)
+        if out_raw
+        else (project / "_bmad-output")
+    )
     return ProjectPaths(
         project=project,
-        implementation_artifacts=_resolve(str(impl), project),
-        planning_artifacts=_resolve(str(plan), project),
-        output_folder=resolve_or_lexical(output_folder),
+        implementation_artifacts=_resolve(str(impl), project, canonical=canonical),
+        planning_artifacts=_resolve(str(plan), project, canonical=canonical),
+        # already routed through `_resolve` when configured; the default branch is a
+        # bare join off `project` and needs the same one-spelling treatment.
+        output_folder=resolve_or_lexical(output_folder) if canonical else output_folder.absolute(),
         repo_root=repo_root,
     )

--- a/src/bmad_loop/bmadconfig.py
+++ b/src/bmad_loop/bmadconfig.py
@@ -135,14 +135,25 @@ def worktree_isolation_conflict(paths: ProjectPaths, isolation: str) -> str | No
 
 
 def _resolve(raw: str, project: Path) -> Path:
-    """Expand `{project-root}` and canonicalize. A config string can name a UNC share
-    of its own, independent of `--project`, so it degrades on the same terms — see
-    `platform_util.resolve_or_lexical` (#552). The degrade is safe *here* because
-    `load_paths` guarantees `project` canonicalized before any config string is
-    resolved: a member that refuses is on some other share and genuinely *is* outside
-    the tree, which is exactly how `rebased`'s `relative_to` will file it."""
+    """Expand `{project-root}` and canonicalize, or raise typed. A config string can
+    name a UNC share of its own, independent of `--project`, so it refuses on the same
+    terms as the root in `load_paths` (#552). Degrading to the lexical spelling was
+    tried and retired: a spelling the OS cannot canonicalize has an *unknowable*
+    location — it can sit lexically inside the project while an in-tree symlink or
+    junction carries it to a dead share outside — so any in-tree/external answer
+    `rebased`'s `relative_to` reads off the spelling is a guess, and a wrong guess
+    sends a worktree-isolated run's artifact writes into a worktree-local directory
+    instead of the configured destination. No member enters a snapshot unresolved."""
     expanded = Path(raw.replace("{project-root}", str(project)))
-    return resolve_or_lexical(expanded)
+    try:
+        return expanded.resolve()
+    except (OSError, RuntimeError) as e:
+        raise BmadConfigError(
+            f"cannot canonicalize the configured path {raw!r} ({expanded}): {e} — "
+            "whether it lies inside or outside the project tree cannot be determined, "
+            "so no run can safely proceed. Run `bmad-loop validate` for what this "
+            "host is doing."
+        ) from e
 
 
 def load_paths(project: Path) -> ProjectPaths:
@@ -194,8 +205,9 @@ def load_paths(project: Path) -> ProjectPaths:
         _resolve(str(out_raw), project)
         if out_raw
         # the default branch is a bare join off the (canonical) root and takes the
-        # same per-member degrade as a configured string would.
-        else resolve_or_lexical(project / "_bmad-output")
+        # same canonicalize-or-raise treatment as a configured string: an in-tree
+        # junction under the default name misclassifies exactly like a configured one.
+        else _resolve(str(project / "_bmad-output"), project)
     )
     return ProjectPaths(
         project=project,

--- a/src/bmad_loop/cli.py
+++ b/src/bmad_loop/cli.py
@@ -71,7 +71,7 @@ from .documents import (
 from .engine import Engine
 from .journal import Journal, load_state, save_state
 from .model import RunState
-from .platform_util import MAX_SEGMENT
+from .platform_util import MAX_SEGMENT, resolve_or_lexical
 from .process_host import ProcessHostError
 
 # The run-composition helpers now live in runsetup.py (the library layer a non-CLI
@@ -129,7 +129,13 @@ class ExitCode(IntEnum):
 
 
 def _project(args: argparse.Namespace) -> Path:
-    return Path(args.project).resolve()
+    """The project root every handler works from, canonicalized.
+
+    Degrades rather than fails when the OS cannot canonicalize it — see
+    :func:`platform_util.resolve_or_lexical` for the decision and its bounds. This
+    is called from ``main()`` before dispatch, so a raise here takes out every
+    subcommand at the backstop, ``diagnose`` and ``validate`` included (#552)."""
+    return resolve_or_lexical(args.project)
 
 
 def _policy_path(project: Path) -> Path:

--- a/src/bmad_loop/platform_util.py
+++ b/src/bmad_loop/platform_util.py
@@ -188,11 +188,87 @@ def is_wsl_unc_path(value: str | Path) -> bool:
     of those match. An extended-length ``\\\\?\\UNC\\...`` prefix the input already
     carried (``ntpath.realpath`` only strips one it added itself) is folded down to the
     plain UNC form here, so that spelling matches too. A spelling this still misses
-    degrades gracefully: the ``mux.selection`` line names the platform regardless."""
+    degrades gracefully: the ``mux.selection`` line names the platform regardless.
+
+    One caller now passes an *un*resolved path: when the OS refuses to canonicalize,
+    :func:`resolve_or_lexical` degrades to ``absolute()``, which is the only way this
+    check runs at all on the host it is for (#552). All four bridge spellings still
+    match — they are already absolute — but the mapped-drive/``subst`` dereference is
+    gone, so a substituted drive letter over a *dead* provider goes unflagged. That is
+    the graceful-degradation case above, not a new one: the finding is a warning, and
+    ``mux.selection`` still names the platform."""
     text = str(value).replace("/", "\\").lower()
     if text.startswith("\\\\?\\unc\\"):
         text = "\\\\" + text[len("\\\\?\\unc\\") :]
     return text.startswith(("\\\\wsl.localhost\\", "\\\\wsl$\\"))
+
+
+# One note per degraded spelling per process. A single invocation canonicalizes the
+# project root at least three times — `main()` pre-dispatch, the handler's own
+# `_project`, then `load_paths` — and one condition must not print three lines.
+_LEXICAL_FALLBACK_NOTED: set[str] = set()
+
+
+def resolve_or_lexical(path: str | Path) -> Path:
+    """``Path(path).resolve()``, degrading to a *lexical* absolutization — and one
+    note on stderr — when the OS refuses to canonicalize the path (#552).
+
+    The condition this exists for: on a Windows host whose WSL UNC provider is
+    registered but not serving, resolving ``\\\\wsl$\\<distro>\\...`` raises
+    ``ERROR_NETNAME_DELETED`` (WinError 64). CPython's non-strict
+    ``ntpath._getfinalpathname_nonstrict`` re-raises any winerror outside its
+    allow-list, and 64 is not on it, so ``resolve()`` fails outright rather than
+    falling back to its own lexical walk. Reached from ``cli._project`` before
+    dispatch, that killed *every* subcommand at ``main()``'s backstop — including
+    ``diagnose`` and ``validate``, whose ``host.win32-on-wsl-path`` finding names
+    that exact host. The warning was unreachable on the only hosts it is for.
+
+    ``RuntimeError`` is caught alongside ``OSError`` because ``resolve()`` raises it,
+    not an ``OSError``, for a symlink loop on the 3.11/3.12 floor — the asymmetry
+    ``install._shield_undo_extension`` documents; the pair is this repo's house guard,
+    applied at 17-odd sites already.
+
+    **Degrade, not fail** — deliberately, and bounded. The fallback is exactly
+    ``Path(path).absolute()``: absolute, nothing else. It is enough for the
+    observation surface, because :func:`is_wsl_unc_path` is purely lexical and every
+    bridge spelling is already absolute, so ``absolute()`` hands it back untouched
+    (pathlib folds ``//wsl.localhost/...`` to the backslash form on the way). It is
+    *not* canonical, so this helper stays at the entry chokepoint — ``cli._project``
+    and ``bmadconfig.load_paths``. The write paths that need a canonical answer keep
+    their bare ``resolve()`` and still raise: ``runs.project_tag`` digests
+    ``str(project.resolve())`` into a session-ownership tag, and two spellings of one
+    project would strand live sessions. A ``run`` on such a host therefore still
+    fails loud a step later, while ``validate``/``diagnose`` now reach the finding
+    that explains it — observation degrades, repair writes raise.
+
+    **Rejected: ``normpath(absolute(path))``.** Collapsing ``..`` lexically is not a
+    respelling, it names a *different directory* whenever the ``..`` crosses a
+    symlink — measured, not reasoned: with ``/home/u/link -> /var/x``,
+    ``/home/u/link/../proj`` opens ``/var/proj``, and normpath yields
+    ``/home/u/proj``. The raw value reaching here is persisted as ``state.project``
+    and reused as a git repo root and a session cwd (``runsetup.build_run_state``,
+    ``runs``, ``resolve``), so that would be a silent wrong-directory write — a
+    failure class ``resolve()`` never had, introduced by the guard meant to soften
+    it. Plain ``absolute()`` keeps the ``..`` and lets the OS dereference it
+    correctly at every use, which is the whole reason to prefer it over a
+    prettier-looking string.
+
+    A relative ``path`` with an unreadable cwd still raises out of ``absolute()``:
+    there is no lexical answer to degrade to, and the backstop is the honest reply."""
+    try:
+        return Path(path).resolve()
+    except (OSError, RuntimeError) as e:
+        lexical = Path(path).absolute()
+        if str(lexical) not in _LEXICAL_FALLBACK_NOTED:
+            _LEXICAL_FALLBACK_NOTED.add(str(lexical))
+            # stderr, never stdout: `<cmd> --json` is a one-object-on-stdout contract.
+            print(
+                f"note: cannot canonicalize {path}: {e} — continuing with the lexical "
+                f"path {lexical} (symlinks are not dereferenced). "
+                "Run `bmad-loop validate` for what this host is doing.",
+                file=sys.stderr,
+            )
+        return lexical
 
 
 def _retry_on_sharing_violation(op: Callable[[], None]) -> None:

--- a/src/bmad_loop/platform_util.py
+++ b/src/bmad_loop/platform_util.py
@@ -204,8 +204,8 @@ def is_wsl_unc_path(value: str | Path) -> bool:
 
 
 # One note per degraded spelling per process. A single invocation canonicalizes the
-# project root at least three times — `main()` pre-dispatch, the handler's own
-# `_project`, then `load_paths` — and one condition must not print three lines.
+# project root at least twice — `main()` pre-dispatch, then the handler's own
+# `_project` — and one condition must not print two lines.
 _LEXICAL_FALLBACK_NOTED: set[str] = set()
 
 
@@ -233,13 +233,18 @@ def resolve_or_lexical(path: str | Path) -> Path:
     observation surface, because :func:`is_wsl_unc_path` is purely lexical and every
     bridge spelling is already absolute, so ``absolute()`` hands it back untouched
     (pathlib folds ``//wsl.localhost/...`` to the backslash form on the way). It is
-    *not* canonical, so this helper stays at the entry chokepoint — ``cli._project``
-    and ``bmadconfig.load_paths``. The write paths that need a canonical answer keep
-    their bare ``resolve()`` and still raise: ``runs.project_tag`` digests
-    ``str(project.resolve())`` into a session-ownership tag, and two spellings of one
-    project would strand live sessions. A ``run`` on such a host therefore still
-    fails loud a step later, while ``validate``/``diagnose`` now reach the finding
-    that explains it — observation degrades, repair writes raise.
+    *not* canonical, so this helper stays at the observation surface —
+    ``cli._project``, which runs pre-dispatch where there is no handler to catch
+    anything, and the configured artifact strings in ``bmadconfig._resolve``, where a
+    member that degrades beside a canonical root is genuinely on some other share.
+    The project root inside ``load_paths`` is the boundary: it raises a typed
+    ``BmadConfigError`` instead, because every artifact path is compared against the
+    root and a half-canonical snapshot is a silent wrong-directory write. The write
+    paths that need a canonical answer keep their bare ``resolve()`` and still raise:
+    ``runs.project_tag`` digests ``str(project.resolve())`` into a session-ownership
+    tag, and two spellings of one project would strand live sessions. So a ``run`` on
+    such a host fails loud at config load, while ``validate``/``diagnose`` still
+    reach the finding that explains it — observation degrades, repair writes raise.
 
     **Rejected: ``normpath(absolute(path))``.** Collapsing ``..`` lexically is not a
     respelling, it names a *different directory* whenever the ``..`` crosses a
@@ -255,24 +260,6 @@ def resolve_or_lexical(path: str | Path) -> Path:
 
     A relative ``path`` with an unreadable cwd still raises out of ``absolute()``:
     there is no lexical answer to degrade to, and the backstop is the honest reply."""
-    resolved = try_resolve(path)
-    return Path(path).absolute() if resolved is None else resolved
-
-
-def try_resolve(path: str | Path) -> Path | None:
-    """``Path(path).resolve()``, or ``None`` when the OS refuses it — emitting the same
-    one-note-per-process explanation as :func:`resolve_or_lexical`, which is built on
-    this.
-
-    Use it when the *fact* of the refusal changes what the caller does next, rather
-    than only the value. The one such caller is ``bmadconfig.load_paths``, which has to
-    hand back an internally consistent :class:`ProjectPaths`: if the project root
-    degrades to lexical while an artifact path underneath it canonicalizes, the two are
-    spelled either side of a symlink, ``ProjectPaths.rebased`` fails its
-    ``relative_to`` and files the artifact dir as configured *outside* the tree — so a
-    worktree-isolated run would write into the original checkout instead of its own
-    worktree. One snapshot, one spelling. Everywhere else the value is all the caller
-    needs, and :func:`resolve_or_lexical` is the shorter way to ask."""
     try:
         return Path(path).resolve()
     except (OSError, RuntimeError) as e:
@@ -286,7 +273,7 @@ def try_resolve(path: str | Path) -> Path | None:
                 "Run `bmad-loop validate` for what this host is doing.",
                 file=sys.stderr,
             )
-        return None
+        return lexical
 
 
 def _retry_on_sharing_violation(op: Callable[[], None]) -> None:

--- a/src/bmad_loop/platform_util.py
+++ b/src/bmad_loop/platform_util.py
@@ -255,6 +255,24 @@ def resolve_or_lexical(path: str | Path) -> Path:
 
     A relative ``path`` with an unreadable cwd still raises out of ``absolute()``:
     there is no lexical answer to degrade to, and the backstop is the honest reply."""
+    resolved = try_resolve(path)
+    return Path(path).absolute() if resolved is None else resolved
+
+
+def try_resolve(path: str | Path) -> Path | None:
+    """``Path(path).resolve()``, or ``None`` when the OS refuses it — emitting the same
+    one-note-per-process explanation as :func:`resolve_or_lexical`, which is built on
+    this.
+
+    Use it when the *fact* of the refusal changes what the caller does next, rather
+    than only the value. The one such caller is ``bmadconfig.load_paths``, which has to
+    hand back an internally consistent :class:`ProjectPaths`: if the project root
+    degrades to lexical while an artifact path underneath it canonicalizes, the two are
+    spelled either side of a symlink, ``ProjectPaths.rebased`` fails its
+    ``relative_to`` and files the artifact dir as configured *outside* the tree — so a
+    worktree-isolated run would write into the original checkout instead of its own
+    worktree. One snapshot, one spelling. Everywhere else the value is all the caller
+    needs, and :func:`resolve_or_lexical` is the shorter way to ask."""
     try:
         return Path(path).resolve()
     except (OSError, RuntimeError) as e:
@@ -268,7 +286,7 @@ def resolve_or_lexical(path: str | Path) -> Path:
                 "Run `bmad-loop validate` for what this host is doing.",
                 file=sys.stderr,
             )
-        return lexical
+        return None
 
 
 def _retry_on_sharing_violation(op: Callable[[], None]) -> None:

--- a/src/bmad_loop/platform_util.py
+++ b/src/bmad_loop/platform_util.py
@@ -235,12 +235,14 @@ def resolve_or_lexical(path: str | Path) -> Path:
     (pathlib folds ``//wsl.localhost/...`` to the backslash form on the way). It is
     *not* canonical, so this helper stays at the observation surface —
     ``cli._project``, which runs pre-dispatch where there is no handler to catch
-    anything, and the configured artifact strings in ``bmadconfig._resolve``, where a
-    member that degrades beside a canonical root is genuinely on some other share.
-    The project root inside ``load_paths`` is the boundary: it raises a typed
-    ``BmadConfigError`` instead, because every artifact path is compared against the
-    root and a half-canonical snapshot is a silent wrong-directory write. The write
-    paths that need a canonical answer keep their bare ``resolve()`` and still raise:
+    anything, and ``bmadconfig.worktree_isolation_conflict``'s comparison, which must
+    not kill ``validate`` ahead of the platform preflight. ``bmadconfig.load_paths``
+    is the boundary and refuses instead — a typed ``BmadConfigError`` for the project
+    root *and* every configured path: a spelling the OS cannot canonicalize has an
+    unknowable location (it can sit lexically inside the project while an in-tree
+    junction carries it to a dead share outside), and classifying it by its spelling
+    is a guess that can redirect a worktree-isolated run's writes. The write paths
+    that need a canonical answer keep their bare ``resolve()`` and still raise:
     ``runs.project_tag`` digests ``str(project.resolve())`` into a session-ownership
     tag, and two spellings of one project would strand live sessions. So a ``run`` on
     such a host fails loud at config load, while ``validate``/``diagnose`` still

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import pytest
 import yaml
 
-from bmad_loop import cli, documents
+from bmad_loop import cli, documents, platform_util
 from bmad_loop.adapters.base import SessionResult, SessionSpec
 from bmad_loop.bmadconfig import ProjectPaths
 from bmad_loop.checks import ValidationReport
@@ -320,6 +320,32 @@ def project(tmp_path: Path, _project_template: Path) -> ProjectPaths:
         implementation_artifacts=root / "_bmad-output" / "implementation-artifacts",
         planning_artifacts=root / "_bmad-output" / "planning-artifacts",
     )
+
+
+UNRESOLVABLE = "stubbed: the provider is registered but not serving"
+
+
+def refuse_to_resolve(monkeypatch, *targets: Path) -> None:
+    """Make ``Path.resolve()`` raise WinError 64 for exactly ``targets`` — the answer
+    a registered-but-not-serving WSL UNC provider gives (#529/#536), and one CPython's
+    non-strict ``ntpath`` allow-list does not absorb, so ``resolve()`` fails outright
+    instead of degrading to its own lexical walk. That is the #552 condition.
+
+    Scoped to named paths on purpose: a blanket stub would break every unrelated
+    resolve in the process, and a row asserting "the command survived" would then pass
+    for a reason that has nothing to do with the guard under test. Also clears the
+    one-note-per-process dedupe set, so a row can assert on a note a previous test in
+    the same session would otherwise have consumed."""
+    real = Path.resolve
+    wanted = {str(t) for t in targets}
+
+    def stub(self, strict: bool = False):
+        if str(self) in wanted:
+            raise OSError(0, UNRESOLVABLE, None, 64)
+        return real(self, strict=strict)
+
+    monkeypatch.setattr(Path, "resolve", stub)
+    monkeypatch.setattr(platform_util, "_LEXICAL_FALLBACK_NOTED", set())
 
 
 def install_bmad_config(paths: ProjectPaths) -> None:

--- a/tests/test_bmadconfig.py
+++ b/tests/test_bmadconfig.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from conftest import install_bmad_config
+from conftest import install_bmad_config, refuse_to_resolve
 
 from bmad_loop import bmadconfig
 from bmad_loop.bmadconfig import ProjectPaths
@@ -121,3 +121,81 @@ def test_worktree_isolation_conflict_compares_normalized_paths(tmp_path: Path) -
     )
     assert paths.repo_root != paths.project, "the two spellings really are different"
     assert bmadconfig.worktree_isolation_conflict(paths, "worktree") is None
+
+
+# ------------- a project root the OS refuses to canonicalize (#552) -------------
+
+
+def _write_config(root: Path, **keys: str) -> None:
+    """The `_bmad/bmm/config.yaml` `load_paths` reads, with arbitrary key overrides —
+    `install_bmad_config` hard-codes `{project-root}` forms, and these rows need a
+    config string that names somewhere else entirely."""
+    body = {
+        "implementation_artifacts": "{project-root}/_bmad-output/implementation-artifacts",
+        "planning_artifacts": "{project-root}/_bmad-output/planning-artifacts",
+        **keys,
+    }
+    cfg = root / "_bmad" / "bmm"
+    cfg.mkdir(parents=True, exist_ok=True)
+    (cfg / "config.yaml").write_text(
+        "".join(f"{k}: '{v}'\n" for k, v in body.items()), encoding="utf-8"
+    )
+
+
+def test_load_paths_degrades_rather_than_re_raising(tmp_path: Path, monkeypatch) -> None:
+    """Hardening `cli._project` alone would not have been enough: `load_paths`
+    re-resolves the very same root, so on the failing host the second call raised the
+    exception the first one had just absorbed — straight past every caller's
+    `except BmadConfigError` and into `main()`'s backstop. `cmd_validate` loads paths
+    before it reaches the platform preflight, so this sits on the critical path for
+    the #332 finding rather than beside it."""
+    root = tmp_path / "p"
+    root.mkdir()
+    _write_config(root)
+    refuse_to_resolve(monkeypatch, root)
+
+    paths = bmadconfig.load_paths(root)
+
+    assert paths.project == root
+    assert paths.implementation_artifacts == root / "_bmad-output" / "implementation-artifacts"
+    assert paths.output_folder == root / "_bmad-output"
+
+
+def test_worktree_isolation_conflict_degrades_rather_than_re_raising(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """`cmd_validate` runs this gate *before* the platform preflight, so under
+    `isolation = "worktree"` a raise here put the #332 finding back out of reach for
+    exactly the operators it is written for. The default shape is what is pinned:
+    no `repo_root` key, so both sides are the project and the gate must pass."""
+    root = tmp_path / "p"
+    root.mkdir()
+    paths = ProjectPaths(
+        project=root,
+        implementation_artifacts=root / "impl",
+        planning_artifacts=root / "plan",
+        output_folder=root / "out",
+    )
+    refuse_to_resolve(monkeypatch, root)
+
+    assert bmadconfig.worktree_isolation_conflict(paths, "worktree") is None
+
+
+def test_load_paths_degrades_for_a_config_path_that_is_itself_unresolvable(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """`_resolve` needs the same treatment as the project root, and not for the same
+    reason: `implementation_artifacts`, `planning_artifacts`, `output_folder` and
+    `repo_root` are arbitrary operator strings, so one of them can name a dead share
+    while `--project` points at a perfectly healthy local directory. Pinned with the
+    project root left resolvable so only the config string can be what degrades."""
+    root = tmp_path / "p"
+    root.mkdir()
+    share = tmp_path / "elsewhere" / "impl"
+    _write_config(root, implementation_artifacts=str(share))
+    refuse_to_resolve(monkeypatch, share)
+
+    paths = bmadconfig.load_paths(root)
+
+    assert paths.implementation_artifacts == share
+    assert paths.project == root.resolve(), "the healthy root still canonicalizes"

--- a/tests/test_bmadconfig.py
+++ b/tests/test_bmadconfig.py
@@ -142,23 +142,26 @@ def _write_config(root: Path, **keys: str) -> None:
     )
 
 
-def test_load_paths_degrades_rather_than_re_raising(tmp_path: Path, monkeypatch) -> None:
+def test_load_paths_raises_typed_when_the_root_cannot_canonicalize(
+    tmp_path: Path, monkeypatch
+) -> None:
     """Hardening `cli._project` alone would not have been enough: `load_paths`
-    re-resolves the very same root, so on the failing host the second call raised the
-    exception the first one had just absorbed — straight past every caller's
-    `except BmadConfigError` and into `main()`'s backstop. `cmd_validate` loads paths
-    before it reaches the platform preflight, so this sits on the critical path for
-    the #332 finding rather than beside it."""
+    re-resolves the very same root, so on the failing host the second call raised a
+    bare OSError — straight past every caller's `except BmadConfigError` and into
+    `main()`'s backstop. The raise stays, but *typed*, which is the whole fix: every
+    caller already catches BmadConfigError, `cmd_validate` records the failure and
+    still reaches the platform preflight that names the host, and `diagnose` never
+    loads paths at all. Degrading instead was tried and retired — a lexical root
+    beside any canonically spelled member is a half-canonical snapshot that `rebased`
+    mis-files, sending a worktree-isolated run's writes into the original checkout,
+    and each review round found another route to that split."""
     root = tmp_path / "p"
     root.mkdir()
     _write_config(root)
     refuse_to_resolve(monkeypatch, root)
 
-    paths = bmadconfig.load_paths(root)
-
-    assert paths.project == root
-    assert paths.implementation_artifacts == root / "_bmad-output" / "implementation-artifacts"
-    assert paths.output_folder == root / "_bmad-output"
+    with pytest.raises(bmadconfig.BmadConfigError, match="cannot canonicalize"):
+        bmadconfig.load_paths(root)
 
 
 def test_worktree_isolation_conflict_degrades_rather_than_re_raising(
@@ -249,19 +252,22 @@ def test_load_paths_degrades_for_a_config_path_that_is_itself_unresolvable(
     assert paths.project == root.resolve(), "the healthy root still canonicalizes"
 
 
-def test_load_paths_keeps_one_spelling_when_the_root_degrades(tmp_path: Path, monkeypatch) -> None:
-    """A ProjectPaths must be internally consistent, not maximally canonical.
+def test_load_paths_refuses_a_degraded_root_beside_canonically_spelled_config_paths(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The route no per-member plumbing could cover, pinned so the raise never quietly
+    becomes a degrade again: an *explicit absolute* artifact path written in
+    config.yaml in canonical spelling needs no `.resolve()` call to arrive canonical.
+    Had the root degraded to its lexical spelling instead of raising, the snapshot
+    would be half-canonical with the two spellings either side of the symlink —
+    `rebased`'s `relative_to` files the in-tree artifact dir as external, and a
+    worktree-isolated run writes into the original checkout. Silent, and a write.
+    Refusing the root is the one boundary that closes this route and every future
+    one at once.
 
-    If the project root degrades to lexical while the artifact paths underneath it
-    canonicalize, the two end up spelled either side of a symlink. `rebased` decides
-    "does this artifact dir live inside the project" with `relative_to`, that answers
-    *no*, and the dir is filed as configured outside the tree and left where it is — so
-    a worktree-isolated run writes into the original checkout instead of its own
-    worktree. Silent, and a write.
-
-    The symlinked root is what makes the row bite: with a canonical `tmp_path` the
-    lexical and resolved spellings are the same string and a half-canonical
-    ProjectPaths would be indistinguishable from a consistent one."""
+    The symlinked root is what makes the row bite: on a canonical `tmp_path` the
+    lexical and canonical spellings are the same string, and the row would stay green
+    with the raise ablated back to a degrade."""
     target = tmp_path / "target"
     target.mkdir()
     root = tmp_path / "p"
@@ -269,19 +275,13 @@ def test_load_paths_keeps_one_spelling_when_the_root_degrades(tmp_path: Path, mo
         root.symlink_to(target, target_is_directory=True)
     except OSError as e:  # Windows without SeCreateSymbolicLink / developer mode
         pytest.skip(f"cannot create a symlink here: {e}")
-    _write_config(root)
-    # Only the root refuses. The artifact paths beneath it resolve perfectly well, and
-    # that is precisely the split that produced the mismatch.
+    # The operator wrote the artifact dir absolutely, already in canonical spelling —
+    # no resolve() is involved in it arriving canonical. Only the root refuses.
+    _write_config(
+        root,
+        implementation_artifacts=str(target / "_bmad-output" / "implementation-artifacts"),
+    )
     refuse_to_resolve(monkeypatch, root)
 
-    paths = bmadconfig.load_paths(root)
-
-    assert paths.implementation_artifacts.is_relative_to(paths.project)
-    assert paths.planning_artifacts.is_relative_to(paths.project)
-    assert paths.output_folder.is_relative_to(paths.project)
-    # the consequence itself, not just the spelling: rebasing onto a worktree has to
-    # move the artifact dirs rather than file them as external
-    moved = paths.rebased(tmp_path / "wt")
-    assert moved.implementation_artifacts == tmp_path / "wt" / "_bmad-output" / (
-        "implementation-artifacts"
-    )
+    with pytest.raises(bmadconfig.BmadConfigError, match="cannot canonicalize"):
+        bmadconfig.load_paths(root)

--- a/tests/test_bmadconfig.py
+++ b/tests/test_bmadconfig.py
@@ -247,3 +247,41 @@ def test_load_paths_degrades_for_a_config_path_that_is_itself_unresolvable(
 
     assert paths.implementation_artifacts == share
     assert paths.project == root.resolve(), "the healthy root still canonicalizes"
+
+
+def test_load_paths_keeps_one_spelling_when_the_root_degrades(tmp_path: Path, monkeypatch) -> None:
+    """A ProjectPaths must be internally consistent, not maximally canonical.
+
+    If the project root degrades to lexical while the artifact paths underneath it
+    canonicalize, the two end up spelled either side of a symlink. `rebased` decides
+    "does this artifact dir live inside the project" with `relative_to`, that answers
+    *no*, and the dir is filed as configured outside the tree and left where it is — so
+    a worktree-isolated run writes into the original checkout instead of its own
+    worktree. Silent, and a write.
+
+    The symlinked root is what makes the row bite: with a canonical `tmp_path` the
+    lexical and resolved spellings are the same string and a half-canonical
+    ProjectPaths would be indistinguishable from a consistent one."""
+    target = tmp_path / "target"
+    target.mkdir()
+    root = tmp_path / "p"
+    try:
+        root.symlink_to(target, target_is_directory=True)
+    except OSError as e:  # Windows without SeCreateSymbolicLink / developer mode
+        pytest.skip(f"cannot create a symlink here: {e}")
+    _write_config(root)
+    # Only the root refuses. The artifact paths beneath it resolve perfectly well, and
+    # that is precisely the split that produced the mismatch.
+    refuse_to_resolve(monkeypatch, root)
+
+    paths = bmadconfig.load_paths(root)
+
+    assert paths.implementation_artifacts.is_relative_to(paths.project)
+    assert paths.planning_artifacts.is_relative_to(paths.project)
+    assert paths.output_folder.is_relative_to(paths.project)
+    # the consequence itself, not just the spelling: rebasing onto a worktree has to
+    # move the artifact dirs rather than file them as external
+    moved = paths.rebased(tmp_path / "wt")
+    assert moved.implementation_artifacts == tmp_path / "wt" / "_bmad-output" / (
+        "implementation-artifacts"
+    )

--- a/tests/test_bmadconfig.py
+++ b/tests/test_bmadconfig.py
@@ -160,7 +160,9 @@ def test_load_paths_raises_typed_when_the_root_cannot_canonicalize(
     _write_config(root)
     refuse_to_resolve(monkeypatch, root)
 
-    with pytest.raises(bmadconfig.BmadConfigError, match="cannot canonicalize"):
+    # the full prefix, not just "cannot canonicalize": _resolve raises a message
+    # sharing that stem for a configured path, and this row pins the ROOT boundary
+    with pytest.raises(bmadconfig.BmadConfigError, match="cannot canonicalize the project root"):
         bmadconfig.load_paths(root)
 
 
@@ -299,5 +301,6 @@ def test_load_paths_refuses_a_degraded_root_beside_canonically_spelled_config_pa
     )
     refuse_to_resolve(monkeypatch, root)
 
-    with pytest.raises(bmadconfig.BmadConfigError, match="cannot canonicalize"):
+    # the full prefix: this row pins the ROOT refusing, not a member's shared stem
+    with pytest.raises(bmadconfig.BmadConfigError, match="cannot canonicalize the project root"):
         bmadconfig.load_paths(root)

--- a/tests/test_bmadconfig.py
+++ b/tests/test_bmadconfig.py
@@ -8,9 +8,9 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from conftest import install_bmad_config, refuse_to_resolve
+from conftest import UNRESOLVABLE, install_bmad_config, refuse_to_resolve
 
-from bmad_loop import bmadconfig
+from bmad_loop import bmadconfig, platform_util
 from bmad_loop.bmadconfig import ProjectPaths
 from bmad_loop.workspace import Workspace
 
@@ -162,7 +162,7 @@ def test_load_paths_degrades_rather_than_re_raising(tmp_path: Path, monkeypatch)
 
 
 def test_worktree_isolation_conflict_degrades_rather_than_re_raising(
-    tmp_path: Path, monkeypatch
+    tmp_path: Path, monkeypatch, capsys
 ) -> None:
     """`cmd_validate` runs this gate *before* the platform preflight, so under
     `isolation = "worktree"` a raise here put the #332 finding back out of reach for
@@ -179,6 +179,54 @@ def test_worktree_isolation_conflict_degrades_rather_than_re_raising(
     refuse_to_resolve(monkeypatch, root)
 
     assert bmadconfig.worktree_isolation_conflict(paths, "worktree") is None
+    assert capsys.readouterr().err == "", "the default shape must not ask the OS at all"
+
+
+def test_worktree_isolation_conflict_survives_a_flapping_resolve(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """The two `resolve_or_lexical` calls below the short-circuit are independent, and
+    the guard catches every `OSError` rather than only a persistent WinError 64. So a
+    provider that fails on one call and answers on the next would have one side degrade
+    to lexical while the other canonicalized — making a path unequal to *itself* and
+    refusing an ordinary isolated run with the #414 text. Comparing raw paths first is
+    what keeps the default shape out of that window.
+
+    The stub fails exactly once, which is the whole scenario: `repo_root` and `project`
+    are the same object here, so any disagreement between the two calls is spurious by
+    construction."""
+    # The root must be reached through a symlink or the row is vacuous: on a canonical
+    # tmp_path the lexical and resolved spellings are the same string, so the two sides
+    # would agree even when one degraded and the other did not, and deleting the
+    # short-circuit would leave this green.
+    target = tmp_path / "target"
+    target.mkdir()
+    root = tmp_path / "p"
+    try:
+        root.symlink_to(target, target_is_directory=True)
+    except OSError as e:  # Windows without SeCreateSymbolicLink / developer mode
+        pytest.skip(f"cannot create a symlink here: {e}")
+    assert root.resolve() != root, "the two spellings really are different"
+
+    paths = ProjectPaths(
+        project=root,
+        implementation_artifacts=root / "impl",
+        planning_artifacts=root / "plan",
+        output_folder=root / "out",
+    )
+    real = Path.resolve
+    failures = [OSError(0, UNRESOLVABLE, None, 64)]
+
+    def flaky(self, strict: bool = False):
+        if str(self) == str(root) and failures:
+            raise failures.pop()
+        return real(self, strict=strict)
+
+    monkeypatch.setattr(Path, "resolve", flaky)
+    monkeypatch.setattr(platform_util, "_LEXICAL_FALLBACK_NOTED", set())
+
+    assert bmadconfig.worktree_isolation_conflict(paths, "worktree") is None
+    assert failures, "the flap never fired — the short-circuit answered first"
 
 
 def test_load_paths_degrades_for_a_config_path_that_is_itself_unresolvable(

--- a/tests/test_bmadconfig.py
+++ b/tests/test_bmadconfig.py
@@ -232,24 +232,40 @@ def test_worktree_isolation_conflict_survives_a_flapping_resolve(
     assert failures, "the flap never fired — the short-circuit answered first"
 
 
-def test_load_paths_degrades_for_a_config_path_that_is_itself_unresolvable(
-    tmp_path: Path, monkeypatch
+@pytest.mark.parametrize(
+    "spelling",
+    [
+        # an absolute path elsewhere: a config string can name a dead share of its
+        # own while `--project` points at a perfectly healthy local directory
+        "external-absolute",
+        # the round-4 shape: spelled *inside* the project, where an in-tree symlink
+        # or junction can carry it to a dead share outside — degrading to this
+        # spelling made `rebased` file it as internal, and a worktree-isolated run
+        # then wrote a worktree-local directory instead of the configured one
+        "in-tree-token",
+    ],
+)
+def test_load_paths_refuses_a_config_path_it_cannot_canonicalize(
+    spelling: str, tmp_path: Path, monkeypatch
 ) -> None:
-    """`_resolve` needs the same treatment as the project root, and not for the same
-    reason: `implementation_artifacts`, `planning_artifacts`, `output_folder` and
-    `repo_root` are arbitrary operator strings, so one of them can name a dead share
-    while `--project` points at a perfectly healthy local directory. Pinned with the
-    project root left resolvable so only the config string can be what degrades."""
+    """`_resolve` takes the same boundary as the project root, and not for the same
+    reason: a config string the OS cannot canonicalize has an *unknowable* location —
+    its lexical spelling can sit inside the project while its target lies outside —
+    so any in-tree/external classification read off the spelling is a guess, and
+    `rebased` acting on a wrong guess is a silent wrong-directory write. Pinned with
+    the project root left resolvable so only the config string is what refuses."""
     root = tmp_path / "p"
     root.mkdir()
-    share = tmp_path / "elsewhere" / "impl"
-    _write_config(root, implementation_artifacts=str(share))
-    refuse_to_resolve(monkeypatch, share)
+    if spelling == "external-absolute":
+        target = tmp_path / "elsewhere" / "impl"
+        _write_config(root, implementation_artifacts=str(target))
+    else:
+        target = root.resolve() / "artifacts"
+        _write_config(root, implementation_artifacts="{project-root}/artifacts")
+    refuse_to_resolve(monkeypatch, target)
 
-    paths = bmadconfig.load_paths(root)
-
-    assert paths.implementation_artifacts == share
-    assert paths.project == root.resolve(), "the healthy root still canonicalizes"
+    with pytest.raises(bmadconfig.BmadConfigError, match="cannot canonicalize the configured"):
+        bmadconfig.load_paths(root)
 
 
 def test_load_paths_refuses_a_degraded_root_beside_canonically_spelled_config_paths(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@
 import argparse
 import io
 import json
+import ntpath
 import os
 import sys
 import types
@@ -11,6 +12,7 @@ from pathlib import Path
 import pytest
 import yaml
 from conftest import (
+    UNRESOLVABLE,
     escalated_run,
     fault_read_text,
     git,
@@ -20,6 +22,7 @@ from conftest import (
     install_dev_shim,
     machine_json,
     mark_ledger_done,
+    refuse_to_resolve,
     spec_path,
     write_gated_ledger,
     write_ledger,
@@ -27,7 +30,7 @@ from conftest import (
     write_sprint,
 )
 
-from bmad_loop import cli
+from bmad_loop import cli, platform_util
 from bmad_loop import policy as policy_mod
 from bmad_loop import runsetup
 from bmad_loop.adapters import multiplexer as mux_mod
@@ -7450,3 +7453,87 @@ def test_dry_run_banner_names_the_isolation_refusal_first(project, capsys):
     assert REFUSAL in fails[0]
     assert len(fails) > 1, "the base-skill problems the banner already reported"
     assert "1-1-a" in out  # the schedule itself still rendered
+
+
+# ------------------- a project root the OS refuses to canonicalize (#552) --------
+
+
+def test_project_degrades_when_the_os_cannot_canonicalize(monkeypatch, capsys, tmp_path):
+    """`_project` runs inside `main()` before dispatch, so a raise here took out every
+    subcommand at the broad backstop — `diagnose` and `validate` included, which are
+    the two that name the host responsible."""
+    refuse_to_resolve(monkeypatch, tmp_path)
+
+    got = cli._project(argparse.Namespace(project=str(tmp_path)))
+
+    assert got == tmp_path
+    assert UNRESOLVABLE in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("command", ["validate", "diagnose"])
+def test_diagnostic_commands_survive_an_unresolvable_project_root(
+    command, project, monkeypatch, capsys
+):
+    """The regression itself. Both commands exist to tell an operator what is wrong
+    with their host; on the one host that answers WinError 64 they were the two that
+    could not run. Asserted through `--json` because it proves three things at once:
+    the handler reached its end, the document is whole, and the stderr note did not
+    leak onto the one-object-on-stdout surface."""
+    install_bmad_config(project)
+    # `diagnose` has an early "no runs found" exit that would let it pass this row
+    # without ever building a document; give it one to report on.
+    escalated_run(project.project)
+    refuse_to_resolve(monkeypatch, project.project)
+
+    rc = cli.main([command, "--json", "--project", str(project.project)])
+
+    captured = capsys.readouterr()
+    # The pre-fix shape: nothing on stdout, `error: [WinError 64] ...` on stderr, rc 1.
+    assert f"error: {UNRESOLVABLE}" not in captured.err
+    assert "cannot canonicalize" in captured.err
+    doc = json.loads(captured.out)  # raises if the note leaked to stdout
+    assert doc["schema_version"] >= 1
+    assert rc in (0, 1)  # a verdict of either kind is a handler that ran
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="UNC resolution is a Windows behavior")
+@pytest.mark.parametrize(
+    "spelling",
+    [
+        "\\\\wsl.localhost\\Ubuntu-24.04\\home\\u\\proj",
+        "\\\\wsl$\\Ubuntu-24.04\\home\\u\\proj",
+    ],
+)
+def test_project_degrades_on_a_real_unc_refusal(spelling, monkeypatch, capsys):
+    """The whole bug, on the platform that has it, through real `Path.resolve()`.
+
+    Technique borrowed from the #536 guards in `test_platform_util.py`: stub the
+    syscall wrapper rather than aim at a live provider, so the row cannot flake on
+    whether a distro happens to be serving on the runner. Unlike those guards this one
+    answers ERROR_NETNAME_DELETED (64), which is *off* `ntpath`'s non-strict
+    allow-list — that is the difference between `realpath` degrading to its own
+    lexical walk and `realpath` raising, and raising is #552. No `_nt_readlink` stub
+    is needed here for exactly that reason: the walk never starts.
+
+    The final assertion is the point of the whole change. `host.win32-on-wsl-path` is
+    the finding that explains this host, `is_wsl_unc_path` is its predicate, and the
+    predicate has to still match what the fallback returns or the command survives
+    with nothing to say."""
+    calls: list[str] = []
+
+    def dead_provider(path):
+        calls.append(path)
+        raise OSError(0, "stubbed: the provider is registered but not serving", None, 64)
+
+    monkeypatch.setattr(ntpath, "_getfinalpathname", dead_provider)
+    monkeypatch.setattr(platform_util, "_LEXICAL_FALLBACK_NOTED", set())
+
+    got = cli._project(argparse.Namespace(project=spelling))
+
+    # Ablation guard: a pathlib that stopped routing resolve() through ntpath would
+    # leave the stub unused, resolve() would succeed, and everything below would pass
+    # while pinning nothing about the degrade.
+    assert calls, "resolve() no longer reaches ntpath._getfinalpathname"
+    assert str(got) == spelling, "absolute() must hand an already-absolute path back whole"
+    assert platform_util.is_wsl_unc_path(got) is True
+    assert "cannot canonicalize" in capsys.readouterr().err

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7496,6 +7496,32 @@ def test_diagnostic_commands_survive_an_unresolvable_project_root(
     assert rc in (0, 1)  # a verdict of either kind is a handler that ran
 
 
+def test_validate_records_the_refused_root_and_still_reaches_later_gates(
+    project, monkeypatch, capsys
+):
+    """The property the typed raise in `load_paths` has to preserve — the reason #552
+    exists: `cmd_validate` catches the BmadConfigError, records it as the
+    `bmad-config` finding, and keeps going, so the gates after the config load (the
+    platform preflight among them) still run on the one host that needs their
+    findings. Pinned on the document rather than the prose: the failure is recorded
+    AND a later gate contributed a finding of its own."""
+    install_bmad_config(project)
+    refuse_to_resolve(monkeypatch, project.project)
+
+    rc = cli.main(["validate", "--json", "--project", str(project.project)])
+
+    doc = json.loads(capsys.readouterr().out)
+    by_check = {}
+    for finding in doc["findings"]:
+        by_check.setdefault(finding["check"], finding)
+    assert by_check["bmad-config"]["severity"] == "problem"
+    assert "cannot canonicalize" in by_check["bmad-config"]["message"]
+    # policy loads after the config gate; its presence is the handler continuing
+    # past the raise rather than dying on it
+    assert "policy" in by_check
+    assert rc == 1
+
+
 @pytest.mark.skipif(sys.platform != "win32", reason="UNC resolution is a Windows behavior")
 @pytest.mark.parametrize(
     "spelling",

--- a/tests/test_platform_util.py
+++ b/tests/test_platform_util.py
@@ -12,7 +12,7 @@ import os
 import stat
 import subprocess
 import sys
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 
 import pytest
 
@@ -1051,3 +1051,126 @@ def test_safe_ref_segment_output_passes_git_check_ref_format(value, template):
         text=True,
     )
     assert proc.returncode == 0, f"{value!r} -> {branch!r}: {proc.stderr.strip()}"
+
+
+# ----------------------------------------------------- resolve_or_lexical (#552)
+
+# One string, asserted on, so a row proves the *cause* reached stderr rather than
+# just that some note did.
+_REFUSAL = "stubbed: the provider is registered but not serving"
+
+
+@pytest.fixture
+def unnoted(monkeypatch):
+    """A clean note-dedupe set. The real one is module state that lives as long as the
+    process, so without this the second test to degrade the same path in a session
+    would assert on a note the first one already consumed."""
+    monkeypatch.setattr(platform_util, "_LEXICAL_FALLBACK_NOTED", set())
+
+
+def _refusing_resolve(exc):
+    def stub(self, strict=False):
+        raise exc
+
+    return stub
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        # What a registered-but-not-serving WSL UNC provider answers. 64 is *off*
+        # ntpath's non-strict allow-list, so resolve() raises rather than falling
+        # back to its own lexical walk — the whole reason this helper exists.
+        OSError(0, _REFUSAL, None, 64),
+        # resolve() raises this, not an OSError, for a symlink loop on the 3.11/3.12
+        # floor. A guard that caught OSError alone would be a floor-only hole.
+        RuntimeError(_REFUSAL),
+    ],
+    ids=["oserror-winerror-64", "runtimeerror-symlink-loop"],
+)
+def test_resolve_or_lexical_degrades_when_the_os_refuses(exc, monkeypatch, capsys, tmp_path):
+    monkeypatch.setattr(platform_util, "_LEXICAL_FALLBACK_NOTED", set())
+    monkeypatch.setattr(Path, "resolve", _refusing_resolve(exc))
+
+    got = platform_util.resolve_or_lexical(tmp_path / "a" / ".." / "b")
+
+    # `..` is *kept*, not collapsed: see the rejected-normpath note on the helper —
+    # folding it lexically names a different directory across a symlink, and this
+    # value is persisted as state.project and reused as a repo root and a cwd.
+    assert got == tmp_path / "a" / ".." / "b"
+    assert got.is_absolute()
+    captured = capsys.readouterr()
+    assert captured.out == ""  # `<cmd> --json` is a one-object-on-stdout contract
+    assert _REFUSAL in captured.err, "the note must carry the cause, not just its own text"
+    assert "cannot canonicalize" in captured.err
+
+
+def test_resolve_or_lexical_keeps_a_relative_path_relative_to_the_cwd(monkeypatch, capsys, unnoted):
+    """`--project` defaults to `"."`, so the degraded path is the common case, not an
+    edge one. `absolute()` is what supplies the root that `resolve()` would have."""
+    monkeypatch.setattr(Path, "resolve", _refusing_resolve(OSError(0, _REFUSAL, None, 64)))
+    assert platform_util.resolve_or_lexical(".") == Path.cwd()
+
+
+def test_resolve_or_lexical_notes_once_per_process(monkeypatch, capsys, tmp_path, unnoted):
+    """One condition, one line. A single invocation canonicalizes the project root at
+    least three times — `main()`'s pre-dispatch `_configure_mux`, the handler's own
+    `_project`, then `load_paths` — and three copies of one note reads as three
+    faults."""
+    monkeypatch.setattr(Path, "resolve", _refusing_resolve(OSError(0, _REFUSAL, None, 64)))
+
+    for _ in range(3):
+        platform_util.resolve_or_lexical(tmp_path)
+
+    assert capsys.readouterr().err.count("cannot canonicalize") == 1
+
+
+def test_resolve_or_lexical_notes_each_distinct_path(monkeypatch, capsys, tmp_path, unnoted):
+    """The dedupe is per path, not a one-shot latch: a second, different path that also
+    degrades is a second thing the operator has not been told about."""
+    monkeypatch.setattr(Path, "resolve", _refusing_resolve(OSError(0, _REFUSAL, None, 64)))
+
+    platform_util.resolve_or_lexical(tmp_path / "a")
+    platform_util.resolve_or_lexical(tmp_path / "b")
+
+    assert capsys.readouterr().err.count("cannot canonicalize") == 2
+
+
+def test_resolve_or_lexical_prefers_the_real_resolve(tmp_path, capsys, unnoted):
+    """The fallback is a fallback. On a working OS this is `Path.resolve()` — symlink
+    dereference included — and it says nothing. Without the second assertion the row
+    would still pass if the helper had degraded, since both answers are absolute."""
+    real = tmp_path / "real"
+    real.mkdir()
+    link = tmp_path / "link"
+    try:
+        link.symlink_to(real, target_is_directory=True)
+    except OSError as e:  # Windows without SeCreateSymbolicLink / developer mode
+        pytest.skip(f"cannot create a symlink here: {e}")
+
+    got = platform_util.resolve_or_lexical(link)
+
+    assert got == real.resolve()
+    assert got != link.absolute(), "took the lexical branch on a host that can resolve"
+    assert capsys.readouterr().err == ""
+
+
+@pytest.mark.parametrize(
+    "spelling",
+    [
+        "\\\\wsl.localhost\\Ubuntu-24.04\\home",
+        "\\\\wsl$\\Ubuntu-24.04\\home",
+        "//wsl.localhost/Ubuntu-24.04/home",
+        "\\\\?\\UNC\\wsl.localhost\\Ubuntu-24.04\\home",
+    ],
+)
+def test_the_lexical_fallback_keeps_every_bridge_spelling_matchable(spelling):
+    """The premise the whole degrade rests on, pinned platform-blind so a Linux run
+    catches a regression too. `absolute()` returns an already-absolute path untouched,
+    so `is_wsl_unc_path` — the #332 predicate, and the reason these commands must live
+    long enough to run — still matches what the fallback hands it. Uses the pure
+    Windows flavour because the real `absolute()` needs a Windows host; the flavour is
+    what decides `is_absolute` and the separator fold, which is the whole claim."""
+    pure = PureWindowsPath(spelling)
+    assert pure.is_absolute(), "absolute() would prepend a POSIX cwd and destroy the prefix"
+    assert platform_util.is_wsl_unc_path(pure) is True


### PR DESCRIPTION
Closes #552

## The decision, re-made after three review rounds

The boundary moved. The first design **degraded** at both entry sites (`cli._project` and `bmadconfig.load_paths`); three codex rounds then found three distinct routes for the degraded root to sit beside a canonically spelled member of the same `ProjectPaths` — a second resolve call (round 1), a canonicalized child (round 2), and an absolute artifact path written canonically in `config.yaml` (round 3), which no `canonical=` plumbing can reach because no `resolve()` call is involved in it arriving canonical. Same harm every time: `rebased`'s `relative_to` files an in-tree artifact dir as external, and a worktree-isolated run writes into the original checkout. Three routes to one split is evidence about the design, not a defect queue, so the design changed:

- **`bmadconfig.load_paths` now raises a typed `BmadConfigError`** when the project root will not canonicalize. No degraded root ever enters a snapshot, so no half-canonical `ProjectPaths` is constructible by any route — the three found, and any not yet found.
- **`cli._project` keeps the degrade** — it runs pre-dispatch, where there is no handler to catch anything, and degrading there is what lets `diagnose`/`validate` run at all on the affected host. Bounded exactly as before: fallback is `absolute()`, one deduped note on stderr.
- **Configured artifact strings refuse on the same terms** (`_resolve` raises the same typed error; round 4). The per-member degrade shipped first, on the assumption that a member refusing beside a canonical root is genuinely external — which holds only when its *lexical spelling* is external. Round 4's counterexample: a member spelled in-tree (`{project-root}/artifacts`) whose in-tree symlink or junction targets a dead share fails `resolve()`, degrades to its in-tree spelling, and `rebased` files it as internal — under worktree isolation the untracked junction is absent from the checkout, so artifact writes land in a fresh worktree-local directory instead of the configured destination. When `resolve()` fails the true location is unknowable; classifying by spelling is a guess. A `ProjectPaths` is now fully canonical or absent.

The #552 goal survives intact, verified not assumed: every `load_paths` caller already catches `BmadConfigError`; `cmd_validate` records the `bmad-config` failure, sets `paths = None`, and continues to the **ungated** `_platform_preflight` where the `host.win32-on-wsl-path` finding lives; `diagnose` never loads paths at all (proved by ablation). A new end-to-end row pins the property on the `--json` document: the `bmad-config` problem finding *and* a later gate's finding in the same document.

The doctrine line still holds — *observation may degrade, repair writes must raise* — the raise just happens at config load now instead of one step later, with a name and a remediation instead of a bare `OSError` at the backstop.

### The invariant, and where it stops

A `ProjectPaths` built by `load_paths` is **fully canonical or absent** — root and every member (since round 4; the first redesign push kept a per-member degrade). Downstream re-resolves of members (e.g. `verify.spec_within_roots`' roots loop, #557) are therefore redundant on a fresh snapshot; their residual exposure is transient faults and the 3.11/3.12 symlink-loop `RuntimeError`, not a persistently degraded member.

`ProjectPaths.rebased` is deliberately **not** hardened: it computes paths for a worktree being provisioned, which is a repair write, and raising there is correct. Whether that raise should be *typed* is #555's question.

## The fallback is `absolute()`, not `normpath(absolute())`

The issue suggested normpath. Measured, and rejected: collapsing `..` lexically is not a respelling, it names a **different directory** whenever the `..` crosses a symlink.

```
/home/u/link -> /var/x
/home/u/link/../proj   absolute() opens /var/proj   (correct)
                       normpath   yields /home/u/proj (different directory)
```

Reproduced with a marker file in each: `absolute()` reads `REAL`, `normpath` reads `WRONG`. The raw `_project` value is persisted as `state.project` and later reused as a git repo root (`runs`) and a session cwd (`resolve.py`), so normpath would have introduced a silent wrong-directory write — a failure class `resolve()` never had, added by the guard meant to soften it. Plain `absolute()` keeps the `..` and lets the OS dereference it correctly at every use.

All four bridge spellings are already absolute, so `absolute()` hands them back whole and the #332 predicate still matches (pinned platform-blind via `PureWindowsPath`).

## Scope

| site | treatment | why |
| --- | --- | --- |
| `cli._project` | degrade + one stderr note | the front door; runs pre-dispatch, no handler above it |
| `load_paths` (project root) | **typed raise** | every member is compared against the root; a degraded root beside any canonical spelling is a silent wrong-directory write |
| `_resolve` (config strings) | **typed raise** (round 4) | arbitrary operator paths with unknowable locations when they refuse — an in-tree spelling can hide an external target behind an in-tree junction, and a spelling-based classification redirects isolated-run writes |
| `worktree_isolation_conflict` | raw compare first, then degrade | gates `validate` ahead of the preflight; a `load_paths`-built ProjectPaths arrives canonical, so the degrade covers hand-built instances and flapping shares |

`try_resolve` is folded back into `resolve_or_lexical` — after the redesign it had exactly one caller left.

### One cost, stated rather than hidden

On a host that cannot canonicalize, `worktree_isolation_conflict` compares lexical to lexical, so a `repo_root` override that merely *respells* the project directory (`p/../p` vs `p`) would be refused with the #414 text — a wrong message where the alternative is no message and no command at all. The default config never reaches it: with no `repo_root` key both sides are the same object, compared raw before the OS is asked.

## Tests

Lowest layer that catches the regression, platform-blind:

- `test_platform_util.py` — the degrade on both `OSError` **and** `RuntimeError` (the 3.11/3.12 symlink-loop asymmetry), `..` kept not collapsed, the note deduped once per process but not latched across distinct paths, stdout kept clean, and the happy path still taking the real `resolve()`.
- `test_bmadconfig.py` — the typed raise on an unresolvable root; the round-3 route pinned exactly (symlinked root + an absolute artifact path written in canonical spelling in config.yaml → `BmadConfigError`, never a half-canonical snapshot); the round-4 refusal for an unresolvable config string under a healthy root, in both spellings (external-absolute, and in-tree via `{project-root}` — the junction shape); `worktree_isolation_conflict`'s raw-compare short-circuit and flap survival.
- `test_cli.py` — `_project`; `validate --json` and `diagnose --json` end to end on a refusing root (document parses, pre-fix `error:` shape absent); and the load-bearing property of the redesign: validate's document carries the `bmad-config` problem finding **and** a later gate's finding, i.e. the handler kept going past the raise.
- One win32 row reusing #536's technique — stub `ntpath._getfinalpathname` to answer 64, never a live provider. No `_nt_readlink` stub is needed: 64 is off the allow-list so the lexical walk never starts (verified against installed CPython source).

The stub helper is shared from `conftest.refuse_to_resolve` and is scoped to named paths — a blanket `Path.resolve` stub would make "the command survived" pass for reasons unrelated to the guard.

**Ablation:** the raise was ablated back to the old degrade and all three new rows reddened (`DID NOT RAISE`, and the validate document row); restored green. The symlinked-root discipline from rounds 2–3 is kept: on a canonical `tmp_path` the lexical and canonical spellings are the same string and these rows would prove nothing.

`uv run pytest -q -n auto`: 5103 passed, 43 skipped, 5 xfailed. `uv run pyright`: clean. `trunk check`: clean.

## Review rounds

All three codex findings were real, all the same class — a degraded root reaching a write-path decision beside a canonical spelling:

**Round 1 (P2, fixed)** — `worktree_isolation_conflict` resolved twice independently; a transient failure between the calls could make a path unequal to itself and refuse an ordinary isolated run. Fixed by comparing raw paths first. That fix stands on its own and is kept.

**Round 2 (P2, fixed)** — `load_paths` could return a half-canonical snapshot when the root degraded and a child canonicalized. Fixed then by threading `canonical=` so members skipped canonicalization when the root failed.

**Round 3 (P2, fixed by redesign)** — an absolute artifact path spelled canonically in config.yaml arrives canonical with no `resolve()` involved, so the round-2 plumbing cannot touch it. This is the round that showed the class cannot be closed member-by-member: the fix is that a degraded root no longer produces a snapshot at all. The round-2 `canonical=` threading is deleted as superseded — the raise closes rounds 2 and 3 by the same boundary, and codex's own suggested remedy ("refuse write-capable isolation after degraded root resolution") is the weaker form of it.

**Round 4 — one accepted, one declined on the facts.** Accepted: the per-member degrade in `_resolve` classified an unresolvable member by its lexical spelling; an in-tree spelling hiding an external target behind an in-tree junction gets filed as internal and isolated-run writes are redirected — `_resolve` now raises the same typed error as the root (see above). Declined: restricting `_project`'s lexical fallback to read-only commands — verified handler by handler, every named mutating command either dies loud at an existing resolve boundary (`delete`/`archive` via `accepted_tags` → `project.resolve()`, `clean` via `load_paths`) or performs direct file I/O through the lexical spelling, which the OS dereferences to the same files (`stop` acts on run-dir contents; `mux set` writes the same policy.toml; a `--force` rmtree targets a name-resolved run dir). The wrong-target class needs a spelling *comparison*, and every comparison site resolves-and-raises; making those raises typed is #559's scope.

## Residual, filed separately

Issue #552's inventory was re-verified against this base and is accurate but incomplete — six further unguarded `resolve()` site families were found and filed as #555–#560 rather than swept into this PR. Each was re-audited against this redesign: none is subsumed (they resolve worktree mounts, run dirs, operator seed strings, agent-reported spec files, and TUI poll paths — not the project root), and none belongs in this diff. Two get narrower under the redesign (`runs.project_tag` becomes unreachable-degraded from `run`'s path since `runsetup` loads paths first; `verify.py`'s `paths.project.resolve()` becomes a redundant re-resolve) — noted on the issues themselves.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Windows WSL and UNC paths when canonical resolution is unavailable.
  * Commands such as `validate` and `diagnose` can continue and report results despite path-resolution failures.
  * Preserved parent-directory components and WSL mapped-drive detection during fallback handling.
  * Added clearer errors when operations requiring canonical paths cannot proceed.

* **Documentation**
  * Added an unreleased changelog entry describing the updated path-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->