### PR TITLE
ci: speed up the test jobs (temp on D:, logical workers, slim sandbox template)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         run: uv sync --locked --all-extras
 
       - name: Run tests
-        run: uv run pytest -q -n auto --durations=15
+        run: uv run pytest -q -n logical --durations=15
 
   test-windows:
     # Real-Windows runner for the deterministic suite (live psmux e2e stays a manual gate).
@@ -92,7 +92,7 @@ jobs:
         env:
           TMP: ${{ runner.temp }}
           TEMP: ${{ runner.temp }}
-        run: uv run pytest -q -n auto --durations=15
+        run: uv run pytest -q -n logical --durations=15
 
   version-sync:
     name: version-sync

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,16 @@ jobs:
         run: uv sync --locked --all-extras
 
       - name: Run tests
+        # pytest roots `tmp_path` at `tempfile.gettempdir()`, which follows
+        # TMP/TEMP on Windows. The user-profile temp has historically sat on the
+        # slow C: volume while the workspace and RUNNER_TEMP sit on D:, so every
+        # per-test sandbox copy crossed to the slower disk; pin both to the
+        # workspace volume. A no-op if the default temp is already there.
+        # Step-level, not job-level: the `runner` context is unavailable in a
+        # job `env:` block, where this would silently expand to empty.
+        env:
+          TMP: ${{ runner.temp }}
+          TEMP: ${{ runner.temp }}
         run: uv run pytest -q -n auto --durations=15
 
   version-sync:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,10 +55,11 @@ jobs:
     # Real-Windows runner for the deterministic suite (live psmux e2e stays a manual gate).
     name: test (windows, py${{ matrix.python-version }})
     runs-on: windows-latest
-    # 20, not the 15 the Linux test job uses: the slowest observed Windows run
+    # 20, not the 15 the Linux test job uses: the slowest pre-lever Windows run
     # took 888s against a 900s cap, so one slow runner was a bad minute away from
-    # a timeout that reads as a test failure. The levers above should pull the
-    # mean well down; this keeps the tail from failing the build first.
+    # a timeout that reads as a test failure. The levers below cut the measured
+    # mean to ~316s, but the leg still spreads 220-348s run to run; the extra
+    # headroom keeps that tail from failing the build first.
     timeout-minutes: 20
     # The suite reads/writes UTF-8 files; Windows' cp1252 default would break plain
     # text I/O. UTF-8 mode (PEP 686's Python 3.15 default) makes the runner match the
@@ -87,10 +88,10 @@ jobs:
 
       - name: Run tests
         # pytest roots `tmp_path` at `tempfile.gettempdir()`, which follows
-        # TMP/TEMP on Windows. The user-profile temp has historically sat on the
-        # slow C: volume while the workspace and RUNNER_TEMP sit on D:, so every
-        # per-test sandbox copy crossed to the slower disk; pin both to the
-        # workspace volume. A no-op if the default temp is already there.
+        # TMP/TEMP on Windows. Measured on the windows-2025 image (2026-08-14):
+        # the default is C:\Users\RUNNER~1\AppData\Local\Temp while the workspace
+        # and RUNNER_TEMP sit on D:\a — so every per-test sandbox copy crossed to
+        # the slower volume. Pinning both to RUNNER_TEMP keeps them on D:.
         # Step-level, not job-level: the `runner` context is unavailable in a
         # job `env:` block, where this would silently expand to empty.
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,11 @@ jobs:
     # Real-Windows runner for the deterministic suite (live psmux e2e stays a manual gate).
     name: test (windows, py${{ matrix.python-version }})
     runs-on: windows-latest
