### PR TITLE
docs(testing): sync the open-flake list

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -253,7 +253,7 @@ source tree, so packaging breaks were invisible until this job existed).
 **Zero-retry flaky policy.** There is no retry mechanism anywhere: no `--reruns`, no retry
 plugin — `pytest-rerunfailures` was removed from the environment precisely because an installed
 retry plugin is an invitation to paper over a real flake. **A flake is a bug**: it gets an
-issue (#360 and #529 are the open instances), a diagnosis, and a deterministic fix — never a
+issue (#360 and #581 are the open instances), a diagnosis, and a deterministic fix — never a
 rerun loop. The main defense is the **frozen-clock pattern, mandatory for time-dependent
 tests**: no unit or seam test sleeps toward a deadline (the real-process gates use short
 settle polls, which is different from waiting out a production timeout). Two sanctioned


### PR DESCRIPTION
## What

Line 256 of `docs/testing.md` was changed to remove reference to #529 and #581 was added.

## Why

#536 did not delete mention of #529 from line 256 in `docs/testing.md`. #360 and #581 are the only open instances. #529 does not have a row in `## Gaps and deviations`, so the inclusion of #529 makes line 256 false. #581's housekeeping section noted the addition of #581 to 256.
Fixes #553

## How

- Deleted mention of #529 on line 256.
- Added #581 to line 256.

## Testing

I verified that there were no other mentions of #529 and that the markdown file still rendered correctly. Trunk wasn't run locally since I am on Windows ARM64, and markdownlint's line-length rule isn't affected since the line did not change in character count. Pytest/pyright were not run since the changes do not touch python.

## Changelog

n/a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the flaky-test policy to reference the current tracking issue while retaining the existing related issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->