### PR TITLE
fix(deferredwork): bound an entry at every CommonMark ATX heading (#516)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,26 +51,17 @@ breaking changes may land in a minor release.
 ### Fixed
 
 - **An indented, tab-separated or empty heading in the deferred-work ledger no longer lets a `gate:`
-  below it hold a story the entry never named (#516).** A canonical entry's span ended only at a `#`
-  run sitting at column zero with exactly one space after it, so three shapes CommonMark spells as
-  ATX headings — up to three spaces of indent, a tab as the separator, and an empty heading — did
-  not end the entry. The span ran on past the section header and the next section's field lines were
-  read as that entry's, so a later column-zero `gate:` landed in an open entry that had declared
-  nothing: `validate` failed (`deferred.hard-gate`) and `run` paused (`story-gate`) on a story that
-  entry never gated, naming an entry the operator would find no gate in. Pre-existing rather than
-  introduced by `gate:` — before that field the same over-long span mis-attributed a `closes:` or a
-  status read; what the field changed is that it can now block dispatch.
-
-  Two reads move with the boundary. A `status:` line below an indented heading now belongs to that
-  heading's section rather than to the entry above it, so such an entry parses with no status and
-  leaves the open set — it used to read as `open`. And because the legacy parser scans what the
-  canonical spans leave behind, a tail below an indented heading is no longer masked by an over-long
-  span and reaches it again as a legacy item.
-
-  Four spaces of indent, or a leading tab, is an indented code block rather than a heading, and
-  those deliberately still end nothing. A heading nested in a list item or a blockquote
-  (`- ## Notes`, `> ## Notes`) is still not a boundary either — it was not one before, so this is no
-  regression, and it is the same line-scope limitation as #327.
+  below it hold a story the entry never named (#516).** A canonical entry ended only at a `#` run at
+  column zero with exactly one space after it, so three shapes CommonMark spells as ATX headings —
+  up to three spaces of indent, a tab as the separator, and an empty heading — ran on past the
+  section header and absorbed the next section's field lines. A later `gate:` then landed in an open
+  entry that had declared nothing: `validate` failed (`deferred.hard-gate`) and `run` paused
+  (`story-gate`) on a story that entry never gated. Two reads move with the boundary: a `status:`
+  below such a heading is now that section's rather than the entry's, so the entry parses with no
+  status and leaves the open set; and a tail below one is no longer masked by an over-long span and
+  reaches the legacy parser again. Four spaces of indent or a leading tab is an indented code block
+  rather than a heading and still ends nothing, and a heading nested in a list item or a blockquote
+  (`- ## Notes`) is still not a boundary either — the same line-scope limitation as #327.
 
 - **Launching with a `--run-id` that already names a run is refused (#602).** The flag pointed at an
   existing run adopted that run's directory and published its own `state.json` over it. The id is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,28 @@ breaking changes may land in a minor release.
 
 ### Fixed
 
+- **An indented, tab-separated or empty heading in the deferred-work ledger no longer lets a `gate:`
+  below it hold a story the entry never named (#516).** A canonical entry's span ended only at a `#`
+  run sitting at column zero with exactly one space after it, so three shapes CommonMark spells as
+  ATX headings — up to three spaces of indent, a tab as the separator, and an empty heading — did
+  not end the entry. The span ran on past the section header and the next section's field lines were
+  read as that entry's, so a later column-zero `gate:` landed in an open entry that had declared
+  nothing: `validate` failed (`deferred.hard-gate`) and `run` paused (`story-gate`) on a story that
+  entry never gated, naming an entry the operator would find no gate in. Pre-existing rather than
+  introduced by `gate:` — before that field the same over-long span mis-attributed a `closes:` or a
+  status read; what the field changed is that it can now block dispatch.
+
+  Two reads move with the boundary. A `status:` line below an indented heading now belongs to that
+  heading's section rather than to the entry above it, so such an entry parses with no status and
+  leaves the open set — it used to read as `open`. And because the legacy parser scans what the
+  canonical spans leave behind, a tail below an indented heading is no longer masked by an over-long
+  span and reaches it again as a legacy item.
+
+  Four spaces of indent, or a leading tab, is an indented code block rather than a heading, and
+  those deliberately still end nothing. A heading nested in a list item or a blockquote
+  (`- ## Notes`, `> ## Notes`) is still not a boundary either — it was not one before, so this is no
+  regression, and it is the same line-scope limitation as #327.
+
 - **Launching with a `--run-id` that already names a run is refused (#602).** The flag pointed at an
   existing run adopted that run's directory and published its own `state.json` over it. The id is
   now claimed exclusively as the directory is created, so a collision aborts the launch before

--- a/src/bmad_loop/data/skills/bmad-loop-sweep/deferred-work-format.md
+++ b/src/bmad_loop/data/skills/bmad-loop-sweep/deferred-work-format.md
@@ -63,9 +63,11 @@ an entry; entries written by hand do not need it.
 **Every field line is exactly one line, and so is the title.** The format is
 line-oriented: readers find each field by scanning for `<name>:` at the start of
 a line, and an entry ends at whichever comes first — the next `### DW-<n>`
-entry, any other `#` .. `######` heading, or a `- source_spec:` flat-append
-bullet. A value carrying a line break therefore does not wrap; it becomes new
-ledger content, and three things can follow:
+entry, any other `#` .. `######` heading (indented up to three spaces, and
+followed by a space, a tab or the end of the line; four spaces or a leading tab
+makes an indented code block, which ends nothing), or a `- source_spec:`
+flat-append bullet. A value carrying a line break therefore does not wrap; it
+becomes new ledger content, and three things can follow:
 
 - a break followed by `### ` mints an entry nobody filed;
 - a break before a `status:` line leaves one entry carrying two, so the ledger

--- a/src/bmad_loop/deferredwork.py
+++ b/src/bmad_loop/deferredwork.py
@@ -27,7 +27,23 @@ from .fences import fenced_spans
 from .platform_util import atomic_write_text, neutralize_surrogates
 
 HEADING_RE = re.compile(r"^### (DW-\d+): (.+?)\s*$", re.MULTILINE)
-ANY_HEADING_RE = re.compile(r"^#{1,6} ", re.MULTILINE)
+# Where a canonical entry ENDS, in every shape CommonMark spells an ATX heading:
+# up to three spaces of indent, a space OR a tab after the hashes, and an empty
+# heading (`##` alone — the separator may be the end of the line). A fourth space
+# of indent is an indented code block rather than a heading, so those lines
+# deliberately keep absorbing, and the indent class is spaces only for that same
+# reason — a leading tab is four columns, so `\t## Notes` is a code block too.
+# Read as permissively as the syntax is, because a missed boundary here does not
+# merely lose a section header: the span runs on and the next section's
+# `status:`/`gate:` lines are read as this entry's, so an open entry that never
+# declared a gate takes a story hostage and the operator finds no gate in the
+# entry the refusal names (#516). Where a miss would WRITE, the strict
+# column-zero reading is the right one (`devcontract`'s destructive edits pin it
+# deliberately); this only decides how far a read reaches.
+# A lookahead rather than a consuming group: `parse_ledger` reads `.start()`, and
+# holding the match to the opener leaves nothing free to grow a dependency on
+# where the separator ended.
+ANY_HEADING_RE = re.compile(r"^ {0,3}#{1,6}(?=[ \t]|$)", re.MULTILINE)
 # The flat appender's opening line, in the two forms this module needs it: as a
 # bullet in the raw ledger (FLAT_ENTRY_RE, the canonical-span boundary in
 # parse_ledger) and as bullet *content* after `_BULLET_RE` has stripped the

--- a/tests/test_deferredwork.py
+++ b/tests/test_deferredwork.py
@@ -2144,6 +2144,105 @@ def test_gates_stop_at_the_canonical_span_boundary():
     assert deferredwork.gates(entry).tokens == ()
 
 
+# ------------------------------------------- ATX heading boundary shapes (#516)
+
+
+@pytest.mark.parametrize(
+    ("heading", "bounds"),
+    [
+        ("## Notes", True),  # control: the column-zero shape that always bounded
+        (" ## Notes", True),  # CommonMark allows one...
+        ("  ## Notes", True),  # ...two...
+        ("   ## Notes", True),  # ...or three spaces of indent
+        ("    ## Notes", False),  # a fourth space is an indented code block
+        ("\t## Notes", False),  # a leading tab is four columns, so also code
+        ("##\tNotes", True),  # a tab is a legal separator
+        ("##", True),  # an empty heading is legal; end of line separates it
+        ("## ", True),  # control: a separator and no title, already bounded
+        ("## Notes ##", True),  # control: a closed ATX heading, already bounded
+        ("##Notes", False),  # no separator at all, so not a heading
+        ("####### Notes", False),  # more than six hashes is not a heading
+    ],
+)
+def test_an_entry_ends_at_every_commonmark_atx_heading_shape(heading, bounds):
+    """`ANY_HEADING_RE` is where a canonical entry stops, so a shape it fails to
+    recognize is one whose section then reads as part of the entry above it: the
+    `gate: 3-2` below lands in an open DW-1 that never named a story, and dispatch
+    hard-pauses on an entry the operator will find no gate in (#516).
+
+    The four ABSORBS rows are the load-bearing half of this table. Each names a
+    line CommonMark says is NOT a heading, and together they are what stops a
+    later simplification of the regex to `^ *#+` — which would bound entries at
+    section headers that do not exist. They are controls, not oversights; a
+    session tidying this table must keep them."""
+    text = (
+        "### DW-1: an unlanded entry\nstatus: open\nsummary: s\nevidence: e\n\n"
+        f"{heading}\n\ngate: 3-2\n"
+    )
+
+    (entry,) = parse_ledger(text)
+
+    assert deferredwork.gates(entry).tokens == (() if bounds else ("3-2",))
+
+
+@pytest.mark.parametrize("heading", [" ## Notes", "   ## Notes", "##\tNotes", "##"])
+def test_a_fenced_heading_of_a_new_shape_does_not_bound_the_entry_either(heading):
+    """The shapes #516 added inherit the fence rule
+    `test_a_fenced_heading_does_not_bound_the_entry_that_quotes_it` pins for the
+    column-zero one: a heading quoted inside an example is documentation, not a
+    boundary, so the live `gate:` below the fence still reaches the entry.
+
+    Asserted against the unfenced control in the same row, because the fenced
+    half alone would pass for the wrong reason — before #516 these shapes bounded
+    nothing anywhere, so a green fenced assertion proved only that the regex had
+    never seen them. The pair is what makes the fence the difference."""
+    quoted = (
+        "# Deferred Work\n\n### DW-01: a real entry\nstatus: open\n\n"
+        f"```markdown\n{heading}\nstatus: done 2026-01-01\n```\n\ngate: 3-2\n"
+    )
+    live = (
+        "# Deferred Work\n\n### DW-01: a real entry\nstatus: open\n\n"
+        f"{heading}\nstatus: done 2026-01-01\n\ngate: 3-2\n"
+    )
+
+    (fenced_entry,) = parse_ledger(quoted)
+    (live_entry,) = parse_ledger(live)
+
+    assert deferredwork.gates(fenced_entry).tokens == ("3-2",)
+    assert deferredwork.gates(live_entry).tokens == ()
+
+
+def test_a_status_under_an_indented_heading_is_the_section_s_and_not_the_entry_s():
+    """A visible behavior change, pinned so it stands as a decision on the record
+    rather than turning up as a surprise. Widening `ANY_HEADING_RE` (#516) ends
+    DW-1's span at the indented heading, which is above the `status:` line — and
+    read against the documented format that is the right answer, because a
+    `status:` below a heading belongs to that section and not to the entry before
+    it. The entry parses with status "" and leaves `open_ids` entirely; it used to
+    read as open."""
+    text = "### DW-1: e\n\n  ## Notes\n\nstatus: open\n"
+
+    (entry,) = parse_ledger(text)
+
+    assert entry.status == ""
+    assert entry.open is False
+    assert open_ids(text) == set()
+
+
+def test_a_tail_below_an_indented_heading_reaches_the_legacy_parser():
+    """The second visible change, and the reason the two parsers cannot be moved
+    independently: `parse_legacy` blanks out every span `parse_ledger` returns
+    before it scans, so one boundary serves both and moving it moves text between
+    them. Before #516 DW-1's span ran past the indented heading and masked the
+    bullet below, hiding a real legacy finding from every reader of the ledger.
+    With the boundary where CommonMark puts it, the tail is legacy's again."""
+    text = "### DW-1: e\nstatus: open\n\n  ## Old stuff\n\n- D-1: a legacy finding\n"
+
+    (legacy,) = parse_legacy(text)
+
+    assert legacy.title == "a legacy finding"
+
+
 @pytest.mark.parametrize(
     ("token", "story_key", "gated"),
     [


### PR DESCRIPTION
Closes #516.

## Problem

`ANY_HEADING_RE` (`src/bmad_loop/deferredwork.py:46`) is where a canonical deferred-work entry's
span ends. It required the `#`s at column zero with exactly one literal space after them, so three
shapes CommonMark spells as ATX headings were not recognised as boundaries:

- **up to three spaces of indentation** before the hashes;
- **a tab as the separator** — `##<TAB>Notes`;
- **an empty heading**, whose separator is the end of the line — `##`.

A missed boundary does not merely lose a section header. The entry's span runs on past it and the
next section's field lines are read as that entry's, so a later column-zero `gate: 3-2` is absorbed
into an entry that never declared it. `Engine._refuse_gated_story` (`src/bmad_loop/engine.py:930`)
gates on any entry that is not `done`, so an open entry carrying an absorbed `gate:` produces a
**spurious hard pause**: `validate` fails `deferred.hard-gate`, and a `run` that skipped validation
pauses `story-gate`, on a story that entry never gated — and the reason names an entry the operator
will find no gate in. It fails closed rather than open, but the run stops on a block nobody wrote.

**Pre-existing, not introduced by #502.** The regex is byte-identical on `main` before that PR and
#502 does not touch it. What #502 changed is the *severity*: before the `gate:` field existed, a
mis-bounded span mis-attributed a `closes:` or a status read; now it can block dispatch.

## Fix

**`src/bmad_loop/deferredwork.py`** — `ANY_HEADING_RE` becomes `^ {0,3}#{1,6}(?=[ \t]|$)`. A
lookahead rather than a consuming group, so the match stays the heading opener itself:
`parse_ledger` reads `.start()`, and nothing downstream can grow a dependency on where the
separator ended.

**`src/bmad_loop/data/skills/bmad-loop-sweep/deferred-work-format.md`** — qualifies the heading
clause that said only "any other `#` .. `######` heading", which is the ambiguity the bug lived in,
with the shape a reader can rely on: indented up to three spaces, and followed by a space, a tab or
the end of the line; four spaces or a leading tab makes an indented code block, which ends nothing.
Clause-level — the surrounding paragraph and the fence rule are untouched.

**`CHANGELOG.md`** — one entry under `## [Unreleased]` → `### Fixed`, stating the consequence
rather than the regex, plus both behavior diffs and the non-claim below.

Four-space-indented and tab-indented headings **deliberately keep absorbing**: CommonMark makes
both indented code blocks rather than headings, and the indent class is literal spaces only for
that same reason — a leading tab is four columns.

The replacement was cross-checked against `markdown-it-py` over 271 generated line shapes and
agrees with CommonMark on 269. The two exceptions are exactly the container-block cases under
**Not fixed**.

## Visible behavior diffs

Both come with the moved boundary, and both are pinned by a test rather than left to surface later.

1. **A `status:` line below an indented heading is now the section's, not the preceding entry's.**
   Such an entry parses with status `""` and drops out of `open_ids()`; it used to read as `open`.
   Read against the documented format this is the right answer — a `status:` under a heading
   belongs to that heading's section. Pinned by
   `test_a_status_under_an_indented_heading_is_the_section_s_and_not_the_entry_s`.

2. **A tail below an indented heading reaches the legacy parser again.** `parse_legacy` blanks out
   every span `parse_ledger` returns before it scans, so one boundary serves both parsers and
   moving it moves text between them. An over-long canonical span used to mask a legacy bullet
   below such a heading, hiding a real finding from every reader of the ledger. Pinned by
   `test_a_tail_below_an_indented_heading_reaches_the_legacy_parser`.

## Not fixed

- **A heading nested in a list item or a blockquote** (`- ## Notes`, `> ## Notes`) still does not
  bound an entry. The old regex missed those too, so this is not a regression — it is the same
  line-scope limitation as the sibling parser defect, and it leaves #327 open.
- **The surviving `HEADING_RE` / `_LINE_HEADING_RE` asymmetry.** The entry-*start* regex
  (`deferredwork.py:29` — column zero and a single space) and the legacy side
  (`deferredwork.py:1102` — `^(#{1,6})[ \t]+`) still disagree with each other, and with this regex,
  about what a heading looks like. Both are deliberately untouched here.

What this PR claims is exactly this: **the entry-boundary regex now recognises every CommonMark ATX
line shape.** Not that the module's heading-parsing family is fixed.

## Testing

`uv run pytest -q -n logical` → **5500 passed, 50 skipped, 5 xfailed** (the 5482-passing baseline at
`6945c60`, plus this branch's 18 new parametrized cases). `uv run pyright` → 0 errors. `trunk fmt`
and `trunk check --all` (256 files) → no issues.

Four new guards in `tests/test_deferredwork.py`:

- `test_an_entry_ends_at_every_commonmark_atx_heading_shape` — 12 rows: the 5 newly-bounding
  shapes, 3 controls that already bounded (`## Notes`, `## ` and `## Notes ##`), and 4 ABSORBS rows
  that must **stay** absorbed (four-space-indented `## Notes`, tab-indented `## Notes`, `##Notes`
  with no separator, and the seven-hash `####### Notes`);
- `test_a_fenced_heading_of_a_new_shape_does_not_bound_the_entry_either` — 4 rows, each asserted
  against its unfenced twin, because the fenced half alone would pass for the wrong reason: before
  this fix these shapes bounded nothing anywhere;
- the two behavior-diff tests named above.

### Ablation evidence

Every guard was ablated against, and the ABSORBS controls against two separate over-permissive
axes, because a single axis leaves half of them vacuous.

| Axis | `ANY_HEADING_RE` set to | Result |
| --- | --- | --- |
| **A** — restore the pre-fix regex | `^#{1,6} ` | **11 failed, 340 passed.** All four new guards redden: 5 rows of the shape table, all 4 rows of the fence test, and both behavior-diff tests. |
| **B1** — the simplification the table's docstring names | `^ *#+` | **3 failed, 348 passed** — exactly the four-space-indented, `##Notes` and `####### Notes` ABSORBS rows. |
| **B2** — admit a tab as indentation | `^[ \t]{0,3}#{1,6}(?=[ \t]\|$)` | **1 failed, 350 passed** — exactly the tab-indented ABSORBS row. |

Reported including the rows that did **not** redden: under axis A the three already-bounding
controls and all four ABSORBS rows correctly stay green. They assert behavior the pre-fix regex
also had, so reddening there would have meant the table was testing the wrong thing. B1 and B2 are
what prove those four rows are load-bearing rather than decorative — B1 alone leaves the tab-indent
row green, because `^ *` cannot match a tab, which is why B2 exists.

`ANY_HEADING_RE` was restored from a byte-copy after the ablations and the SHA-256 re-checked
against the pre-ablation file, so no ablation edit survived into the diff.

## Changelog

Entry added under `## [Unreleased]` → `### Fixed`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed deferred-work parsing so valid Markdown headings reliably end entries.
  * Correctly handles headings with limited indentation, tabs, empty headings, and headings up to six levels.
  * Prevents code blocks, quoted headings, list-nested headings, and malformed headings from incorrectly ending entries or reassigning status and gate information.
  * Improved discovery of legacy deferred-work items after entry boundaries.

* **Documentation**
  * Updated the deferred-work format guidance with the revised heading rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->