### PR TITLE
fix: validate limits policy scalar types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ breaking changes may land in a minor release.
 
 ### Fixed
 
+- **Reject mismatched TOML scalar types for every `limits.*` policy field (#278).**
+  Quoted booleans and other coercible values now raise `PolicyError` instead of silently changing
+  the configured limit or enabling a disabled behavior.
+
 - **Attempt-owned spec-only retries no longer demand a false manual rollback (#123).** A
   bound plain attempt whose only residue is its lifecycle flip is restored to its pre-attempt
   lifecycle status and proven Git-clean before retry. A resolved re-drive may instead retain an

--- a/src/bmad_loop/policy.py
+++ b/src/bmad_loop/policy.py
@@ -666,6 +666,34 @@ def _validate_plugin_settings(name: str, raw: dict[str, Any], specs: Any) -> Non
             )
 
 
+def _limit_int(raw: dict[str, Any], key: str, default: int) -> int:
+    value = raw.get(key, default)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise PolicyError(f"limits.{key} must be an integer: got {value!r}")
+    return value
+
+
+def _limit_float(raw: dict[str, Any], key: str, default: float) -> float:
+    value = raw.get(key, default)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise PolicyError(f"limits.{key} must be a number: got {value!r}")
+    return float(value)
+
+
+def _limit_bool(raw: dict[str, Any], key: str, default: bool) -> bool:
+    value = raw.get(key, default)
+    if not isinstance(value, bool):
+        raise PolicyError(f"limits.{key} must be a boolean: got {value!r}")
+    return value
+
+
+def _limit_str(raw: dict[str, Any], key: str, default: str) -> str:
+    value = raw.get(key, default)
+    if not isinstance(value, str):
+        raise PolicyError(f"limits.{key} must be a string: got {value!r}")
+    return value
+
+
 def load(path: Path | None) -> Policy:
     """Load policy from a TOML file; a missing file yields all defaults.
 
@@ -730,63 +758,46 @@ def loads(text: str, plugin_schemas: dict[str, Any] | None = None) -> Policy:
             f"gates.retrospective must be one of {sorted(RETRO_MODES)}: got {gates.retrospective!r}"
         )
 
-    # the budget knobs gate enforce-mode termination, so a coerced bool/float
-    # (true -> 1 token) must be rejected, not silently accepted (same rule as
-    # scm.preserve_keep below). The per-story cap is checked here on the same
-    # terms even though it only warns: a coerced `true` caps a whole story at 1
-    # token, which now fires at the first session boundary of every story.
-    max_tokens_per_story = limits_d.get("max_tokens_per_story", LimitsPolicy.max_tokens_per_story)
-    if isinstance(max_tokens_per_story, bool) or not isinstance(max_tokens_per_story, int):
-        raise PolicyError(
-            f"limits.max_tokens_per_story must be an integer: got {max_tokens_per_story!r}"
-        )
-    max_tokens_per_session = limits_d.get(
-        "max_tokens_per_session", LimitsPolicy.max_tokens_per_session
-    )
-    if isinstance(max_tokens_per_session, bool) or not isinstance(max_tokens_per_session, int):
-        raise PolicyError(
-            f"limits.max_tokens_per_session must be an integer: got {max_tokens_per_session!r}"
-        )
-    session_budget_grace_s = limits_d.get(
-        "session_budget_grace_s", LimitsPolicy.session_budget_grace_s
-    )
-    if isinstance(session_budget_grace_s, bool) or not isinstance(session_budget_grace_s, int):
-        raise PolicyError(
-            f"limits.session_budget_grace_s must be an integer: got {session_budget_grace_s!r}"
-        )
-
     limits = LimitsPolicy(
-        max_review_cycles=int(limits_d.get("max_review_cycles", LimitsPolicy.max_review_cycles)),
-        max_dev_attempts=int(limits_d.get("max_dev_attempts", LimitsPolicy.max_dev_attempts)),
-        max_followup_reviews=int(
-            limits_d.get("max_followup_reviews", LimitsPolicy.max_followup_reviews)
+        max_review_cycles=_limit_int(limits_d, "max_review_cycles", LimitsPolicy.max_review_cycles),
+        max_dev_attempts=_limit_int(limits_d, "max_dev_attempts", LimitsPolicy.max_dev_attempts),
+        max_followup_reviews=_limit_int(
+            limits_d, "max_followup_reviews", LimitsPolicy.max_followup_reviews
         ),
-        session_timeout_min=int(
-            limits_d.get("session_timeout_min", LimitsPolicy.session_timeout_min)
+        session_timeout_min=_limit_int(
+            limits_d, "session_timeout_min", LimitsPolicy.session_timeout_min
         ),
-        git_timeout_s=int(limits_d.get("git_timeout_s", LimitsPolicy.git_timeout_s)),
-        teardown_grace_s=int(limits_d.get("teardown_grace_s", LimitsPolicy.teardown_grace_s)),
-        stop_without_result_nudges=int(
-            limits_d.get("stop_without_result_nudges", LimitsPolicy.stop_without_result_nudges)
+        git_timeout_s=_limit_int(limits_d, "git_timeout_s", LimitsPolicy.git_timeout_s),
+        teardown_grace_s=_limit_int(limits_d, "teardown_grace_s", LimitsPolicy.teardown_grace_s),
+        stop_without_result_nudges=_limit_int(
+            limits_d, "stop_without_result_nudges", LimitsPolicy.stop_without_result_nudges
         ),
-        dev_stall_grace_s=int(limits_d.get("dev_stall_grace_s", LimitsPolicy.dev_stall_grace_s)),
-        dev_stall_nudges=int(limits_d.get("dev_stall_nudges", LimitsPolicy.dev_stall_nudges)),
-        dev_stall_nudges_cap=int(
-            limits_d.get("dev_stall_nudges_cap", LimitsPolicy.dev_stall_nudges_cap)
+        dev_stall_grace_s=_limit_int(limits_d, "dev_stall_grace_s", LimitsPolicy.dev_stall_grace_s),
+        dev_stall_nudges=_limit_int(limits_d, "dev_stall_nudges", LimitsPolicy.dev_stall_nudges),
+        dev_stall_nudges_cap=_limit_int(
+            limits_d, "dev_stall_nudges_cap", LimitsPolicy.dev_stall_nudges_cap
         ),
-        workflow_stall_nudges_cap=int(
-            limits_d.get("workflow_stall_nudges_cap", LimitsPolicy.workflow_stall_nudges_cap)
+        workflow_stall_nudges_cap=_limit_int(
+            limits_d, "workflow_stall_nudges_cap", LimitsPolicy.workflow_stall_nudges_cap
         ),
-        dev_contract_nudge=bool(
-            limits_d.get("dev_contract_nudge", LimitsPolicy.dev_contract_nudge)
+        dev_contract_nudge=_limit_bool(
+            limits_d, "dev_contract_nudge", LimitsPolicy.dev_contract_nudge
         ),
-        max_tokens_per_story=max_tokens_per_story,
-        cache_read_weight=float(limits_d.get("cache_read_weight", LimitsPolicy.cache_read_weight)),
-        session_budget_mode=str(
-            limits_d.get("session_budget_mode", LimitsPolicy.session_budget_mode)
+        max_tokens_per_story=_limit_int(
+            limits_d, "max_tokens_per_story", LimitsPolicy.max_tokens_per_story
         ),
-        max_tokens_per_session=max_tokens_per_session,
-        session_budget_grace_s=session_budget_grace_s,
+        cache_read_weight=_limit_float(
+            limits_d, "cache_read_weight", LimitsPolicy.cache_read_weight
+        ),
+        session_budget_mode=_limit_str(
+            limits_d, "session_budget_mode", LimitsPolicy.session_budget_mode
+        ),
+        max_tokens_per_session=_limit_int(
+            limits_d, "max_tokens_per_session", LimitsPolicy.max_tokens_per_session
+        ),
+        session_budget_grace_s=_limit_int(
+            limits_d, "session_budget_grace_s", LimitsPolicy.session_budget_grace_s
+        ),
     )
     if limits.max_review_cycles < 1 or limits.max_dev_attempts < 1:
         raise PolicyError("limits.max_review_cycles and limits.max_dev_attempts must be >= 1")

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -435,6 +435,41 @@ def test_dev_contract_nudge_default_parse_and_template():
     assert doc["limits"]["dev_contract_nudge"] == policy.LimitsPolicy.dev_contract_nudge
 
 
+def test_dev_contract_nudge_rejects_non_boolean():
+    with pytest.raises(policy.PolicyError, match=r"limits\.dev_contract_nudge must be a boolean"):
+        policy.loads('[limits]\ndev_contract_nudge = "false"\n')
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "max_review_cycles",
+        "max_dev_attempts",
+        "max_followup_reviews",
+        "session_timeout_min",
+        "git_timeout_s",
+        "teardown_grace_s",
+        "stop_without_result_nudges",
+        "dev_stall_grace_s",
+        "dev_stall_nudges",
+        "dev_stall_nudges_cap",
+        "workflow_stall_nudges_cap",
+        "max_tokens_per_story",
+        "max_tokens_per_session",
+        "session_budget_grace_s",
+    ],
+)
+def test_limits_integer_fields_reject_non_integer(key):
+    with pytest.raises(policy.PolicyError, match=rf"limits\.{key} must be an integer"):
+        policy.loads(f'[limits]\n{key} = "1"\n')
+
+
+@pytest.mark.parametrize("bad", ["true", '"0.5"'])
+def test_cache_read_weight_rejects_non_number(bad):
+    with pytest.raises(policy.PolicyError, match=r"limits\.cache_read_weight must be a number"):
+        policy.loads(f"[limits]\ncache_read_weight = {bad}\n")
+
+
 def test_session_budget_mode_default_parse_and_template():
     import tomllib
 
@@ -450,6 +485,11 @@ def test_session_budget_mode_default_parse_and_template():
 def test_invalid_session_budget_mode():
     with pytest.raises(policy.PolicyError, match=r"limits\.session_budget_mode"):
         policy.loads('[limits]\nsession_budget_mode = "sometimes"\n')
+
+
+def test_session_budget_mode_rejects_non_string():
+    with pytest.raises(policy.PolicyError, match=r"limits\.session_budget_mode must be a string"):
+        policy.loads("[limits]\nsession_budget_mode = 1\n")
 
 
 def test_max_tokens_per_story_default_and_parse():

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -436,10 +436,13 @@ def test_dev_contract_nudge_default_parse_and_template():
 
 
 def test_dev_contract_nudge_rejects_non_boolean():
+    """Ablation: delete `_limit_bool`'s conditional and raise, retaining
+    `return value`; this test fails because the string is returned unchanged."""
     with pytest.raises(policy.PolicyError, match=r"limits\.dev_contract_nudge must be a boolean"):
         policy.loads('[limits]\ndev_contract_nudge = "false"\n')
 
 
+@pytest.mark.parametrize("bad", ["true", "1.5", '"1"'])
 @pytest.mark.parametrize(
     "key",
     [
@@ -459,15 +462,26 @@ def test_dev_contract_nudge_rejects_non_boolean():
         "session_budget_grace_s",
     ],
 )
-def test_limits_integer_fields_reject_non_integer(key):
+def test_limits_integer_fields_reject_non_integer(key, bad):
+    """Ablation: delete `_limit_int`'s conditional and raise, retaining
+    `return value`; all rows fail because bad scalars are accepted or reach
+    downstream validation without the required integer `PolicyError`."""
     with pytest.raises(policy.PolicyError, match=rf"limits\.{key} must be an integer"):
-        policy.loads(f'[limits]\n{key} = "1"\n')
+        policy.loads(f"[limits]\n{key} = {bad}\n")
 
 
 @pytest.mark.parametrize("bad", ["true", '"0.5"'])
 def test_cache_read_weight_rejects_non_number(bad):
+    """Ablation: delete `_limit_float`'s conditional and raise; both rows fail
+    because `float` accepts the boolean and quoted-number values."""
     with pytest.raises(policy.PolicyError, match=r"limits\.cache_read_weight must be a number"):
         policy.loads(f"[limits]\ncache_read_weight = {bad}\n")
+
+
+def test_cache_read_weight_accepts_integer_as_float():
+    value = policy.loads("[limits]\ncache_read_weight = 1\n").limits.cache_read_weight
+    assert value == 1.0
+    assert isinstance(value, float)
 
 
 def test_session_budget_mode_default_parse_and_template():
@@ -488,6 +502,8 @@ def test_invalid_session_budget_mode():
 
 
 def test_session_budget_mode_rejects_non_string():
+    """Ablation: delete `_limit_str`'s conditional and raise; this test fails
+    because the downstream options check raises a different `PolicyError`."""
     with pytest.raises(policy.PolicyError, match=r"limits\.session_budget_mode must be a string"):
         policy.loads("[limits]\nsession_budget_mode = 1\n")
 


### PR DESCRIPTION
## What

Reject TOML scalar-type mismatches across every `limits.*` policy field before constructing `LimitsPolicy`.

## Why

Bare `int()`, `float()`, `str()`, and `bool()` coercions could silently change policy meaning. In particular, `dev_contract_nudge = "false"` evaluated to true.

Fixes #278

## How

- Route integer, number, boolean, and string limits through strict type validators.
- Preserve the existing range and option checks after type validation.
- Cover every integer field with TOML boolean, float, and quoted-integer cases, plus the number, boolean, and string validators.
- Record single-gate ablation evidence for all four scalar validators.

## Testing

Local candidate `66faf2ca44973e4d03854a0f0d0d5484072e5d8b`:

- `uv sync --all-extras --locked`
- `uv run pytest tests/test_policy.py tests/test_settings_schema.py -q` — 193 passed
- `uv run pytest -q -n auto --durations=15`
- `uv run pyright`
- `trunk check --all`
- `uv run python scripts/release.py check`
- `git diff --check`

[Exact-head CI run 32089380448](https://github.com/bmad-code-org/bmad-loop/actions/runs/32089380448) passed on the same SHA:

- Ubuntu Python 3.11, 3.12, 3.13, and 3.14
- Native Windows Python 3.11 and 3.14
- Pyright, trunk lint, version-sync, and packaging
- Both Windows jobs used `PYTHONUTF8=1` and completed the full deterministic suite with 5,799 passed, 200 skipped, and zero failures
- CodeRabbit completed successfully with no new actionable comments

No macOS CI result is claimed.

## Changelog

Added a Fixed entry under Unreleased.

AI assistance was used; I reviewed the resulting diff and tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Policy limit settings now reject mismatched TOML value types instead of silently converting them.
  * Invalid integer, numeric, boolean, and string values consistently report clear policy errors.
  * Existing defaults and range validation remain unchanged.

* **Documentation**
  * Added changelog coverage for stricter policy type validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->