-    timeout-minutes: 15
+    # 20, not the 15 the Linux test job uses: the slowest observed Windows run
+    # took 888s against a 900s cap, so one slow runner was a bad minute away from
+    # a timeout that reads as a test failure. The levers above should pull the
+    # mean well down; this keeps the tail from failing the build first.
+    timeout-minutes: 20
     # The suite reads/writes UTF-8 files; Windows' cp1252 default would break plain
     # text I/O. UTF-8 mode (PEP 686's Python 3.15 default) makes the runner match the
     # files under test; the conftest guard enforces the same for local win32 runs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ bmad-loop is a deterministic Python orchestrator that drives unattended BMAD-met
 
 ```bash
 uv sync --all-extras          # setup (extras: tui, non-linux, opencode)
-uv run pytest -q              # test suite (-n auto to parallelize)
+uv run pytest -q              # test suite (-n logical to parallelize)
 uv run pytest tests/test_engine.py -q   # single file
 uv run pyright                # typecheck — same pinned version CI runs
 trunk fmt                     # format changed files

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -19,10 +19,13 @@ and every negative assertion proven by ablation.**
 - Configuration is two settings under `[tool.pytest.ini_options]` in `pyproject.toml`:
   `testpaths = ["tests"]` and `asyncio_mode = "auto"`. There is no `addopts`, no marker
   registry, no `filterwarnings` (the last is under triage — #548).
-- `uv run pytest -q` runs everything runnable on the host; `-n auto` (pytest-xdist) is
+- `uv run pytest -q` runs everything runnable on the host; `-n logical` (pytest-xdist) is
   supported because every test builds its state from per-test fixtures (the template repo is
-  per-worker). A test that fails only under xdist load is a flake, which is a bug — #360 is
-  the open instance. Live/E2E modules skip themselves when their host requirements are
+  per-worker). Prefer `logical` over `auto`: `psutil` is installed on every platform here
+  (the `non-linux` extra carries no environment marker, and CI syncs `--all-extras`), so
+  xdist's `auto` resolves to the _physical_ core count — half the vCPUs on the hosted
+  runners. CI passes `-n logical` in both test jobs for that reason. A test that fails only
+  under xdist load is a flake, which is a bug — #360 is the open instance. Live/E2E modules skip themselves when their host requirements are
   absent — selection is in-file, never in config.
 - Only builtin pytest marks appear: `parametrize`, `skipif`, `usefixtures`, and exactly one
   `xfail(strict=True)` (a pinned known defect, see [Ablation records](#ablation-records)).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -326,6 +326,13 @@ def _project_template(
     (root / "src.txt").write_text("original\n")
     (root / ".gitignore").write_text(".bmad-loop/runs/\n")  # as `bmad-loop init` would
     git(root, "init", "-q", "-b", "main")
+    # `git init` seeds 14 dead `*.sample` hooks nothing here reads, and every test
+    # replicated all 14 through `project`'s copytree. Drop the files only — NOT via
+    # `git init --template=` (an empty template also drops `.git/hooks/` itself and
+    # `.git/info/exclude`, which tests do depend on: three sites write
+    # `.git/hooks/pre-commit` with no mkdir, and the install tests read info/exclude).
+    for sample in (root / ".git" / "hooks").glob("*.sample"):
+        sample.unlink()
     # Local config: copies (and their worktrees) inherit it via the copied .git/config.
     git(root, "config", "user.email", "test@test")
     git(root, "config", "user.name", "test")

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -1,0 +1,33 @@
+"""Contract tests for the sandbox fixtures in `tests/conftest.py`.
+
+`project` hands every test a copytree clone of a session-scoped template repo, so
+the template's shape is a shared dependency of most of the suite. What is pinned
+here is the part of that shape other modules rely on without asserting it.
+"""
+
+from __future__ import annotations
+
+
+def test_template_drops_sample_hooks_but_keeps_hooks_dir_and_exclude(project):
+    """`git init` seeds 14 dead `*.sample` hooks that nothing reads; the template
+    deletes the files so each per-test copy stops replicating them.
+
+    Both halves are load-bearing, and they pull against each other: the obvious
+    shortcut for the first (`git init --template=` pointed at an empty dir) also
+    removes `.git/hooks/` itself and `.git/info/exclude`, which the suite does
+    depend on — three sites write `.git/hooks/pre-commit` with no `mkdir`
+    (tests/test_engine.py twice, tests/test_verify.py once) and
+    tests/test_install.py reads `.git/info/exclude`. Deleting the sample files
+    is therefore the only cleanup that satisfies both.
+
+    Ablation target: delete the `sample.unlink()` loop from `_project_template`
+    and the first assertion fails alone; swap that loop for an empty
+    `git init --template=` and the first assertion passes while the two
+    survival assertions fail instead — disjoint failures, which is what proves
+    the two halves are independent rather than one implying the other."""
+    git_dir = project.project / ".git"
+    hooks = git_dir / "hooks"
+
+    assert list(hooks.glob("*.sample")) == []
+    assert hooks.is_dir()
+    assert (git_dir / "info" / "exclude").is_file()

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -180,6 +180,13 @@ def test_discover_missing_override_notes(tmp_path):
 def test_discover_location_redacts_username(tmp_path, monkeypatch):
     # a munged-cwd dir embedding a username must not survive verbatim
     monkeypatch.setenv("HOME", str(tmp_path))
+    # `_redact_location` resolves the home it collapses to `~` via
+    # os.path.expanduser, which reads HOME on POSIX but USERPROFILE (then
+    # HOMEDRIVE+HOMEPATH) on Windows — never HOME. Setting only HOME left the
+    # win32 leg asserting the `~` branch while merely *happening* to be in it,
+    # because pytest's tmp_path sat under the real profile dir; it broke the
+    # moment TMP moved to another volume. Set both, as test_sanitize.py does.
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
     path = _write_jsonl(tmp_path / ".secret-home-dir" / "abc-123.jsonl", CLAUDE_ROWS)
     found = probe.discover_transcript("none", cli="x", hints=probe.Hints(transcript=str(path)))
     assert found.location.startswith("~/")

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -178,7 +178,15 @@ def test_discover_missing_override_notes(tmp_path):
 
 
 def test_discover_location_redacts_username(tmp_path, monkeypatch):
-    # a munged-cwd dir embedding a username must not survive verbatim
+    """A munged-cwd dir embedding a username must not survive verbatim.
+
+    Ablation target: drop the `not sanitize.looks_like_identifier(c)` leg from
+    `_redact_location`'s `comp()` and this fails alone, on the
+    `".secret-home-dir" not in found.location` assertion. That leg is the only
+    one that redacts this component — the name is not identifier-shaped, and the
+    `embeds_current_username` leg beside it does not match it — so the negative
+    assertion is answering about the gate it names and not about some unrelated
+    reason the string could be absent."""
     monkeypatch.setenv("HOME", str(tmp_path))
     # `_redact_location` resolves the home it collapses to `~` via
     # os.path.expanduser, which reads HOME on POSIX but USERPROFILE (then


### PR DESCRIPTION
## Baseline

Measured on 2026-08-14 against live CI logs:

| | mean | max | timeout |
| --- | --- | --- | --- |
| `test-windows` | **699 s** | **888 s** | 900 s |
| `test` (Linux) | **215 s** | — | 900 s |

The "Run tests" step is 95%+ of the Windows job, and the overhead is spread evenly across the suite (~0.635 s/test on Windows vs ~0.176 s/test on Linux) rather than concentrated in a few slow tests — so this is per-test constant cost, not a handful of bad tests.

## Levers

Each is its own commit.

| # | Lever | Expected effect |
| --- | --- | --- |
| 1 | **Pin `TMP`/`TEMP` to `runner.temp`** on the Windows "Run tests" step | pytest roots `tmp_path` at `tempfile.gettempdir()`, which follows `TMP`/`TEMP` on Windows. The user-profile temp has historically sat on the slow C: volume while the workspace and `RUNNER_TEMP` sit on D:, so every per-test sandbox copytree crossed to the slower disk. pip measured −28% from the same redirect ([pypa/pip#13129](https://github.com/pypa/pip/issues/13129)). No-op if the default temp is already on D:. |
| 2 | **`-n auto` → `-n logical`** in *both* test jobs | `psutil` is in the `non-linux` extra with no environment marker (pyproject.toml:34) and CI installs `--all-extras`, so xdist's `auto` resolves to `psutil.cpu_count(logical=False)` — the *physical* count, ~2 on the 4-vCPU hosted runners. `logical` asks for the vCPU count and self-adapts if runner shape changes. Applies to Linux too: same situation there. |
| 3 | **Drop git's 14 dead `*.sample` hooks** from the session-scoped sandbox template | ~1,500 tests each copytree the template; all 14 sample files were replicated per test and nothing reads them. |
| 4 | **Windows `timeout-minutes: 15 → 20`** | The max observed run was 888 s against a 900 s cap — one slow runner away from a timeout that reads as a test failure. Headroom for the tail while the levers above pull the mean down. Windows only. |

### Notes on what was deliberately *not* done

- The `git init --template=` shortcut is wrong here: an empty template also removes `.git/hooks/` and `.git/info/exclude`, and tests depend on both — three sites write `.git/hooks/pre-commit` with no `mkdir` (tests/test_engine.py:940, tests/test_engine.py:3002, tests/test_verify.py:2600) and tests/test_install.py reads `.git/info/exclude`. Only the `*.sample` files are deleted.
- Lever 1 is set at **step** level, not job level. The `runner` context is unavailable in a job `env:` block — actionlint rejects it, and the expression would expand to empty, which Python's `tempfile` then skips. Job-level would have been silently inert.
- The stale 2025 advice circulating for this problem (remove the D: drive, Defender exclusion tricks) does not apply: today's image is windows-2025-vs2026, the workspace / `RUNNER_TEMP` / `UV_CACHE_DIR` already live on `D:\a`, and Defender is already disabled on hosted runners.

## Diagnostics commit — will be stripped

The last commit adds a temporary `Diagnostics (STRIP BEFORE MERGE)` step to both test jobs, printing the runner's default tempdir, `RUNNER_TEMP`, and psutil's physical/logical CPU counts. It carries no `TMP`/`TEMP` override on purpose, so it shows both where the temp defaulted *and* where the pin moves it — with the override it could only echo the pinned value back.

**This commit will be reverted once the first runs confirm the tempdir location and the worker counts.** The measurements land in a PR comment below.

## Local verification

- `uv run pytest -q -n logical` — 5461 passed, 44 skipped, 5 xfailed
- `uv run pytest -q tests/test_engine.py tests/test_verify.py tests/test_install.py` — 970 passed, 23 skipped (the tests that touch `.git/hooks` and `.git/info/exclude`)
- `trunk check` — clean (actionlint + zizmor cover the workflow edit)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test reliability across Linux and Windows environments.
  * Ensured temporary test files remain in the appropriate workspace location on Windows.
  * Improved handling of platform-specific user directories and repository test fixtures.

* **Documentation**
  * Updated testing guidance to recommend predictable logical worker allocation for parallel test runs.
  * Clarified hosted-runner behavior and development test commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->