### PR TITLE
fix: stop sixteen writers truncating or stranding what they rewrite (#363, #379)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,16 +82,16 @@ breaking changes may land in a minor release.
   rather than dropping it. Nothing else would ever surface that — `validate` reports a board parked
   with no record, but never a record left over for a park that is in no commit.
 
-- **Five writers under `.bmad-loop/` no longer strand an untracked temp when their replace fails
+- **Four writers under `.bmad-loop/` no longer strand an untracked temp when their replace fails
   (#363).** Each built a fixed-name temp and then `os.replace`d it, and `atomic_replace` does no
   cleanup of its own. No ignore rule covers those names — `init` writes `.bmad-loop/runs/`,
   `.bmad-loop/cache/`, `.bmad-loop/policy.toml` and `_bmad/render/` — so a failed replace left an
   untracked file holding `verify.worktree_clean` False until a human deleted it by hand.
 
-  - Four route through the helpers, which name the temp uniquely per write and remove it on any
-    raise: the pre-answer store (`decisions.json`), both of the sweep's `decisions.json` writes,
-    `policy.toml`'s `[mux] backend` writer, and the TUI settings editor's save. The last two built
-    the _same_ `.bmad-loop/policy.toml.tmp` path, so they could also collide with each other.
+  - Three route through the helpers, which name the temp uniquely per write and remove it on any
+    raise: the pre-answer store (`.bmad-loop/decisions.json`), `policy.toml`'s `[mux] backend`
+    writer, and the TUI settings editor's save. The last two built the _same_
+    `.bmad-loop/policy.toml.tmp` path, so they could also collide with each other.
   - `archive_run` keeps writing its own tarball — the path goes to `tarfile.open`, so there is no
     payload for a helper to take — and gains the unlink-on-raise guard instead. Its temp was also
     misnamed: `with_suffix` replaces only the last suffix, so `<id>.tar.gz` yielded
@@ -100,10 +100,12 @@ breaking changes may land in a minor release.
   Under a monorepo `repo_root:` override this surfaces as a failing `validate` and TUI rather than
   a blocked `run`: `run` and `sweep` probe the repo root, `validate` and the TUI probe the project.
 
-  Three more temp-and-replace writers were hardened the same way without having been exposed — the
-  two park-record writers behind `bmad-loop confirm` and `drop`, and `devcontract`'s spec writer.
-  They gain the fsync before the replace, a unique temp name in place of a fixed `.tmp` sibling two
-  concurrent writers would collide on, and the shared unlink-on-raise in place of a hand-rolled one.
+  Five more temp-and-replace writers took the same helper without having been exposed: the sweep's
+  two `decisions.json` writes, whose file is the per-run one under the gitignored
+  `.bmad-loop/runs/<id>/` and not the project-level store named above; the two park-record writers
+  behind `bmad-loop confirm` and `drop`, which already carried a hand-rolled guard; and
+  `devcontract`'s spec writer. All five gain the fsync before the replace and a unique temp name in
+  place of a fixed `.tmp` sibling that two concurrent writers would collide on.
 
   **Scope, for both entries above.** This closes the _raise_ path, and only that. The helpers stage
   at `mkstemp(dir=target.parent, suffix=".tmp")`, so a `SIGKILL` mid-write still strands a temp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,32 @@ breaking changes may land in a minor release.
   refuses a linked config outright, before the write. These two files also land at `0600` rather than
   `0644` from now on, the same tightening as above.
 
+- **The put-backs are atomic too (#363, #379).** Four write sites that restore a file _after_
+  something already failed, the last of the family. Each of them runs at the worst possible moment
+  for a second loss.
+
+  - `safe_rollback` captures `.bmad-loop/policy.toml` before the `git reset --hard` and writes it
+    back after, so an operator's config survives a rollback whether it was committed or not. That
+    put-back now goes through `atomic_write_bytes`. It lands immediately after a rollback that has
+    already discarded the attempt's work, and a truncated TOML is not a smaller config — it is a
+    parse error the next `run` refuses on.
+  - The park records `bmad-loop confirm` reads — the per-story file and the legacy machine-local
+    index `drop` prunes — were already temp-and-replace and keep that behaviour. They gain the fsync
+    before the replace, a temp named uniquely per write in place of the fixed `.tmp` sibling two
+    writers would collide on, and the shared unlink-on-raise in place of their hand-rolled one. A
+    record left truncated by a lost host reads as a park owing nothing while the board still says a
+    human owes something.
+  - The engine's restore of a park record after a failed commit writes atomically as well, and
+    journals its own failure as `park-record-rollback-failed` rather than dropping it. Nothing else
+    would surface that: `validate` reports a board parked with no record, never a record left over
+    for a park that is in no commit.
+
+  All four replace the file _by name_ (`follow_symlinks=False`), matching `policy.write_mux_backend`
+  and `record_park`, the other writers of the same two files. For the two that were direct writes
+  this is a change rather than a preservation — they opened the name, and so wrote through any link
+  planted at it, on paths a driven session can reach. Both files land at `0600` rather than `0644`
+  from now on, the same tightening as above.
+
 ## [0.10.0] — 2026-08-14
 
 Much of this section is the `release/0.9.x` hotfix line brought forward onto `main` (#433).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,27 @@ breaking changes may land in a minor release.
   fixed `<spec>.md.tmp` that two concurrent writers would collide on. Specs written by these paths
   land at `0600` rather than `0644`, the same tightening the five writers above took.
 
+- **A failed write can no longer shred your CLI settings file (#379).** Both writers that register the
+  completion hook — `init` and each isolated worktree's provisioning — parse the whole config, merge
+  the relay into it, and write all of it back through a truncating write. Your permission allowlist,
+  `env`, MCP entries and your own hooks survive only by round-tripping through that one call, so a
+  short write (a full disk, a quota) published a _prefix_ of the JSON. Both now go through
+  `atomic_write_text`, which writes a temp and replaces it, leaving the original whole on any fault.
+
+  JSON has no partial read — a prefix of an object is a parse error, not a smaller object — so unlike
+  the board and the ledgers this loss was never silent, just unrecoverable. `init` refused on the next
+  run with `is not valid JSON; fix it and re-run init`, pointing the operator at a file it had shredded
+  itself, and refusing before the merge meant re-running could not rebuild it. In a worktree it was
+  quieter and worse: nothing re-reads that copy, so the session simply started against unparseable
+  settings, the CLI fell back to its defaults, the Stop hook was never registered and the run idled to
+  timeout with nothing naming the cause.
+
+  Both keep following symlinks, as the writes they replace did. `init` resolves the config path and
+  refuses anything landing outside the project, so the only links reaching it point back inside — an
+  in-repo indirection that would otherwise be replaced by a regular file on the first run. Provisioning
+  refuses a linked config outright, before the write. These two files also land at `0600` rather than
+  `0644` from now on, the same tightening as above.
+
 ## [0.10.0] — 2026-08-14
 
 Much of this section is the `release/0.9.x` hotfix line brought forward onto `main` (#433).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,7 +116,9 @@ breaking changes may land in a minor release.
 - **An atomic write no longer fails on a file whose name fills the filesystem's limit.** The helpers
   stage a temp named after their target, and `mkstemp` inserts eight random characters, so the temp
   ran `len(name) + 13` — long enough that a target with a perfectly legal name produced an illegal
-  _temp_ name and the write died with `ENAMETOOLONG`. On ext4 the cutoff was a 243-byte basename.
+  _temp_ name and the write died with `ENAMETOOLONG` — or, on Windows, with `ENOENT` carrying
+  `winerror` 206, which is the same condition under a different name. On ext4 the cutoff was a
+  243-byte basename.
   Latent in the helpers since they were written, and reachable from this release because the story
   spec writers moved onto them: a spec is named by your planning skills, and nothing bounds that
   name. When the readable temp name cannot fit, the helpers now fall back to a short digest of it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,106 +7,109 @@ breaking changes may land in a minor release.
 
 ## [Unreleased]
 
+### Changed
+
+- **Files the orchestrator replaces by name now land at `0600`.** Those writes pass
+  `follow_symlinks=False`, and that mode deliberately carries nothing over from the target — not
+  its permission bits, not its xattrs — so the new contents arrive at `mkstemp`'s private default.
+  Affected: `.bmad-loop/decisions.json`, `.bmad-loop/policy.toml`, the park records under
+  `.bmad-loop/operator/`, and any story spec written through `set_frontmatter_status`,
+  `set_frontmatter_field` or `devcontract`. Most were already being reset to `0644` on every
+  rewrite — the hand-rolled temp they replaced was created at `0666 & ~umask` and `os.replace`
+  swapped _that_ inode into place — so for those the delta is `0644` → `0600`. Git records no mode
+  but the exec bit, so nothing downstream of a commit notices.
+
+  The no-follow choice is made per **file**, not per call site: once one writer of a file replaces
+  it by name, every writer of that file has to, or they disagree about what the path means.
+  Applying it that way brought four writers into line that had been direct
+  `write_text`/`write_bytes` calls — `verify.safe_rollback`, the engine's park-record restore,
+  `set_frontmatter_status` and `set_frontmatter_field`. Those four opened the name, and so wrote
+  _through_ any symlink planted at it; they now replace it. That is a real change at those four,
+  and what makes it safe is the same per-file rule: each of those files already had a
+  name-replacing sibling writer (`policy.write_mux_backend`, `record_park`,
+  `devcontract._atomic_write_spec`), so no link at those names survived the orchestrator anyway.
+  Files with no name-replacing sibling keep following symlinks — `sprint-status.yaml` and your
+  CLI's `settings.json`, both operator-curated, so a board or a config kept outside the tree and
+  linked in keeps being a link.
+
+- **`atomic_write_bytes` accepts `follow_symlinks`, as its text sibling already did.** The default
+  stays `True`, which the private-git-exclude writer depends on: it pre-creates the target
+  precisely so the helper has a umask mode to carry over, and git silently ignores an exclude file
+  it cannot read.
+
 ### Fixed
 
-- **Five writers under `.bmad-loop/` can no longer leave an untracked temp file behind (#363, #379).**
-  Each wrote a fixed-name temp and then `os.replace`d it, and `atomic_replace` does no cleanup of
-  its own — so a failed replace stranded the temp. No ignore rule covers those names (`init` writes
-  `.bmad-loop/runs/`, `.bmad-loop/cache/`, `.bmad-loop/policy.toml` and `_bmad/render/`), which left
-  an untracked file holding `verify.worktree_clean` False until a human deleted it by hand. Under a
-  monorepo `repo_root:` override that surfaces as a failing `validate` and TUI rather than a blocked
-  `run`, which probe the repo root instead.
+- **A failed write can no longer truncate the sprint board, a story spec, your CLI settings or your
+  policy file (#379).** Seven writers read a file, merged into it, and wrote the whole thing back
+  through a truncating `Path.write_*` — so a fault partway through (ENOSPC, EIO, a quota) published
+  a _prefix_ of the file and destroyed the rest. All seven now go through
+  `platform_util.atomic_write_text` / `atomic_write_bytes`: contents to a temp, fsync, replace.
 
-  - Four now route through `atomic_write_text`/`atomic_write_bytes`, which name the temp uniquely per
-    write, fsync before the replace, and remove the temp on any raise: the pre-answer store
-    (`decisions.json`), both of the sweep's `decisions.json` writes, `policy.toml`'s `[mux] backend`
-    writer, and the TUI settings editor's save. The last two built the _same_
-    `.bmad-loop/policy.toml.tmp` path, so they could also collide with each other.
+  Most of these fail _quietly_ — the file still parses afterwards, so nothing downstream raises:
+
+  - **The sprint board.** `sprintstatus.advance` is the orchestrator's sole write path to
+    `sprint-status.yaml`. YAML cut at a line boundary is still a valid mapping, just a smaller one,
+    so the epics past the tear ceased to exist and the run walked off the end of the sprint instead
+    of erroring.
+  - **A story spec.** A spec is laid out `before + edited + after`, so a write that faulted after
+    the frontmatter had landed left intact frontmatter saying `status: done` over a decapitated
+    body — a spec that lies, which the loop then commits. `set_frontmatter_status`,
+    `set_frontmatter_field` and `devcontract`'s four in-place rewriters now share one call.
+    `devcontract` was already atomic and recorded the measured cost: fault injection on the old
+    truncating write cut a 46-byte spec to 12.
+  - **`.bmad-loop/policy.toml`.** `safe_rollback` captures it before the `git reset --hard` and
+    writes it back after, so your orchestration config survives a rollback whether or not it was
+    committed. A truncated TOML is not a smaller config — it is a parse error the next `run`
+    refuses on, which is the failure the whole restore exists to prevent.
+  - **The park records.** The engine restores a story's record when the commit it was written for
+    fails. A record left truncated reads as a park owing nothing, while the board still says a
+    human owes something.
+
+  Your CLI's `settings.json` is the loud one. Both writers that register the completion hook —
+  `init` and each isolated worktree's provisioning — parse the whole config, merge the relay into
+  it, and write all of it back, so your permission allowlist, `env`, MCP entries and your own hooks
+  survived only by round-tripping through that one call. JSON has no partial read — a prefix of an
+  object is a parse error, not a smaller object — so this was never silent, just unrecoverable:
+  `init` refused on the next run with `is not valid JSON; fix it and re-run init`, pointing you at
+  a file it had shredded itself, and refusing _before_ the merge meant re-running could not rebuild
+  it. In a worktree it was quieter and worse — nothing re-reads that copy, so the session started
+  against unparseable settings, the CLI fell back to its defaults, the Stop hook was never
+  registered, and the run idled to timeout with nothing naming the cause.
+
+  Three of the seven are **put-backs**: they restore a file _after_ something has already failed,
+  which is the worst possible moment for a second loss. One of them, the engine's restore of a park
+  record after a failed commit, now journals its own failure as `park-record-rollback-failed`
+  rather than dropping it. Nothing else would ever surface that — `validate` reports a board parked
+  with no record, but never a record left over for a park that is in no commit.
+
+- **Five writers under `.bmad-loop/` no longer strand an untracked temp when their replace fails
+  (#363).** Each built a fixed-name temp and then `os.replace`d it, and `atomic_replace` does no
+  cleanup of its own. No ignore rule covers those names — `init` writes `.bmad-loop/runs/`,
+  `.bmad-loop/cache/`, `.bmad-loop/policy.toml` and `_bmad/render/` — so a failed replace left an
+  untracked file holding `verify.worktree_clean` False until a human deleted it by hand.
+
+  - Four route through the helpers, which name the temp uniquely per write and remove it on any
+    raise: the pre-answer store (`decisions.json`), both of the sweep's `decisions.json` writes,
+    `policy.toml`'s `[mux] backend` writer, and the TUI settings editor's save. The last two built
+    the _same_ `.bmad-loop/policy.toml.tmp` path, so they could also collide with each other.
   - `archive_run` keeps writing its own tarball — the path goes to `tarfile.open`, so there is no
     payload for a helper to take — and gains the unlink-on-raise guard instead. Its temp was also
     misnamed: `with_suffix` replaces only the last suffix, so `<id>.tar.gz` yielded
     `<id>.tar.tar.gz.tmp`. It is now `<id>.tar.gz.tmp`.
-  - These five files land at `0600` rather than `0644` from now on. The hand-rolled temp was created
-    at `0666 & ~umask` and `os.replace` swapped _that_ inode into place, so they were already being
-    reset to `0644` on every rewrite; the replacement carries no mode over, which tightens them to
-    `mkstemp`'s private default.
 
-  Scope: this closes the _raise_ path. A `SIGKILL` mid-write can still strand a temp, and on Windows
-  `os.replace` is not guaranteed atomic — what is guaranteed is that a failed write cannot truncate
-  the original.
+  Under a monorepo `repo_root:` override this surfaces as a failing `validate` and TUI rather than
+  a blocked `run`: `run` and `sweep` probe the repo root, `validate` and the TUI probe the project.
 
-- **`atomic_write_bytes` accepts `follow_symlinks`, as its text sibling already did.** Without it the
-  bytes helper could not express the no-follow choice the `policy.toml` writer needs — that writer
-  reads and writes bytes on purpose, to preserve a CRLF file's line endings. The default stays
-  `True`, which the private-git-exclude caller depends on.
+  Three more temp-and-replace writers were hardened the same way without having been exposed — the
+  two park-record writers behind `bmad-loop confirm` and `drop`, and `devcontract`'s spec writer.
+  They gain the fsync before the replace, a unique temp name in place of a fixed `.tmp` sibling two
+  concurrent writers would collide on, and the shared unlink-on-raise in place of a hand-rolled one.
 
-- **A failed write can no longer silently shrink the sprint board or behead a spec (#379).** Both are
-  read-modify-rewrites that went out through a truncating write, and both fail _quietly_ — the file
-  still parses afterwards, so nothing downstream raises.
-
-  - `sprintstatus.advance` is the orchestrator's sole write path to `sprint-status.yaml`. A board cut
-    at a line boundary is still a valid mapping, just a smaller one, so the epics past the tear cease
-    to exist and the run walks off the end of the sprint instead of erroring. It now writes through
-    `atomic_write_text`, following symlinks as the write it replaced did — a board kept outside the
-    tree and symlinked in keeps being a symlink.
-  - The three writers of a story spec — `set_frontmatter_status`, `set_frontmatter_field` and
-    `devcontract`'s four in-place rewriters — now share one call: `atomic_write_bytes` with
-    `follow_symlinks=False`. A spec is laid out `before + edited + after`, so a torn write could
-    publish intact frontmatter saying `status: done` over a truncated body — a spec that lies, which
-    the loop then commits. The bytes helper, never the text one: these writers are byte-verbatim by
-    contract, and text mode would relay every line ending in the file on Windows.
-
-  `devcontract` was already atomic and keeps its behaviour; it drops its hand-rolled temp for the
-  shared helper, which adds an fsync before the replace and a temp name unique per write instead of a
-  fixed `<spec>.md.tmp` that two concurrent writers would collide on. Specs written by these paths
-  land at `0600` rather than `0644`, the same tightening the five writers above took.
-
-- **A failed write can no longer shred your CLI settings file (#379).** Both writers that register the
-  completion hook — `init` and each isolated worktree's provisioning — parse the whole config, merge
-  the relay into it, and write all of it back through a truncating write. Your permission allowlist,
-  `env`, MCP entries and your own hooks survive only by round-tripping through that one call, so a
-  short write (a full disk, a quota) published a _prefix_ of the JSON. Both now go through
-  `atomic_write_text`, which writes a temp and replaces it, leaving the original whole on any fault.
-
-  JSON has no partial read — a prefix of an object is a parse error, not a smaller object — so unlike
-  the board and the ledgers this loss was never silent, just unrecoverable. `init` refused on the next
-  run with `is not valid JSON; fix it and re-run init`, pointing the operator at a file it had shredded
-  itself, and refusing before the merge meant re-running could not rebuild it. In a worktree it was
-  quieter and worse: nothing re-reads that copy, so the session simply started against unparseable
-  settings, the CLI fell back to its defaults, the Stop hook was never registered and the run idled to
-  timeout with nothing naming the cause.
-
-  Both keep following symlinks, as the writes they replace did. `init` resolves the config path and
-  refuses anything landing outside the project, so the only links reaching it point back inside — an
-  in-repo indirection that would otherwise be replaced by a regular file on the first run. Provisioning
-  refuses a linked config outright, before the write. These two files also land at `0600` rather than
-  `0644` from now on, the same tightening as above.
-
-- **The put-backs are atomic too (#363, #379).** Four write sites that restore a file _after_
-  something already failed, the last of the family. Each of them runs at the worst possible moment
-  for a second loss.
-
-  - `safe_rollback` captures `.bmad-loop/policy.toml` before the `git reset --hard` and writes it
-    back after, so an operator's config survives a rollback whether it was committed or not. That
-    put-back now goes through `atomic_write_bytes`. It lands immediately after a rollback that has
-    already discarded the attempt's work, and a truncated TOML is not a smaller config — it is a
-    parse error the next `run` refuses on.
-  - The park records `bmad-loop confirm` reads — the per-story file and the legacy machine-local
-    index `drop` prunes — were already temp-and-replace and keep that behaviour. They gain the fsync
-    before the replace, a temp named uniquely per write in place of the fixed `.tmp` sibling two
-    writers would collide on, and the shared unlink-on-raise in place of their hand-rolled one. A
-    record left truncated by a lost host reads as a park owing nothing while the board still says a
-    human owes something.
-  - The engine's restore of a park record after a failed commit writes atomically as well, and
-    journals its own failure as `park-record-rollback-failed` rather than dropping it. Nothing else
-    would surface that: `validate` reports a board parked with no record, never a record left over
-    for a park that is in no commit.
-
-  All four replace the file _by name_ (`follow_symlinks=False`), matching `policy.write_mux_backend`
-  and `record_park`, the other writers of the same two files. For the two that were direct writes
-  this is a change rather than a preservation — they opened the name, and so wrote through any link
-  planted at it, on paths a driven session can reach. Both files land at `0600` rather than `0644`
-  from now on, the same tightening as above.
+  **Scope, for both entries above.** This closes the _raise_ path, and only that. The helpers stage
+  at `mkstemp(dir=target.parent, suffix=".tmp")`, so a `SIGKILL` mid-write still strands a temp
+  that `worktree_clean` reads as dirty; and on Windows `os.replace` is
+  `MoveFileEx(MOVEFILE_REPLACE_EXISTING)`, which is not guaranteed atomic and may fall back to a
+  non-atomic copy. What holds everywhere is that a failed write cannot truncate the original.
 
 ## [0.10.0] — 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,27 @@ breaking changes may land in a minor release.
   reads and writes bytes on purpose, to preserve a CRLF file's line endings. The default stays
   `True`, which the private-git-exclude caller depends on.
 
+- **A failed write can no longer silently shrink the sprint board or behead a spec (#379).** Both are
+  read-modify-rewrites that went out through a truncating write, and both fail _quietly_ — the file
+  still parses afterwards, so nothing downstream raises.
+
+  - `sprintstatus.advance` is the orchestrator's sole write path to `sprint-status.yaml`. A board cut
+    at a line boundary is still a valid mapping, just a smaller one, so the epics past the tear cease
+    to exist and the run walks off the end of the sprint instead of erroring. It now writes through
+    `atomic_write_text`, following symlinks as the write it replaced did — a board kept outside the
+    tree and symlinked in keeps being a symlink.
+  - The three writers of a story spec — `set_frontmatter_status`, `set_frontmatter_field` and
+    `devcontract`'s four in-place rewriters — now share one call: `atomic_write_bytes` with
+    `follow_symlinks=False`. A spec is laid out `before + edited + after`, so a torn write could
+    publish intact frontmatter saying `status: done` over a truncated body — a spec that lies, which
+    the loop then commits. The bytes helper, never the text one: these writers are byte-verbatim by
+    contract, and text mode would relay every line ending in the file on Windows.
+
+  `devcontract` was already atomic and keeps its behaviour; it drops its hand-rolled temp for the
+  shared helper, which adds an fsync before the replace and a temp name unique per write instead of a
+  fixed `<spec>.md.tmp` that two concurrent writers would collide on. Specs written by these paths
+  land at `0600` rather than `0644`, the same tightening the five writers above took.
+
 ## [0.10.0] — 2026-08-14
 
 Much of this section is the `release/0.9.x` hotfix line brought forward onto `main` (#433).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ breaking changes may land in a minor release.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Five writers under `.bmad-loop/` can no longer leave an untracked temp file behind (#363, #379).**
+  Each wrote a fixed-name temp and then `os.replace`d it, and `atomic_replace` does no cleanup of
+  its own — so a failed replace stranded the temp. No ignore rule covers those names (`init` writes
+  `.bmad-loop/runs/`, `.bmad-loop/cache/`, `.bmad-loop/policy.toml` and `_bmad/render/`), which left
+  an untracked file holding `verify.worktree_clean` False until a human deleted it by hand. Under a
+  monorepo `repo_root:` override that surfaces as a failing `validate` and TUI rather than a blocked
+  `run`, which probe the repo root instead.
+
+  - Four now route through `atomic_write_text`/`atomic_write_bytes`, which name the temp uniquely per
+    write, fsync before the replace, and remove the temp on any raise: the pre-answer store
+    (`decisions.json`), both of the sweep's `decisions.json` writes, `policy.toml`'s `[mux] backend`
+    writer, and the TUI settings editor's save. The last two built the _same_
+    `.bmad-loop/policy.toml.tmp` path, so they could also collide with each other.
+  - `archive_run` keeps writing its own tarball — the path goes to `tarfile.open`, so there is no
+    payload for a helper to take — and gains the unlink-on-raise guard instead. Its temp was also
+    misnamed: `with_suffix` replaces only the last suffix, so `<id>.tar.gz` yielded
+    `<id>.tar.tar.gz.tmp`. It is now `<id>.tar.gz.tmp`.
+  - These five files land at `0600` rather than `0644` from now on. The hand-rolled temp was created
+    at `0666 & ~umask` and `os.replace` swapped _that_ inode into place, so they were already being
+    reset to `0644` on every rewrite; the replacement carries no mode over, which tightens them to
+    `mkstemp`'s private default.
+
+  Scope: this closes the _raise_ path. A `SIGKILL` mid-write can still strand a temp, and on Windows
+  `os.replace` is not guaranteed atomic — what is guaranteed is that a failed write cannot truncate
+  the original.
+
+- **`atomic_write_bytes` accepts `follow_symlinks`, as its text sibling already did.** Without it the
+  bytes helper could not express the no-follow choice the `policy.toml` writer needs — that writer
+  reads and writes bytes on purpose, to preserve a CRLF file's line endings. The default stays
+  `True`, which the private-git-exclude caller depends on.
+
 ## [0.10.0] — 2026-08-14
 
 Much of this section is the `release/0.9.x` hotfix line brought forward onto `main` (#433).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,15 @@ breaking changes may land in a minor release.
   `MoveFileEx(MOVEFILE_REPLACE_EXISTING)`, which is not guaranteed atomic and may fall back to a
   non-atomic copy. What holds everywhere is that a failed write cannot truncate the original.
 
+- **An atomic write no longer fails on a file whose name fills the filesystem's limit.** The helpers
+  stage a temp named after their target, and `mkstemp` inserts eight random characters, so the temp
+  ran `len(name) + 13` — long enough that a target with a perfectly legal name produced an illegal
+  _temp_ name and the write died with `ENAMETOOLONG`. On ext4 the cutoff was a 243-byte basename.
+  Latent in the helpers since they were written, and reachable from this release because the story
+  spec writers moved onto them: a spec is named by your planning skills, and nothing bounds that
+  name. When the readable temp name cannot fit, the helpers now fall back to a short digest of it
+  rather than failing — the OS decides, so there is no guess at a per-filesystem byte limit.
+
 ## [0.10.0] — 2026-08-14
 
 Much of this section is the `release/0.9.x` hotfix line brought forward onto `main` (#433).

--- a/src/bmad_loop/decisions.py
+++ b/src/bmad_loop/decisions.py
@@ -27,7 +27,7 @@ import re
 from pathlib import Path
 
 from . import bmadconfig, deferredwork, runs, verify
-from .platform_util import atomic_replace
+from .platform_util import atomic_write_text
 from .sweep import Decision, DecisionOption, validate_triage
 
 STORE_REL = Path(".bmad-loop") / "decisions.json"
@@ -55,11 +55,18 @@ def load_pre_answers(project: Path) -> dict[str, dict]:
 
 
 def _write_store(project: Path, data: dict) -> None:
+    """#363: via the helper, not a hand-rolled tmp+replace. The store lives at a
+    path nothing gitignores, so a failed replace used to strand
+    `.bmad-loop/decisions.tmp` as an untracked file and hold `worktree_clean`
+    False until a human deleted it; the helper removes its temp on any raise.
+
+    ``follow_symlinks=False`` is the behaviour-preserving choice — `os.replace`
+    never dereferenced this destination either — and the security one: a driven
+    session can write under `.bmad-loop/`, so honouring a link planted here would
+    hand it a host-side write to any operator-writable path."""
     path = store_path(project)
     path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_suffix(".tmp")
-    tmp.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
-    atomic_replace(tmp, path)
+    atomic_write_text(path, json.dumps(data, indent=2, sort_keys=True), follow_symlinks=False)
 
 
 def record_pre_answer(project: Path, dw_id: str, option: DecisionOption, *, date: str) -> None:

--- a/src/bmad_loop/devcontract.py
+++ b/src/bmad_loop/devcontract.py
@@ -30,7 +30,7 @@ from typing import Any
 from . import deferredwork
 from .fences import fenced as _fenced
 from .frontmatter import _edit_frontmatter_block, status_of
-from .platform_util import atomic_replace
+from .platform_util import atomic_write_bytes
 from .verify import DEV_WORKFLOW, operator_actions_of, read_frontmatter
 
 # The section the skill appends on EVERY terminal path (success and blocked),
@@ -556,22 +556,23 @@ def _atomic_write_spec(spec_path: Path, text: str) -> None:
     rename, so an interrupted / short / disk-full write can never truncate the
     canonical spec — a failed repair must lose no work (fault injection on the old
     truncating ``write_text`` reduced a 46-byte spec to 12). Bytes are written
-    verbatim (``write_bytes``, not ``write_text``): every caller here has already
-    captured and preserved the file's own line endings, and ``write_text``'s
+    verbatim (``atomic_write_bytes``, not the text sibling): every caller here has
+    already captured and preserved the file's own line endings, and text mode's
     ``newline=None`` default would re-translate ``\\n``→``\\r\\n`` on Windows. The
-    ``.tmp`` sibling ends in ``.tmp`` (not ``.md``), so the ``*.md`` artifact scans
-    never see it. On any failure the temp file is removed and the error re-raised —
-    the callers impose best-effort, the writer never swallows."""
-    tmp = spec_path.with_suffix(spec_path.suffix + ".tmp")
-    try:
-        tmp.write_bytes(text.encode("utf-8"))
-        atomic_replace(tmp, spec_path)
-    except BaseException:
-        try:
-            tmp.unlink()
-        except OSError:
-            pass
-        raise
+    temp ends in ``.tmp`` (not ``.md``), so the ``*.md`` artifact scans never see
+    it. On any failure the temp file is removed and the error re-raised — the
+    callers impose best-effort, the writer never swallows.
+
+    Now a thin name over `platform_util.atomic_write_bytes` (#379) rather than a
+    hand-rolled temp: same shape, plus an fsync before the replace and a temp name
+    unique per write instead of a fixed ``<spec>.md.tmp`` two concurrent writers
+    would collide on. ``follow_symlinks=False`` keeps the name-replacing semantics
+    the `atomic_replace` here always had — the spec path comes from a
+    session-driven scan, so writing THROUGH a planted link would hand that session
+    a host-side write wherever it chose. The two `frontmatter`-side writers of
+    these same files land on the identical call (#379); this wrapper stays for its
+    callers' ``str``-in signature and this docstring."""
+    atomic_write_bytes(spec_path, text.encode("utf-8"), follow_symlinks=False)
 
 
 def _render_status_line(line: str, m: re.Match[str], value: str) -> str:

--- a/src/bmad_loop/engine.py
+++ b/src/bmad_loop/engine.py
@@ -2524,7 +2524,7 @@ class Engine:
             task.restore_patch = None
         except verify.GitError as e:
             self._restore_deferred_closes(task, snapshot)
-            self._restore_park_record(park_record)
+            self._restore_park_record(task, park_record)
             self._escalate(task, f"commit failed: {e}")
         except BaseException:
             # A failed commit is not the only way out of this window: the signal
@@ -2535,7 +2535,7 @@ class Engine:
             # ledger flipped — and the park record written — for a commit that
             # does not exist. Restore, then re-raise untouched.
             self._restore_deferred_closes(task, snapshot)
-            self._restore_park_record(park_record)
+            self._restore_park_record(task, park_record)
             raise
         # Final-phase rule: AWAITING_OPERATOR iff the task carries actions,
         # otherwise DONE. Derived from PERSISTED task state, never from a local
@@ -2628,24 +2628,61 @@ class Engine:
             return None
         return (path, prior)
 
-    def _restore_park_record(self, record: tuple[Path, str | None] | None) -> None:
+    def _restore_park_record(self, task: StoryTask, record: tuple[Path, str | None] | None) -> None:
         """Put the park record back the way `_write_park_record` found it, for
         the failure arms of the commit window: a `GitError` escalation or a
         pass-through raise must not leave a record — untracked, in a tree the
         next story's `git add -A` would sweep — for a commit that does not
-        exist. Best-effort like `_restore_deferred_closes`: the restore runs
-        under an exception already in flight and must never replace it."""
+        exist. Best-effort like `_restore_deferred_closes`, and for the same two
+        reasons that arm imposes: in the `BaseException` arm an exception is
+        genuinely travelling and this must not replace it, while in the
+        `GitError` arm the error is already HANDLED and `_escalate` raises a
+        fresh `RunPaused` — so the hazard there is preempting the escalation,
+        which would strand the story in COMMITTING with no diagnosis on the
+        record. Either way, this never raises.
+
+        The put-back is atomic (#379). A torn restore leaves the record neither
+        as the park wrote it nor as it was found, and `load` reads a truncated
+        record as an entry owing nothing — a park silently discharged by a
+        rollback of the commit it was written for.
+
+        `OSError` stays the guard, and stays wide enough BECAUSE of
+        `follow_symlinks=False`: no-follow skips `Path.resolve` entirely, so the
+        pre-3.13 `RuntimeError`-on-symlink-loop that forced
+        `_restore_deferred_closes` (and `tui.launch`) to widen to `Exception`
+        cannot arise on this path. That widening is a property of the resolve,
+        not of the helper — do not copy it back here. The no-follow itself is
+        right for the same reason it is right in `operatoractions.record_park`,
+        which writes this exact file: machine-minted, under a project root a
+        driven session writes all run long.
+
+        A failure is journaled rather than dropped, matching the model above:
+        `validate` reports a board parked with no record but never a record left
+        over for a park that is in no commit, so nothing else would ever surface
+        this. The journal call is itself suppressed — a restore that must not
+        raise cannot be allowed to raise on the way to saying it failed."""
         if record is None:
             return
         path, prior = record
-        with contextlib.suppress(OSError):
+        try:
             if prior is None:
                 path.unlink(missing_ok=True)
                 parent = path.parent
                 if parent.is_dir() and not any(parent.iterdir()):
                     parent.rmdir()
             else:
-                path.write_text(prior, encoding="utf-8")
+                atomic_write_text(path, prior, follow_symlinks=False)
+        except OSError as e:
+            with contextlib.suppress(Exception):
+                self.journal.append(
+                    "park-record-rollback-failed",
+                    story_key=task.story_key,
+                    record=str(path),
+                    # named, not bare `str(e)`: an errno message alone cannot say
+                    # whether the disk or the path was at fault. Matches
+                    # `deferred-close-rollback-failed`.
+                    error=f"{e.__class__.__name__}: {e}",
+                )
 
     def _notify_park(self, task: StoryTask) -> None:
         """Tell the human a story is waiting on them, and exactly what for.

--- a/src/bmad_loop/frontmatter.py
+++ b/src/bmad_loop/frontmatter.py
@@ -1,16 +1,23 @@
 """Pure spec-frontmatter parsing: read the YAML ``---``…``---`` block, normalize
 the status token, and rewrite ``status:`` in place.
 
-Zero git/subprocess dependencies (only stdlib + PyYAML) so pure domain modules
-(``stories``, ``devcontract``) can read spec status without importing ``verify``
-and dragging in its whole git surface (assessment finding F-1). ``verify``
-re-exports these names, so every existing ``verify.<name>`` / ``from .verify
-import <name>`` call site stays valid. (The same docstring rule bars importing
-``platform_util`` here — it pulls in ``subprocess`` — so this module's writes are
-a plain ``write_bytes``, not ``atomic_replace``: byte-preserving, but not atomic.
-``read_bytes().decode`` on the way in for the same reason — ``read_text``'s
-universal-newline translation would hand the writer an all-LF copy of a CRLF
-spec, and every line ending in the file would be relaid on the way back out.)
+No git dependency, so a pure domain module can read spec status without importing
+``verify`` and dragging in its whole git surface (assessment finding F-1).
+``stories`` still collects on that: ``import bmad_loop.stories`` genuinely leaves
+``bmad_loop.verify`` out of ``sys.modules``. ``devcontract`` no longer does — it
+imports ``verify`` directly for `read_frontmatter` and `operator_actions_of` — so
+the rule now has one beneficiary, not the two it was written for. ``verify``
+re-exports these names either way, so every existing ``verify.<name>`` /
+``from .verify import <name>`` call site stays valid.
+
+That rule is about ``verify``, NOT about ``subprocess``: this module imports
+``platform_util`` (#379), which pulls ``subprocess`` in, and both named modules
+already paid that cost anyway — ``devcontract`` imports it directly and
+``stories`` reaches it through ``deferredwork``. So the writes here are atomic as
+well as byte-verbatim: ``read_bytes().decode`` in, ``atomic_write_bytes`` out.
+The byte path is load-bearing on its own — ``read_text``'s universal-newline
+translation would hand the writer an all-LF copy of a CRLF spec, and every line
+ending in the file would be relaid on the way back out.
 
 READER AND WRITER DEGRADE IN OPPOSITE DIRECTIONS, deliberately. `read_frontmatter`
 turns an unparseable or undecodable block into ``{}``: it runs on the observation
@@ -30,6 +37,8 @@ from pathlib import Path
 from typing import Any
 
 import yaml
+
+from .platform_util import atomic_write_bytes
 
 
 def _split_frontmatter(text: str) -> tuple[str, str, str] | None:
@@ -365,8 +374,21 @@ def set_frontmatter_status(path: Path, status: str) -> bool:
     through ``read_text``/``write_text`` instead relaid the whole file — CRLF in,
     LF out on POSIX, and every LF out as CRLF on Windows — which is the largest
     violation a writer contracted to "only the status value changes" can commit.
-    Not atomic (see the module docstring); a torn write is a separate concern
-    from a byte-preserving one.
+
+    The rewrite is also atomic (#379): the bytes go out through
+    `platform_util.atomic_write_bytes`, which is byte-verbatim on the same terms
+    as `write_bytes` and additionally leaves either the old file or the whole new
+    one. That matters most here, where the layout is ``before + edited + after``
+    — a truncating write that faults after the frontmatter has landed leaves
+    intact frontmatter saying ``status: done`` over a decapitated body, a spec
+    that lies and that the loop then commits. `devcontract._atomic_write_spec`
+    reached the same conclusion on the same files, with fault injection: it cut a
+    46-byte spec to 12.
+
+    ``follow_symlinks=False``, matching that sibling's name-replacing
+    `atomic_replace`. A spec path is handed to this writer from a session-driven
+    scan, so honouring a link planted there would aim a host-side write wherever
+    that session chose.
 
     Returns True when the file was rewritten. Returns False for **nothing to
     change** only: no file, no frontmatter block, no top-level `status` for
@@ -393,5 +415,5 @@ def set_frontmatter_status(path: Path, status: str) -> bool:
     edited = _edit_frontmatter_block(block, "status", status, pattern=_STATUS_KEY_RE)
     if edited is None:
         return False
-    path.write_bytes((before + edited + after).encode("utf-8"))
+    atomic_write_bytes(path, (before + edited + after).encode("utf-8"), follow_symlinks=False)
     return True

--- a/src/bmad_loop/install.py
+++ b/src/bmad_loop/install.py
@@ -31,7 +31,7 @@ from typing import Any, NamedTuple
 
 from .adapters.profile import ALIASES, CLIProfile, ProfileError, load_profiles
 from .checks import Finding
-from .platform_util import atomic_write_bytes, file_lock
+from .platform_util import atomic_write_bytes, atomic_write_text, file_lock
 from .policy import POLICY_TEMPLATE
 from .process_host import get_process_host
 from .verify import GitError, git_bytes
@@ -1252,7 +1252,22 @@ def _register_hooks(project: Path, profile: CLIProfile) -> int:
     }
     config, changed = merge_hooks(config, registrations, profile.hooks.dialect)
     if changed:
-        config_path.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+        # atomic_write_text, never write_text (#379), the same rule
+        # `_worktree_local_exclude` states for its bytes sibling. This is a
+        # read-modify-REWRITE of a file `init` does not own: the parse above kept
+        # the operator's permission allowlist, env, MCP entries and their own
+        # hooks, and every one of them is re-serialized here. `"w"` TRUNCATES
+        # before writing, so a short write (ENOSPC, a full quota) publishes a
+        # PREFIX of that JSON — and unlike the ledgers, this failure is loud in
+        # the worst way: the next `init` reads it back, fails json.loads, and
+        # prints "is not valid JSON; fix it and re-run init" (above) at a human
+        # whose file this tool just shredded. The helper leaves the original
+        # untouched on any raise. follow_symlinks stays at the default, matching
+        # the `write_text` it replaces: `_confined_to` above resolves the path and
+        # refuses anything landing outside the project, so the only links reaching
+        # this write point back INSIDE it — an in-repo indirection the operator
+        # arranged, which a name-replacement would orphan on the first init.
+        atomic_write_text(config_path, json.dumps(config, indent=2) + "\n")
         print(f"  hooks registered ({profile.name}): {config_path}")
     else:
         print(f"  hooks already registered ({profile.name})")

--- a/src/bmad_loop/operatoractions.py
+++ b/src/bmad_loop/operatoractions.py
@@ -52,7 +52,6 @@ drifted entries itself, so nothing gates on the record.
 
 from __future__ import annotations
 
-import contextlib
 import json
 from dataclasses import dataclass
 from pathlib import Path
@@ -60,7 +59,7 @@ from pathlib import Path
 from . import devcontract, sprintstatus, verify
 from .bmadconfig import ProjectPaths
 from .frontmatter import operator_actions_of, read_frontmatter, status_of
-from .platform_util import atomic_replace, safe_segment
+from .platform_util import atomic_write_text, safe_segment
 
 RECORDS_REL = Path(".bmad-loop") / "operator"
 LEGACY_STORE_REL = Path(".bmad-loop") / "operator-actions.json"
@@ -147,9 +146,23 @@ def record_park(
     overwrites rather than accumulates: a story owes whatever its latest park
     says it owes, and a stale action list is worse than none.
 
-    The write is atomic (temp + replace) and the temp file is unlinked on any
-    raise: this runs just ahead of ``finalize_commit``'s ``git add -A``, and a
-    stranded ``.tmp`` would ride the story's own commit."""
+    The write goes through :func:`platform_util.atomic_write_text` (#379), which
+    carries the unlink-on-raise this used to hand-roll — hence no try/except here;
+    two nested guards would only obscure which one runs — and adds the two things
+    the hand-rolled version lacked. The temp is *uniquely* named instead of the
+    fixed ``.tmp`` sibling: this runs just ahead of ``finalize_commit``'s ``git
+    add -A``, so a stranded temp rides the story's own commit forever, and one
+    fixed name is what two writers of the same key would collide on. And the
+    contents are fsynced *before* the replace publishes them — a host losing power
+    just after the rename otherwise comes back with the record's name pointing at
+    blocks that were never written, which :func:`load` reads as an entry owing
+    nothing while the board still says a human owes something.
+
+    ``follow_symlinks=False`` preserves what the bare ``os.replace`` did (it never
+    dereferenced this destination) and matches what the record is: machine-minted,
+    under a project root a driven session can write. The record now lands at
+    ``mkstemp``'s ``0600`` rather than the hand-rolled temp's ``0644``; git carries
+    no mode but the exec bit, so nothing downstream of the commit notices."""
     path = record_path(project, story_key)
     path.parent.mkdir(parents=True, exist_ok=True)
     record = {
@@ -159,14 +172,7 @@ def record_park(
         "run_id": run_id,
         "parked_at": parked_at,
     }
-    tmp = path.with_suffix(".tmp")
-    try:
-        tmp.write_text(json.dumps(record, indent=2, sort_keys=True), encoding="utf-8")
-        atomic_replace(tmp, path)
-    except BaseException:
-        with contextlib.suppress(OSError):
-            tmp.unlink(missing_ok=True)
-        raise
+    atomic_write_text(path, json.dumps(record, indent=2, sort_keys=True), follow_symlinks=False)
     return path
 
 
@@ -205,29 +211,25 @@ def _drop_legacy(project: Path, story_key: str) -> bool:
     rewritten as ``{}``: nothing writes the legacy file anymore, and an empty
     husk would read as "an index with nothing parked" forever.
 
-    The rewrite unlinks its temp on any raise, like `record_park` — but for the
-    opposite reason. `drop` runs out of band from `confirm`, not inside a commit
-    window, so the hazard is not a temp RIDING a commit but one OUTLIVING the
-    failure: `.bmad-loop/` is not ignored (`install` excludes only `runs/`,
-    `cache/` and `policy.toml`, and the pre-#356 exclude line was the anchored
-    literal `operator-actions.json`, never its `.tmp` sibling), so a stranded
-    `.bmad-loop/operator-actions.tmp` is an untracked file to
-    `verify.worktree_clean` — a dirty tree blocking the next run's preflight and
-    the epic-boundary auto-sweep, over a prune of a store nothing writes."""
+    The rewrite goes through the same helper `record_park` uses and inherits its
+    unlink-on-raise — but the temp matters here for the opposite reason. `drop`
+    runs out of band from `confirm`, not inside a commit window, so the hazard is
+    not a temp RIDING a commit but one OUTLIVING the failure: `.bmad-loop/` is not
+    ignored (`install` excludes only `runs/`, `cache/` and `policy.toml`, and the
+    pre-#356 exclude line was the anchored literal `operator-actions.json`, never
+    its `.tmp` sibling), so a stranded `.bmad-loop/operator-actions.tmp` is an
+    untracked file to `verify.worktree_clean` — a dirty tree blocking the next
+    run's preflight and the epic-boundary auto-sweep, over a prune of a store
+    nothing writes. The helper's temp carries a random infix, so even that
+    surviving name is no longer one a second `drop` of a different key collides
+    on mid-write."""
     path = legacy_store_path(project)
     data = _load_legacy(project)
     if story_key not in data:
         return False
     del data[story_key]
     if data:
-        tmp = path.with_suffix(".tmp")
-        try:
-            tmp.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
-            atomic_replace(tmp, path)
-        except BaseException:
-            with contextlib.suppress(OSError):
-                tmp.unlink(missing_ok=True)
-            raise
+        atomic_write_text(path, json.dumps(data, indent=2, sort_keys=True), follow_symlinks=False)
     else:
         path.unlink(missing_ok=True)
     return True

--- a/src/bmad_loop/platform_util.py
+++ b/src/bmad_loop/platform_util.py
@@ -445,6 +445,19 @@ def atomic_write_bytes(path: Path, data: bytes, *, follow_symlinks: bool = True)
     _atomic_write(path, data, mode="wb", encoding=None, follow_symlinks=follow_symlinks)
 
 
+def _is_name_too_long(exc: OSError) -> bool:
+    """True if ``exc`` is the filesystem refusing a name for its LENGTH, under
+    either platform's spelling of that condition.
+
+    Two spellings because win32 does not use the POSIX one: CPython's
+    ``PC/errmap.h`` maps ``ERROR_FILENAME_EXCED_RANGE`` to ``ENOENT``, so there
+    the errno is indistinguishable from an absent directory and only
+    ``.winerror`` tells them apart (see ``_WINERROR_FILENAME_EXCED_RANGE``)."""
+    if exc.errno == errno.ENAMETOOLONG:
+        return True
+    return getattr(exc, "winerror", None) == _WINERROR_FILENAME_EXCED_RANGE
+
+
 def _mkstemp_beside(target: Path) -> tuple[int, str]:
     """``mkstemp`` in ``target``'s own directory, prefixed with its name so the
     temp is recognisably that target's staging file — and so it ends in ``.tmp``
@@ -478,19 +491,33 @@ def _mkstemp_beside(target: Path) -> tuple[int, str]:
     this whole fallback dead on Windows — where, per the ``MAX_PATH`` note above,
     it is if anything easier to reach than on ext4.
 
-    A second failure propagates — that one is the DIRECTORY being too long, which
-    no choice of prefix can fix."""
+    The rungs STRICTLY SHORTEN, and the last one carries no prefix at all. A
+    digest is 16 characters, so on its own it is not a fallback — against a
+    basename of 16 or fewer it stages a name no shorter than the one that just
+    failed, and retrying at the same width cannot succeed. That is unreachable
+    where the binding limit is per-component (a POSIX ``NAME_MAX`` rung is only
+    reached past 242 characters, far above the digest) and reachable where it is
+    the whole path, which is the win32 case: a short basename in a directory near
+    ``MAX_PATH`` overflows on the staging suffix alone. So the digest rung is used
+    only while it actually shortens, and a bare ``mkstemp`` — the shortest name
+    this function can produce — always ends the ladder.
+
+    Only a failure at that last rung propagates, and by then the claim it carries
+    is true: no choice of prefix can fix it, so what does not fit is the
+    DIRECTORY."""
     directory = str(target.parent)
-    try:
-        return tempfile.mkstemp(dir=directory, prefix=target.name + ".", suffix=".tmp")
-    except OSError as e:
-        too_long = e.errno == errno.ENAMETOOLONG or (
-            getattr(e, "winerror", None) == _WINERROR_FILENAME_EXCED_RANGE
-        )
-        if not too_long:
-            raise
     digest = hashlib.blake2b(os.fsencode(target.name), digest_size=8).hexdigest()
-    return tempfile.mkstemp(dir=directory, prefix=digest + ".", suffix=".tmp")
+    rungs = [target.name + "."]
+    if len(digest) < len(target.name):
+        rungs.append(digest + ".")
+    rungs.append("")
+    for prefix in rungs[:-1]:
+        try:
+            return tempfile.mkstemp(dir=directory, prefix=prefix, suffix=".tmp")
+        except OSError as e:
+            if not _is_name_too_long(e):
+                raise
+    return tempfile.mkstemp(dir=directory, prefix=rungs[-1], suffix=".tmp")
 
 
 def _atomic_write(

--- a/src/bmad_loop/platform_util.py
+++ b/src/bmad_loop/platform_util.py
@@ -502,9 +502,16 @@ def _mkstemp_beside(target: Path) -> tuple[int, str]:
     only while it actually shortens, and a bare ``mkstemp`` — the shortest name
     this function can produce — always ends the ladder.
 
-    Only a failure at that last rung propagates, and by then the claim it carries
-    is true: no choice of prefix can fix it, so what does not fit is the
-    DIRECTORY."""
+    Only a failure at that last rung propagates. No choice of *prefix* can fix
+    that one — there is no prefix left — but that is a narrower statement than "the
+    directory is too long", and the difference is #596: ``mkstemp`` will not
+    generate a name below 12 characters (8 random, plus the ``.tmp`` this helper
+    needs to stay out of ``devcontract``'s ``*.md`` scans). What does not fit at
+    the last rung is therefore the directory PLUS those 12, which a target with a
+    shorter basename can still clear on a direct write. Shrinking below the floor
+    means abandoning ``mkstemp``, and with it the entropy that keeps the staged
+    name unpredictable where a less-trusted writer can reach it — see #591 for the
+    cost of a guessable temp name."""
     directory = str(target.parent)
     digest = hashlib.blake2b(os.fsencode(target.name), digest_size=8).hexdigest()
     rungs = [target.name + "."]

--- a/src/bmad_loop/platform_util.py
+++ b/src/bmad_loop/platform_util.py
@@ -45,6 +45,14 @@ _REPLACE_ATTEMPTS = 12
 _REPLACE_BASE_S = 0.02
 _REPLACE_CAP_S = 0.7
 
+# Windows-only: the "name does not fit" errno is not ENAMETOOLONG. CPython's
+# PC/errmap.h maps ERROR_FILENAME_EXCED_RANGE (206) to ENOENT and does not map
+# ERROR_BUFFER_OVERFLOW (111) at all — it falls to the EINVAL default — so
+# ENAMETOOLONG is effectively unreachable there and only .winerror tells.
+# ERROR_INVALID_NAME (123) is deliberately NOT here: it also fires for a name
+# holding characters win32 forbids outright, which no shorter prefix fixes.
+_WINERROR_FILENAME_EXCED_RANGE = 206
+
 # Reserved on Windows regardless of extension: CON.txt is as illegal as CON. The
 # COM0/LPT0 and superscript (COM¹/COM²/COM³) forms are reserved by the same rule,
 # as are the console device names CONIN$/CONOUT$.
@@ -463,13 +471,23 @@ def _mkstemp_beside(target: Path) -> tuple[int, str]:
     ``os.fsencode``, not ``str.encode``: a POSIX filename is arbitrary bytes and
     may carry surrogates that a strict UTF-8 encode would raise on.
 
-    A second ``ENAMETOOLONG`` propagates — that one is the DIRECTORY being too
-    long, which no choice of prefix can fix."""
+    The retry keys on TWO spellings of one condition, because win32 does not use
+    the POSIX one: ``ERROR_FILENAME_EXCED_RANGE`` arrives as ``ENOENT`` and is
+    distinguishable only by ``.winerror`` (see
+    ``_WINERROR_FILENAME_EXCED_RANGE``). Keying on ``ENAMETOOLONG`` alone left
+    this whole fallback dead on Windows — where, per the ``MAX_PATH`` note above,
+    it is if anything easier to reach than on ext4.
+
+    A second failure propagates — that one is the DIRECTORY being too long, which
+    no choice of prefix can fix."""
     directory = str(target.parent)
     try:
         return tempfile.mkstemp(dir=directory, prefix=target.name + ".", suffix=".tmp")
     except OSError as e:
-        if e.errno != errno.ENAMETOOLONG:
+        too_long = e.errno == errno.ENAMETOOLONG or (
+            getattr(e, "winerror", None) == _WINERROR_FILENAME_EXCED_RANGE
+        )
+        if not too_long:
             raise
     digest = hashlib.blake2b(os.fsencode(target.name), digest_size=8).hexdigest()
     return tempfile.mkstemp(dir=directory, prefix=digest + ".", suffix=".tmp")

--- a/src/bmad_loop/platform_util.py
+++ b/src/bmad_loop/platform_util.py
@@ -407,20 +407,33 @@ def atomic_write_text(path: Path, text: str, *, follow_symlinks: bool = True) ->
     _atomic_write(path, text, mode="w", encoding="utf-8", follow_symlinks=follow_symlinks)
 
 
-def atomic_write_bytes(path: Path, data: bytes) -> None:
+def atomic_write_bytes(path: Path, data: bytes, *, follow_symlinks: bool = True) -> None:
     """Replace ``path``'s contents with ``data`` atomically — the byte-exact
     sibling of :func:`atomic_write_text`, whose docstring carries the shared
-    contract (symlinks followed, mode and xattrs preserved when the target already
-    exists, a fresh target left at ``mkstemp``'s private ``0600``, fsync before the
-    replace, temp removed on any failure).
+    contract (mode and xattrs preserved when the target already exists and
+    symlinks are followed, a fresh target left at ``mkstemp``'s private ``0600``,
+    fsync before the replace, temp removed on any failure).
 
-    The one difference is the whole point: ``data`` lands byte-for-byte. No encode
-    and no newline translation, so a payload carrying LF keeps LF on Windows and
-    bytes that are not valid text in any codec survive the round trip. Callers
-    handling filesystem-derived content want this variant — a POSIX filename is
-    arbitrary bytes, and an operator's git exclude file may be in any legacy
-    encoding at all."""
-    _atomic_write(path, data, mode="wb", encoding=None)
+    ``follow_symlinks`` behaves exactly as it does there. The default resolves
+    ``path`` first, so a file symlinked into the repo keeps being a symlink and
+    the real file is what gets rewritten — a replace against the link itself would
+    turn it into a regular file and orphan the target. ``follow_symlinks=False``
+    inverts that: the *name* is replaced, whatever it points at, and mode and
+    xattrs are then not inherited at all. Right for a machine-minted file living
+    somewhere a less-trusted writer can reach, where honouring a planted link
+    would aim this write at a path of that writer's choosing; wrong for the
+    operator-curated files the default was built for — including the private git
+    exclude ``install._worktree_local_exclude`` writes, which pre-creates the
+    target precisely so this helper has a umask mode to carry over.
+
+    The one difference from the text sibling is the whole point: ``data`` lands
+    byte-for-byte. No encode and no newline translation, so a payload carrying LF
+    keeps LF on Windows and bytes that are not valid text in any codec survive the
+    round trip. Callers handling filesystem-derived content want this variant — a
+    POSIX filename is arbitrary bytes, and an operator's git exclude file may be
+    in any legacy encoding at all — as do callers who read bytes to preserve a
+    file's existing line endings (``policy.write_mux_backend``)."""
+    _atomic_write(path, data, mode="wb", encoding=None, follow_symlinks=follow_symlinks)
 
 
 def _atomic_write(

--- a/src/bmad_loop/platform_util.py
+++ b/src/bmad_loop/platform_util.py
@@ -19,6 +19,7 @@ the same key must run both.
 
 from __future__ import annotations
 
+import errno
 import hashlib
 import os
 import random
@@ -436,6 +437,44 @@ def atomic_write_bytes(path: Path, data: bytes, *, follow_symlinks: bool = True)
     _atomic_write(path, data, mode="wb", encoding=None, follow_symlinks=follow_symlinks)
 
 
+def _mkstemp_beside(target: Path) -> tuple[int, str]:
+    """``mkstemp`` in ``target``'s own directory, prefixed with its name so the
+    temp is recognisably that target's staging file — and so it ends in ``.tmp``
+    rather than the target's extension, which `devcontract._atomic_write_spec`
+    depends on to keep its temps out of the ``*.md`` artifact scans.
+
+    ``mkstemp`` inserts 8 random characters between prefix and suffix, so the temp
+    name runs ``len(target.name) + 13``. A basename within 13 bytes of the
+    filesystem's ``NAME_MAX`` therefore makes the TEMP name illegal at a path the
+    target itself is perfectly legal at. Measured on ext4 (``NAME_MAX`` 255): a
+    242-byte basename stages fine, 243 raises ``ENAMETOOLONG`` while the direct
+    write it replaced succeeded through 255 (#595).
+
+    The fallback replaces the readable prefix with a digest of it rather than
+    truncating it. Truncation is the obvious fix and it is wrong: ``NAME_MAX``
+    counts BYTES while Python slices CHARACTERS, so a bounded character slice
+    neither guarantees a legal name nor avoids splitting a UTF-8 sequence — and
+    the limit is not portably knowable anyway (``os.pathconf`` is POSIX-only,
+    NTFS counts UTF-16 code units, and win32 is usually bound by ``MAX_PATH`` on
+    the whole path instead). Letting the OS answer needs none of that arithmetic:
+    the common path keeps the readable name, and only a basename that cannot fit
+    degrades to a fixed-width digest.
+
+    ``os.fsencode``, not ``str.encode``: a POSIX filename is arbitrary bytes and
+    may carry surrogates that a strict UTF-8 encode would raise on.
+
+    A second ``ENAMETOOLONG`` propagates — that one is the DIRECTORY being too
+    long, which no choice of prefix can fix."""
+    directory = str(target.parent)
+    try:
+        return tempfile.mkstemp(dir=directory, prefix=target.name + ".", suffix=".tmp")
+    except OSError as e:
+        if e.errno != errno.ENAMETOOLONG:
+            raise
+    digest = hashlib.blake2b(os.fsencode(target.name), digest_size=8).hexdigest()
+    return tempfile.mkstemp(dir=directory, prefix=digest + ".", suffix=".tmp")
+
+
 def _atomic_write(
     path: Path,
     payload: str | bytes,
@@ -471,7 +510,7 @@ def _atomic_write(
     private ``0600`` is the right mode for the machine-minted file this mode
     exists for."""
     target = path.resolve() if follow_symlinks else path
-    fd, tmp_name = tempfile.mkstemp(dir=str(target.parent), prefix=target.name + ".", suffix=".tmp")
+    fd, tmp_name = _mkstemp_beside(target)
     tmp = Path(tmp_name)
     try:
         with os.fdopen(fd, mode, encoding=encoding) as fh:

--- a/src/bmad_loop/policy.py
+++ b/src/bmad_loop/policy.py
@@ -19,7 +19,7 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
 
-from .platform_util import atomic_replace, has_parent_ref, is_absolute_path, names_tree_root
+from .platform_util import atomic_write_bytes, has_parent_ref, is_absolute_path, names_tree_root
 
 POLICY_FILE = Path(".bmad-loop") / "policy.toml"
 
@@ -1393,6 +1393,13 @@ def write_mux_backend(path: Path, name: str | None) -> None:
         )
 
     path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_suffix(".toml.tmp")
-    tmp.write_bytes(result.encode("utf-8"))
-    atomic_replace(tmp, path)
+    # #363: the helper removes its temp on any raise — the hand-rolled tmp here was
+    # the fixed name `.bmad-loop/policy.toml.tmp`, which nothing gitignores (the
+    # ignore line is the anchored literal `.bmad-loop/policy.toml`) and which
+    # `tui.settings.PolicyDoc.save` built identically, so the two could collide.
+    # The BYTES helper, not the text one: this function reads bytes and writes bytes
+    # on purpose (see the decode above) so a CRLF policy.toml keeps its endings.
+    # follow_symlinks=False replaces the name, as the bare replace did; a driven
+    # session can write this exact path (runsetup), so a link planted here must be
+    # clobbered rather than written through.
+    atomic_write_bytes(path, result.encode("utf-8"), follow_symlinks=False)

--- a/src/bmad_loop/runs.py
+++ b/src/bmad_loop/runs.py
@@ -1045,7 +1045,9 @@ def archive_run(project: Path, run_dir: Path, *, force: bool = False) -> Path:
     # init writes `.bmad-loop/runs/`, `.bmad-loop/cache/`, `.bmad-loop/policy.toml`
     # and `_bmad/render/`, and `archive/` matches none of them. So a stranded temp
     # here is an untracked file holding `worktree_clean` False until a human removes
-    # it — the same exposure the four helper-converted sites had.
+    # it — the same exposure `decisions._write_store`, `policy.write_mux_backend` and
+    # `tui.settings.PolicyDoc.save` had. (Not the sweep's two `decisions.json`
+    # writes, which look like the same fix but write under the ignored run dir.)
     try:
         with tarfile.open(tmp, "w:gz") as tar:
             tar.add(run_dir, arcname=run_dir.name)

--- a/src/bmad_loop/runs.py
+++ b/src/bmad_loop/runs.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import json
 import math
@@ -1035,10 +1036,24 @@ def archive_run(project: Path, run_dir: Path, *, force: bool = False) -> Path:
     archive_dir = project / ARCHIVE_DIR
     archive_dir.mkdir(parents=True, exist_ok=True)
     dest = archive_dir / f"{run_dir.name}.tar.gz"
-    tmp = dest.with_suffix(".tar.gz.tmp")
-    with tarfile.open(tmp, "w:gz") as tar:
-        tar.add(run_dir, arcname=run_dir.name)
-    atomic_replace(tmp, dest)
+    # `with_name`, not `with_suffix`: the latter replaces only the LAST suffix, so
+    # on `<id>.tar.gz` (stem `<id>.tar`) it produced `<id>.tar.tar.gz.tmp` — not the
+    # name this docstring implies, and not one any cleanup could be written against.
+    tmp = dest.with_name(dest.name + ".tmp")
+    # #363: the guard, not a helper — the path is handed to `tarfile.open`, so there
+    # is no payload for `atomic_write_*` to take. Nothing gitignores this directory:
+    # init writes `.bmad-loop/runs/`, `.bmad-loop/cache/`, `.bmad-loop/policy.toml`
+    # and `_bmad/render/`, and `archive/` matches none of them. So a stranded temp
+    # here is an untracked file holding `worktree_clean` False until a human removes
+    # it — the same exposure the four helper-converted sites had.
+    try:
+        with tarfile.open(tmp, "w:gz") as tar:
+            tar.add(run_dir, arcname=run_dir.name)
+        atomic_replace(tmp, dest)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            tmp.unlink(missing_ok=True)
+        raise
     shutil.rmtree(run_dir)
     _discard_state_dir(project, run_dir.name)  # same tail as delete_run
     return dest

--- a/src/bmad_loop/sprintstatus.py
+++ b/src/bmad_loop/sprintstatus.py
@@ -15,6 +15,8 @@ from pathlib import Path
 
 import yaml
 
+from .platform_util import atomic_write_text
+
 EPIC_RE = re.compile(r"^epic-(\d+)$")
 RETRO_RE = re.compile(r"^epic-(\d+)-retrospective$")
 RETRO_ITEM_RE = re.compile(r"^epic-(\d+)-retro-item-(\d+)-(.+)$")
@@ -243,6 +245,19 @@ def advance(path: Path, story_key: str, target: str, *, now: str | None = None) 
     refresh `last_updated` when `now` is given. Comments/structure are preserved
     via line edits. Returns the story's status after the call (== `target` on a
     write), or None when nothing was eligible.
+
+    The rewrite is atomic (#379). This is a read-modify-rewrite of the board, and
+    a truncating `write_text` that faults partway through corrupts it SILENTLY:
+    YAML cut at a line boundary is still a valid mapping, just a smaller one, so
+    the epics past the tear cease to exist rather than raising. AGENTS.md makes
+    this the orchestrator's sole write path to sprint-status.yaml, so nothing
+    downstream would contradict the shortened board — the run would simply walk
+    off the end of the sprint. `atomic_write_text` keeps the file entire: either
+    the old contents or the whole new ones, never a prefix.
+
+    Symlinks are FOLLOWED (the helper's default), which is what the truncating
+    write did too — the board is an operator-curated file at a project-relative
+    path, and a repo that symlinks it somewhere must keep being a symlink.
     """
     if not path.is_file():
         return None
@@ -279,7 +294,7 @@ def advance(path: Path, story_key: str, target: str, *, now: str | None = None) 
         changed = _set_mapping_value(lines, "last_updated", now) or changed
 
     if changed:
-        path.write_text("".join(lines), encoding="utf-8")
+        atomic_write_text(path, "".join(lines))
     return target
 
 

--- a/src/bmad_loop/sweep.py
+++ b/src/bmad_loop/sweep.py
@@ -951,8 +951,15 @@ class SweepEngine(Engine):
             )
             seeded = True
         if seeded:
-            # #363: the helper unlinks its temp on any raise. follow_symlinks=False
-            # replaces the NAME, which is what the bare replace did too.
+            # Same helper as `decisions._write_store` (#363), but NOT for #363's
+            # reason: `decisions_path` here is the PER-RUN file under
+            # `.bmad-loop/runs/<id>/`, which init gitignores, so a stranded temp
+            # was never untracked and never held `worktree_clean` False. The
+            # project-level `.bmad-loop/decisions.json` is a different file with a
+            # near-identical temp name — that is the exposed one. Taken anyway for
+            # the fsync and the unique temp name, which two writers of one key
+            # would otherwise collide on. follow_symlinks=False replaces the NAME,
+            # which is what the bare replace did too.
             atomic_write_text(decisions_path, json.dumps(answers, indent=2), follow_symlinks=False)
         pending = [d for d in plan.decisions if d.id not in answers]
         answered_interactively = False
@@ -989,7 +996,7 @@ class SweepEngine(Engine):
                     "effect": option.effect,
                     "answered_at": self._today(),
                 }
-                atomic_write_text(  # #363, as the seeded write above
+                atomic_write_text(  # same file, same reasoning as the seeded write above (#363)
                     decisions_path, json.dumps(answers, indent=2), follow_symlinks=False
                 )
                 self.journal.append(

--- a/src/bmad_loop/sweep.py
+++ b/src/bmad_loop/sweep.py
@@ -21,7 +21,7 @@ from . import deferredwork, gates, verify
 from .engine import Engine
 from .escalation import critical_escalations, env_fault_pause_reason, session_failure_reason
 from .model import Phase, StoryTask
-from .platform_util import atomic_replace, atomic_write_text, neutralize_surrogates
+from .platform_util import atomic_write_text, neutralize_surrogates
 from .statemachine import advance
 from .workspace import discard_worktree
 
@@ -951,9 +951,9 @@ class SweepEngine(Engine):
             )
             seeded = True
         if seeded:
-            tmp = decisions_path.with_suffix(".tmp")
-            tmp.write_text(json.dumps(answers, indent=2), encoding="utf-8")
-            atomic_replace(tmp, decisions_path)
+            # #363: the helper unlinks its temp on any raise. follow_symlinks=False
+            # replaces the NAME, which is what the bare replace did too.
+            atomic_write_text(decisions_path, json.dumps(answers, indent=2), follow_symlinks=False)
         pending = [d for d in plan.decisions if d.id not in answers]
         answered_interactively = False
         if not self.prompting:
@@ -989,9 +989,9 @@ class SweepEngine(Engine):
                     "effect": option.effect,
                     "answered_at": self._today(),
                 }
-                tmp = decisions_path.with_suffix(".tmp")
-                tmp.write_text(json.dumps(answers, indent=2), encoding="utf-8")
-                atomic_replace(tmp, decisions_path)
+                atomic_write_text(  # #363, as the seeded write above
+                    decisions_path, json.dumps(answers, indent=2), follow_symlinks=False
+                )
                 self.journal.append(
                     "decision-answered",
                     dw_id=decision.id,

--- a/src/bmad_loop/tui/settings.py
+++ b/src/bmad_loop/tui/settings.py
@@ -15,7 +15,7 @@ from typing import Any
 import tomlkit
 
 from .. import policy as policy_mod
-from ..platform_util import atomic_replace
+from ..platform_util import atomic_write_text
 
 STAGES = ("dev", "review", "triage")
 
@@ -104,7 +104,11 @@ class PolicyDoc:
         return tomlkit.dumps(self._doc)
 
     def save(self, path: Path) -> None:
+        """#363: via the helper, which removes its temp on any raise. The
+        hand-rolled temp was the fixed name `.bmad-loop/policy.toml.tmp` —
+        gitignored by nothing, and byte-identical to the one
+        `policy.write_mux_backend` built, so the settings editor and the mux
+        writer raced on one name. Raises rather than degrades: the screen catches
+        OSError to show "save failed", which requires the raise to reach it."""
         path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = path.with_suffix(".toml.tmp")
-        tmp.write_text(self.dumps(), encoding="utf-8")
-        atomic_replace(tmp, path)
+        atomic_write_text(path, self.dumps(), follow_symlinks=False)

--- a/src/bmad_loop/verify.py
+++ b/src/bmad_loop/verify.py
@@ -30,6 +30,7 @@ from .frontmatter import (
     status_of,
 )
 from .model import StoryTask, VerifyOutcome
+from .platform_util import atomic_write_bytes
 from .policy import POLICY_FILE, Policy
 from .sprintstatus import STATUS_ORDER, story_status
 
@@ -1375,10 +1376,16 @@ def set_frontmatter_field(path: Path, key: str, value: str) -> bool:
     appended, so the spec carried the key twice and the reader resolved the
     wrong one.
 
-    Byte-preserving on the same terms as its sibling: ``read_bytes().decode`` in,
-    ``write_bytes`` out, so a CRLF spec is not relaid to LF (nor an LF one to
-    CRLF on Windows) by a write contracted to move one field. The INSERTED line
-    takes the block's own ending, not a bare ``\\n``.
+    Byte-preserving on the same terms as its sibling: ``read_bytes().decode`` in
+    and bytes out, so a CRLF spec is not relaid to LF (nor an LF one to CRLF on
+    Windows) by a write contracted to move one field. The INSERTED line takes the
+    block's own ending, not a bare ``\\n``.
+
+    Atomic on the same terms too (#379) — `platform_util.atomic_write_bytes`,
+    ``follow_symlinks=False``, matching what `devcontract._atomic_write_spec`
+    already does to the same files. Use the BYTES helper and not the text one:
+    `atomic_write_text` keeps ``Path.write_text``'s translating newline default,
+    which would relay ``\\n``→``\\r\\n`` on Windows and undo the paragraph above.
     """
     if not path.is_file():
         return False
@@ -1390,7 +1397,7 @@ def set_frontmatter_field(path: Path, key: str, value: str) -> bool:
     edited = _edit_frontmatter_block(block, key, value, insert=True)
     if edited is None:
         return False
-    path.write_bytes((before + edited + after).encode("utf-8"))
+    atomic_write_bytes(path, (before + edited + after).encode("utf-8"), follow_symlinks=False)
     return True
 
 

--- a/src/bmad_loop/verify.py
+++ b/src/bmad_loop/verify.py
@@ -1000,7 +1000,19 @@ def safe_rollback(
         current = policy_path.read_bytes() if policy_path.is_file() else None
         if current != policy_content:
             policy_path.parent.mkdir(parents=True, exist_ok=True)
-            policy_path.write_bytes(policy_content)
+            # Atomic, and by NAME (#379). This is a put-back after a rollback has
+            # already discarded the run's work, so a torn write costs the operator
+            # their orchestration config on top of it — and a truncated policy.toml
+            # is not a smaller config but a parse error the next `bmad-loop run`
+            # refuses on, which is the failure the whole restore exists to avoid.
+            # `follow_symlinks=False` is a real change here (a bare `write_bytes`
+            # opens the name and so writes THROUGH a link), and it is the right
+            # one twice over: `policy.write_mux_backend` already replaces this same
+            # file by name, so no link at this path survives the orchestrator
+            # anyway; and `runsetup` states a driven session can write
+            # `.bmad-loop/policy.toml`, so honouring a link planted there would aim
+            # a host-side write at a path of that session's choosing.
+            atomic_write_bytes(policy_path, policy_content, follow_symlinks=False)
     if baseline_untracked is None:
         return  # no snapshot to diff against: never delete untracked files
     created = untracked_files(repo) - set(baseline_untracked)

--- a/src/bmad_loop/worktree_flow.py
+++ b/src/bmad_loop/worktree_flow.py
@@ -60,6 +60,7 @@ from .install import (
     strip_relay_hooks,
 )
 from .model import Phase
+from .platform_util import atomic_write_text
 from .process_host import get_process_host
 from .workspace import (
     UnitWorkspace,
@@ -825,7 +826,19 @@ def provision_worktree(
         # zero, and a pin would claim orchestrator ownership of a file this run
         # never modified, hiding a story's own edit to it for no benefit.
         if config != baseline_config:
-            config_path.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+            # atomic_write_text, never write_text (#379). `_register_hooks` states
+            # the rule at length; the stakes are higher here. This config is the
+            # SEEDED copy of the operator's own — allowlist, env, MCP entries and
+            # their hooks all round-trip through the parse above — and a truncating
+            # `"w"` publishes a prefix of it on a short write. Nothing downstream
+            # re-reads it to complain, either: the session starts against a settings
+            # file whose JSON no longer parses, so the CLI falls back to its defaults
+            # and the Stop hook never registers. That is #363's stall with no
+            # diagnostic. follow_symlinks stays at the default, matching the
+            # `write_text` it replaces — and the symlink question is already settled
+            # above this line, by the component-wise refusal walk that skips the
+            # profile entirely when any component of the path is a link.
+            atomic_write_text(config_path, json.dumps(config, indent=2) + "\n")
             pin_degrade = _pin_tracked_config_rewrite(worktree, profile.hooks.config_path)
             if pin_degrade is not None and on_degraded is not None:
                 on_degraded(pin_degrade)

--- a/tests/test_decisions.py
+++ b/tests/test_decisions.py
@@ -68,6 +68,45 @@ def test_load_pre_answers_tolerates_garbage(project):
     assert decisions.load_pre_answers(project.project) == {}
 
 
+def test_record_pre_answer_write_failure_raises_and_keeps_the_store(project, monkeypatch):
+    """#363. `_write_store` is a read-modify-rewrite of a file nothing gitignores,
+    so its temp must not outlive a failed write: a stranded
+    `.bmad-loop/decisions.tmp` is an untracked file that holds `worktree_clean`
+    False until a human deletes it. Routing through the helper is what closes that
+    — it unlinks its own temp on any raise — and the raise still reaches the caller.
+
+    Patched at decisions' OWN binding, never `Path.write_text`: the helper writes
+    through an `mkstemp` fd via `os.fdopen`, so a `Path` patch never fires and the
+    test would pass having exercised nothing.
+
+    Ablation A3: revert `_write_store` to the hand-rolled `tmp.write_text(...)` +
+    `atomic_replace` and this reddens alone — loudly, as an AttributeError from
+    `monkeypatch.setattr`, because the module binding disappears with the revert."""
+    path = decisions.store_path(project.project)
+    decisions.record_pre_answer(
+        project.project,
+        "DW-7",
+        DecisionOption(key="1", label="Build it", effect="build", intent="do it"),
+        date="2026-06-13",
+    )
+    before = path.read_bytes()
+
+    def boom(path, text, *, follow_symlinks=True):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(decisions, "atomic_write_text", boom)
+    with pytest.raises(OSError, match="disk full"):
+        decisions.record_pre_answer(
+            project.project,
+            "DW-9",
+            DecisionOption(key="2", label="Keep as is", effect="keep-open"),
+            date="2026-06-14",
+        )
+
+    assert path.read_bytes() == before
+    assert b"DW-9" not in path.read_bytes()  # the specific mutation that must not land
+
+
 # ------------------------------------------------------- discovery
 
 

--- a/tests/test_devcontract.py
+++ b/tests/test_devcontract.py
@@ -1,6 +1,7 @@
 """Tests for the generic bmad-dev-auto -> result.json translation shim."""
 
 import os
+import sys
 from dataclasses import FrozenInstanceError
 from pathlib import Path
 
@@ -1212,21 +1213,96 @@ def test_append_bare_cr_terminated_spec_makes_heading_visible(tmp_path):
     ids=["append", "strip", "reset"],
 )
 def test_repair_write_failure_never_truncates_spec(tmp_path, monkeypatch, writer, original):
-    """#276: the three in-place spec rewriters are atomic (tmp + ``atomic_replace``).
-    A failed rename (disk-full, interruption, short write) leaves the original spec
-    byte-for-byte intact with no ``.tmp`` litter — the "a failed repair never loses
-    work" invariant (fault injection on the old truncating write reduced a 46-byte
-    spec to 12)."""
+    """#276: the three in-place spec rewriters are atomic. A failed write (disk-full,
+    interruption, short write) leaves the original spec byte-for-byte intact with no
+    ``.tmp`` litter — the "a failed repair never loses work" invariant (fault
+    injection on the old truncating write reduced a 46-byte spec to 12).
+
+    #379 moved `_atomic_write_spec` onto `platform_util.atomic_write_bytes`, so the
+    fault is injected at devcontract's OWN binding of that helper. The litter
+    assertion still grades this module: it fires if a rewriter ever mints a temp of
+    its own before delegating. The helper's internal unlink-on-raise is graded where
+    it lives, by test_platform_util's `os.replace` boom rows."""
     sp = _write(tmp_path, "spec-a.md", original)
 
-    def boom(tmp, target):
+    def boom(path, data, *, follow_symlinks=True):
         raise OSError("no space left on device")
 
-    monkeypatch.setattr(devcontract, "atomic_replace", boom)
+    monkeypatch.setattr(devcontract, "atomic_write_bytes", boom)
     with pytest.raises(OSError, match="no space left"):
         writer(sp)
     assert sp.read_text(encoding="utf-8") == original  # original untouched
-    assert list(tmp_path.glob("*.tmp")) == []  # temp file cleaned up, no litter
+    assert list(tmp_path.glob("*.tmp")) == []  # no temp minted here, no litter
+
+
+def test_atomic_write_spec_hands_the_helper_bytes_not_text(tmp_path, monkeypatch):
+    """#379 moved this writer onto `platform_util.atomic_write_bytes`. Grades the
+    BYTES half of that choice platform-independently: `test_..._preserves_crlf`
+    below already forbids relaying a CRLF spec, but `atomic_write_text` keeps
+    `Path.write_text`'s translating newline default and on POSIX
+    `os.linesep == "\\n"`, so swapping the text helper in reddens that row on
+    WINDOWS ONLY and CI's Linux leg would call the swap green.
+
+    So inspect the payload the helper is handed, upstream of any translation. The
+    binding is WRAPPED rather than replaced, so the real write still happens.
+
+    BOTH helper names are wrapped into the same list, the text one with
+    `raising=False` since this module does not import it. That is what makes the
+    `isinstance` line the assertion that fires: wrapping only the bytes name would
+    grade "the bytes helper was called", so the swap would redden on an empty `seen`
+    and this row would be claiming more than it checked.
+
+    Ablation: swap `atomic_write_bytes` for `atomic_write_text` in
+    `_atomic_write_spec` (dropping the `.encode`) and this reddens on every
+    platform, on the `isinstance` row."""
+    seen: list[bytes | str] = []
+    real = devcontract.atomic_write_bytes
+
+    def record(path, data, *, follow_symlinks=True):
+        seen.append(data)
+        blob = data if isinstance(data, bytes) else data.encode("utf-8")
+        real(path, blob, follow_symlinks=follow_symlinks)
+
+    monkeypatch.setattr(devcontract, "atomic_write_bytes", record)
+    monkeypatch.setattr(devcontract, "atomic_write_text", record, raising=False)
+    sp = tmp_path / "spec-a.md"
+    sp.write_bytes(b"---\r\nstatus: done\r\n---\r\n\r\n# Story\r\n\r\nbody\r\n")
+
+    devcontract.append_auto_run_result(sp, "done")
+
+    assert len(seen) == 1  # exactly one write — no retry loop crept in
+    assert isinstance(seen[0], bytes)
+    assert b"## Auto Run Result\r\n" in seen[0]
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlinks")
+def test_atomic_write_spec_replaces_a_planted_symlink(tmp_path):
+    """The row that grades this SITE's `follow_symlinks=False` argument rather than
+    the helper's implementation of it (pinned in test_platform_util.py, where the
+    helper is called directly).
+
+    Behaviour-preserving, not a tightening: the `atomic_replace` this replaced never
+    dereferenced its destination either, so passing the default True would have
+    CHANGED what these four rewriters do. It is also the security choice — the spec
+    path reaches them from a scan of a directory a driven session owns, so writing
+    THROUGH a link planted at that name would hand the session a host-side write to
+    any operator-writable path.
+
+    Ablation: drop `follow_symlinks=False` in `_atomic_write_spec` and this reddens
+    alone — alone in both directions, since it does not reach the two
+    `frontmatter`-side writers of these same specs. Each of those passes its own
+    literal and carries its own row (tests/test_frontmatter.py,
+    tests/test_resolve.py)."""
+    original = "---\nstatus: done\n---\n\nbody\n"
+    real = _write(tmp_path, "someone-elses-file", original)
+    link = tmp_path / "spec-a.md"
+    link.symlink_to(real)
+
+    assert devcontract.reset_spec_status(link, "in-progress") is True
+
+    assert not link.is_symlink()  # the NAME was replaced
+    assert verify.read_frontmatter(link)["status"] == "in-progress"
+    assert real.read_text(encoding="utf-8") == original  # not written through
 
 
 # ------------------------------ append_operator_confirmation (#335 part 3)
@@ -1337,10 +1413,10 @@ def test_operator_confirmation_write_failure_raises_and_keeps_the_spec(tmp_path,
     never made."""
     sp = _write(tmp_path, "spec-a.md", _PARKED)
 
-    def boom(tmp, target):
+    def boom(path, data, *, follow_symlinks=True):
         raise OSError("no space left on device")
 
-    monkeypatch.setattr(devcontract, "atomic_replace", boom)
+    monkeypatch.setattr(devcontract, "atomic_write_bytes", boom)
     with pytest.raises(OSError, match="no space left"):
         devcontract.append_operator_confirmation(sp, _ACTIONS, date="2026-07-28")
     assert sp.read_text(encoding="utf-8") == _PARKED

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1536,6 +1536,112 @@ def test_a_failed_commit_restores_the_park_record(project):
     assert not operatoractions.records_dir(project.project).exists()
 
 
+def _park_over_an_earlier_record(project, actions):
+    """A story that has been parked BEFORE, its record committed. Reaches the
+    restore's other branch: with a prior on disk `_write_park_record` captures
+    it, so the failure arms take the put-back write rather than the unlink the
+    row above covers."""
+    from bmad_loop import operatoractions
+
+    operatoractions.record_park(
+        project.project,
+        "1-1-a",
+        actions=actions,
+        spec_file="docs/spec-1-1-a.md",
+        run_id="run-0",
+        parked_at="2026-07-01",
+    )
+    record = operatoractions.record_path(project.project, "1-1-a")
+    git(project.project, "add", str(record))
+    git(project.project, "commit", "-q", "-m", "an earlier park's record")
+    engine = _park_engine(project)
+    _reject_commits(project)
+    return engine, record
+
+
+def test_a_failed_commit_puts_an_earlier_park_record_back(project):
+    """The restore's OTHER branch, and it was untested: a re-park over a record
+    that already exists must put the PRIOR text back, not just delete what this
+    attempt wrote. Left alone the committed record claims this run's actions for
+    a commit that does not exist, so `confirm` would discharge a park against a
+    tracked file whose content no history carries.
+
+    Byte-for-byte, and the put-back is atomic (#379): a torn restore leaves the
+    record neither version, and `load` reads a truncated record as an entry
+    owing nothing — the park silently discharged by the rollback.
+
+    Ablation: replace the `atomic_write_text` call with `pass` and this fails —
+    the record keeps this attempt's actions."""
+    from bmad_loop import operatoractions
+
+    prior_actions = ["the earlier park's action"]
+    engine, record = _park_over_an_earlier_record(project, prior_actions)
+    before = record.read_text(encoding="utf-8")
+
+    summary = engine.run()
+
+    assert summary.awaiting_operator == 0 and summary.paused  # the commit really did fail
+    assert engine.state.tasks["1-1-a"].phase == Phase.ESCALATED
+    assert record.read_text(encoding="utf-8") == before  # byte-for-byte
+    assert operatoractions.load(project.project)["1-1-a"]["actions"] == prior_actions
+    # and it did not raise on the way: the restore reports its own failures
+    kinds = {e["kind"] for e in engine.journal.entries()}
+    assert "park-record-rollback-failed" not in kinds
+
+
+def test_a_failed_park_record_rollback_is_journaled_not_raised(project, monkeypatch):
+    """The restore runs INSIDE the commit window's except arms, so anything it
+    raises displaces what those arms exist to carry: the `GitError` arm would
+    skip `_escalate` and strand the story in COMMITTING with no diagnosis, and
+    the `BaseException` arm would skip its bare `raise` and swap a graceful
+    `RunStopped` for a write complaint.
+
+    The oracle is NOT a `pytest.raises` — the whole property is that nothing
+    escapes. It is the run's disposition (the failed COMMIT's, not the failed
+    rollback's) plus the journal line, because a bare suppress would leave this
+    invisible: `validate` reports a board parked with no record, never a record
+    left over for a park in no commit.
+
+    `OSError` is the injected type deliberately. Unlike `_restore_deferred_closes`
+    this site passes `follow_symlinks=False`, so no `Path.resolve` runs and the
+    pre-3.13 `RuntimeError`-on-symlink-loop cannot arise — widening the guard here
+    would be copying a fix for a call this one does not make.
+
+    Patched as bound in `engine` and FILTERED BY FILENAME: the module has four
+    `atomic_write_text` sites on one binding, so a module-wide boom survives a
+    revert of this site and would go green by crashing from a different one.
+
+    Ablation: delete the `self.journal.append` and this fails on the journal row
+    alone; delete the whole `except OSError` arm and it fails on `not
+    summary.crashed` — the escaping OSError preempts the escalation."""
+    from bmad_loop import operatoractions
+
+    engine, record = _park_over_an_earlier_record(project, ["the earlier park's action"])
+    real = platform_util.atomic_write_text
+
+    def boom(path, text, *, follow_symlinks=True):
+        if Path(path).name == record.name:
+            raise OSError(30, "Read-only file system")
+        return real(path, text, follow_symlinks=follow_symlinks)
+
+    monkeypatch.setattr("bmad_loop.engine.atomic_write_text", boom)
+
+    summary = engine.run()
+
+    # the disposition is the failed COMMIT's, not the failed rollback's
+    assert summary.paused and not summary.crashed
+    assert engine.state.tasks["1-1-a"].phase == Phase.ESCALATED
+    reasons = [e["reason"] for e in engine.journal.entries() if e["kind"] == "story-escalated"]
+    assert len(reasons) == 1 and reasons[0].startswith("commit failed:")
+    # the rollback's own failure is on the record, naming the type — `str(e)`
+    # alone cannot say whether the disk or the path was at fault
+    failed = [e for e in engine.journal.entries() if e["kind"] == "park-record-rollback-failed"]
+    assert len(failed) == 1 and failed[0]["error"].startswith("OSError: ")
+    # honest about what did NOT happen: the restore never landed, so the record
+    # still claims a park no commit carries. Advisory, journaled, human-attended.
+    assert operatoractions.load(project.project)["1-1-a"]["actions"] == ACTIONS
+
+
 def test_an_unresolvable_spec_path_still_records_the_park(project, monkeypatch):
     """`_park_spec_relpath` resolves inside a try catching `(OSError, ValueError)`,
     and below 3.13 `Path.resolve` reports a symlink loop as `RuntimeError` —

--- a/tests/test_frontmatter.py
+++ b/tests/test_frontmatter.py
@@ -14,6 +14,8 @@ RAISES rather than returning a `False` nobody reads when the reader can see a
 status it cannot safely move.
 """
 
+import sys
+
 import pytest
 import yaml
 
@@ -445,3 +447,106 @@ def test_the_verified_edit_is_never_a_yaml_round_trip(tmp_path):
     assert fm["status"] == "done" and fm["tags"] == ["a", "b"]
     assert list(fm) == ["title", "tags", "status", "owner"]  # order survives
     assert yaml.safe_dump(fm) not in spec.read_text()  # ...and it is not a dump
+
+
+# ------------------------------------------------------------ ATOMIC WRITE (#379)
+#
+# The writer was byte-preserving but truncating; the module docstring called a torn
+# write "a separate concern". `devcontract._atomic_write_spec` had already disproved
+# that on the same files, with fault injection: it cut a 46-byte spec to 12. These
+# three rows grade the three distinct choices at this call site — that it goes
+# through the helper at all, that it is the BYTES helper, and that it does not
+# follow a link.
+
+
+def test_set_frontmatter_status_write_failure_raises_and_keeps_the_spec(tmp_path, monkeypatch):
+    """A spec is laid out `before + edited + after`, so the truncating write this
+    replaced could publish intact frontmatter saying `status: done` over a
+    decapitated body — a spec that lies, which the loop then commits. The helper
+    leaves either the old file or the whole new one, and the raise still propagates:
+    this is the repair path, and repair writes must raise (AGENTS.md).
+
+    Patched at frontmatter's OWN binding, never `Path.write_bytes`: the helper writes
+    through an `mkstemp` fd via `os.fdopen`, so a `Path` patch never fires and this
+    would pass having exercised nothing. `verify` holds a SEPARATE binding of the
+    same helper for `set_frontmatter_field` — patching one does not reach the other,
+    which is why that site has a row of its own in tests/test_resolve.py.
+
+    Ablation: restore `path.write_bytes(...)` at the call site and this reddens
+    alone, on `pytest.raises` not raising (the import stays, so the stub still
+    installs — it simply never gets called)."""
+    spec = _spec(tmp_path, _PLAIN)
+    before = spec.read_bytes()
+
+    def boom(path, data, *, follow_symlinks=True):
+        raise OSError("no space left on device")
+
+    monkeypatch.setattr(frontmatter, "atomic_write_bytes", boom)
+    with pytest.raises(OSError, match="no space left"):
+        frontmatter.set_frontmatter_status(spec, "done")
+
+    assert spec.read_bytes() == before
+    assert b"status: done" not in spec.read_bytes()  # the mutation that must not land
+
+
+def test_set_frontmatter_status_hands_the_helper_bytes_not_text(tmp_path, monkeypatch):
+    """Grades BYTES-vs-text at this site, platform-independently. The LINE ENDINGS
+    section above already forbids relaying a CRLF spec — but `atomic_write_text`
+    keeps `Path.write_text`'s translating newline default, and on POSIX
+    `os.linesep == "\\n"`, so swapping the text helper in reddens those rows on
+    WINDOWS ONLY and CI's Linux leg would call the swap green.
+
+    So inspect the payload the helper is handed, upstream of any translation: bytes,
+    carrying CRLF verbatim. The binding is WRAPPED rather than replaced, so the real
+    write still happens and the surrounding round-trip is unchanged.
+
+    BOTH helper names are wrapped into the same list, the text one with
+    `raising=False` since this module does not import it. That is what makes the
+    `isinstance` line the assertion that fires: wrapping only the bytes name would
+    grade "the bytes helper was called", so the swap would redden on an empty `seen`
+    and this row would be claiming more than it checked.
+
+    Ablation: swap `atomic_write_bytes` for `atomic_write_text` (dropping the
+    `.encode`) and this reddens on every platform, on the `isinstance` row."""
+    seen: list[bytes | str] = []
+    real = frontmatter.atomic_write_bytes
+
+    def record(path, data, *, follow_symlinks=True):
+        seen.append(data)
+        blob = data if isinstance(data, bytes) else data.encode("utf-8")
+        real(path, blob, follow_symlinks=follow_symlinks)
+
+    monkeypatch.setattr(frontmatter, "atomic_write_bytes", record)
+    monkeypatch.setattr(frontmatter, "atomic_write_text", record, raising=False)
+    spec = _spec(tmp_path, "---\r\ntitle: t\r\nstatus: in-review\r\n---\r\n\r\nbody\r\n")
+
+    assert frontmatter.set_frontmatter_status(spec, "done") is True
+
+    assert len(seen) == 1  # exactly one write — no retry loop crept in
+    assert isinstance(seen[0], bytes)
+    assert b"status: done\r\n" in seen[0]
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlinks")
+def test_set_frontmatter_status_replaces_a_planted_symlink(tmp_path):
+    """The row that grades this SITE's `follow_symlinks=False` argument rather than
+    the helper's implementation of it (pinned in test_platform_util.py, where the
+    helper is called directly).
+
+    Behaviour-preserving first: `devcontract._atomic_write_spec` writes these same
+    specs through a name-replacing `atomic_replace`, so the no-follow default is the
+    family's existing semantics, not a tightening. It is also the security choice —
+    the spec path reaches this writer from a scan of a directory a driven session
+    owns, so writing THROUGH a link planted at that name would hand the session a
+    host-side write to any operator-writable path.
+
+    Ablation: drop `follow_symlinks=False` at the call and this reddens alone."""
+    real = _spec(tmp_path, _PLAIN, name="someone-elses-file")
+    link = tmp_path / "spec.md"
+    link.symlink_to(real)
+
+    assert frontmatter.set_frontmatter_status(link, "done") is True
+
+    assert not link.is_symlink()  # the NAME was replaced
+    assert frontmatter.read_frontmatter(link)["status"] == "done"
+    assert real.read_bytes() == _PLAIN.encode("utf-8")  # not written through

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -825,6 +825,165 @@ def test_register_hooks_refuses_a_config_path_symlinked_out_of_the_project(tmp_p
     assert "escapes the project" in capsys.readouterr().out
 
 
+# ------------------------------------------------ atomic hook-config rewrite (#379)
+#
+# `_register_hooks` and `provision_worktree` both PARSE the operator's hook config,
+# merge the relay registration into the parsed object, and write the whole thing
+# back. The permission allowlist, `env`, the MCP entries and the project's own hooks
+# survive only because they round-trip through that one rewrite — so a truncating
+# write does not lose "the hooks", it loses the file.
+
+_OPERATOR_SETTINGS = (
+    json.dumps(
+        {
+            "permissions": {"allow": ["Bash(git status:*)", "Read(//srv/notes/**)"], "deny": []},
+            "env": {"HOUSE_TOKEN": "keep-me"},
+            "hooks": {
+                "PreToolUse": [
+                    {"matcher": "Bash", "hooks": [{"type": "command", "command": "make lint"}]}
+                ]
+            },
+            "mcpServers": {"house": {"command": "node", "args": ["mcp.js"]}},
+        },
+        indent=2,
+    )
+    + "\n"
+)
+
+
+def _operator_keys(path: Path) -> dict:
+    """Everything in the operator's settings that is not ours to touch."""
+    parsed = json.loads(path.read_text(encoding="utf-8"))
+    return {
+        "permissions": parsed["permissions"],
+        "env": parsed["env"],
+        "mcpServers": parsed["mcpServers"],
+        "PreToolUse": parsed["hooks"]["PreToolUse"],
+    }
+
+
+def test_register_hooks_merge_preserves_the_operators_own_settings(tmp_path):
+    """The positive control for the two rows below, and the statement of what is at
+    risk: the merge keeps every key it did not come for.
+
+    Without this, the write-failure row could pass over a rewrite that had already
+    lost the allowlist before any fault — "the bytes did not change" says nothing
+    about what the successful path writes."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    claude = get_profile("claude")
+    config = project / claude.hooks.config_path
+    config.parent.mkdir(parents=True)
+    config.write_text(_OPERATOR_SETTINGS, encoding="utf-8")
+    before = _operator_keys(config)
+
+    assert _register_hooks(project, claude) == 0
+
+    assert _operator_keys(config) == before
+    hooks = json.loads(config.read_text(encoding="utf-8"))["hooks"]
+    assert set(claude.hooks.events) <= set(hooks)
+    # names the relay marker the write-failure row asserts ABSENT, so that row's
+    # negative is graded against a string this path provably produces
+    assert "bmad_loop_hook" in hooks["Stop"][0]["hooks"][0]["command"]
+
+
+def test_a_truncated_hook_config_makes_the_next_init_refuse(tmp_path, capsys):
+    """The PRE-FIX failure mode this phase makes unreachable, pinned as a property
+    of the FILE FORMAT rather than of the writer — deliberately green on both sides
+    of the fix, because nothing else in the suite states what a short write here
+    costs.
+
+    JSON has no partial-read: a prefix of an object is not a smaller object, it is
+    a parse error. So unlike the board and the ledgers, this truncation is LOUD —
+    and loud in the worst way. `init` refuses, and the message it prints tells the
+    human to go fix a file that this very tool shredded on its last run, with no
+    copy of the lost content anywhere. The re-run cannot repair it either: the
+    refusal comes before the merge, so init never writes again."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    claude = get_profile("claude")
+    config = project / claude.hooks.config_path
+    config.parent.mkdir(parents=True)
+    config.write_text(_OPERATOR_SETTINGS, encoding="utf-8")
+    assert _register_hooks(project, claude) == 0  # whole file: merged and moved on
+    whole = config.read_text(encoding="utf-8")
+    capsys.readouterr()
+
+    # a short write, cut deterministically inside the object rather than at a
+    # fraction of the length: what a torn ENOSPC write publishes is a prefix.
+    config.write_text(whole[: whole.index('"env"')], encoding="utf-8")
+
+    assert _register_hooks(project, claude) == 1
+
+    assert "is not valid JSON; fix it and re-run init" in capsys.readouterr().out
+    assert "HOUSE_TOKEN" not in config.read_text(encoding="utf-8")  # and it is gone
+
+
+def test_register_hooks_write_failure_raises_and_leaves_the_config_entire(tmp_path, monkeypatch):
+    """#379. The registration is a read-modify-rewrite, so the truncating
+    `write_text` it replaced could publish the prefix the row above characterizes.
+    The helper writes a temp and replaces it, so a fault leaves the original whole.
+
+    The raise is deliberate and is NOT caught into the `return 1` arm above: that
+    arm's message is "your file is broken, fix it", which would be a lie about a
+    file still sitting intact on disk. A write that could not happen is init
+    failing, and init already fails by exception elsewhere.
+
+    Patched at install's OWN binding of the helper, never `Path.write_text`: the
+    helper writes through an `mkstemp` fd via `os.fdopen`, so a `Path` patch never
+    fires and this would pass having exercised nothing.
+
+    Ablation: restore `config_path.write_text(...)` at the call site and this
+    reddens alone."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    claude = get_profile("claude")
+    config = project / claude.hooks.config_path
+    config.parent.mkdir(parents=True)
+    config.write_text(_OPERATOR_SETTINGS, encoding="utf-8")
+    before = config.read_bytes()
+
+    def boom(path, text, *, follow_symlinks=True):
+        raise OSError("no space left on device")
+
+    monkeypatch.setattr(install_mod, "atomic_write_text", boom)
+    with pytest.raises(OSError, match="no space left"):
+        _register_hooks(project, claude)
+
+    assert config.read_bytes() == before
+    assert _operator_keys(config)["env"] == {"HOUSE_TOKEN": "keep-me"}
+    assert "bmad_loop_hook" not in config.read_text(encoding="utf-8")  # the lost mutation
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlinks")
+def test_register_hooks_writes_through_a_config_symlinked_inside_the_project(tmp_path):
+    """The row that grades this SITE's `follow_symlinks` argument — the default,
+    which is what preserves the behaviour of the `write_text` it replaced.
+
+    An out-of-project link is refused above by `_confined_to`, which resolves before
+    it compares, so the only links that REACH this write point back inside the
+    project: an in-repo indirection the operator arranged. Replacing the name
+    instead would turn the link into a regular file on the first `init` and leave
+    them editing a settings file nothing reads.
+
+    Ablation: pass `follow_symlinks=False` at the call site and this reddens
+    alone — the link becomes a regular file and `real` keeps its pre-init bytes."""
+    project = tmp_path / "proj"
+    claude = get_profile("claude")
+    link = project / claude.hooks.config_path
+    link.parent.mkdir(parents=True)
+    real = project / "config" / "claude-settings.json"
+    real.parent.mkdir(parents=True)
+    real.write_text(_OPERATOR_SETTINGS, encoding="utf-8")
+    link.symlink_to(real)
+
+    assert _register_hooks(project, claude) == 0
+
+    assert link.is_symlink()  # still a link, not turned into a regular file
+    assert set(claude.hooks.events) <= set(json.loads(real.read_text())["hooks"])
+    assert _operator_keys(real)["env"] == {"HOUSE_TOKEN": "keep-me"}
+
+
 @pytest.mark.skipif(os.name == "nt", reason="POSIX symlinks")
 def test_provision_refuses_a_live_hook_config_symlink(tmp_path):
     wt, repo = tmp_path / "wt", tmp_path / "repo"
@@ -883,6 +1042,81 @@ def test_provision_refuses_a_cyclic_hook_config_symlink(tmp_path):
     provision_worktree(wt, [claude], repo)
 
     assert config.is_symlink()
+
+
+def test_provision_worktree_merge_preserves_the_operators_own_settings(tmp_path):
+    """The positive control for the row below, and the reason the write matters at
+    all here: the config being rewritten is the SEEDED copy of the operator's own,
+    so the allowlist, `env` and the MCP entries the isolated session needs all
+    round-trip through this one call.
+
+    It also establishes the precondition the fault row depends on — the write is
+    guarded by `if config != baseline_config`, so a shape where strip-then-merge
+    nets to zero never reaches it and any fault injected there passes vacuously.
+    This shape provably does reach it: the file changed."""
+    wt, repo = tmp_path / "wt", tmp_path / "repo"
+    repo.mkdir()
+    claude = get_profile("claude")
+    config = wt / claude.hooks.config_path
+    config.parent.mkdir(parents=True)
+    config.write_text(_OPERATOR_SETTINGS, encoding="utf-8")
+    before = _operator_keys(config)
+
+    provision_worktree(wt, [claude], repo)
+
+    assert _operator_keys(config) == before
+    hooks = json.loads(config.read_text(encoding="utf-8"))["hooks"]
+    assert set(claude.hooks.events) <= set(hooks)
+    assert str(repo / ".bmad-loop" / "bmad_loop_hook.py") in hooks["Stop"][0]["hooks"][0]["command"]
+
+
+def test_provision_worktree_write_failure_raises_and_leaves_the_config_entire(
+    tmp_path, monkeypatch
+):
+    """#379, the second of the two hook-config rewriters. Same read-modify-rewrite
+    as `_register_hooks`, worse consequence: nothing re-reads this file to complain.
+    The isolated session simply starts against a settings file whose JSON no longer
+    parses, the CLI falls back to its defaults, the Stop hook is not registered, and
+    the run idles to timeout with no diagnostic naming the cause.
+
+    Patched at worktree_flow's OWN binding: the site reached is the module's only
+    user of `atomic_write_text`, so no filename filter is needed to know which write
+    the fault landed on — but it must not be `Path.write_text`, which the helper's
+    `mkstemp` fd never goes through.
+
+    That the raise arrives at all is the non-vacuity proof: the boom is unreachable
+    unless `config != baseline_config` let control past the guard, which is the
+    precondition the row above pins independently.
+
+    No symlink row pairs with this one, unlike `_register_hooks`: the component-wise
+    refusal walk above the write skips the profile entirely when any component of
+    the path is a link, so `follow_symlinks` is unobservable at this site and the
+    four `test_provision_refuses_*_symlink` rows are what grade it.
+
+    Ablation: restore `config_path.write_text(...)` at the call site and this
+    reddens alone."""
+    wt, repo = tmp_path / "wt", tmp_path / "repo"
+    repo.mkdir()
+    claude = get_profile("claude")
+    config = wt / claude.hooks.config_path
+    config.parent.mkdir(parents=True)
+    config.write_text(_OPERATOR_SETTINGS, encoding="utf-8")
+    before = config.read_bytes()
+
+    import bmad_loop.worktree_flow as wtf
+
+    def boom(path, text, *, follow_symlinks=True):
+        raise OSError("no space left on device")
+
+    monkeypatch.setattr(wtf, "atomic_write_text", boom)
+    with pytest.raises(OSError, match="no space left"):
+        provision_worktree(wt, [claude], repo)
+
+    assert config.read_bytes() == before
+    assert _operator_keys(config)["mcpServers"] == {
+        "house": {"command": "node", "args": ["mcp.js"]}
+    }
+    assert "bmad_loop_hook" not in config.read_text(encoding="utf-8")  # the lost mutation
 
 
 def test_provision_worktree_empty_profiles_is_noop(tmp_path):

--- a/tests/test_operatoractions.py
+++ b/tests/test_operatoractions.py
@@ -10,6 +10,7 @@ drifted.
 from __future__ import annotations
 
 import json
+import sys
 
 import pytest
 from conftest import git, install_bmad_config, spec_path, write_spec, write_sprint
@@ -163,15 +164,23 @@ def test_the_record_is_written_atomically_and_parsable(project):
 
 def test_a_failed_record_write_leaves_no_tmp_residue(project, monkeypatch):
     """The record is written just ahead of `finalize_commit`'s `git add -A`, so
-    a stranded `.tmp` would ride the story's own commit — one story's half-write
+    a stranded temp would ride the story's own commit — one story's half-write
     polluting its own history forever.
 
-    Ablation: drop the unlink in `record_park`'s except arm and this fails."""
+    The fault is injected at `platform_util.atomic_replace`, one layer BELOW the
+    helper `record_park` now delegates to (#379), and that placement is the whole
+    test: stubbing `atomic_write_text` itself would mean no temp was ever
+    created, so "no residue" would pass for that reason rather than for the
+    unlink. Faulting the publish instead runs the helper's real body — mkstemp,
+    write, fsync — so the assertion grades a temp that genuinely existed.
+
+    Ablation: drop the `tmp.unlink()` in `platform_util._atomic_write`'s except
+    arm and this fails."""
 
     def boom(tmp, target):
         raise OSError(28, "No space left on device")
 
-    monkeypatch.setattr(operatoractions, "atomic_replace", boom)
+    monkeypatch.setattr("bmad_loop.platform_util.atomic_replace", boom)
     with pytest.raises(OSError):
         operatoractions.record_park(
             project.project,
@@ -183,6 +192,35 @@ def test_a_failed_record_write_leaves_no_tmp_residue(project, monkeypatch):
         )
     records = operatoractions.records_dir(project.project)
     assert not list(records.glob("*.tmp")) and not list(records.glob("*.json"))
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlinks")
+def test_the_record_replaces_a_planted_symlink_by_name(project, tmp_path):
+    """#379. The one row that grades this SITE's `follow_symlinks=False` argument
+    rather than the helper's implementation of it, which `test_platform_util.py`
+    pins by calling the helper directly.
+
+    Behaviour-preserving: the hand-rolled write this replaced ended in
+    `os.replace`, which never dereferenced its destination either, so passing the
+    default True here would have CHANGED what `record_park` does rather than
+    merely relaxing it. It is also what the record IS — a machine-minted file
+    under a project root a driven session writes all run long — so honouring a
+    link planted at the record's own name would turn the park's bookkeeping into
+    a host-side write at a path of that session's choosing.
+
+    Ablation: drop `follow_symlinks=False` in `record_park` and this reddens
+    alone — the link survives and the planted target is what gets rewritten."""
+    outside = tmp_path / "someone-elses-file"
+    outside.write_text("not a park record\n", encoding="utf-8")
+    link = operatoractions.record_path(project.project, "1-1-a")
+    link.parent.mkdir(parents=True, exist_ok=True)
+    link.symlink_to(outside)
+
+    _record_only(project)
+
+    assert not link.is_symlink()  # the NAME was replaced
+    assert operatoractions.load(project.project)["1-1-a"]["actions"] == ACTIONS
+    assert outside.read_text(encoding="utf-8") == "not a park record\n"  # not through
 
 
 # ------------------------------------------------------- git sees the record
@@ -268,11 +306,15 @@ def test_a_failed_legacy_prune_leaves_no_tmp_residue(project, monkeypatch):
     blocks the next run's preflight and the epic-boundary auto-sweep.
 
     TWO entries, deliberately: with one, the prune takes the `else` arm and
-    unlinks the store outright, never reaching `atomic_replace`. That is what
-    the `pytest.raises` is for — it fails LOUDLY on `DID NOT RAISE` rather than
+    unlinks the store outright, never reaching the rewrite. That is what the
+    `pytest.raises` is for — it fails LOUDLY on `DID NOT RAISE` rather than
     letting the residue assertion pass over a rewrite that never ran.
 
-    Ablation: drop the unlink in `_drop_legacy`'s except arm and this fails."""
+    Faulted at `platform_util.atomic_replace` for its sibling row's reason (#379):
+    below the helper, so a temp is really created and really unlinked.
+
+    Ablation: drop the `tmp.unlink()` in `platform_util._atomic_write`'s except
+    arm and this fails."""
 
     def boom(tmp, target):
         raise OSError(28, "No space left on device")
@@ -283,7 +325,7 @@ def test_a_failed_legacy_prune_leaves_no_tmp_residue(project, monkeypatch):
     before = sorted(p.name for p in store.parent.iterdir())
     assert before == ["operator-actions.json"]  # a snapshot with something IN it
 
-    monkeypatch.setattr(operatoractions, "atomic_replace", boom)
+    monkeypatch.setattr("bmad_loop.platform_util.atomic_replace", boom)
     with pytest.raises(OSError):
         operatoractions.drop(project.project, "1-1-a")
 
@@ -293,6 +335,34 @@ def test_a_failed_legacy_prune_leaves_no_tmp_residue(project, monkeypatch):
     # the entry stays confirmable once whatever broke the write is fixed.
     assert sorted(p.name for p in store.parent.iterdir()) == before
     assert sorted(operatoractions.load(project.project)) == ["1-1-a", "2-2-b"]
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlinks")
+def test_the_legacy_prune_replaces_a_planted_symlink_by_name(project, tmp_path):
+    """The `_drop_legacy` half of the record row above (#379): same argument, a
+    different write, and its own ablation. Reachable for a different reason too —
+    `drop` is what `bmad-loop confirm` calls, out of band and on a machine whose
+    repo a driven session has been writing all run long.
+
+    TWO entries again, so the prune takes the rewrite arm; the one-entry `else`
+    arm unlinks the store outright and never reaches the helper at all.
+
+    Ablation: drop `follow_symlinks=False` in `_drop_legacy` and this reddens
+    alone — the link survives and the planted target is what gets rewritten."""
+    _legacy_entry(project, "1-1-a")
+    _legacy_entry(project, "2-2-b")
+    store = operatoractions.legacy_store_path(project.project)
+    kept = store.read_text(encoding="utf-8")
+    outside = tmp_path / "someone-elses-file"
+    outside.write_text(kept, encoding="utf-8")  # the store's real bytes, behind the link
+    store.unlink()
+    store.symlink_to(outside)
+
+    assert operatoractions.drop(project.project, "1-1-a") is True
+
+    assert not store.is_symlink()  # the NAME was replaced
+    assert sorted(operatoractions.load(project.project)) == ["2-2-b"]
+    assert outside.read_text(encoding="utf-8") == kept  # not written through
 
 
 def test_drop_matches_the_records_own_key_not_its_filename(project):

--- a/tests/test_platform_util.py
+++ b/tests/test_platform_util.py
@@ -676,6 +676,75 @@ def test_atomic_write_bytes_writes_through_a_symlink(tmp_path):
     assert real.read_bytes() == b"after"
 
 
+# The no-follow trio for the BYTES helper (#363), mirroring the text trio above.
+# The bytes sibling grew `follow_symlinks` when `policy.write_mux_backend` moved onto
+# it: that site reads and writes bytes to preserve a CRLF policy.toml's endings, and
+# needs no-follow because a driven session can write `.bmad-loop/policy.toml`.
+#
+# ABLATION A1: drop the `follow_symlinks=follow_symlinks` forward in
+# `atomic_write_bytes` (leave the parameter, so callers still typecheck) and these
+# three redden together while the TEXT trio and the True-default pins above stay
+# green — the disjointness is what shows the forward, not the shared `_atomic_write`
+# body, is what these grade.
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlinks")
+def test_atomic_write_bytes_no_follow_replaces_the_link(tmp_path):
+    """The inverse of the sibling above: the *name* is replaced, whatever it points
+    at. Honouring a planted link would aim a machine-minted write at a path of the
+    planter's choosing, and no preflight check is what makes this safe — `os.replace`
+    does not dereference its destination, so a link planted after any check would
+    have run is clobbered rather than written through."""
+    real = tmp_path / "someone-elses-file"
+    real.write_bytes(b"before")
+    link = tmp_path / "record"
+    link.symlink_to(real)
+
+    platform_util.atomic_write_bytes(link, b"after", follow_symlinks=False)
+
+    assert not link.is_symlink()
+    assert link.read_bytes() == b"after"
+    assert real.read_bytes() == b"before"  # untouched
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX mode bits")
+def test_atomic_write_bytes_no_follow_does_not_inherit_a_link_targets_mode(tmp_path):
+    """A name being replaced rather than updated carries nothing of whatever it used
+    to point at — inheriting the target's mode would let a planted link choose the
+    new record's permissions."""
+    real = tmp_path / "someone-elses-file"
+    real.write_bytes(b"before")
+    real.chmod(0o666)
+    link = tmp_path / "record"
+    link.symlink_to(real)
+
+    platform_util.atomic_write_bytes(link, b"after", follow_symlinks=False)
+
+    assert stat.S_IMODE(link.stat().st_mode) == 0o600  # mkstemp's private default
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX mode bits")
+def test_atomic_write_bytes_no_follow_does_not_inherit_a_plain_files_mode(tmp_path):
+    """No-follow inherits nothing and takes no probe to decide it — the sibling above
+    covers the link, this covers the plain file, which is the case a probe would have
+    said yes to. 0o640 for the reason every mode pin here gives: `mkstemp` already
+    ARRIVES at 0600, so only a mode it does not arrive with can tell inheritance from
+    its absence.
+
+    Ablation A2: change `_atomic_write`'s `if follow_symlinks and target.exists():`
+    to `if target.exists():` and this reddens together with the three other
+    "does_not_inherit" rows (both helpers), while both "replaces_the_link" rows stay
+    green — so it bites on inheritance itself, not on anything else no-follow does."""
+    target = tmp_path / "record"
+    target.write_bytes(b"before")
+    target.chmod(0o640)
+
+    platform_util.atomic_write_bytes(target, b"after", follow_symlinks=False)
+
+    assert target.read_bytes() == b"after"
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+
+
 def test_atomic_write_bytes_preserves_extended_attributes(tmp_path):
     """Skipped where the platform or filesystem has no user xattrs, exactly as the
     text sibling is — the helper is best-effort there by design."""

--- a/tests/test_platform_util.py
+++ b/tests/test_platform_util.py
@@ -920,6 +920,28 @@ def test_atomic_write_bytes_stages_a_basename_that_fills_name_max(tmp_path, monk
     assert list(tmp_path.glob("*.tmp")) == []
 
 
+def _exceed_range() -> OSError:
+    """Win32's "the name does not fit", which arrives as ENOENT and is told apart
+    from a missing directory only by `.winerror` — see `_is_name_too_long`."""
+    exceeded = OSError(errno.ENOENT, "The filename or extension is too long")
+    exceeded.winerror = 206  # pyright: ignore[reportAttributeAccessIssue]
+    return exceeded
+
+
+def _failing_mkstemp(prefixes: list[str], fail_first: int):
+    """A `mkstemp` that records each prefix it is handed and refuses the first
+    `fail_first` attempts with win32's too-long error, then delegates."""
+    real_mkstemp = tempfile.mkstemp
+
+    def fake_mkstemp(*, dir, prefix, suffix):
+        prefixes.append(prefix)
+        if len(prefixes) <= fail_first:
+            raise _exceed_range()
+        return real_mkstemp(dir=dir, prefix=prefix, suffix=suffix)
+
+    return fake_mkstemp
+
+
 def test_atomic_write_bytes_stages_via_digest_when_win32_reports_exceed_range(
     tmp_path, monkeypatch
 ):
@@ -936,38 +958,97 @@ def test_atomic_write_bytes_stages_via_digest_when_win32_reports_exceed_range(
     Driven through an injected error rather than a real long name because this
     runs on POSIX too, where no path produces winerror 206 — and a
     `skipif(win32)` row would leave the branch unexercised on every CI leg but
-    two. The injection is the mechanism the code actually reads (`getattr(e,
-    "winerror", None)`), so it is the predicate under test, not a stand-in for it.
+    two. The injection is the mechanism the code actually reads
+    (`_is_name_too_long`), so it is the predicate under test, not a stand-in.
 
-    Asserts the SECOND prefix stopped being the readable one rather than matching
-    the digest: what has to hold is that the retry re-prefixed, not which scheme
-    produced it — same reason as the row above.
+    The basename is deliberately LONGER than a 16-character digest, which is what
+    puts the digest rung on the ladder at all — see the row below for the short
+    basename that skips it.
 
-    Ablation: drop the `getattr(e, "winerror", ...)` disjunct in `_mkstemp_beside`
-    and this fails alone, on the injected `OSError` propagating out of
-    `atomic_write_bytes` before any assertion. The POSIX `..._fills_name_max` row
-    stays green under it — it arrives on the errno arm, which the ablation leaves
-    intact."""
-    target = tmp_path / "spec.md"
-    real_mkstemp = tempfile.mkstemp
+    Asserts the retry STRICTLY SHORTENED rather than matching the digest: what
+    has to hold is that the next attempt is narrower than the one that failed,
+    not which scheme produced it.
+
+    Ablation: drop the `.winerror` arm of `_is_name_too_long` and all THREE
+    win32-injected rows redden together, on the injected `OSError` propagating out
+    of `atomic_write_bytes` before any assertion — they share that predicate, so
+    no one of them can fail alone under it. The disjointness proof is the row that
+    stays GREEN: POSIX `..._fills_name_max` arrives on the errno arm, which this
+    ablation leaves intact, so the two arms genuinely cover different conditions
+    rather than one masking the other."""
+    target = tmp_path / ("s" * 40 + ".md")
     prefixes: list[str] = []
-
-    def fake_mkstemp(*, dir, prefix, suffix):
-        prefixes.append(prefix)
-        if len(prefixes) == 1:
-            exceeded = OSError(errno.ENOENT, "The filename or extension is too long")
-            exceeded.winerror = 206  # pyright: ignore[reportAttributeAccessIssue]
-            raise exceeded
-        return real_mkstemp(dir=dir, prefix=prefix, suffix=suffix)
-
-    monkeypatch.setattr(platform_util.tempfile, "mkstemp", fake_mkstemp)
+    monkeypatch.setattr(platform_util.tempfile, "mkstemp", _failing_mkstemp(prefixes, 1))
 
     platform_util.atomic_write_bytes(target, b"payload")
 
     assert target.read_bytes() == b"payload"
     assert len(prefixes) == 2  # the retry happened at all
+    assert prefixes[0] == target.name + "."
+    assert prefixes[1] != ""  # the DIGEST rung, not the bare one
+    assert len(prefixes[1]) < len(prefixes[0])  # strictly shorter than what failed
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_atomic_write_bytes_skips_the_digest_rung_when_it_would_not_shorten(tmp_path, monkeypatch):
+    """A digest is 16 characters, so against a basename that short or shorter it
+    is not a fallback at all — it stages a name no NARROWER than the one that
+    just failed, and a retry at the same width cannot succeed.
+
+    Unreachable where the binding limit is per-component: a POSIX `NAME_MAX` rung
+    is only reached past a 242-character basename, far above the digest. Reachable
+    where the limit is the whole path, which is the win32 `MAX_PATH` case — a
+    short basename in a deep directory overflows on the staging suffix alone, and
+    a 29-character digest temp is then LONGER than the readable one it replaced.
+
+    So the ladder drops that rung and goes straight to a bare `mkstemp`, the
+    shortest name this function can produce.
+
+    Ablation: append the digest rung unconditionally and this reddens alone, on
+    `prefixes[1] == ""` — the digest is attempted for a 7-character basename it
+    cannot help. The long-basename row above stays green, because there the
+    digest genuinely shortens and the rung belongs on the ladder."""
+    target = tmp_path / "spec.md"  # 7 chars — a 16-char digest is no improvement
+    prefixes: list[str] = []
+    monkeypatch.setattr(platform_util.tempfile, "mkstemp", _failing_mkstemp(prefixes, 1))
+
+    platform_util.atomic_write_bytes(target, b"payload")
+
+    assert target.read_bytes() == b"payload"
     assert prefixes[0] == "spec.md."
-    assert prefixes[1] != "spec.md."  # the digest replaced the readable prefix
+    assert len(prefixes) == 2  # no wasted attempt at a name that cannot fit
+    assert prefixes[1] == ""  # straight to the shortest name available
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_atomic_write_bytes_ends_the_ladder_at_a_bare_temp(tmp_path, monkeypatch):
+    """When the digest rung ALSO cannot fit, the ladder still has one rung left.
+
+    This is the case that makes the docstring's closing claim true. Keying the
+    fallback on a single digest retry meant a second failure was reported as "the
+    directory is too long, which no prefix can fix" while a shorter prefix — the
+    empty one — would in fact have fit. Only once the last rung carries no prefix
+    at all is a failure there genuinely about the directory.
+
+    Ablation: delete the trailing bare rung so the ladder ends at the digest and
+    TWO rows redden — this one, on the second injected `OSError` propagating, and
+    the skip row above. Measured, not assumed: the bare rung is the fallback for
+    both of them, since a basename too short for the digest has no other rung to
+    fall to. They stay separate rows because they reach it for different reasons —
+    one because the digest was skipped, one because the digest was tried and also
+    failed — and only this one pins that a THIRD attempt exists at all."""
+    target = tmp_path / ("s" * 40 + ".md")
+    prefixes: list[str] = []
+    monkeypatch.setattr(platform_util.tempfile, "mkstemp", _failing_mkstemp(prefixes, 2))
+
+    platform_util.atomic_write_bytes(target, b"payload")
+
+    assert target.read_bytes() == b"payload"
+    assert len(prefixes) == 3
+    assert prefixes[2] == ""  # the shortest name the function can stage
+    # every rung strictly narrower than the one it replaced
+    assert [len(p) for p in prefixes] == sorted((len(p) for p in prefixes), reverse=True)
+    assert len(set(prefixes)) == 3
     assert list(tmp_path.glob("*.tmp")) == []
 
 
@@ -986,8 +1067,10 @@ def test_atomic_write_bytes_propagates_a_staging_error_that_is_not_a_long_name(
     make one winerror mean two things in one codebase.
 
     Ablation: relax the guard so nothing re-raises and this reddens alone, on
-    `len(calls) == 1` reading 2 — the second, doomed `mkstemp` runs under the
-    digest prefix. Note which assertion does NOT catch it: `caught.value.errno ==
+    `len(calls) == 1` reading 2 — the second, doomed `mkstemp` runs under the next
+    rung, which for this 7-character basename is the BARE one (a 16-character
+    digest cannot shorten it). Note which assertion does NOT catch it:
+    `caught.value.errno ==
     EACCES` still passes, because the retry fails the same way the first attempt
     did. The call count is the load-bearing assertion here; an errno check alone
     would pass through the widened guard and pin nothing."""

--- a/tests/test_platform_util.py
+++ b/tests/test_platform_util.py
@@ -871,6 +871,53 @@ def test_atomic_write_bytes_creates_a_missing_target_at_the_private_mode(tmp_pat
         assert stat.S_IMODE(target.stat().st_mode) == 0o600
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX pathconf(PC_NAME_MAX)")
+def test_atomic_write_bytes_stages_a_basename_that_fills_name_max(tmp_path, monkeypatch):
+    """A target whose basename is the longest the filesystem allows still writes
+    (#595). `mkstemp` inserts 8 random chars between prefix and suffix, so the temp
+    runs `len(basename) + 13` — meaning a target that is itself perfectly legal
+    produced an ILLEGAL temp name and the write died with ENAMETOOLONG.
+
+    A regression, not a pre-existing limit: the direct `write_bytes` that
+    `set_frontmatter_status`/`set_frontmatter_field` used before this branch
+    accepted the same name, and specs are named by BMAD's planning skills, not by
+    anything here that bounds them (`safe_segment`'s MAX_SEGMENT caps story keys
+    and run-dir segments, not spec basenames).
+
+    Sized from the filesystem's own `PC_NAME_MAX` rather than a hardcoded 255,
+    which is per-filesystem — on a box where it is smaller a fixed 252 would fail
+    while CREATING the fixture, reddening this row for a reason that is not the
+    property.
+
+    The staged name is recorded and asserted legal rather than compared to the
+    digest: what has to hold is that the temp fits, not which scheme produced it.
+
+    Ablation: delete the `except OSError` fallback in `_mkstemp_beside` and this
+    fails alone, on `OSError: [Errno 36] File name too long` raised before any
+    assertion. `..._temp_name_is_unique_per_call` and
+    `..._stages_in_the_targets_own_directory` stay green under it — both use short
+    names, which never reach the fallback."""
+    name_max = os.pathconf(str(tmp_path), "PC_NAME_MAX")
+    target = tmp_path / ("s" * (name_max - len(".md")) + ".md")
+    assert len(os.fsencode(target.name)) == name_max  # PRECONDITION: the limit itself
+    staged: list[str] = []
+    real_replace = os.replace
+
+    def record(src, dst):
+        staged.append(os.path.basename(str(src)))
+        real_replace(src, dst)
+
+    monkeypatch.setattr(platform_util.os, "replace", record)
+
+    platform_util.atomic_write_bytes(target, b"payload")
+
+    assert target.read_bytes() == b"payload"
+    assert len(staged) == 1
+    assert len(os.fsencode(staged[0])) <= name_max
+    assert staged[0].endswith(".tmp")  # devcontract's *.md scans must skip it
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
 # --------------------------------------------------------------- retrying_unlink
 
 

--- a/tests/test_platform_util.py
+++ b/tests/test_platform_util.py
@@ -7,11 +7,13 @@ the legacy ``platform_util`` entry points still delegate, plus the real
 
 from __future__ import annotations
 
+import errno
 import ntpath
 import os
 import stat
 import subprocess
 import sys
+import tempfile
 from pathlib import Path, PureWindowsPath
 
 import pytest
@@ -916,6 +918,94 @@ def test_atomic_write_bytes_stages_a_basename_that_fills_name_max(tmp_path, monk
     assert len(os.fsencode(staged[0])) <= name_max
     assert staged[0].endswith(".tmp")  # devcontract's *.md scans must skip it
     assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_atomic_write_bytes_stages_via_digest_when_win32_reports_exceed_range(
+    tmp_path, monkeypatch
+):
+    """The #595 fallback also fires for win32's spelling of "the name does not
+    fit", which is NOT ENAMETOOLONG.
+
+    CPython's `PC/errmap.h` maps `ERROR_FILENAME_EXCED_RANGE` (206) to ENOENT, and
+    does not map `ERROR_BUFFER_OVERFLOW` (111) at all — it falls to the EINVAL
+    default. So on Windows nothing raises ENAMETOOLONG and only `.winerror`
+    carries the distinction: keying the retry on the errno alone left the whole
+    fallback DEAD on the one platform where, per `MAX_PATH`, the staged name is
+    easiest to overflow.
+
+    Driven through an injected error rather than a real long name because this
+    runs on POSIX too, where no path produces winerror 206 — and a
+    `skipif(win32)` row would leave the branch unexercised on every CI leg but
+    two. The injection is the mechanism the code actually reads (`getattr(e,
+    "winerror", None)`), so it is the predicate under test, not a stand-in for it.
+
+    Asserts the SECOND prefix stopped being the readable one rather than matching
+    the digest: what has to hold is that the retry re-prefixed, not which scheme
+    produced it — same reason as the row above.
+
+    Ablation: drop the `getattr(e, "winerror", ...)` disjunct in `_mkstemp_beside`
+    and this fails alone, on the injected `OSError` propagating out of
+    `atomic_write_bytes` before any assertion. The POSIX `..._fills_name_max` row
+    stays green under it — it arrives on the errno arm, which the ablation leaves
+    intact."""
+    target = tmp_path / "spec.md"
+    real_mkstemp = tempfile.mkstemp
+    prefixes: list[str] = []
+
+    def fake_mkstemp(*, dir, prefix, suffix):
+        prefixes.append(prefix)
+        if len(prefixes) == 1:
+            exceeded = OSError(errno.ENOENT, "The filename or extension is too long")
+            exceeded.winerror = 206  # pyright: ignore[reportAttributeAccessIssue]
+            raise exceeded
+        return real_mkstemp(dir=dir, prefix=prefix, suffix=suffix)
+
+    monkeypatch.setattr(platform_util.tempfile, "mkstemp", fake_mkstemp)
+
+    platform_util.atomic_write_bytes(target, b"payload")
+
+    assert target.read_bytes() == b"payload"
+    assert len(prefixes) == 2  # the retry happened at all
+    assert prefixes[0] == "spec.md."
+    assert prefixes[1] != "spec.md."  # the digest replaced the readable prefix
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_atomic_write_bytes_propagates_a_staging_error_that_is_not_a_long_name(
+    tmp_path, monkeypatch
+):
+    """The retry stays NARROW: an `OSError` that is not "the name does not fit"
+    propagates on the first attempt instead of being retried under a digest.
+
+    The negative control for the row above. Widening the predicate to a bare
+    `except OSError` — or folding in `ERROR_INVALID_NAME` (123), which also fires
+    for characters win32 forbids outright and no shorter prefix can rescue — would
+    turn an unrelated staging failure into a second doomed `mkstemp` and surface
+    the RETRY's exception rather than the real one. `install.py` already assigns
+    123 the opposite meaning (`_ABSENCE_WINERRORS`), so admitting it here would
+    make one winerror mean two things in one codebase.
+
+    Ablation: relax the guard so nothing re-raises and this reddens alone, on
+    `len(calls) == 1` reading 2 — the second, doomed `mkstemp` runs under the
+    digest prefix. Note which assertion does NOT catch it: `caught.value.errno ==
+    EACCES` still passes, because the retry fails the same way the first attempt
+    did. The call count is the load-bearing assertion here; an errno check alone
+    would pass through the widened guard and pin nothing."""
+    target = tmp_path / "spec.md"
+    calls: list[str] = []
+
+    def fake_mkstemp(*, dir, prefix, suffix):
+        calls.append(prefix)
+        raise OSError(errno.EACCES, "Permission denied")
+
+    monkeypatch.setattr(platform_util.tempfile, "mkstemp", fake_mkstemp)
+
+    with pytest.raises(OSError) as caught:
+        platform_util.atomic_write_bytes(target, b"payload")
+
+    assert caught.value.errno == errno.EACCES  # the REAL error, not the retry's
+    assert len(calls) == 1  # never retried
+    assert not target.exists()
 
 
 # --------------------------------------------------------------- retrying_unlink

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -1,4 +1,5 @@
 import json
+import sys
 
 import pytest
 
@@ -1001,6 +1002,98 @@ def test_write_mux_backend_preserves_crlf_line_ending(tmp_path):
     p.write_bytes(b'[mux]\r\nbackend = "old"\r\n')
     policy.write_mux_backend(p, "new")
     assert b'backend = "new"\r\n' in p.read_bytes()
+
+
+def test_write_mux_backend_hands_the_helper_bytes(tmp_path, monkeypatch):
+    """#363. The CRLF pin above does NOT grade the bytes-vs-text choice on Linux:
+    `atomic_write_text` passes `newline=None`, whose translation is a no-op wherever
+    `os.linesep == "\\n"`, so swapping the text helper in reddens that row on WINDOWS
+    ONLY and CI's Linux leg would call the swap green.
+
+    This grades it platform-independently by inspecting the payload the helper is
+    handed, upstream of any newline translation: bytes, carrying CRLF verbatim. The
+    binding is WRAPPED rather than replaced so the real write still happens and the
+    surrounding round-trip behaviour is unchanged.
+
+    Ablation: swap `atomic_write_bytes` for `atomic_write_text` in
+    `write_mux_backend` (dropping the `.encode`) and this reddens on every platform,
+    on the `isinstance(..., bytes)` row. The exact-length assertion also pins
+    "exactly one write", so a retry loop cannot creep in unnoticed."""
+    seen: list[bytes] = []
+    real = policy.atomic_write_bytes
+
+    def record(path, data, *, follow_symlinks=True):
+        seen.append(data)
+        real(path, data, follow_symlinks=follow_symlinks)
+
+    monkeypatch.setattr(policy, "atomic_write_bytes", record)
+    p = tmp_path / "policy.toml"
+    p.write_bytes(b'[mux]\r\nbackend = "old"\r\n')
+
+    policy.write_mux_backend(p, "new")
+
+    assert len(seen) == 1
+    assert isinstance(seen[0], bytes)
+    assert b'backend = "new"\r\n' in seen[0]
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlinks")
+def test_write_mux_backend_replaces_a_planted_symlink(tmp_path):
+    """#363. The one row that grades this SITE's `follow_symlinks=False` argument
+    rather than the helper's implementation of it — everything else about no-follow
+    is pinned in test_platform_util.py, where the helper is called directly.
+
+    It is behaviour-preserving first: `os.replace` never dereferenced this
+    destination either, so passing the default True here would have CHANGED what
+    the function does, not merely relaxed it. It is also the security choice —
+    `runsetup` states a driven session can write `.bmad-loop/policy.toml`, so
+    writing THROUGH a link planted at that name would hand the session a host-side
+    write to any operator-writable path.
+
+    Ablation: drop `follow_symlinks=False` at the `write_mux_backend` call and this
+    reddens alone (the link survives and the planted target is rewritten). Without
+    this row that mutation is a KNOWN GREEN ablation — no other consumer test
+    plants a symlink at the paths these five sites write."""
+    real = tmp_path / "someone-elses-file"
+    real.write_bytes(b'[mux]\nbackend = "old"\n')
+    link = tmp_path / "policy.toml"
+    link.symlink_to(real)
+
+    policy.write_mux_backend(link, "new")
+
+    assert not link.is_symlink()  # the NAME was replaced
+    assert policy.load(link).mux.backend == "new"
+    assert real.read_bytes() == b'[mux]\nbackend = "old"\n'  # not written through
+
+
+def test_write_mux_backend_write_failure_raises_and_keeps_the_file(tmp_path, monkeypatch):
+    """#363. The hand-rolled temp this replaced was the fixed name
+    `.bmad-loop/policy.toml.tmp`, which nothing gitignores — the init line is the
+    anchored literal `.bmad-loop/policy.toml`, which does not cover a `.tmp` suffix —
+    so a failed replace stranded an untracked file that held `worktree_clean` False.
+    The helper removes its own temp on any raise, and the raise still propagates.
+
+    Patched at policy's OWN binding: the helper writes through an `mkstemp` fd via
+    `os.fdopen`, so a `Path.write_bytes` patch never fires and passes vacuously.
+
+    Ablation A5: revert `write_mux_backend` to `tmp.write_bytes(...)` +
+    `atomic_replace` and this reddens together with the bytes pin above — both as
+    an AttributeError from `monkeypatch.setattr`, since the `atomic_write_bytes`
+    binding they share disappears with the revert. The pre-existing CRLF row stays
+    green, which is the point of the bytes pin: CRLF alone does not grade this."""
+    p = tmp_path / "policy.toml"
+    p.write_bytes(b'[mux]\nbackend = "old"\n')
+    before = p.read_bytes()
+
+    def boom(path, data, *, follow_symlinks=True):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(policy, "atomic_write_bytes", boom)
+    with pytest.raises(OSError, match="disk full"):
+        policy.write_mux_backend(p, "new")
+
+    assert p.read_bytes() == before
+    assert b'backend = "new"' not in p.read_bytes()  # the mutation that must not land
 
 
 def test_write_mux_backend_rejects_bad_name(tmp_path):

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -1,6 +1,7 @@
 """Escalation-resolution: context build, re-arm, spec field writer, session."""
 
 import json
+import sys
 
 import pytest
 import yaml
@@ -186,6 +187,108 @@ def test_set_frontmatter_field_inserts_without_introducing_a_foreign_line_ending
     assert text == "---\rtitle: t\rstatus: done\rbaseline_revision: abc123\r---\r\rbody\r"
     assert "\n" not in text
     assert verify.read_frontmatter(spec)["baseline_revision"] == "abc123"
+
+
+# --- set_frontmatter_field: atomic write (#379) ---
+#
+# Three rows for the three distinct choices at this call site — that it routes
+# through the helper at all, that it is the BYTES helper, and that it does not
+# follow a link. `verify` holds its own binding of `atomic_write_bytes`, separate
+# from `frontmatter`'s; tests/test_frontmatter.py grades the sibling status writer
+# through that other binding, and neither set reaches the other's site.
+
+
+def test_set_frontmatter_field_write_failure_raises_and_keeps_the_spec(tmp_path, monkeypatch):
+    """A spec is laid out `before + edited + after`, so the truncating `write_bytes`
+    this replaced could publish intact frontmatter over a decapitated body. Worse
+    here than for the status sibling: the field this writer re-stamps is
+    `baseline_revision`, the anchor the patch-restore re-arm computes every later
+    diff against, so a spec that keeps the key while losing the body is one the
+    re-arm then treats as authoritative.
+
+    Patched at verify's OWN binding, never `Path.write_bytes`: the helper writes
+    through an `mkstemp` fd via `os.fdopen`, so a `Path` patch never fires and this
+    would pass having exercised nothing.
+
+    Ablation: restore `path.write_bytes(...)` at the call site and this reddens
+    alone, on `pytest.raises` not raising — the import stays, so the stub still
+    installs, it simply never gets called."""
+    spec = tmp_path / "spec.md"
+    spec.write_text(SPEC, encoding="utf-8")
+    before = spec.read_bytes()
+
+    def boom(path, data, *, follow_symlinks=True):
+        raise OSError("no space left on device")
+
+    monkeypatch.setattr(verify, "atomic_write_bytes", boom)
+    with pytest.raises(OSError, match="no space left"):
+        verify.set_frontmatter_field(spec, "baseline_revision", "abc123")
+
+    assert spec.read_bytes() == before
+    assert b"baseline_revision" not in spec.read_bytes()  # the insert that must not land
+
+
+def test_set_frontmatter_field_hands_the_helper_bytes_not_text(tmp_path, monkeypatch):
+    """Grades BYTES-vs-text at this site, platform-independently.
+    `test_set_frontmatter_field_replaces_without_relaying_crlf` above already forbids
+    relaying — but `atomic_write_text` keeps `Path.write_text`'s translating newline
+    default and on POSIX `os.linesep == "\\n"`, so swapping the text helper in
+    reddens that row on WINDOWS ONLY and CI's Linux leg would call the swap green.
+
+    So inspect the payload the helper is handed, upstream of any translation. The
+    binding is WRAPPED rather than replaced, so the real write still happens.
+
+    BOTH helper names are wrapped into the same list, the text one with
+    `raising=False` since `verify` does not import it. That is what makes the
+    `isinstance` line the assertion that fires: wrapping only the bytes name would
+    grade "the bytes helper was called", so the swap would redden on an empty `seen`
+    and this row would be claiming more than it checked.
+
+    Ablation: swap `atomic_write_bytes` for `atomic_write_text` (dropping the
+    `.encode`) and this reddens on every platform, on the `isinstance` row."""
+    seen: list[bytes | str] = []
+    real = verify.atomic_write_bytes
+
+    def record(path, data, *, follow_symlinks=True):
+        seen.append(data)
+        blob = data if isinstance(data, bytes) else data.encode("utf-8")
+        real(path, blob, follow_symlinks=follow_symlinks)
+
+    monkeypatch.setattr(verify, "atomic_write_bytes", record)
+    monkeypatch.setattr(verify, "atomic_write_text", record, raising=False)
+    spec = tmp_path / "spec.md"
+    spec.write_bytes(b"---\r\ntitle: t\r\nstatus: done\r\n---\r\n\r\nbody\r\n")
+
+    assert verify.set_frontmatter_field(spec, "baseline_revision", "abc123") is True
+
+    assert len(seen) == 1  # exactly one write — no retry loop crept in
+    assert isinstance(seen[0], bytes)
+    assert b"baseline_revision: abc123\r\n" in seen[0]
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlinks")
+def test_set_frontmatter_field_replaces_a_planted_symlink(tmp_path):
+    """The row that grades this SITE's `follow_symlinks=False` argument rather than
+    the helper's implementation of it (pinned in test_platform_util.py, where the
+    helper is called directly).
+
+    Same reasoning as the two sibling writers of these files: no-follow matches the
+    name-replacing `atomic_replace` `devcontract._atomic_write_spec` already used,
+    and the spec path reaches this writer from a scan of a directory a driven session
+    owns — writing THROUGH a planted link would hand that session a host-side write
+    to any operator-writable path.
+
+    Ablation: drop `follow_symlinks=False` at the call and this reddens alone."""
+    real = tmp_path / "someone-elses-file"
+    real.write_text(SPEC, encoding="utf-8")
+    link = tmp_path / "spec.md"
+    link.symlink_to(real)
+
+    assert verify.set_frontmatter_field(link, "baseline_revision", "abc123") is True
+
+    assert not link.is_symlink()  # the NAME was replaced
+    assert verify.read_frontmatter(link)["baseline_revision"] == "abc123"
+    assert real.read_text(encoding="utf-8") == SPEC  # not written through
 
 
 # ----------------------------------------------------------- build_context

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -1755,11 +1755,84 @@ def test_archive_run(tmp_path):
     assert dest == tmp_path / ".bmad-loop" / "archive" / "20260611-100000-aaaa.tar.gz"
     assert dest.is_file()
     assert not run_dir.exists()  # original removed
-    assert not dest.with_suffix(".tar.gz.tmp").exists()  # temp cleaned via replace
+    # An exhaustive listing, not `not dest.with_suffix(".tar.gz.tmp").exists()`: that
+    # spelling was the SAME buggy expression as the source it graded (`with_suffix`
+    # replaces only the last suffix, so on `<id>.tar.gz` it yields
+    # `<id>.tar.tar.gz.tmp`), and right only by accident. After the #363 filename fix
+    # it named a path existing under neither spelling and would have gone silently
+    # vacuous. Listing the directory cannot: it names every leftover, whatever it is
+    # called.
+    assert [p.name for p in dest.parent.iterdir()] == ["20260611-100000-aaaa.tar.gz"]
     with tarfile.open(dest) as tar:
         names = tar.getnames()
     assert "20260611-100000-aaaa/state.json" in names
     assert "20260611-100000-aaaa/journal.jsonl" in names
+
+
+def test_archive_run_names_its_temp_after_the_destination(tmp_path, monkeypatch):
+    """#363's filename half, and it needs its own test because NOTHING else grades
+    it: on the happy path `atomic_replace` consumes the temp under either spelling,
+    and the new `except BaseException` guard unlinks it whatever it is named — so
+    reverting the fix reddens no other row in this file. Recording the name handed to
+    `os.replace` is the only place the spelling is observable.
+
+    `dest.with_suffix(".tar.gz.tmp")` yielded `<id>.tar.tar.gz.tmp`, because
+    `with_suffix` replaces only the LAST suffix and `<id>.tar.gz` has stem
+    `<id>.tar` — not the name the docstring implied, and not one any cleanup could
+    have been written against.
+
+    `run_dir` is built BEFORE the patch on purpose: `save_state` writes through the
+    same `os.replace`, and building it after would pollute `seen` with a call that
+    has nothing to do with the archive.
+
+    Ablation A9: restore `dest.with_suffix(".tar.gz.tmp")` and this reddens alone —
+    `test_archive_run` and the guard test below stay GREEN, which is exactly why
+    this row exists rather than being folded into either."""
+    run_dir = _make_state_run(tmp_path, "20260611-100000-aaaa")
+    seen: list[str] = []
+    real = os.replace
+
+    def record(src, dst):
+        seen.append(os.path.basename(src))
+        real(src, dst)
+
+    monkeypatch.setattr(platform_util.os, "replace", record)
+    dest = runs.archive_run(tmp_path, run_dir)
+
+    # an exact list, so it also pins "exactly one replace" — a retry loop or a second
+    # write creeping in here would redden rather than pass on a substring match
+    assert seen == [dest.name + ".tmp"]
+
+
+def test_archive_run_failed_replace_strands_no_temp(tmp_path, monkeypatch):
+    """#363. `.bmad-loop/archive/` is gitignored by NOTHING — `bmad-loop init` writes
+    `.bmad-loop/runs/`, `.bmad-loop/cache/`, `.bmad-loop/policy.toml` and
+    `_bmad/render/` — so a temp stranded here is an untracked file that holds
+    `verify.worktree_clean` False until a human deletes it by hand.
+
+    This site cannot use `atomic_write_*`: the path is handed to `tarfile.open`, so
+    there is no payload for a helper to take. It gets the house guard instead, the
+    one `operatoractions.record_park` uses.
+
+    A PLAIN OSError, never PermissionError: `_retry_on_sharing_violation` treats
+    PermissionError (and winerror 5/32) as the transient Windows sharing violation
+    and would burn ~5 s of jittered backoff before propagating it.
+
+    Ablation A8: delete the `except BaseException` guard and ONLY the third assertion
+    reddens — the first two are pinned by statement ordering (`shutil.rmtree` runs
+    after the replace), not by the guard, so the leftover-temp row is the one that
+    grades it."""
+    run_dir = _make_state_run(tmp_path, "20260611-100000-aaaa")
+
+    def boom(src, dst):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(platform_util.os, "replace", boom)
+    with pytest.raises(OSError, match="disk full"):
+        runs.archive_run(tmp_path, run_dir)
+
+    assert (run_dir / "state.json").is_file()  # the run survives a failed archive
+    assert list((tmp_path / ".bmad-loop" / "archive").iterdir()) == []  # no temp left
 
 
 def test_archive_run_refuses_while_the_agent_session_is_live(tmp_path, monkeypatch):

--- a/tests/test_sprintstatus_advance.py
+++ b/tests/test_sprintstatus_advance.py
@@ -1,6 +1,9 @@
 """Tests for the orchestrator-owned sprint-status writer (generic-skill path)."""
 
+import sys
 from pathlib import Path
+
+import pytest
 
 from bmad_loop import sprintstatus
 
@@ -276,3 +279,80 @@ def test_a_line_with_trailing_whitespace_and_no_comment_is_refused(tmp_path):
         lines = [line]
         assert sprintstatus._set_mapping_value(lines, "3-2-x", "done") is False
         assert "".join(lines) == line
+
+
+# ------------------------------------------------------------ atomic rewrite (#379)
+
+
+def test_a_truncated_board_still_parses_and_yields_fewer_keys(tmp_path):
+    """The PRE-FIX failure mode this phase exists to make unreachable, pinned as a
+    property of the FILE FORMAT rather than of the writer — deliberately green on
+    both sides of the fix, because nothing else in the suite states why the board
+    needed atomicity more than the ledgers did.
+
+    A ledger cut mid-write reads as an obviously shorter ledger. A board cut at a
+    line boundary is still a valid YAML mapping with a valid `development_status`,
+    so `load` RAISES NOTHING: the epics past the tear simply cease to exist, and
+    AGENTS.md makes `advance` the sole write path, so nothing downstream is holding
+    a second copy that would contradict the shortened one. The run walks off the end
+    of the sprint instead of erroring."""
+    p = _write(tmp_path)
+    whole = sprintstatus.load(p)
+    assert set(whole.epics) == {3, 4} and len(whole.stories) == 3
+
+    torn = SPRINT[: SPRINT.index("  epic-4:")]  # a short write ending at a line boundary
+    p.write_text(torn, encoding="utf-8")
+
+    shrunk = sprintstatus.load(p)  # NOT a SprintStatusError — that is the whole problem
+    assert set(shrunk.epics) == {3}  # epic 4 silently gone
+    assert len(shrunk.stories) == 2 and sprintstatus.story_status(p, "4-1-thing") is None
+
+
+def test_advance_write_failure_raises_and_leaves_the_board_entire(tmp_path, monkeypatch):
+    """#379. `advance` is a read-modify-rewrite, so the truncating `write_text` it
+    replaced could publish the prefix the row above characterizes. The helper writes
+    a temp and replaces it, so a fault leaves the original whole, and the raise still
+    reaches the caller — repair writes must raise (AGENTS.md).
+
+    Patched at sprintstatus' OWN binding of the helper, never `Path.write_text`: the
+    helper writes through an `mkstemp` fd via `os.fdopen`, so a `Path` patch never
+    fires and this would pass having exercised nothing.
+
+    Ablation: restore `path.write_text(...)` at the call site and this reddens
+    alone."""
+    p = _write(tmp_path)
+    before = p.read_bytes()
+
+    def boom(path, text, *, follow_symlinks=True):
+        raise OSError("no space left on device")
+
+    monkeypatch.setattr(sprintstatus, "atomic_write_text", boom)
+    with pytest.raises(OSError, match="no space left"):
+        sprintstatus.advance(p, "3-2-digest-delivery", "in-progress")
+
+    assert p.read_bytes() == before
+    assert b"3-2-digest-delivery: in-progress" not in p.read_bytes()  # the lost mutation
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlinks")
+def test_advance_writes_through_a_symlinked_board(tmp_path):
+    """The row that grades this SITE's `follow_symlinks` argument — the DEFAULT
+    here, unlike the three spec writers, which pass False to match the
+    name-replacing `atomic_replace` they already had.
+
+    The default is what preserves behaviour: `write_text` opened through a link, so
+    a repo that keeps its board outside the tree and symlinks it in kept being a
+    symlink. Replacing the NAME instead would silently orphan the real file on the
+    first advance and leave the operator editing a board nothing reads.
+
+    Ablation: pass `follow_symlinks=False` at the call and this reddens alone."""
+    real = tmp_path / "elsewhere" / "sprint-status.yaml"
+    real.parent.mkdir()
+    real.write_text(SPRINT, encoding="utf-8")
+    link = tmp_path / "sprint-status.yaml"
+    link.symlink_to(real)
+
+    assert sprintstatus.advance(link, "3-2-digest-delivery", "in-progress") == "in-progress"
+
+    assert link.is_symlink()  # still a link, not turned into a regular file
+    assert sprintstatus.story_status(real, "3-2-digest-delivery") == "in-progress"

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -2155,7 +2155,7 @@ def test_preanswered_keep_open_suppresses_prompt_and_persists(project):
     assert decisions.load_pre_answers(project.project)["DW-1"]["effect"] == "keep-open"
 
 
-# ------------------------------------------- #363: the two `decisions.json` writes
+# ------------------------------- the two per-run `decisions.json` writes (cf. #363)
 #
 # `sweep.atomic_write_text` is ONE module binding shared by FOUR call sites: the
 # `_ensure_migration` ledger restore, the two `_decisions_phase` writes below, and
@@ -2171,9 +2171,17 @@ def test_preanswered_keep_open_suppresses_prompt_and_persists(project):
 
 
 def test_seeded_decisions_write_failure_strands_nothing(project, monkeypatch):
-    """#363, the pre-answer-seeded write. Before the move to the helper this was a
-    hand-rolled `decisions.json.tmp` + `atomic_replace`; a failed replace left the
-    temp behind, and under `.bmad-loop/` nothing gitignores it.
+    """The pre-answer-seeded write. Before the move to the helper this was a
+    hand-rolled `decisions.json.tmp` + `atomic_replace`, and a failed replace left
+    the temp behind.
+
+    NOT #363's exposure, despite the shared helper and the shared filename. This
+    `decisions.json` is `engine.run_dir / "decisions.json"` — under
+    `.bmad-loop/runs/<id>/`, which `init` gitignores — so a stranded temp here was
+    never untracked and never held `worktree_clean` False. #363's file is the
+    project-level `.bmad-loop/decisions.json` (`decisions._write_store`), a
+    different file one directory up. What this row pins is the helper's
+    unlink-on-raise on a site that took it for the fsync and the unique temp name.
 
     The `decision-preanswered` journal line is a PRECONDITION, not decoration: it is
     appended before the write, so without it `assert not ... .exists()` would pass
@@ -2227,8 +2235,10 @@ def test_seeded_decisions_write_failure_strands_nothing(project, monkeypatch):
 
 
 def test_interactive_decision_write_failure_strands_nothing(project, monkeypatch):
-    """#363, the interactive write — the same hand-rolled shape as the seeded one
-    above, on the same path, a few lines further down.
+    """The interactive write — the same hand-rolled shape as the seeded one above,
+    on the same path, a few lines further down, and covered by the same correction
+    in that docstring: this is the per-run `decisions.json`, not #363's
+    project-level store.
 
     Two preconditions rather than one. `decision-pending` is appended before
     `prompter.ask`, so it proves the phase was entered; `decision-answered` is

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -24,7 +24,9 @@ from conftest import (
     write_spec,
 )
 
-from bmad_loop import deferredwork, runs, verify
+from bmad_loop import deferredwork, runs
+from bmad_loop import sweep as sweep_mod
+from bmad_loop import verify
 from bmad_loop.adapters.base import SessionResult
 from bmad_loop.adapters.mock import MockAdapter
 from bmad_loop.journal import Journal, load_state, save_state
@@ -2153,6 +2155,123 @@ def test_preanswered_keep_open_suppresses_prompt_and_persists(project):
     assert decisions.load_pre_answers(project.project)["DW-1"]["effect"] == "keep-open"
 
 
+# ------------------------------------------- #363: the two `decisions.json` writes
+#
+# `sweep.atomic_write_text` is ONE module binding shared by FOUR call sites: the
+# `_ensure_migration` ledger restore, the two `_decisions_phase` writes below, and
+# `_write_bundle_intent`. A bare module-wide boom would make the "revert this site"
+# ablation pass for the WRONG REASON — the run still crashes on "disk full", just
+# raised from somewhere else — so both stubs below filter on the FILENAME and
+# delegate otherwise, and both plans carry ZERO bundles so the bundle-intent write
+# is unreachable too.
+#
+# The filter is safe against the project-level pre-answer store, which is also named
+# `decisions.json`: that goes through `decisions.atomic_write_text`, a different
+# module's binding, which these patches do not touch.
+
+
+def test_seeded_decisions_write_failure_strands_nothing(project, monkeypatch):
+    """#363, the pre-answer-seeded write. Before the move to the helper this was a
+    hand-rolled `decisions.json.tmp` + `atomic_replace`; a failed replace left the
+    temp behind, and under `.bmad-loop/` nothing gitignores it.
+
+    The `decision-preanswered` journal line is a PRECONDITION, not decoration: it is
+    appended before the write, so without it `assert not ... .exists()` would pass
+    for the entirely different reason that the phase was never entered.
+
+    Ablation A4: revert this site to `tmp.write_text(...)` + `atomic_replace` and
+    this reddens on the assertions (not, as in the decisions/policy/tui-settings
+    rows, on an AttributeError) — the `sweep.atomic_write_text` binding survives the
+    revert because three other sites still use it. That is exactly why the stub
+    filters by filename: a module-wide boom would keep this green through the
+    revert, crashing on a write this test is not about."""
+    from bmad_loop import decisions
+    from bmad_loop.sweep import DecisionOption
+
+    write_ledger(project, {"DW-1": "open"})
+    decisions.record_pre_answer(
+        project.project,
+        "DW-1",
+        DecisionOption(key="2", label="Keep", effect="keep-open"),
+        date="2026-06-12",
+    )
+    plan = triage_result(  # keep-open only: no bundle, so no bundle-intent write
+        ["DW-1"],
+        decisions=[
+            _decision(
+                "DW-1",
+                [
+                    {"key": "1", "label": "Build", "effect": "build", "intent": "x"},
+                    {"key": "2", "label": "Keep", "effect": "keep-open"},
+                ],
+                recommendation="2",
+            )
+        ],
+    )
+    engine, _ = make_sweep(project, [triage_effect(plan)], prompting=False)
+
+    real = sweep_mod.atomic_write_text
+
+    def boom(path, text, *, follow_symlinks=True):
+        if Path(path).name == "decisions.json":
+            raise OSError("disk full")
+        real(path, text, follow_symlinks=follow_symlinks)
+
+    monkeypatch.setattr(sweep_mod, "atomic_write_text", boom)
+    summary = engine.run()
+
+    assert summary.crashed and "disk full" in str(summary.crash_error)
+    assert '"decision-preanswered"' in journal_text(engine)  # PRECONDITION: site reached
+    assert not (engine.run_dir / "decisions.json").exists()
+    assert list(engine.run_dir.glob("decisions*.tmp")) == []  # no stranded temp
+
+
+def test_interactive_decision_write_failure_strands_nothing(project, monkeypatch):
+    """#363, the interactive write — the same hand-rolled shape as the seeded one
+    above, on the same path, a few lines further down.
+
+    Two preconditions rather than one. `decision-pending` is appended before
+    `prompter.ask`, so it proves the phase was entered; `decision-answered` is
+    appended AFTER the write, so its ABSENCE places the raise between the ask and
+    that append — i.e. exactly at the site under test, not somewhere upstream that
+    would have skipped the write entirely.
+
+    Ablation A7: revert this site and it reddens on the assertions, for the reason
+    the seeded twin's docstring gives — the shared binding survives the revert, so
+    only the filename filter makes the row grade this site."""
+    write_ledger(project, {"DW-1": "open"})
+    plan = triage_result(  # close-only: no bundle, so no bundle-intent write
+        ["DW-1"],
+        decisions=[
+            _decision(
+                "DW-1",
+                [
+                    {"key": "1", "label": "Close it", "effect": "close", "resolution": "moot"},
+                    {"key": "2", "label": "Keep open", "effect": "keep-open"},
+                ],
+            )
+        ],
+    )
+    engine, _ = make_sweep(project, [triage_effect(plan)], answers=["1"], prompting=True)
+
+    real = sweep_mod.atomic_write_text
+
+    def boom(path, text, *, follow_symlinks=True):
+        if Path(path).name == "decisions.json":
+            raise OSError("disk full")
+        real(path, text, follow_symlinks=follow_symlinks)
+
+    monkeypatch.setattr(sweep_mod, "atomic_write_text", boom)
+    summary = engine.run()
+
+    journal = journal_text(engine)
+    assert summary.crashed and "disk full" in str(summary.crash_error)
+    assert '"decision-pending"' in journal  # PRECONDITION: the prompt was reached
+    assert '"decision-answered"' not in journal  # the raise landed AT the write
+    assert not (engine.run_dir / "decisions.json").exists()
+    assert list(engine.run_dir.glob("decisions*.tmp")) == []  # no stranded temp
+
+
 def test_max_bundles_truncation(project):
     write_ledger(project, {"DW-1": "open", "DW-2": "open", "DW-3": "open"})
     plan = triage_result(
@@ -2863,10 +2982,23 @@ def test_migration_restore_write_failure_propagates_and_keeps_the_ledger(project
     before the failure did — the run crashed with the ledger at zero bytes, and
     the `_safe_reset` that would have restored it was already spent.
 
-    The patch is module-wide but reaches exactly one call — probed on this
-    harness, `_ensure_migration`'s restore is the only `sweep.atomic_write_text`
-    a failed migration reaches; the bundle-intent write needs a triage plan this
-    run never gets to."""
+    The patch is module-wide but reaches exactly one call — re-probed on this
+    harness by COUNTING calls through the stub, not by reading line order. The
+    raising stub fires once, on the ledger restore.
+
+    `sweep.atomic_write_text` has four call sites and the other three are all out
+    of reach here: the two `_decisions_phase` writes (#363) and the bundle-intent
+    write each need a triage plan carrying decisions or bundles, and this run
+    crashes in `_ensure_migration` before the decisions phase is entered.
+    Delegating instead of raising confirms it — the run then reaches two writes,
+    both the ledger, one per migration attempt.
+
+    The stub takes `**_kw` because those decisions writes pass
+    `follow_symlinks=False`. Two positional parameters are enough for the restore
+    (it passes neither keyword), but should a keyword-passing site ever become
+    reachable here, a narrow stub would meet it as a TypeError — the run would
+    still crash, just on the wrong fault, reddening the "disk full" assertion in a
+    way that points nowhere near the cause."""
     write_legacy_ledger(project, LEGACY_LEDGER)
     manifest = legacy_manifest()
     half = (
@@ -2879,7 +3011,7 @@ def test_migration_restore_write_failure_propagates_and_keeps_the_ledger(project
     bad = migrate_effect(project, half, [{"key": manifest[0]["key"], "dw_id": "DW-1"}])
     engine, _ = make_sweep(project, [bad, bad])
 
-    def boom(path, text):
+    def boom(path, text, **_kw):
         raise OSError("disk full")
 
     monkeypatch.setattr("bmad_loop.sweep.atomic_write_text", boom)

--- a/tests/test_tui_settings.py
+++ b/tests/test_tui_settings.py
@@ -10,12 +10,14 @@ from __future__ import annotations
 
 import tomllib
 
+import pytest
 from test_tui_app import until
 from textual.widgets import Collapsible, Input, Select, Switch
 
 from bmad_loop import policy as policy_mod
 from bmad_loop.plugins import load_plugins
 from bmad_loop.policy import POLICY_FILE, POLICY_TEMPLATE
+from bmad_loop.tui import settings as settings_mod
 from bmad_loop.tui.app import BmadLoopApp
 from bmad_loop.tui.screens.dashboard import DashboardScreen
 from bmad_loop.tui.screens.settings_screen import SettingsScreen
@@ -127,7 +129,47 @@ def test_save_creates_parent_and_leaves_no_tmp(tmp_path):
     doc.set("limits", "max_dev_attempts", 3)
     doc.save(path)
     assert policy_mod.load(path).limits.max_dev_attempts == 3
+    # name-agnostic on purpose: it grades "nothing left behind", not which name the
+    # temp had, so it survived the #363 move from a fixed `.toml.tmp` to the helper's
+    # mkstemp name unchanged.
     assert list(path.parent.iterdir()) == [path]
+
+
+def test_save_failure_raises_and_keeps_the_file(tmp_path, monkeypatch):
+    """#363. `save` is a read-modify-rewrite of `.bmad-loop/policy.toml`, and its
+    hand-rolled temp was the fixed name `policy.toml.tmp` — gitignored by nothing,
+    and byte-identical to the one `policy.write_mux_backend` built, so the settings
+    editor and the mux writer raced on one name. The helper's per-write `mkstemp`
+    name removes the collision and the temp on any raise.
+
+    It must RAISE rather than degrade: `settings_screen` catches OSError to show
+    "save failed: …", so a swallowed error would render a success the operator's
+    file does not have.
+
+    Patched at the settings module's OWN binding, never `Path.write_text`: the
+    helper writes through an `mkstemp` fd via `os.fdopen`, so a `Path` patch never
+    fires and the test would pass having exercised nothing.
+
+    Ablation A6: revert `save` to `tmp.write_text(...)` + `atomic_replace` and this
+    reddens alone, as an AttributeError from `monkeypatch.setattr` — the binding
+    disappears with the revert."""
+    path = tmp_path / ".bmad-loop" / "policy.toml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("[limits]\nmax_dev_attempts = 3\n", encoding="utf-8")
+    before = path.read_bytes()
+
+    doc = PolicyDoc.load(path)
+    doc.set("limits", "max_dev_attempts", 9)
+
+    def boom(path, text, *, follow_symlinks=True):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(settings_mod, "atomic_write_text", boom)
+    with pytest.raises(OSError, match="disk full"):
+        doc.save(path)
+
+    assert path.read_bytes() == before
+    assert b"max_dev_attempts = 9" not in path.read_bytes()  # the mutation, not landed
 
 
 def test_validate_with_project_enforces_plugin_coupling(tmp_path):

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1905,6 +1905,85 @@ def test_safe_rollback_restores_committed_policy_on_clean_tree(project):
     assert pol.read_text() == "[scm]\nrollback_on_failure = true\n"  # survived
 
 
+def test_safe_rollback_restores_the_policy_through_the_atomic_helper(project, monkeypatch):
+    """#379. The put-back was a bare `policy_path.write_bytes`, which truncates
+    the file to zero and refills it in place: a host lost mid-write comes back
+    with the operator's config neither reverted nor restored, and a truncated
+    TOML is not a smaller config but a parse error the next `bmad-loop run`
+    refuses on — arriving immediately after a rollback that already discarded the
+    attempt's work. The helper fsyncs before the replace, so the crash window
+    yields the old file or the whole new one.
+
+    Graded by WRAPPING the binding rather than replacing it: the real write still
+    lands, so the content assertion below is not measuring the stub. Recording
+    the call also pins "exactly one write", which the guard above it is there to
+    guarantee — a retry loop or a second unconditional write could not creep in
+    unnoticed.
+
+    Ablation: revert the call to `policy_path.write_bytes(policy_content)` and
+    this reddens on `len(seen) == 1` — the helper is never reached."""
+    repo = project.project
+    baseline = verify.rev_parse_head(repo)  # baseline predates policy.toml
+    pol = repo / ".bmad-loop" / "policy.toml"
+    pol.parent.mkdir(parents=True, exist_ok=True)
+    pol.write_bytes(b"[scm]\nrollback_on_failure = true\n")
+    git(repo, "add", "-f", str(pol))
+    git(repo, "commit", "-q", "-m", "add policy after baseline")
+    seen: list[tuple[Path, bytes]] = []
+    real = verify.atomic_write_bytes
+
+    def record(path, data, *, follow_symlinks=True):
+        seen.append((Path(path), data))
+        real(path, data, follow_symlinks=follow_symlinks)
+
+    monkeypatch.setattr(verify, "atomic_write_bytes", record)
+
+    verify.safe_rollback(repo, baseline, baseline_untracked=None, keep=(".bmad-loop",))
+
+    assert len(seen) == 1
+    assert seen[0] == (pol, b"[scm]\nrollback_on_failure = true\n")
+    assert pol.read_bytes() == b"[scm]\nrollback_on_failure = true\n"  # and it landed
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX symlinks")
+def test_safe_rollback_replaces_a_policy_symlink_by_name(project):
+    """#379. The one row that grades this SITE's `follow_symlinks=False` argument.
+    Unlike the other writers moved to the helper on this branch, the expression
+    replaced here was a direct `write_bytes` — which opens the name and so writes
+    THROUGH a planted link — so no-follow is a genuine change of behaviour, not a
+    preservation of what `os.replace` already did.
+
+    It is still the right change. `policy.write_mux_backend` already replaces this
+    same file by name, so a link at `.bmad-loop/policy.toml` does not survive the
+    orchestrator anyway; and `runsetup` states a driven session can write that
+    path, which makes the link a session-chosen redirect for a host-side write.
+    The reachable exploit is narrow but real, and it is exactly what this row
+    builds: the restore only fires when the reset CHANGED what the name reads, so
+    the redirect has to aim at a tracked in-repo file — which the reset then
+    reverts and this write immediately clobbers with policy bytes.
+
+    Ablation: drop `follow_symlinks=False` and this reddens alone — the link
+    survives and `shared.toml` is the file that gets rewritten."""
+    repo = project.project
+    shared = repo / "shared.toml"  # tracked, and NOT the operator's policy
+    shared.write_bytes(b"[scm]\nrollback_on_failure = false\n")
+    git(repo, "add", str(shared))
+    git(repo, "commit", "-q", "-m", "a tracked file a session could aim at")
+    baseline = verify.rev_parse_head(repo)
+    pol = repo / ".bmad-loop" / "policy.toml"
+    pol.parent.mkdir(parents=True, exist_ok=True)
+    pol.symlink_to(Path("..") / "shared.toml")
+    # the capture reads THROUGH the link, and the reset reverts what it points at,
+    # so the put-back is reached with the link still standing
+    shared.write_bytes(b"[scm]\nrollback_on_failure = true\n")
+
+    verify.safe_rollback(repo, baseline, baseline_untracked=None, keep=(".bmad-loop",))
+
+    assert not pol.is_symlink()  # the NAME was replaced
+    assert pol.read_bytes() == b"[scm]\nrollback_on_failure = true\n"
+    assert shared.read_bytes() == b"[scm]\nrollback_on_failure = false\n"  # not through
+
+
 def test_attempt_dirty_ignores_lone_policy_edit(project):
     """A diff confined to policy.toml is operator config, not the attempt's
     dirtiness — so a stopped attempt whose only residue is a policy edit reads as

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1946,6 +1946,90 @@ def test_worktree_clean_flags_untracked_non_policy(project):
     assert not verify.worktree_clean(project.project)
 
 
+def _porcelain(repo) -> set[str]:
+    """`git status --porcelain` as a set of RAW records.
+
+    Not conftest's `git()`: that returns `stdout.strip()`, which eats the leading
+    status space of the FIRST line only — so ` M path` arrives as `M path` or not,
+    depending on sort order. These assertions are about the exact two-character
+    status field, so they need the bytes git actually emitted."""
+    proc = subprocess.run(
+        ["git", "-C", str(repo), "status", "--porcelain"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return set(proc.stdout.splitlines())
+
+
+def test_worktree_clean_flags_a_stranded_policy_temp(project):
+    """#363's PREMISE, not its fix — nothing here exercises the atomic-write
+    change. It pins the reason the issue matters: a `.bmad-loop/policy.toml.tmp`
+    left behind by a failed replace is an UNTRACKED file that no ignore rule
+    covers, so `worktree_clean` goes False and stays False until a human deletes
+    it. Deleting the temp is what flips the verdict back, with the policy edit
+    still on disk.
+
+    Every porcelain assertion below is a PRECONDITION, deliberately spelled as an
+    exhaustive set rather than a fixture. `conftest._isolate_ambient_git_ignores`
+    is session-scoped and autouse, so it is inherited with no opt-in — but it
+    deliberately does NOT set `GIT_CONFIG_NOSYSTEM` (that would suppress
+    Git-for-Windows' system `core.autocrlf`), which leaves a system
+    `core.excludesFile`, a system `status.showUntrackedFiles=no`, and
+    `.git/info/exclude` all reachable. Step 6's single line closes every one of
+    them at once — plus untracked-dir collapsing — and does it as a LOUD red on
+    the precondition rather than a silent green on the verdict.
+
+    Ablation A10: change verify.py's `:(exclude){POLICY_FILE_REL}` to
+    `:(exclude){POLICY_FILE_REL}*` and step 7 reddens ALONE — the trailing glob
+    swallows the `.tmp` sibling too, which is the fake-green this test exists to
+    catch. `test_worktree_clean_ignores_policy_file` and
+    `test_worktree_clean_flags_untracked_non_policy` stay green.
+
+    Ablation A11: delete the `:(exclude)` element entirely and the OTHER direction
+    reddens — `test_worktree_clean_ignores_policy_file` goes red, and here it is
+    step 5's CONTROL that fires, ABORTING this test before step 7 is ever reached.
+    Read that precisely: under A11 step 7 does not "stay green", it does not run.
+    The pair is graded by WHICH STEP each ablation reddens — 7 for A10, 5 for A11 —
+    because steps 4-5 and 6-8 present git-visible states identical but for one
+    file and demand OPPOSITE verdicts. That is what makes this grade which NAME the
+    exclude covers, in both directions, rather than merely that it has one."""
+    repo = project.project
+    pol = repo / ".bmad-loop" / "policy.toml"
+    tmp = repo / ".bmad-loop" / "policy.toml.tmp"
+
+    # 1. track the policy file — this also makes `.bmad-loop/` a TRACKED directory,
+    #    so git can never collapse the untracked record below to `?? .bmad-loop/`
+    pol.parent.mkdir(parents=True, exist_ok=True)
+    pol.write_text('[gates]\nmode = "none"\n')
+    git(repo, "add", "-f", str(pol))
+    git(repo, "commit", "-q", "-m", "track policy")
+
+    assert _porcelain(repo) == set()  # 2. no ambient dirt
+    assert verify.worktree_clean(repo)  # 3. baseline verdict
+
+    # 4. PRECONDITION: git DOES see the edit
+    pol.write_text('[gates]\nmode = "per-epic"\n')
+    assert _porcelain(repo) == {" M .bmad-loop/policy.toml"}
+
+    assert verify.worktree_clean(repo)  # 5. CONTROL: policy.toml itself reads CLEAN
+
+    # 6. PRECONDITION: untracked reporting is ON, at FILE granularity, and nothing
+    #    ignores `*.tmp` — one line closing showUntrackedFiles=no, a system
+    #    excludesFile, .git/info/exclude and dir-collapsing together
+    tmp.write_text('[gates]\nmode = "per-epic"\n')
+    assert _porcelain(repo) == {
+        " M .bmad-loop/policy.toml",
+        "?? .bmad-loop/policy.toml.tmp",
+    }
+
+    assert not verify.worktree_clean(repo)  # 7. THE GRADED ASSERTION
+
+    # 8. differential: the verdict flips back with the policy edit still on disk
+    tmp.unlink()
+    assert verify.worktree_clean(repo)
+
+
 # ------------------------------------------------- git pathspec hardening (#423)
 #
 # Every fixture below is built in PYTHON, never through a shell: fish and zsh


### PR DESCRIPTION
## What

Sixteen writers across the orchestrator either read-modify-rewrote a file through a truncating
`Path.write_*`, or hand-rolled a temp and `os.replace`d it with no cleanup of their own. Fifteen now
route through `platform_util.atomic_write_text` / `atomic_write_bytes`; `runs.archive_run` cannot
(its path goes to `tarfile.open`, so there is no payload to hand over) and gains the house
unlink-on-raise guard plus a corrected temp filename. `atomic_write_bytes` gains the
`follow_symlinks` parameter its text sibling already had.

Closes #363
Closes #379
Closes #595

## Why

Two distinct failures, one family of writers.

**Truncation (#379).** `Path.write_text` opens `"w"`, which truncates before writing. Where the code
reads a file, merges, then writes the whole thing back, a fault partway through (ENOSPC, EIO, quota)
publishes a *prefix* and destroys the rest. Most of these fail **quietly** — the file still parses
afterwards, so nothing downstream raises. A sprint board cut at a line boundary is a valid mapping,
just a smaller one, so the epics past the tear cease to exist. A spec is `before + edited + after`,
so a fault after the frontmatter lands leaves intact frontmatter saying `status: done` over a
decapitated body — a spec that lies, which the loop then commits. Your `.claude/settings.json` is the
loud one: JSON has no partial read, so `init` refuses on the next run with *"is not valid JSON; fix
it and re-run init"*, pointing you at a file it shredded itself, and refusing **before** the merge
means re-running cannot rebuild it.

**Stranded temps (#363).** `atomic_replace` is `os.replace` plus a win32 sharing-violation retry and
does no cleanup, so a failed replace leaves the temp. No ignore rule covers those names — `init`
writes `.bmad-loop/runs/`, `.bmad-loop/cache/`, `.bmad-loop/policy.toml` and `_bmad/render/` — so the
leftover is an **untracked** file holding `verify.worktree_clean` False until a human deletes it.

Both issue bodies are stale in ways that matter; corrections are posted on
[#363](https://github.com/bmad-code-org/bmad-loop/issues/363#issuecomment-5298482859) and
[#379](https://github.com/bmad-code-org/bmad-loop/issues/379#issuecomment-5298494672). The two that
changed this PR:

- **Four exposed `.bmad-loop/` callers, not three.** `tui/settings.py` `PolicyDoc.save` built the
  byte-identical `.bmad-loop/policy.toml.tmp` that `policy.write_mux_backend` built — two writers
  racing on one name.
- **The sweep's two `decisions.json` writes are *not* #363-exposed**, though this PR initially
  claimed they were. They write `self.run_dir / "decisions.json"`, and `runsetup.py:824` puts
  `run_dir` at `.bmad-loop/runs/<id>/`, inside the ignored directory. #363's file is the
  project-level `.bmad-loop/decisions.json` — a different file one directory up, with a
  near-identical temp name. They keep the helper for the fsync and the unique name; only the stated
  motive was wrong (`9395d1e`).

Impact of #363 is also narrower than "blocks the next run": `cmd_run`/`cmd_sweep` probe
`paths.repo_root` while `cmd_validate` and the TUI probe `project`, so under a supported monorepo
`repo_root:` override these temps fail validate and the TUI but do **not** block run or sweep.

## The rule: `follow_symlinks` is chosen per FILE, not per call site

The choice cannot be read off the call site's prior expression. **A file whose semantics are already
name-replacement gets `follow_symlinks=False` across all of its writers** — otherwise two writers of
one path disagree about what that path means. Files with no name-replacing sibling keep the default
and go on following symlinks.

Applying it per file brought **four** previously-bare writers into line. Those four opened the name
and so wrote *through* any link planted at it; they now replace it. That is a real behaviour change
at those four, not a preservation — and what makes it safe is the same per-file argument: each of
those files already had a name-replacing sibling, so no link at those names survived the
orchestrator anyway.

Note the families marked ⚠ below: they are **mixed**, containing bare-write call sites that took
`False`. That is why the shorthand "name-replacing writers → `False`, bare writers → default" is
wrong here, and why the rule has to be stated per file.

| File | Site | Prior expression | `follow_symlinks` |
| --- | --- | --- | --- |
| `.bmad-loop/decisions.json` | `decisions._write_store` | tmp + `atomic_replace` | `False` |
| `.bmad-loop/runs/<id>/decisions.json` | `sweep._decisions_phase` (seeded) | tmp + `atomic_replace` | `False` |
| | `sweep._decisions_phase` (answered) | tmp + `atomic_replace` | `False` |
| ⚠ `.bmad-loop/policy.toml` | `policy.write_mux_backend` | tmp + `atomic_replace` (bytes) | `False` |
| | `tui.settings.PolicyDoc.save` | tmp + `atomic_replace` | `False` |
| | `verify.safe_rollback` | **bare `write_bytes`** | `False` — **changed** |
| ⚠ story spec `.md` | `devcontract._atomic_write_spec` | tmp + `atomic_replace` (bytes) | `False` |
| | `frontmatter.set_frontmatter_status` | **bare `write_bytes`** | `False` — **changed** |
| | `verify.set_frontmatter_field` | **bare `write_bytes`** | `False` — **changed** |
| ⚠ park records | `operatoractions.record_park` | tmp + `atomic_replace` | `False` |
| | `operatoractions._drop_legacy` | tmp + `atomic_replace` | `False` |
| | `Engine._restore_park_record` | **bare `write_text`** | `False` — **changed** |
| `sprint-status.yaml` | `sprintstatus.advance` | bare `write_text` | default (follows) |
| `.claude/settings.json` | `install._register_hooks` | bare `write_text` | default (follows) |
| | `worktree_flow.provision_worktree` | bare `write_text` | default (follows) |
| `.bmad-loop/archive/<id>.tar.gz` | `runs.archive_run` | `tarfile` + `atomic_replace` | n/a — guard only |

Twelve `False`, of which four are real changes and eight are preservations. Three keep the default:
the board and both settings writers are operator-curated files at project-relative paths, where a
repo that symlinks one in must keep it a symlink. `init` additionally resolves its config path and
refuses anything landing outside the project, so the only links reaching it point back inside;
provisioning refuses a linked config outright, before the write.

**Operator-visible: the twelve `False` files now land at `0600`.** No-follow skips `copymode` and
xattrs entirely — that mode deliberately carries nothing over from the target — so contents arrive
at `mkstemp`'s private default. For the eight that were temp-and-replace this is `0644` → `0600`
(the hand-rolled temp was created at `0666 & ~umask` and `os.replace` swapped *that* inode in, so
they were already being reset on every rewrite); the four that were direct writes previously kept
whatever mode the file had. Git records no mode but the exec bit, so nothing downstream of a commit
notices.

## Also in this PR

- `atomic_write_bytes` takes keyword-only `follow_symlinks`, default `True` — which
  `install._worktree_local_exclude` depends on, since it pre-creates the target precisely so the
  helper has a umask mode to carry, and git silently ignores an exclude file it cannot read.
- `Engine._restore_park_record` gains a `task` parameter and journals a new kind,
  `park-record-rollback-failed`, instead of dropping the error. Nothing else would surface it:
  `validate` reports a board parked with no record, but never a record left over for a park that is
  in no commit. The journal call is itself suppressed — a restore that must not raise cannot be
  allowed to raise on the way to saying it failed.
- `runs.archive_run`'s temp was misnamed: `with_suffix` replaces only the last suffix, so
  `<id>.tar.gz` yielded `<id>.tar.tar.gz.tmp`. Now `dest.with_name(dest.name + ".tmp")`.
- **`_mkstemp_beside` (#595), from the codex gate.** The helpers stage a temp named after their
  target and `mkstemp` inserts eight random characters, so the temp ran `len(name) + 13` — a target
  with a legal name produced an *illegal* temp name and the write died with `ENAMETOOLONG` (ext4
  cutoff: a 243-byte basename). Latent in the helpers all along, and reachable from here because the
  spec writers moved onto them — specs are named by the planning skills, and `safe_segment`'s
  `MAX_SEGMENT` bounds story keys and run-dir segments, not spec basenames. Fixed by asking the OS
  rather than guessing a limit: try the readable prefix, and on `ENAMETOOLONG` alone retry once with
  a digest of the name. A character-slice bound would have been wrong — `NAME_MAX` counts bytes
  while Python slices characters, and the limit is not portably knowable.
- `frontmatter.py`'s module docstring and `set_frontmatter_status`'s both asserted the
  non-atomicity was a deliberate trade-off. Changing the code without them would leave the module
  contradicting itself, so both are rewritten. The layering rule they cite is about `verify`, not
  `subprocess`, and it now has one beneficiary rather than two — measured: `import bmad_loop.stories`
  leaves `bmad_loop.verify` out of `sys.modules`, `import bmad_loop.devcontract` does not.

## Non-goals

Stated explicitly because each is adjacent enough to look covered, and none is:

- **Concurrency / lost updates — #286 and #469.** Atomic writes serialize nothing. Two writers of one
  file still race; what changes is that the loser's write is now *quiet and whole* rather than
  interleaved. If anything this makes the lost-update failure harder to spot, which is exactly why
  #469 exists as the distinct half of #379 (its title says so). No locking is added here.
- **`SIGKILL` and win32 replace atomicity.** The helpers close the **raise** path only. They stage at
  `mkstemp(dir=target.parent, suffix=".tmp")`, so a `SIGKILL` mid-write still strands a temp that
  `worktree_clean` reads as dirty — #363's exposure, untouched by this PR for that fault. And on
  Windows `os.replace` is `MoveFileEx(MOVEFILE_REPLACE_EXISTING)`, which is not guaranteed atomic and
  can fall back to a non-atomic copy. The claim that holds on every platform is the narrow one: **a
  failed write cannot truncate the original.**
- **The auto-sweep trigger burn — #501.** A stranded temp could hold `worktree_clean` False and so
  fail a pre-launch auto-sweep, which #501 shows burns its trigger for the life of the run. Removing
  one cause of a failed sweep does not fix what a failed sweep then does.
- **Exclusive temp creation in `archive_run` — now #591.** Raised by CodeRabbit here and deferred as
  pre-existing: the tarball temp is created non-exclusively at a predictable name, and the guard
  unlinks that name without checking ownership.
- **The silent `JSONDecodeError` swallow in `provision_worktree` — now #592.** This PR removes its
  *cause* (the write it feeds is atomic now) but not the policy: an unparseable settings.json is
  still replaced with a hooks-only config, with no message.

The codex gate's `ENAMETOOLONG` finding is **not** on this list — it was the one finding that is a
regression this PR introduced rather than a pre-existing property, so it is fixed here (#595) rather
than deferred.

## Testing

`uv run pytest -q` → **5457 passed, 44 skipped, 5 xfailed**. `uv run pyright` → 0 errors.
`trunk check --all --no-fix` → 255 files, no issues.

Twenty-eight ablations, run **singly** and restored from `cp` backups (never `git checkout`, which
has destroyed in-flight work in this repo). Per-row evidence is in the commit messages; the rows that
carry the argument:

- **A1/A2 (helper layer).** Dropping the `follow_symlinks` forward reddens exactly the new bytes trio
  while the text trio and the `True`-default pins stay green — that disjointness is the evidence.
  Widening `_atomic_write`'s mode-inheritance gate reddens all four `does_not_inherit` rows across
  both helpers, with both `replaces_the_link` rows green.
- **A3–A7, A24–A27 (one per site).** Each reverts exactly one site and reddens exactly that site's
  test. **The failure mode differs, and that is the point.** Where the reverted site is its module's
  only user of the helper, the binding disappears with the revert and the row reddens as an
  `AttributeError` from `monkeypatch.setattr`. Where other sites share the binding — `sweep` has four
  call sites on one `atomic_write_text` — **the binding survives the revert**, so a bare module-wide
  boom stub would keep the row green by crashing from a different site. Those stubs filter on
  `Path(path).name` and delegate otherwise, and their plans carry zero bundles so the bundle-intent
  write is unreachable.
- **A10/A11 (the `worktree_clean` premise ladder).** Widening the pathspec to
  `:(exclude)…policy.toml*` reddens step 7 alone; deleting the exclude entirely reddens step 5's
  control instead — which fires *first*, so step 7 never runs under A11. Graded by **which step**
  each ablation reddens; that asymmetry is what proves the pair grades which *name* the exclude
  covers.
- **A28 (`_mkstemp_beside`).** Deleting the `ENAMETOOLONG` fallback reddens the new row **alone**
  (1 failed, 310 passed), inside `mkstemp` before any assertion. Both neighbouring temp-name rows
  stay green under it — they use short names, so neither reaches the fallback, which is why this
  needed its own row rather than an assertion bolted onto an existing one.
- **A27 is green, and is reported as green.** `provision_worktree`'s component-wise refusal walk
  checks `is_symlink()` on every path component including the file, so no symlink ever reaches the
  write and no row can distinguish the argument. The property is covered from the other side by the
  four `test_provision_refuses_*_symlink` rows. Closing it would need a row asserting something the
  code cannot do.

Known green and recorded rather than closed: dropping `follow_symlinks=False` at several sites
reddens nothing, because no consumer test plants a symlink at those paths — the property is graded at
the helper layer, plus one POSIX symlink row (A12) at the `policy` site.

Two things were re-probed empirically rather than reasoned about. The failed-migration test's
module-wide patch was re-counted **through the stub** (one call when raising — the ledger restore;
two when delegating, both the ledger), because its docstring's enumeration of "the only write this
reaches" went stale once this branch added sites to that binding. And the gitignore behaviour was
confirmed in a throwaway repo with `GIT_CONFIG_NOSYSTEM=1`, since this repo's own `.gitignore`
carries `.bmad-loop/archive/`, which `init` does not write — making the archive case invisible here.

## Changelog

Consolidated under `## [Unreleased]` into `### Changed` (the `0600` / `follow_symlinks` rule) and
`### Fixed` (the truncation family, then the stranded temps), replacing the five per-phase entries
that had accumulated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of file updates by preventing partial or corrupted writes when saves fail.
  * Preserved existing files after errors during settings, policies, sprint boards, decisions, archives, and rollback operations.
  * Added safer handling for symbolic links and long filenames across supported platforms.
  * Temporary files are now cleaned up reliably, with secure permissions applied during writes.
* **Documentation**
  * Updated the unreleased changelog with the improved write-safety behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->