### PR TITLE
fix: close the codec except-family holes in the diag writer, tmux captures, and plugin hooks (#380, #383)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,36 @@ breaking changes may land in a minor release.
   name. When the readable temp name cannot fit, the helpers now fall back to a short digest of it
   rather than failing — the OS decides, so there is no guess at a per-filesystem byte limit.
 
+- **A best-effort diagnostic write no longer takes the run down, and POSIX tmux captures no longer
+  raise on an undecodable byte (#380).** Both halves are one defect: an exception net that names one
+  direction of the Unicode hierarchy while the other escapes it. `_append_diag_jsonl` serializes
+  with `ensure_ascii=False` and writes through a UTF-8 handle, so a story spec whose filename holds
+  a byte the filesystem codec could not decode arrived surrogate-escaped and failed at the encode
+  with `UnicodeEncodeError` — a `UnicodeError`, so a `ValueError`, not an `OSError` — straight past
+  a guard whose stated contract is that an unwritable run dir must never break the completion loop.
+  The guard is now `(OSError, UnicodeError)` and the breadcrumb is dropped instead of crashing the
+  run. Separately and visibly: `tmux_base`'s `_ERRORS` was the strict handler on POSIX while the
+  Windows backend already set `"backslashreplace"`, so a capture holding such a byte raised out of
+  the one place tmux is spawned; it now comes back with that byte rendered as a `\xNN` escape, and a
+  session name or window title carrying one reads back escaped. Fixing the decode at its source
+  rather than at the fourteen catch sites is deliberate — most of them return a sentinel, so
+  catching there would have converted a crash into a wrong answer (`[]` reads as "window dead").
+  `_ENCODING` stays `None`, so POSIX keeps the locale codec and only stops being strict. This closes
+  the diagnostic writer and the capture decode; it does not sweep the wider `except`-tuple family.
+
+- **A plugin hook or version probe whose child emits a non-UTF-8 byte no longer crashes the run
+  (#383).** `subprocess.run(..., text=True)` decodes with the locale codec at `errors="strict"`, and
+  the `UnicodeDecodeError` that raises is neither an `OSError` nor a `SubprocessError`, so it
+  escaped both captures' guards. The declarative-hook transport is the run-crashing half: `_HookError`
+  is the bus's designed channel for "the hook could not run to completion", and the decode happens
+  after the child has exited — so a hook that actually **passed** took its exit code down with the
+  run instead of being classified. `probe.run_version_help` documents "Never raises", and a
+  `--version`/`--help` banner carrying such a byte made that false. Both now decode with
+  `errors="replace"`, so the hook's verdict survives and a fault is classified through the normal
+  channel. Visible change: those bytes now show as `�` (U+FFFD) in journal entries, hook advisory
+  text and probe documents. The `except` tuples are deliberately not widened — the fix is to stop
+  raising, and a widened tuple would guard a fault nothing could ablate into existence.
+
 ## [0.10.0] — 2026-08-14
 
 Much of this section is the `release/0.9.x` hotfix line brought forward onto `main` (#433).

--- a/src/bmad_loop/adapters/generic.py
+++ b/src/bmad_loop/adapters/generic.py
@@ -326,14 +326,19 @@ class _ResultFileMixin:
     def _append_diag_jsonl(self, task_id: str, filename: str, payload: dict) -> None:
         """Append ``payload`` as one JSON line to ``tasks/<task_id>/<filename>``.
         Pure observability, best-effort: an unwritable run dir must never break
-        the completion loop."""
+        the completion loop. ``ensure_ascii=False`` is why the guard names more
+        than OSError: it leaves a lone surrogate — what a POSIX filename holding
+        a non-UTF-8 byte becomes, surrogate-escaped — in the dumped str, which
+        then hits the UTF-8 encode inside ``fh.write`` as a UnicodeEncodeError.
+        That is a ValueError, not an OSError; ``UnicodeError`` covers it and the
+        decode direction both (#380)."""
         try:
             path = self.tasks_dir / task_id / filename
             path.parent.mkdir(parents=True, exist_ok=True)
             line = json.dumps(payload, ensure_ascii=False)
             with path.open("a", encoding="utf-8") as fh:
                 fh.write(line + "\n")
-        except OSError:
+        except (OSError, UnicodeError):
             pass
 
     def _note_resultless_stop(self, task_id: str, verdict: str, detail: str = "") -> None:

--- a/src/bmad_loop/adapters/tmux_base.py
+++ b/src/bmad_loop/adapters/tmux_base.py
@@ -59,10 +59,12 @@ class BaseTmuxBackend(TerminalMultiplexer):
     #: Output decoding for captured tmux text. ``None`` (POSIX) = locale default,
     #: byte-identical to a bare ``text=True``; a Windows leaf sets ``"utf-8"``.
     _ENCODING: str | None = None
-    #: Decode error handling to pair with :attr:`_ENCODING`. ``None`` (POSIX) =
-    #: the default strict handler; a Windows leaf sets ``"backslashreplace"`` so
-    #: a stray non-UTF-8 byte degrades visibly instead of raising mid-capture.
-    _ERRORS: str | None = None
+    #: Decode error handling to pair with :attr:`_ENCODING`. ``"backslashreplace"``
+    #: on every platform (#380): a stray byte the codec cannot decode degrades
+    #: visibly to a ``\xNN`` escape in the captured text instead of raising
+    #: mid-capture. Honored even where :attr:`_ENCODING` is None, so POSIX keeps
+    #: the locale codec and only stops being strict. A leaf may still override.
+    _ERRORS: str | None = "backslashreplace"
     #: Diagnostic from the last :meth:`version` probe (see
     #: :meth:`TerminalMultiplexer.version_error`). A class-level default so an
     #: instance that never probed answers None instead of AttributeError.
@@ -322,12 +324,14 @@ class BaseTmuxBackend(TerminalMultiplexer):
         # answer to "is it alive?" is "unknowable" -> MultiplexerError. A real dead
         # window still returns [] via the returncode != 0 path below (no exception).
         #
-        # UnicodeError is a transport failure too: _run decodes with the strict
-        # POSIX handler (see version()), so an undecodable byte in the capture
-        # raises a ValueError-family error that neither exception arm above names.
-        # It must not escape raw — prune_ctl_windows takes its post-kill verdict
-        # from this probe and only a MultiplexerError lands the candidates in
-        # `unverifiable` rather than aborting cleanup mid-receipt (#435).
+        # UnicodeError is a transport failure too. _run no longer decodes strictly
+        # on any platform (_ERRORS is backslashreplace, #380), so this arm is now
+        # defence for a leaf that overrides _ERRORS back to a strict handler: such
+        # a decode raises a ValueError-family error that neither exception arm
+        # above names. It stays because the seam-honesty contract above is what
+        # callers rely on — prune_ctl_windows takes its post-kill verdict from this
+        # probe and only a MultiplexerError lands the candidates in `unverifiable`
+        # rather than aborting cleanup mid-receipt (#435).
         try:
             probe = self._run(
                 ["list-windows", "-t", f"={session}", "-F", "#{window_id}"], check=False
@@ -502,14 +506,15 @@ class BaseTmuxBackend(TerminalMultiplexer):
             return None
         try:
             raw = self._tmux("-V")
-        # UnicodeError is in the list because _run decodes with the LOCALE codec
-        # and the strict handler on POSIX (_ENCODING/_ERRORS are None there;
-        # the Windows leaf sets utf-8/backslashreplace, so this arm is POSIX-
-        # only). A byte that codec cannot decode — UTF-8 in practice under PEP
-        # 538/540 — raises: a corrupt install, or a binary emitting text in
-        # another encoding, exactly what this diagnostic exists for. It is a
-        # ValueError, outside the SubprocessError/OSError family, so it escaped
-        # as a raw crash for every caller above to guard.
+        # UnicodeError is in the list for a leaf that overrides _ERRORS back to a
+        # strict handler. _run still decodes with the LOCALE codec on POSIX
+        # (_ENCODING is None there), but no longer strictly on any platform
+        # (_ERRORS is backslashreplace, #380), so an undecodable byte — a corrupt
+        # install, or a binary emitting text in another encoding, exactly what
+        # this diagnostic exists for — now degrades to a \xNN escape rather than
+        # raising. Where a leaf does restore strictness it is a ValueError,
+        # outside the SubprocessError/OSError family, so it would escape as a raw
+        # crash for every caller above to guard; this arm keeps that closed.
         except (MultiplexerError, subprocess.SubprocessError, OSError, UnicodeError) as exc:
             # None stays the seam's answer, but the identity of the failure is
             # what separates a crashing binary from one that reports no version

--- a/src/bmad_loop/plugins/bus.py
+++ b/src/bmad_loop/plugins/bus.py
@@ -45,7 +45,14 @@ def _run_subprocess(
 ) -> tuple[int, str]:
     """Default declarative-hook transport: a shell command with the plugin env,
     capturing output. shell=True is intentional (mirrors the deterministic verify
-    commands + the legacy engine ``*_cmd`` hooks)."""
+    commands + the legacy engine ``*_cmd`` hooks).
+
+    Output decodes with ``errors="replace"`` (#383): a hook's output is arbitrary
+    operator-tool text whose bytes are not ours to constrain, and a strict decode
+    raised ``UnicodeDecodeError`` — a ``ValueError``, named by neither ``except``
+    arm below — which escaped ``_HookError``, the bus's designed
+    transport-failure channel, and crashed the run, losing even a passing hook's
+    exit code. Same fix and reasoning as ``verify.run_verify_commands`` (#378)."""
     try:
         proc = subprocess.run(  # nosec B602 - operator-authored plugin command
             cmd,
@@ -54,6 +61,7 @@ def _run_subprocess(
             env=env,
             capture_output=True,
             text=True,
+            errors="replace",
             timeout=timeout,
         )
     except subprocess.TimeoutExpired as e:

--- a/src/bmad_loop/probe.py
+++ b/src/bmad_loop/probe.py
@@ -182,7 +182,12 @@ class Hints:
 
 def _run_capture(argv: list[str], timeout_s: float) -> str | None:
     try:
-        proc = subprocess.run(argv, capture_output=True, text=True, timeout=timeout_s)
+        # errors="replace" is what keeps run_version_help's documented "Never
+        # raises" true (#383): a banner byte the locale codec cannot decode is a
+        # UnicodeDecodeError — a ValueError, outside the guard below.
+        proc = subprocess.run(
+            argv, capture_output=True, text=True, errors="replace", timeout=timeout_s
+        )
     except (OSError, subprocess.SubprocessError):
         return None
     out = (proc.stdout or "") + (proc.stderr or "")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ that simulate the side effects skill sessions would have on disk."""
 
 from __future__ import annotations
 
+import io
 import json
 import shutil
 import subprocess
@@ -33,6 +34,39 @@ if sys.platform == "win32" and not sys.flags.utf8_mode:
         "(e.g. `set PYTHONUTF8=1 && uv run pytest`). The suite assumes UTF-8 to "
         "match the files under test; CI's windows job sets this automatically."
     )
+
+
+def _codec_rejects_bad_byte() -> bool:
+    """Whether byte 0xff is undecodable in the codec ``text=True`` will use.
+
+    Probes ``TextIOWrapper`` with ``encoding=None`` rather than naming a codec,
+    because that is the very default ``subprocess``'s text mode resolves for the
+    child's streams — asking the machinery beats predicting it from the locale.
+    """
+    try:
+        io.TextIOWrapper(io.BytesIO(b"\xff")).read()
+    except UnicodeDecodeError:
+        return True
+    return False
+
+
+# Guard for every test whose subject is a STRICT DECODE of subprocess output.
+# Byte 0xff is undecodable only in UTF-8/ASCII; every ISO-8859-x and cp125x codec
+# maps all 256 byte values, so under such a locale the strict decode never raises
+# and those tests pass *with the bug restored* — a silent vacuity rather than a
+# failure (verified: under LC_ALL=et_EE.iso885915 the #378 ablation passes). No
+# single byte is undecodable everywhere, so this skips instead, leaving each test
+# either exercising the fault or saying plainly that it did not. CI is always on
+# the exercising side: the Linux legs run UTF-8 and the Windows legs set
+# PYTHONUTF8=1 (.github/workflows/ci.yml).
+#
+# Shared here because three test modules need it; test_verify.py predates that and
+# still carries its own local copy.
+needs_strict_codec = pytest.mark.skipif(
+    not _codec_rejects_bad_byte(),
+    reason="host codec decodes 0xff (e.g. an ISO-8859-x locale), so nothing here "
+    "would exercise the strict decode this fix is about",
+)
 
 
 @pytest.fixture

--- a/tests/test_generic_tmux.py
+++ b/tests/test_generic_tmux.py
@@ -1017,6 +1017,37 @@ def test_resultless_stop_breadcrumb_write_failure_is_swallowed(tmp_path):
     adapter._note_resultless_stop("3-1-dev-1", "pending", "detail")  # must not raise
 
 
+def test_resultless_stop_breadcrumb_surrogate_detail_is_swallowed(tmp_path):
+    """The other half of the same promise: a lone surrogate must not escape
+    `_append_diag_jsonl` either, and it is NOT an OSError like the sibling above.
+
+    `ensure_ascii=False` leaves the surrogate in the dumped str, so it reaches the
+    UTF-8 encode inside `fh.write` as a UnicodeEncodeError — a ValueError, which
+    the pre-#380 `except OSError` did not name. "/tmp/bad\\udcff.md" is exactly the
+    shape a POSIX filename holding a non-UTF-8 byte takes once the filesystem API
+    surrogate-escapes it, and six `_note_resultless_stop` call sites interpolate
+    such a path straight into `detail`.
+
+    NOT codec-conditional, and must never grow a locale skipif: the fault is an
+    ENCODE to UTF-8, pinned by `encoding="utf-8"` in `path.open`, so a lone
+    surrogate is unencodable on every host whatever that host's locale decodes.
+
+    Ablation: narrow the guard back to `except OSError:` and this fails alone, on
+    the UnicodeEncodeError escaping the writer.
+    """
+    adapter, _ = make_dev_adapter(tmp_path)
+    adapter._note_resultless_stop("3-1-dev-1", "pending", "/tmp/bad\udcff.md")  # must not raise
+
+    # Dropped, not written — and that absence is the anti-vacuity half. "Did not
+    # raise" alone would pass just as well if the encode had never failed; the
+    # missing line is what proves the fault fired and the widened guard ate it.
+    assert _breadcrumbs(adapter) == []
+
+    # ...and the swallow left the writer usable for the next breadcrumb.
+    adapter._note_resultless_stop("3-1-dev-1", "pending", "plain")
+    assert [crumb["detail"] for crumb in _breadcrumbs(adapter)] == ["plain"]
+
+
 def test_generic_dev_disables_nudges(tmp_path):
     adapter, _ = make_dev_adapter(tmp_path)
     assert adapter._stop_nudges == 0

--- a/tests/test_hook_bus.py
+++ b/tests/test_hook_bus.py
@@ -18,7 +18,13 @@ from __future__ import annotations
 import sys
 
 import pytest
-from conftest import committing_crash_state, dev_effect, review_effect, write_sprint
+from conftest import (
+    committing_crash_state,
+    dev_effect,
+    needs_strict_codec,
+    review_effect,
+    write_sprint,
+)
 
 from bmad_loop.adapters.mock import MockAdapter
 from bmad_loop.engine import Engine
@@ -244,6 +250,48 @@ def test_real_subprocess_runner_reports_exit_code(tmp_path):
     cmd = "echo hi& exit 7" if sys.platform == "win32" else "printf hi; exit 7"
     rc, out = _run_subprocess(cmd, cwd=str(tmp_path), env={}, timeout=10)
     assert rc == 7 and "hi" in out
+
+
+@needs_strict_codec
+def test_real_subprocess_runner_replaces_undecodable_output(tmp_path):
+    """A hook child emitting a byte the locale codec cannot decode is decoded
+    with replacement, not strictly: the strict decode raised UnicodeDecodeError —
+    a ValueError, named by neither `except` arm — which escaped `_HookError`, the
+    bus's designed transport-failure channel, and crashed the run instead of
+    being classified.
+
+    The exit code is asserted because it pins the sharpest consequence: the hook
+    had already run to completion, so a *passing* hook took the run down and its
+    verdict was lost with it. U+FFFD is asserted rather than merely "did not
+    raise" — under `needs_strict_codec` the codec provably cannot decode the
+    byte, so `errors="replace"` is the only thing that could have produced that
+    character. Its *count* stays unasserted (that is what varies by codec), and
+    the ASCII on both sides pins that only the offending byte was replaced.
+
+    Driven through a real child on purpose: a monkeypatched `subprocess.run`
+    never runs the stdlib decode, so such a test passes with the bug restored.
+
+    Ablation: remove `errors="replace"` from `_run_subprocess` and this fails
+    with UnicodeDecodeError."""
+    # Interpreter is `sys.executable`, never a bare `python`: the tests run under
+    # uv, where no `python` need be on PATH. The double quotes are honored by
+    # both sh and cmd, so the one string works on either host shell.
+    script = tmp_path / "emit383.py"
+    script.write_text(
+        "import sys\n"
+        "sys.stdout.buffer.write(b'before \\xff after\\n')\n"
+        "sys.stdout.buffer.flush()\n"
+        "sys.exit(7)\n",
+        encoding="utf-8",
+    )
+
+    rc, out = _run_subprocess(
+        f'"{sys.executable}" "{script}"', cwd=str(tmp_path), env={}, timeout=10
+    )
+
+    assert rc == 7  # the hook verdict a strict decode used to lose entirely
+    assert "�" in out  # the replacement, not a survivor
+    assert "before" in out and "after" in out
 
 
 def test_shared_persists_across_stages():

--- a/tests/test_multiplexer.py
+++ b/tests/test_multiplexer.py
@@ -11,8 +11,10 @@ import json
 import os
 import shlex
 import subprocess
+import sys
 
 import pytest
+from conftest import needs_strict_codec
 
 from bmad_loop.adapters import multiplexer, tmux_base
 from bmad_loop.adapters.base import SessionSpec
@@ -259,13 +261,16 @@ def test_seam_methods_never_leak_raw_subprocess_error(boom_run, tmp_path):
 
 
 def test_list_window_ids_decode_fault_raises_the_seam_type(monkeypatch):
-    """A byte the strict POSIX codec cannot decode is a transport failure like a
-    timeout: the liveness probe must answer MultiplexerError ("unknowable"), not
-    leak the raw UnicodeDecodeError — prune_ctl_windows' post-kill verdict and
-    the engine's window_alive catch only the seam type (#435).
+    """A byte the codec cannot decode is a transport failure like a timeout: the
+    liveness probe must answer MultiplexerError ("unknowable"), not leak the raw
+    UnicodeDecodeError — prune_ctl_windows' post-kill verdict and the engine's
+    window_alive catch only the seam type (#435).
 
-    Deliberately scoped to list_window_ids: the sentinel-returner methods still
-    leak a POSIX decode fault, which stays #380's territory.
+    Since #380 `_run` decodes with backslashreplace on every platform, nothing
+    reaches this arm from a stock capture; the fault is injected here instead.
+    The arm still guards a leaf that overrides `_ERRORS` back to a strict handler
+    — which is why the fault below is monkeypatched in rather than produced by a
+    real child, and why this test stays green with or without that fix.
     """
     monkeypatch.setattr(tmux_base.shutil, "which", lambda _name: "/usr/bin/tmux")
 
@@ -277,6 +282,37 @@ def test_list_window_ids_decode_fault_raises_the_seam_type(monkeypatch):
     with pytest.raises(MultiplexerError) as excinfo:
         mux.list_window_ids("s")
     assert not isinstance(excinfo.value, UnicodeError)
+
+
+@needs_strict_codec
+def test_run_decodes_an_undecodable_byte_instead_of_raising():
+    """A capture carrying a byte the codec cannot decode comes back with that byte
+    rendered as a visible \\xNN escape; `_run` does not raise (#380).
+
+    POSIX left `_ERRORS` at None — the STRICT handler — so a stray byte in any
+    tmux capture raised out of the one spawn primitive, and the fourteen guards
+    that catch only (SubprocessError, OSError) let it through. Fixing it here, at
+    the source, rather than at those catch sites is deliberate: most of them
+    return a sentinel ([], None, {}), so catching a decode fault there would turn
+    a crash into a WRONG ANSWER (see the seam-honesty note on list_window_ids).
+
+    Drives a REAL child, never a monkeypatched `subprocess.run`. Only a real spawn
+    executes the stdlib decode this fix changes, so a faked seam would pass
+    identically with `_ERRORS` back at None — the fake-green #378 was bitten by.
+    `sys.executable`, never a bare `python`: the suite runs under uv, where no
+    `python` need be on PATH (see tests/test_verify.py's note on this).
+
+    Ablation: set BaseTmuxBackend._ERRORS back to None and this fails alone, on
+    the UnicodeDecodeError escaping `_run`.
+    """
+
+    class PyBackend(TmuxMultiplexer):
+        # the "tmux binary" is this interpreter, so _run spawns something whose
+        # bytes we choose; everything else about the primitive is untouched.
+        _BINARY = sys.executable
+
+    proc = PyBackend()._run(["-c", 'import sys; sys.stdout.buffer.write(b"ok-\\xff-tail")'])
+    assert proc.stdout == "ok-\\xff-tail"
 
 
 def test_seam_honesty_holds_for_psmux_style_run_override(monkeypatch):
@@ -458,14 +494,16 @@ def test_version_error_records_the_probe_crash_version_swallows(monkeypatch):
 
 
 def test_version_error_records_undecodable_probe_output(monkeypatch):
-    """Pins the `UnicodeError` arm of version()'s catch. A strictly-decoding
-    _run (POSIX: _ENCODING/_ERRORS both None) raises UnicodeDecodeError out of
-    subprocess itself on a binary emitting an undecodable byte — a corrupt
-    install, the very case #428 is about — and it is a ValueError, outside the
-    SubprocessError/OSError family, so without the arm it escapes as a raw crash
-    that every guard above turns back into an unexplained None. The raise is
-    injected rather than decoded for real: this owns the except clause, not the
-    decoding (tmux_base documents that half)."""
+    """Pins the `UnicodeError` arm of version()'s catch. A strictly-decoding _run
+    raises UnicodeDecodeError out of subprocess itself on a binary emitting an
+    undecodable byte — a corrupt install, the very case #428 is about — and it is
+    a ValueError, outside the SubprocessError/OSError family, so without the arm
+    it escapes as a raw crash that every guard above turns back into an
+    unexplained None. Since #380 `_run` is no longer strict on any platform
+    (_ERRORS is backslashreplace), the arm now covers a leaf that overrides it
+    back to a strict handler. The raise is injected rather than decoded for real:
+    this owns the except clause, not the decoding (tmux_base documents that
+    half) — which is also why it is unaffected by that default."""
 
     def boom(argv, **k):
         raise UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte")
@@ -554,11 +592,15 @@ def test_run_posix_default_passes_no_encoding_and_no_env(monkeypatch):
 
     TmuxMultiplexer()._run(["list-windows"])
 
-    # byte-identical to today: locale-default decode (encoding=None ≡ bare text=True),
-    # inherit the parent env (env=None).
+    # The locale-default codec (encoding=None ≡ bare text=True) and the inherited
+    # parent env (env=None) are both unchanged; only strictness went away. errors is
+    # backslashreplace on every platform since #380, so an undecodable byte degrades
+    # to a visible \xNN escape instead of raising out of the one spawn primitive.
+    # This pins the KWARG; the decode it actually produces is pinned against a real
+    # child by test_run_decodes_an_undecodable_byte_instead_of_raising.
     assert rec.kwargs["text"] is True
     assert rec.kwargs["encoding"] is None
-    assert rec.kwargs["errors"] is None
+    assert rec.kwargs["errors"] == "backslashreplace"
     assert rec.kwargs["env"] is None
 
 

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -3,9 +3,10 @@ CLI plumbing, and end-to-end scrub-through. No live CLI required."""
 
 import json
 import re
+import sys
 
 import pytest
-from conftest import machine_json
+from conftest import machine_json, needs_strict_codec
 from test_probe_hook import run_hook
 
 from bmad_loop import cli, probe, sanitize
@@ -705,3 +706,47 @@ def test_redact_location_drops_the_root_anchor_on_every_flavour(monkeypatch):
     assert probe._redact_location(PureWindowsPath("C:/build/s-1/t.jsonl")) == (
         "/<redacted>/build/s-1/t.jsonl"
     )
+
+
+# ----------------------------------------------------------- version / help
+
+
+@needs_strict_codec
+def test_run_capture_replaces_undecodable_banner_bytes(tmp_path):
+    """A --version/--help banner carrying a byte the locale codec cannot decode
+    is decoded with replacement, not strictly, so `run_version_help`'s documented
+    "Never raises" stays true: a strict decode raises UnicodeDecodeError, a
+    ValueError, which `_run_capture`'s `(OSError, subprocess.SubprocessError)`
+    guard does not name.
+
+    U+FFFD is asserted rather than inferred from "did not raise" — under
+    `needs_strict_codec` the codec provably cannot decode the byte, so
+    `errors="replace"` must have put it there. Its *count* stays unasserted, that
+    being what varies by codec, and the ASCII on both sides pins that only the
+    offending byte was replaced.
+
+    Driven through a real child on purpose: a monkeypatched `subprocess.run`
+    never runs the stdlib decode, so such a test passes with the bug restored.
+
+    Ablation: remove `errors="replace"` from `_run_capture` and this fails with a
+    raised UnicodeDecodeError — not with a None return, which the guard above
+    would have to catch to produce."""
+    # Interpreter is `sys.executable`, never a bare `python`: the tests run under
+    # uv, where no `python` need be on PATH.
+    script = tmp_path / "emit383.py"
+    script.write_text(
+        "import sys\n"
+        "sys.stdout.buffer.write(b'before \\xff after\\n')\n"
+        "sys.stdout.buffer.flush()\n",
+        encoding="utf-8",
+    )
+
+    out = probe._run_capture([sys.executable, str(script)], 10)
+
+    # Load-bearing, not decoration: None is this function's failure sentinel, so
+    # this is the assertion that separates "decoded with replacement" from
+    # "swallowed the fault and reported no banner at all". Do not weaken it to a
+    # bare "did not raise" — that passes on the sentinel too.
+    assert out is not None
+    assert "�" in out  # the replacement, not a survivor
+    assert "before" in out and "after" in out


### PR DESCRIPTION
Closes #380
Closes #383

## Problem

Both issues are the same defect genus: **an exception net that names one direction of the Unicode error hierarchy while the other escapes it.**

`UnicodeEncodeError` and `UnicodeDecodeError` are both `UnicodeError` ⊂ `ValueError`. Neither is an `OSError`, and neither is a `SubprocessError`. So:

- `except OSError` catches **neither** direction;
- the post-kill rescue's `except (OSError, UnicodeDecodeError)` catches the decode half while the **encode** half escapes.

Every site in this PR is a best-effort observation path whose stated contract is that it must never escalate — a diagnostic breadcrumb, a liveness capture, a plugin-hook transport, a `--version` banner. Every one of them escalated to a run-killing crash.

**#380, encode half.** `_append_diag_jsonl` (the shared writer behind `_note_resultless_stop` and `_note_lifecycle`) serializes with `json.dumps(..., ensure_ascii=False)` and writes through a handle pinned to `encoding="utf-8"`. `ensure_ascii=False` is what makes the bug exist: `json.dumps` does **not** raise on a lone surrogate — it returns a `str` that still holds it, and the fault fires later, at the encode inside `fh.write`. A POSIX filename holding a non-UTF-8 byte arrives surrogate-escaped, and six `_note_resultless_stop` call sites interpolate such a path straight into `detail`. That defeated two stated contracts: "an unwritable run dir must never break the completion loop", and the rescue that "must never escalate a clean stall/timeout into an exception, which the engine does not contain per-task".

**#380, decode half.** `tmux_base._ERRORS` was `None` — the strict handler — on POSIX, while the Windows leaf already set `"backslashreplace"`. A tmux capture holding an undecodable byte therefore raised out of `_run`, the one place tmux is spawned.

**#383.** `subprocess.run(..., text=True)` decodes with the **locale** codec at `errors="strict"`. `plugins/bus.py` guarded `(TimeoutExpired, OSError)`; `probe.py` guarded `(OSError, SubprocessError)`. Neither names the fault. The bus half is the run-crashing one: `_HookError` is the designed channel for "the hook could not run to completion" — `_dispatch` catches it, journals `plugin-hook-error`, and either fails open or adds a defer veto — and failure isolation is the bus's stated contract per its module docstring. A `UnicodeDecodeError` bypassed that channel entirely and escaped into the engine. Worse, the decode happens inside `run`, *after* the child has exited, so **a hook that actually passed took its own exit code down with the run.** The decoded bytes are arbitrary output from an operator's own tool — not a path, so nothing constrains them to the run's encoding.

## Fix

| File | Change |
| --- | --- |
| `adapters/generic.py` | `_append_diag_jsonl`'s guard widened `except OSError` → `except (OSError, UnicodeError)` — covers both directions at once, the form #374/#375 already landed in `install.py`. |
| `adapters/tmux_base.py` | `_ERRORS = "backslashreplace"` on the base class. |
| `plugins/bus.py` | `errors="replace"` on `_run_subprocess`, the declarative-hook transport. |
| `probe.py` | `errors="replace"` on `_run_capture`, the version/help capture. |

**Why `tmux_base` is fixed at the source rather than at the catch sites.** There are fourteen catch sites still naming only `(SubprocessError, OSError)`. Widening them would have been *actively worse*: most of those methods return a **sentinel** on exception (`[]`, `None`, `{}`), so catching a decode fault there converts a crash into a **wrong answer** — the file argues this itself, that "a sentinel `[]` would falsely read as 'window dead → session crashed'". Setting `_ERRORS` stops the raise at the single place tmux is spawned, so no sentinel is ever reached for this cause. `_ENCODING` deliberately stays `None`: POSIX keeps the locale codec and only stops being strict (`errors=` is honored when `encoding=None`).

**Why `"replace"` and not `surrogateescape` in #383.** Both captures feed text **forward** and never back to a filesystem API — bus output goes to `_apply_stdout` and the journal; probe output goes to `sanitize.scrub_text` and into the probe document, rendered with `json.dumps(..., ensure_ascii=False)` and written as UTF-8. `surrogateescape` would seed that string with lone surrogates, which cannot be encoded to UTF-8 — converting this bug into **the exact encode-side crash #380 fixes in the other half of this PR.** `"replace"` yields U+FFFD, an ordinary character that encodes cleanly.

The `except` tuples in #383 are deliberately **not** widened. The fix is to stop raising, not to catch more; a `UnicodeDecodeError` can no longer occur at either site, so a widened tuple would be a guard nothing could ablate into failing.

## Scope note

- **`tui/app.py` `_commit_subject` — the third sighting listed in #383 — was already fixed by #390 / PR #544 and is untouched here. This PR does not claim it.** It routes through the `verify.git_bytes` chokepoint and takes **bytes**, decoding with `errors="replace"` itself (`tui/app.py:855`). Its regression test `test_commit_subject_routes_the_chokepoint_and_replaces_undecodable_bytes` was re-run green as proof.
- **Two `tmux_base` guards were already widened to `UnicodeError` by earlier unrelated work** — `0fccbef` (#435) for `list_window_ids`, `c07d906` for `version()`. Both are **kept**: they still guard a leaf that overrides `_ERRORS` back to a strict handler. But the comments justifying them with "POSIX is strict" were corrected, because that premise no longer holds after this change. Three such stale comments in total (`list_window_ids`, `version()`, and two test docstrings).
- **`tests/test_verify.py` keeps its own local copy of the `needs_strict_codec` marker** rather than importing the new shared one from `conftest.py`. De-duplicating it would drag an otherwise-untouched file into this PR. Deliberate; follow-up filed as #608.
- **Nothing else was folded in.** Named-and-declined sites are listed under *Out of scope* below.

## Visible behavior diffs

Both fixes swap a crash for degraded output. Three user-visible changes, stated plainly:

1. **POSIX tmux captures containing an undecodable byte now return `\xNN` escapes instead of raising.** A session name or window title carrying such a byte reads back **escaped**. This matches what the Windows backend already did.
2. **Plugin-hook output and `--version`/`--help` probe banners containing bytes the locale codec cannot decode now show `�` (U+FFFD)** — in journal entries, hook advisory text and probe documents — where the run previously crashed.
3. **A diagnostic breadcrumb whose payload holds a lone surrogate is now silently DROPPED** rather than crashing the run. That is inside `_append_diag_jsonl`'s documented best-effort contract, but it is a real change and reviewers should see it stated rather than inferred.

## Out of scope

Each of these was found, examined, and **declined** as a code change here; a follow-up issue is filed for each.

- **`adapters/generic.py` `_write_heartbeat` — #606.** Byte-for-byte the same shape as the fixed `_append_diag_jsonl` (`json.dumps(..., ensure_ascii=False)` under `except OSError: pass`) but **unreachable**: both call sites (`generic.py:634-641`, `opencode_http.py:1080-1087`) pass scalars only — `ts`, `remaining_s`, `stall_armed`, `stall_nudges_sent` — so the encoded string is surrogate-free by construction and a widened guard would be one nothing could ablate. Left alone deliberately. The follow-up adds a comment recording *why* it is inert, so the next codec sweep does not re-find and re-litigate it, and so a future payload gaining a path-derived string is caught.
- **The unity plugin scripts under `src/bmad_loop/data/plugins/unity/` — #607.** Same narrow guard around `text=True` captures: `unity_ready.py:113` and `:129` (guarded by `except subprocess.TimeoutExpired` alone), `unity_quiesce.py:111`, `unity_plugin.py:408`, `unity_setup.py:182`, `:324` and `:402` (no `try` at all). Shipped plugin **data**, not orchestrator core, and neither issue names them — folding them in would widen a bundled fix past the two issues it closes.
- **De-duplicating `needs_strict_codec` between `tests/conftest.py` and `tests/test_verify.py` — #608.**

## Testing

Four new tests, one per guard:

| Test | Guard |
| --- | --- |
| `tests/test_generic_tmux.py::test_resultless_stop_breadcrumb_surrogate_detail_is_swallowed` | `generic.py` encode |
| `tests/test_multiplexer.py::test_run_decodes_an_undecodable_byte_instead_of_raising` | `tmux_base.py` decode |
| `tests/test_hook_bus.py::test_real_subprocess_runner_replaces_undecodable_output` | `bus.py` decode |
| `tests/test_probe.py::test_run_capture_replaces_undecodable_banner_bytes` | `probe.py` decode |

One pre-existing test updated: `test_run_posix_default_passes_no_encoding_and_no_env` asserted `errors is None`. `encoding` and `env` stay `None`, so its name still holds — it pins the kwarg, while the new test pins the decode it actually produces.

### Ablation evidence — one line per new guard

Each ablation was run **singly**, against a `cp` backup (never `git checkout`), then restored byte-identical and re-confirmed green. Actual exception types below, not paraphrases:

- **`generic.py` encode** — guard reverted to `except OSError:`; the encode test failed **alone** with `UnicodeEncodeError: 'utf-8' codec can't encode character '\udcff' in position 69: surrogates not allowed`, raised at `src/bmad_loop/adapters/generic.py:340` on `fh.write(line + "\n")`.
- **`tmux_base.py` decode** — `_ERRORS` reverted to `None`; the decode test failed **alone** with `UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 3: invalid start byte` at `subprocess.py:1099`. The traceback's own frame read `data = b'ok-\xff-tail', encoding = 'UTF-8', errors = 'strict'` — a real child's decode, not an injected raise.
- **`bus.py` decode** — `errors="replace"` deleted; `test_real_subprocess_runner_replaces_undecodable_output` failed with `UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 7: invalid start byte`, raised from `subprocess.py:1099 _translate_newlines` (`encoding = 'UTF-8', errors = 'strict'`). The traceback's `Popen` repr read `returncode: 7` — making the lost-verdict consequence directly visible: the child had already exited 7 when the decode killed the call.
- **`probe.py` decode** — `errors="replace"` deleted; `test_run_capture_replaces_undecodable_banner_bytes` failed with the same `UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 7: invalid start byte` — a **raised** exception, not a `None` return, confirming the `(OSError, SubprocessError)` guard does not catch it and that nothing in the test swallows the fault.

### Real children, not fakes

**Both #383 tests and the `tmux_base` decode test drive REAL child processes** (`_BINARY = sys.executable`), never a monkeypatched `subprocess.run`. This is load-bearing, not incidental: a faked seam **never executes the stdlib decode**, so such a test passes **identically with the bug restored** — the exact fake-green this repo was bitten by in #378.

### Skip guard

The three codec-conditional tests carry `conftest`'s shared `needs_strict_codec` skipif. Byte `0xff` is undecodable only under UTF-8/ASCII — every ISO-8859-x and cp125x codec maps all 256 byte values, so under such a locale the strict decode never raises and the test would go **vacuously green**. CI is always on the exercising side: the Linux legs run UTF-8, and the Windows legs set `PYTHONUTF8: '1'` (`.github/workflows/ci.yml`), so `needs_strict_codec` evaluates true on both and the tests **run** rather than skip.

The encode test is deliberately **not** codec-conditional: that fault is an encode *to* UTF-8, so a lone surrogate is unencodable on every host whatever the locale.

### Gates

Full suite green — **5486 passed, 50 skipped, 5 xfailed**. `uv run pyright` clean (0 errors, 0 warnings). `trunk fmt` clean. `trunk check --all --no-fix` clean across 256 files. bandit still passes: the `# nosec B602` on `bus.py`'s `subprocess.run` survived the edit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of non-UTF-8 output from hooks, version checks, and terminal sessions.
  * Prevented invalid diagnostic data from interrupting runs; affected breadcrumbs are safely skipped.
  * Preserved process results and error handling when command output contains undecodable characters.
  * Terminal output now displays problematic bytes using readable replacement characters or escapes.

* **Tests**
  * Added regression coverage for Unicode and undecodable subprocess output scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->