### PR TITLE
fix(verify): split the value from the diagnostic in every git output probe (#442)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,19 @@ breaking changes may land in a minor release.
 
 ### Fixed
 
+- **A git that warns while still exiting 0 no longer corrupts the answers the orchestrator reads
+  back from it (#442).** An unknown `core.fsyncMethod` value or a `core.fsmonitor` hook that cannot
+  exec is a property of the host's git config rather than a failure, but the shared git helper handed
+  callers `stdout` and `stderr` merged — so every probe that read git's text as the ANSWER took the
+  advisory for data. Silently: a rollback candidate list grew a phantom path, a commit list grew a
+  phantom sha, and the sha and branch probes answered with the warning appended — the last of which
+  reached the baselines persisted in run state, so a resume graded a warning-carrying string against
+  a clean one and read "moved". Loudly: preserve-ref retention raised `PrunePreserveError`,
+  `commit_paths` raised where its contract reports nothing to commit, and the worktree snapshot
+  failed outright — which since #340 is a gate and not a safety net, so a noisy host had no working
+  rollback at all. Thirteen value-reading probes now take stdout alone; the ~45 call sites that only
+  check a return code are unchanged, and a failing git call still carries its stderr.
+
 - **An indented, tab-separated or empty heading in the deferred-work ledger no longer lets a `gate:`
   below it hold a story the entry never named (#516).** A canonical entry ended only at a `#` run at
   column zero with exactly one space after it, so three shapes CommonMark spells as ATX headings —

--- a/src/bmad_loop/verify.py
+++ b/src/bmad_loop/verify.py
@@ -480,10 +480,16 @@ def _path_under_any(path: str, prefixes: tuple[str, ...]) -> bool:
 def untracked_files(repo: Path) -> set[str]:
     """Untracked, non-ignored paths (repo-relative posix), mirroring what a
     plain `git clean -fd` (no -x) treats as removable. Ignored files are
-    excluded, so they are never rollback candidates."""
-    rc, out = _git(repo, "ls-files", "--others", "--exclude-standard")
+    excluded, so they are never rollback candidates.
+
+    Reads stdout ALONE (`_git_out`): `ls-files` exits 0 while still writing to
+    stderr, and against `_git`'s merged stream that chatter splits into a phantom
+    untracked path — a PRISTINE tree answers with one, and because this function's
+    contract is what `git clean -fd` would remove, the phantom is a rollback
+    candidate. Silent, on every host whose git config warns (#442)."""
+    rc, out, detail = _git_out(repo, "ls-files", "--others", "--exclude-standard")
     if rc != 0:
-        raise GitError(f"git ls-files --others failed in {repo}: {out}")
+        raise GitError(f"git ls-files --others failed in {repo}: {detail}")
     return {line.strip() for line in out.splitlines() if line.strip()}
 
 
@@ -664,10 +670,15 @@ def commits_above(repo: Path, baseline: str) -> list[str]:
     not assume a strict newest-first / HEAD-first ordering across merges or clock
     skew; callers that need the tip should read HEAD directly). Empty when HEAD is
     at or behind baseline. Raises GitError on a git failure (a bad baseline is a
-    real error, never quietly "no commits")."""
-    rc, out = _git(repo, "rev-list", f"{baseline}..HEAD")
+    real error, never quietly "no commits").
+
+    Reads stdout ALONE (`_git_out`): git exits 0 while still warning on stderr, and
+    against the merged stream that warning is a phantom sha handed to
+    :func:`preserve_commits` — "Empty when HEAD is at or behind baseline" stops
+    holding on any host whose git config warns (#442)."""
+    rc, out, detail = _git_out(repo, "rev-list", f"{baseline}..HEAD")
     if rc != 0:
-        raise GitError(f"git rev-list {baseline}..HEAD failed in {repo}: {out}")
+        raise GitError(f"git rev-list {baseline}..HEAD failed in {repo}: {detail}")
     return [line for line in out.splitlines() if line]
 
 
@@ -733,10 +744,16 @@ def _prune_refs(
     :class:`PrunePreserveError` — after attempting every tail ref — when any
     individual delete failed. One stuck ref must not wedge the retention for
     everything behind it, so deletes are per-ref best-effort and the error
-    carries both what was deleted and what was not."""
+    carries both what was deleted and what was not.
+
+    Reads stdout ALONE (`_git_out`): `for-each-ref` exits 0 while still warning on
+    stderr, and against `_git`'s merged stream that warning enters ``refs``, lands
+    in the ``refs[keep:]`` tail and is handed to ``delete`` — which fails, so
+    retention raises :class:`PrunePreserveError` on every host whose git config
+    warns (#442)."""
     if keep <= 0:
         return []
-    rc, out = _git(
+    rc, out, detail = _git_out(
         repo,
         "for-each-ref",
         # ties on committerdate (same-second rollbacks) break by ascending
@@ -750,7 +767,7 @@ def _prune_refs(
         prefix,
     )
     if rc != 0:
-        raise GitError(f"git for-each-ref {label} failed in {repo}: {out}")
+        raise GitError(f"git for-each-ref {label} failed in {repo}: {detail}")
     refs = [line.removeprefix(strip) for line in out.splitlines() if line]
     deleted: list[str] = []
     failed: list[str] = []
@@ -1178,10 +1195,17 @@ def worktree_prune(repo: Path) -> None:
 
 
 def worktree_list(repo: Path) -> list[Path]:
-    """Paths of every worktree attached to `repo` (the main checkout first)."""
-    rc, out = _git(repo, "worktree", "list", "--porcelain")
+    """Paths of every worktree attached to `repo` (the main checkout first).
+
+    Reads stdout ALONE (`_git_out`) so the record parse does not depend on no
+    stderr line ever starting with ``"worktree "``. The advisories measured for
+    #442 — an unknown `core.fsyncMethod` value and its family — do NOT start that
+    way, so the `startswith` filter screens them out and this parse was correct by
+    accident rather than by construction; the filter stays as a second, independent
+    screen."""
+    rc, out, detail = _git_out(repo, "worktree", "list", "--porcelain")
     if rc != 0:
-        raise GitError(f"git worktree list failed in {repo}: {out}")
+        raise GitError(f"git worktree list failed in {repo}: {detail}")
     paths = []
     for line in out.splitlines():
         if line.startswith("worktree "):
@@ -1356,7 +1380,14 @@ def capture_diff(repo: Path, baseline: str, *, max_file_bytes: int | None = None
     for forensics. Returns "" when there is nothing to capture.
 
     Unlike `_git`, the tracked diff is read from stdout alone and left verbatim
-    (no strip, no stderr merge) so the patch stays applyable.
+    (no strip, no stderr merge) so the patch stays applyable, as is the
+    `--no-index` spawn below it. The untracked leg now matches those two
+    (`_git_out`, #442): its `ls-files` exits 0 while still
+    warning on stderr, so against the merged stream the warning splits off as a
+    phantom rel. Measured, that phantom is inert here — `diff --no-index` cannot
+    access it and exits 1, exactly the code the loop below already tolerates as
+    "the files differ", with empty stdout — so this leg is converted for the same
+    reason its two neighbours read stdout alone, not on a demonstrated corruption.
 
     max_file_bytes caps the size of each *untracked* file included: a file larger
     than the cap is skipped and replaced with a one-line marker naming it and its
@@ -1368,9 +1399,9 @@ def capture_diff(repo: Path, baseline: str, *, max_file_bytes: int | None = None
         raise GitError(f"git diff {baseline} failed in {repo}: {proc.stderr.strip()}")
     parts = [proc.stdout]
 
-    rc, out = _git(repo, "ls-files", "--others", "--exclude-standard")
+    rc, out, detail = _git_out(repo, "ls-files", "--others", "--exclude-standard")
     if rc != 0:
-        raise GitError(f"git ls-files --others failed in {repo}: {out}")
+        raise GitError(f"git ls-files --others failed in {repo}: {detail}")
     for rel in out.splitlines():
         rel = rel.strip()
         if not rel:

--- a/src/bmad_loop/verify.py
+++ b/src/bmad_loop/verify.py
@@ -884,6 +884,16 @@ def snapshot_worktree(
     reset past work it could not park (only a re-drive, whose caller contract
     forbids pausing, still journals and lets the human-directed reset run).
 
+    The three reads whose text IS the answer — ``write-tree``,
+    ``rev-parse <head>^{tree}`` and ``commit-tree`` — take stdout ALONE
+    (``_git_out``, #442). Git exits 0 while still warning on stderr, and against
+    the merged stream all three answer a warning-suffixed "sha": the
+    ``tree == head_tree`` comparison then reads unequal on a tree identical to
+    HEAD, and ``update-ref`` is handed a non-ref. Because of the gate above, that
+    leaves a host whose git config warns with no working rollback at all. The
+    rc-only ``_git_env`` calls stay on the merge — they spend their output on a
+    raise and never read it as a value.
+
     Not every failure here is a :class:`GitError`: spawn faults arrive typed as
     :class:`GitSpawnError` since #343, but the ``TemporaryDirectory`` below can
     raise a plain ``OSError`` outright (ENOSPC/EMFILE) — a filesystem fault no
@@ -906,14 +916,13 @@ def snapshot_worktree(
             rc, out = _git_env(repo, "add", "--", *new, env=env)
             if rc != 0:
                 raise GitError(f"git add (snapshot untracked) failed in {repo}: {out}")
-        rc, tree = _git_env(repo, "write-tree", env=env)
+        rc, tree, detail = _git_out(repo, "write-tree", env=env)
         if rc != 0:
-            raise GitError(f"git write-tree (snapshot) failed in {repo}: {tree}")
-    tree = tree.strip()
-    rc, head_tree = _git(repo, "rev-parse", f"{head}^{{tree}}")
+            raise GitError(f"git write-tree (snapshot) failed in {repo}: {detail}")
+    rc, head_tree, detail = _git_out(repo, "rev-parse", f"{head}^{{tree}}")
     if rc != 0:
-        raise GitError(f"git rev-parse {head}^{{tree}} failed in {repo}: {head_tree}")
-    if tree == head_tree.strip():
+        raise GitError(f"git rev-parse {head}^{{tree}} failed in {repo}: {detail}")
+    if tree == head_tree:
         return None  # working tree identical to HEAD — nothing uncommitted to park
     # A synthetic identity (merged over os.environ) so the snapshot commit succeeds
     # with no git user.name/user.email configured — else the best-effort caller would
@@ -925,12 +934,11 @@ def snapshot_worktree(
         "GIT_COMMITTER_NAME": "bmad-loop",
         "GIT_COMMITTER_EMAIL": "bmad-loop@localhost",
     }
-    rc, snap = _git_env(
+    rc, snap, detail = _git_out(
         repo, "commit-tree", tree, "-p", head, "-m", "attempt worktree snapshot", env=ident
     )
     if rc != 0:
-        raise GitError(f"git commit-tree (snapshot) failed in {repo}: {snap}")
-    snap = snap.strip()
+        raise GitError(f"git commit-tree (snapshot) failed in {repo}: {detail}")
     rc, out = _git(repo, "update-ref", ref_name, snap)
     if rc != 0:
         raise GitError(f"git update-ref {ref_name} {snap[:12]} failed in {repo}: {out}")
@@ -1011,7 +1019,7 @@ def safe_rollback(
     policy_path = repo / POLICY_FILE_REL
     policy_content = policy_path.read_bytes() if policy_path.is_file() else None
 
-    rc, out = _git(repo, "stash", "create")
+    rc, out, detail = _git_out(repo, "stash", "create")
     # A failed `stash create` silently empties `snapshot`, which disables the whole
     # preserve restore below — the reset would then revert the very paths the caller
     # asked to keep (a resolved re-drive's corrected spec), with no error anywhere.
@@ -1019,9 +1027,13 @@ def safe_rollback(
     # no `preserve` the snapshot is unused, so the degrade stays correct there (both
     # sweep callers rely on it). A clean tree is not a failure — it exits rc 0 with
     # empty output, which the line below keeps handling as "nothing to restore from".
+    # Reading stdout ALONE is what makes that last sentence true on a host whose git
+    # warns at rc 0 (#442): against the merge the warning IS the "snapshot", so the
+    # restore below ran `checkout warning:… -- <dir>` after the reset had already
+    # destroyed the preserved content — destructive first, then loud.
     if rc != 0 and preserve:
-        raise GitError(f"git stash create failed in {repo}: {out}")
-    snapshot = out.strip() if rc == 0 else ""
+        raise GitError(f"git stash create failed in {repo}: {detail}")
+    snapshot = out if rc == 0 else ""
     rc, out = _git(repo, "reset", "--hard", baseline)
     if rc != 0:
         raise GitError(f"git reset --hard {baseline} failed: {out}")
@@ -1044,6 +1056,13 @@ def safe_rollback(
         # dir restores everything beneath it exactly as before.
         for d in preserve:
             rc, out = _git(repo, "checkout", snapshot, "--", *_literal_specs([d]))
+            # Deliberately still the MERGED read (#442), unlike the `stash create`
+            # above: this inspects text on the ERROR path, where git's "did not
+            # match" lands on STDERR — stdout alone can never contain it, so the
+            # substring would stop matching and a benign empty preserve dir would
+            # raise. INVERSE ablation: convert this `_git` to `_git_out` and read
+            # the stdout half here, and `test_safe_rollback_tolerates_empty_preserve_dir`
+            # fails on an unexpected GitError.
             if rc != 0 and "did not match" not in out:
                 raise GitError(f"git checkout {snapshot[:12]} -- {d} failed: {out}")
     if policy_content is not None:
@@ -2544,9 +2563,14 @@ def commit_paths(repo: Path, message: str, paths: list[Path]) -> str | None:
     rc, out = _git(repo, "add", "--", *specs)
     if rc != 0:
         raise GitError(f"git add failed: {out}")
-    rc, out = _git(repo, "status", "--porcelain", "--", *specs)
+    # Stdout ALONE (`_git_out`, #442): this is an EMPTINESS test, and `status` exits 0
+    # while still warning on stderr — against the merge an unchanged path set reads
+    # non-empty, the early-out below is skipped, and `git commit` runs with nothing
+    # staged and raises where the contract says return None. The `add` above and the
+    # `commit` below stay on `_git`: both are rc-only, and stderr is their diagnostic.
+    rc, out, detail = _git_out(repo, "status", "--porcelain", "--", *specs)
     if rc != 0:
-        raise GitError(f"git status failed: {out}")
+        raise GitError(f"git status failed: {detail}")
     if not out:
         return None  # nothing changed in these paths
     # pathspec form commits only `rels`, ignoring any other staged changes

--- a/src/bmad_loop/verify.py
+++ b/src/bmad_loop/verify.py
@@ -179,6 +179,34 @@ def _git_raw(repo: Path, *args: str) -> tuple[int, str]:
     return proc.returncode, proc.stdout
 
 
+def _git_out(repo: Path, *args: str, env: dict[str, str] | None = None) -> tuple[int, str, str]:
+    """Like `_git`, but hands the VALUE and the DIAGNOSTIC back separately —
+    `(returncode, stdout.strip(), (stdout + stderr).strip())`.
+
+    For every caller that reads git's text as the ANSWER rather than only checking
+    the return code. `_git`'s merge is right for the "raise with a message" callers,
+    where stderr is the informative half, and wrong for these: git writes advisories
+    to stderr while still exiting 0 — an unknown `core.fsyncMethod` value, a
+    `core.fsmonitor` hook that cannot exec, a stale-index advisory, `core.hooksPath`
+    pointing at a missing directory — so against the merged stream a warning is
+    indistinguishable from data (#442). A sha probe answers "<sha>\\nwarning: ...", an
+    emptiness read answers non-empty, and a line-splitting read grows a phantom record.
+    None of that is an error path; it is the normal path on a host whose git config the
+    orchestrator does not control.
+
+    The third element keeps the error messages unchanged: a caller raises with the
+    merged text exactly as `_git` did, so a failure still carries stderr. Reach for
+    this whenever the text is the answer; leave `_git` to the rc-only callers.
+    `worktree_clean` and `path_tracked` (#441) predate this helper and spell the same
+    split inline against `_run_git`; `_git_raw` is the third variant, for `-z` output
+    whose records can begin with a space and which `.strip()` would corrupt.
+
+    `env` mirrors `_git_env`, for the snapshot path's throwaway `GIT_INDEX_FILE` and
+    synthetic-identity calls that also read a sha back."""
+    proc = _run_git(["git", "-C", str(repo), *args], repo, env=env)
+    return proc.returncode, proc.stdout.strip(), (proc.stdout + proc.stderr).strip()
+
+
 def _git_env(repo: Path, *args: str, env: dict[str, str]) -> tuple[int, str]:
     """Like `_git` but runs with an explicit environment — used to point git at a
     throwaway `GIT_INDEX_FILE` so a snapshot can stage the tree without touching
@@ -215,9 +243,12 @@ def git_bytes(
 
 
 def rev_parse_head(repo: Path) -> str:
-    rc, out = _git(repo, "rev-parse", "HEAD")
+    """The sha HEAD resolves to. Reads stdout alone (`_git_out`): git exits 0 while
+    still warning on stderr, and a warning-suffixed "sha" flows into `same_commit`
+    comparisons and into persisted run baselines (#442)."""
+    rc, out, detail = _git_out(repo, "rev-parse", "HEAD")
     if rc != 0:
-        raise GitError(f"git rev-parse HEAD failed in {repo}: {out}")
+        raise GitError(f"git rev-parse HEAD failed in {repo}: {detail}")
     return out
 
 
@@ -227,14 +258,16 @@ def last_commit_for(repo: Path, path: Path) -> str:
     the repo. Backs the derived provenance of an operator park record, which is
     written into the very commit it rides and so cannot store its own sha. Git
     failures raise :class:`GitError` like every sibling; only the path relation
-    degrades silently, mirroring `commit_paths`' outside-the-repo contract."""
+    degrades silently, mirroring `commit_paths`' outside-the-repo contract. Reads
+    stdout alone (`_git_out`), since a git that warns at rc 0 would otherwise make
+    this answer a warning-suffixed "sha" (#442)."""
     try:
         rel = Path(path).resolve().relative_to(repo.resolve()).as_posix()
     except (OSError, RuntimeError, ValueError):
         return ""
-    rc, out = _git(repo, "log", "-n", "1", "--format=%H", "--", rel)
+    rc, out, detail = _git_out(repo, "log", "-n", "1", "--format=%H", "--", rel)
     if rc != 0:
-        raise GitError(f"git log failed in {repo}: {out}")
+        raise GitError(f"git log failed in {repo}: {detail}")
     return out
 
 
@@ -1050,10 +1083,12 @@ def _prune_empty_parents(start: Path, repo: Path) -> None:
 
 
 def current_branch(repo: Path) -> str:
-    """The branch name HEAD points at, or "HEAD" when detached."""
-    rc, out = _git(repo, "rev-parse", "--abbrev-ref", "HEAD")
+    """The branch name HEAD points at, or "HEAD" when detached. Reads stdout alone
+    (`_git_out`): git exits 0 while still warning on stderr, and the merged stream
+    would answer a branch name with the warning appended (#442)."""
+    rc, out, detail = _git_out(repo, "rev-parse", "--abbrev-ref", "HEAD")
     if rc != 0:
-        raise GitError(f"git rev-parse --abbrev-ref HEAD failed in {repo}: {out}")
+        raise GitError(f"git rev-parse --abbrev-ref HEAD failed in {repo}: {detail}")
     return out
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -203,6 +203,39 @@ def git(repo: Path, *args: str) -> str:
     return proc.stdout.strip()
 
 
+NOISY_GIT_KEY = "core.fsyncMethod"
+NOISY_GIT_VALUE = "bmad-loop-not-a-method"
+
+
+def make_git_noisy(repo: Path) -> str:
+    """Give `repo` a git config that writes to stderr while still exiting 0, and
+    return the warning text.
+
+    The suite's only host-noise dimension. An unknown VALUE for a known KEY is a
+    `warning:` on stderr at rc 0, not an error — measured at git 2.55.0 for every
+    subcommand verify.py reads text from. Without it no row in the #442 family is
+    falsifiable, because a quiet git makes the merged and stdout-alone reads
+    indistinguishable.
+
+    Measures rather than predicting. `core.fsyncMethod` only exists from git 2.36,
+    and below that the key is simply UNKNOWN, which git ignores in silence — so on an
+    older git every caller of this helper would pass with the bug restored. That is a
+    vacuous green, not a pass, so this skips instead, naming the version it saw. CI is
+    always on the exercising side. Same argument as `needs_strict_codec` in
+    tests/test_verify.py, which probes the codec rather than inferring it from the
+    locale."""
+    git(repo, "config", NOISY_GIT_KEY, NOISY_GIT_VALUE)
+    proc = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"], capture_output=True, text=True
+    )
+    if proc.returncode != 0 or not proc.stderr.strip():
+        version = subprocess.run(
+            ["git", "-C", str(repo), "version"], capture_output=True, text=True
+        ).stdout.strip()
+        pytest.skip(f"{version} does not warn at rc 0 for an unknown {NOISY_GIT_KEY} value")
+    return proc.stderr.strip()
+
+
 # ------------------------------------------------ machine-readable CLI output
 
 

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -7,6 +7,10 @@ here is the part of that shape other modules rely on without asserting it.
 
 from __future__ import annotations
 
+from conftest import make_git_noisy
+
+from bmad_loop import verify
+
 
 def test_template_drops_sample_hooks_but_keeps_hooks_dir_and_exclude(project):
     """`git init` seeds 14 dead `*.sample` hooks that nothing reads; the template
@@ -31,3 +35,32 @@ def test_template_drops_sample_hooks_but_keeps_hooks_dir_and_exclude(project):
     assert list(hooks.glob("*.sample")) == []
     assert hooks.is_dir()
     assert (git_dir / "info" / "exclude").is_file()
+
+
+def test_make_git_noisy_produces_rc_zero_stderr(project):
+    """The anti-vacuity guard for the suite's only host-noise dimension (#442).
+
+    `make_git_noisy` is what makes the merged and the stdout-alone reads
+    distinguishable; its whole premise is that an unknown VALUE for a known config
+    KEY is a `warning:` on stderr at rc 0, not an error. If a future git ever stops
+    emitting it, THIS test fails loudly — instead of the four tests that depend on
+    the helper all passing for the wrong reason, with the bug restored. Do not
+    delete it as a duplicate of them: it is the only row that would notice.
+
+    Ablation target: delete the `git config` line from `make_git_noisy` and the
+    premise is dead — the helper's own probe catches it, so this row and the four
+    that depend on the helper all report SKIPPED, none PASSED. Delete the probe as
+    well, so nothing masks the dead premise, and this row FAILS on the stderr
+    assertion. Deleting the probe ALONE reddens nothing while the host git still
+    warns, and that is the point rather than a gap: the probe is what turns a future
+    silent git into four skips instead of four false greens, and this row into the
+    one loud failure."""
+    repo = project.project
+    make_git_noisy(repo)
+
+    proc = verify._run_git(["git", "-C", str(repo), "rev-parse", "HEAD"], repo)
+
+    assert proc.returncode == 0  # a warning, not a failure
+    assert proc.stderr.strip()  # git really did write to stderr
+    sha = proc.stdout.strip()
+    assert len(sha) == 40 and all(c in "0123456789abcdef" for c in sha)

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -3725,7 +3725,13 @@ def test_prune_preserve_dirty_refs_deletes_oldest_beyond_keep(project):
 
 
 def test_prune_preserve_dirty_refs_keep_zero_never_runs_git(project, monkeypatch):
-    """keep=0 means "never prune" — return [] without even invoking git."""
+    """keep=0 means "never prune" — return [] without even invoking git.
+
+    Both helpers are patched, not just `_git`: the `for-each-ref` LISTING moved to
+    `_git_out` (#442) while the deletes still route via `_git`, so a `_git`-only
+    guard stays green against a regression that lists and then deletes nothing.
+    Measured, not assumed — with the early return deleted and no dirty ref present,
+    the `_git`-only form passes and this form fails on the listing."""
     repo = project.project
     _dirty_ref(repo, "run-0")
 
@@ -3733,6 +3739,7 @@ def test_prune_preserve_dirty_refs_keep_zero_never_runs_git(project, monkeypatch
         raise AssertionError("git must not run when keep=0")
 
     monkeypatch.setattr(verify, "_git", _boom)
+    monkeypatch.setattr(verify, "_git_out", _boom)
     assert verify.prune_preserve_dirty_refs(repo, keep=0) == []
     monkeypatch.undo()
     assert _dirty_ref_names(repo) == ["refs/attempt-preserve-dirty/run-0"]

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1772,7 +1772,12 @@ def test_safe_rollback_raises_when_the_preserve_snapshot_cannot_be_taken(project
     Raise before the reset instead.
 
     Ablation target: drop the `if rc != 0 and preserve: raise` from safe_rollback
-    and this fails — the spec comes back reverted, quietly."""
+    and this fails — the spec comes back reverted, quietly.
+
+    The fake stands on `_git_out`, which is the helper the `stash create` site reads
+    through since #442 — on `_git` it would simply never fire, and the test would go
+    green because nothing raised anywhere. The `pytest.raises` below is what proves
+    it fired."""
     repo = project.project
     spec = project.implementation_artifacts / "spec-1-1-a.md"
     spec.write_text("frozen: original\n")
@@ -1783,14 +1788,14 @@ def test_safe_rollback_raises_when_the_preserve_snapshot_cannot_be_taken(project
     artifact_rel = project.implementation_artifacts.relative_to(repo).as_posix()
     spec.write_text("frozen: corrected\n")
 
-    real_git = verify._git
+    real_git_out = verify._git_out
 
-    def fake_git(r, *args):
+    def fake_git_out(r, *args, env=None):
         if args[:2] == ("stash", "create"):
-            return 1, "fatal: unable to write temporary index"
-        return real_git(r, *args)
+            return 1, "", "fatal: unable to write temporary index"
+        return real_git_out(r, *args, env=env)
 
-    monkeypatch.setattr(verify, "_git", fake_git)
+    monkeypatch.setattr(verify, "_git_out", fake_git_out)
     with pytest.raises(verify.GitError, match="git stash create"):
         verify.safe_rollback(
             repo,
@@ -1808,22 +1813,31 @@ def test_safe_rollback_degrades_stash_failure_when_nothing_to_preserve(project, 
     the snapshot is unused, so a `stash create` failure stays a non-event — both
     sweep call sites reset with no preserve and must not start failing.
 
-    INVERSE ablation: drop the `and preserve` guard and this fails."""
+    INVERSE ablation: drop the `and preserve` guard and this fails.
+
+    The fake stands on `_git_out`, the helper the `stash create` site reads through
+    since #442. `fired` is not decoration: this test's whole assertion is that
+    NOTHING happened, so a fake patched onto the wrong helper would leave it green
+    while proving nothing at all — the failure it exists to catch and the fake going
+    inert are indistinguishable from the outside."""
     repo = project.project
     baseline = verify.rev_parse_head(repo)
     snap = sorted(verify.untracked_files(repo))
     (repo / "src.txt").write_text("dev attempt\n")
 
-    real_git = verify._git
+    real_git_out = verify._git_out
+    fired: list[str] = []
 
-    def fake_git(r, *args):
+    def fake_git_out(r, *args, env=None):
         if args[:2] == ("stash", "create"):
-            return 1, "fatal: unable to write temporary index"
-        return real_git(r, *args)
+            fired.append("stash")
+            return 1, "", "fatal: unable to write temporary index"
+        return real_git_out(r, *args, env=env)
 
-    monkeypatch.setattr(verify, "_git", fake_git)
+    monkeypatch.setattr(verify, "_git_out", fake_git_out)
     verify.safe_rollback(repo, baseline, baseline_untracked=snap)  # no preserve
 
+    assert fired == ["stash"]  # the injected failure actually reached the site
     assert (repo / "src.txt").read_text() == "original\n"  # reset still happened
 
 
@@ -1843,6 +1857,95 @@ def test_safe_rollback_tolerates_empty_preserve_dir(project):
         preserve=("_bmad-output",),  # no tracked files here at snapshot time
     )
     assert (repo / "src.txt").read_text() == "original\n"  # source still reverted
+
+
+def test_safe_rollback_restores_a_preserve_dir_under_host_noise(project):
+    """REAL-GIT axis (#442), on the family's most destructive row. `git stash create`
+    exits 0 while still warning on stderr, so against `_git`'s merge `snapshot` became
+    "<sha>\\nwarning: …" — a non-ref. The restore below then ran
+    `git checkout '<non-ref>' -- <dir>`, which fails "fatal: invalid reference" (NOT
+    the tolerated "did not match"), so safe_rollback raised — after the
+    `git reset --hard` had already discarded the content `preserve` names. Destructive
+    first, then loud.
+
+    Both halves are load-bearing: the absent raise, and the corrected content on disk.
+    A fix that merely stopped raising would leave the spec reverted just as silently
+    as the failure this restore exists to prevent.
+
+    Ablation target: put the `stash create` back on `_git` (the merge) and this fails,
+    on `GitError: git checkout … fatal: invalid reference` — together with
+    `test_safe_rollback_degrades_on_a_clean_tree_under_host_noise`, which grades the
+    same site from its empty-stdout side. Measured, that revert reddens two further
+    rows: `…_raises_when_the_preserve_snapshot_cannot_be_taken` and
+    `…_degrades_stash_failure_when_nothing_to_preserve`, whose injected failures are
+    patched onto `_git_out` because the site reads through it. Four rows, one site."""
+    repo = project.project
+    make_git_noisy(repo)
+    spec = project.implementation_artifacts / "spec-1-1-a.md"
+    spec.write_text("frozen: original\n")
+    git(repo, "add", "-A")
+    git(repo, "commit", "-q", "-m", "spec")
+    baseline = verify.rev_parse_head(repo)
+    snap = sorted(verify.untracked_files(repo))
+    artifact_rel = project.implementation_artifacts.relative_to(repo).as_posix()
+
+    spec.write_text("frozen: corrected\n")  # the resolve workflow's correction
+    git(repo, "add", "-A")
+    git(repo, "commit", "-q", "-m", "spec correction")  # committed above baseline
+    (repo / "src.txt").write_text("dev attempt\n")  # dirt, so `stash create` has a tree
+
+    verify.safe_rollback(
+        repo,
+        baseline,
+        baseline_untracked=snap,
+        keep=(".bmad-loop", artifact_rel),
+        preserve=(artifact_rel,),
+    )
+
+    assert (repo / "src.txt").read_text() == "original\n"  # the reset ran
+    assert spec.read_text() == "frozen: corrected\n"  # and the restore ran after it
+
+
+def test_safe_rollback_degrades_on_a_clean_tree_under_host_noise(project):
+    """The empty-stdout row of that same site. `git stash create` on a clean tree exits
+    0 with EMPTY stdout, so under host noise the merged read was the warning and
+    nothing else — making `snapshot` a non-ref exactly where the code's own comment
+    promises "nothing to restore from", and turning the documented degrade into a
+    raise (after the reset).
+
+    "Treated as empty" is observed through behavior rather than by reaching into the
+    function: with no restore attempted the preserve dir comes back at BASELINE
+    content — the clean-tree degrade policy.toml is restored separately to work
+    around. A restore driven by a corrupt snapshot cannot produce that; pre-fix it
+    raises before it could.
+
+    Ablation target: put the `stash create` back on `_git` (the merge) and this fails,
+    on `GitError: git checkout … fatal: invalid reference` — together with
+    `test_safe_rollback_restores_a_preserve_dir_under_host_noise`."""
+    repo = project.project
+    make_git_noisy(repo)
+    spec = project.implementation_artifacts / "spec-1-1-a.md"
+    spec.write_text("frozen: original\n")
+    git(repo, "add", "-A")
+    git(repo, "commit", "-q", "-m", "spec")
+    baseline = verify.rev_parse_head(repo)
+    snap = sorted(verify.untracked_files(repo))
+    artifact_rel = project.implementation_artifacts.relative_to(repo).as_posix()
+
+    spec.write_text("frozen: corrected\n")
+    git(repo, "add", "-A")
+    git(repo, "commit", "-q", "-m", "spec correction")  # committed: no working-tree dirt
+    assert git(repo, "status", "--porcelain", "--untracked-files=no") == ""  # nothing to stash
+
+    verify.safe_rollback(
+        repo,
+        baseline,
+        baseline_untracked=snap,
+        keep=(".bmad-loop", artifact_rel),
+        preserve=(artifact_rel,),
+    )
+
+    assert spec.read_text() == "frozen: original\n"  # empty snapshot => no restore
 
 
 def test_safe_rollback_preserves_uncommitted_policy_edit(project):
@@ -2833,6 +2936,30 @@ def test_commit_paths_noop_when_unchanged(project):
     assert verify.commit_paths(project.project, "noop", [project.project.parent / "x"]) is None
 
 
+def test_commit_paths_noops_on_unchanged_paths_under_host_noise(project):
+    """REAL-GIT axis (#442), the same no-op contract as its sibling above, on a host
+    whose git warns. `status --porcelain` exits 0 while writing that warning to
+    stderr, so against `_git`'s merge an UNCHANGED path set reads NON-EMPTY: the
+    `if not out: return None` early-out is skipped and `git commit` runs with nothing
+    staged, exiting 1. The function then raised
+    `GitError("git commit failed: … nothing to commit …")` precisely where its
+    contract promises None — and every caller committing an optional artifact (an
+    operator park record, a ledger carry) took that raise.
+
+    The HEAD assertion is the second half: a fix that returned None while still
+    committing would satisfy the first alone.
+
+    Ablation target: put the `status` read back on `_git` (the merge) and this fails
+    alone, on that GitError."""
+    repo = project.project
+    make_git_noisy(repo)
+    head = verify.rev_parse_head(repo)
+
+    assert verify.commit_paths(repo, "noop", [repo / "src.txt"]) is None
+
+    assert verify.rev_parse_head(repo) == head  # and nothing was committed
+
+
 def test_apply_patch_replays_saved_diff(project):
     """A patch saved off the baseline re-applies cleanly onto that same baseline —
     tracked edits AND new (untracked) files — reproducing the reverted attempt."""
@@ -3813,6 +3940,70 @@ def test_snapshot_worktree_unknown_baseline_skips_untracked(project):
     tree = git(repo, "ls-tree", "-r", "--name-only", ref)
     assert "src.txt" in tree  # tracked edit captured
     assert "user_untracked.txt" not in tree  # unknown-baseline untracked left untouched
+
+
+def test_snapshot_worktree_parks_a_dirty_tree_under_host_noise(project):
+    """REAL-GIT axis (#442): `write-tree` and `commit-tree` exit 0 while still warning
+    on stderr, so against `_git`'s merge both answered a warning-suffixed "sha" —
+    `commit-tree` was handed a non-object, or `update-ref` a non-commit, and
+    snapshot_worktree raised. Since #340 that ref is a GATE, not a safety net: a plain
+    rollback refuses to reset past work it could not park. So a host whose git config
+    warns had no working rollback at all, on every attempt.
+
+    The tree comparison is what stops this passing on a ref that exists but points at
+    nothing useful — a snapshot whose tree equals HEAD's has parked none of the work
+    it was called to save.
+
+    Ablation targets, reverted singly and measured — the two are NOT symmetric:
+
+    * `write-tree` back on `_git_env` (the merge): this fails on
+      `GitError: git commit-tree (snapshot) failed … fatal: not a valid object
+      name`, the corrupt tree carried into the next call. It reddens
+      `test_snapshot_worktree_still_noops_on_a_clean_tree_under_host_noise` too, and
+      not incidentally: a corrupt `tree` cannot equal a clean `head_tree`, so the
+      clean-tree no-op stops returning early and walks into the same call. Recorded
+      because the overlap is real, and because miscounting it would credit that row
+      with coverage of this site.
+    * `commit-tree` back on `_git_env`: this fails ALONE, on
+      `GitError: git update-ref refs/attempt-preserve-dirty/run-noisy … not a valid
+      SHA1` — a clean tree returns before ever reaching it."""
+    repo = project.project
+    make_git_noisy(repo)
+    ref_name = "refs/attempt-preserve-dirty/run-noisy"
+    (repo / "src.txt").write_text("attempt work\n")  # the uncommitted edit to park
+
+    ref = verify.snapshot_worktree(repo, ref_name, baseline_untracked=[])
+
+    assert ref == ref_name
+    assert verify.ref_exists(repo, ref_name) is True
+    # and it parked the work: the snapshot's tree is not just a copy of HEAD's
+    assert git(repo, "rev-parse", f"{ref_name}^{{tree}}") != git(repo, "rev-parse", "HEAD^{tree}")
+    assert git(repo, "show", f"{ref_name}:src.txt") == "attempt work"
+
+
+def test_snapshot_worktree_still_noops_on_a_clean_tree_under_host_noise(project):
+    """The comparison row. `rev-parse <head>^{tree}` also exits 0 while warning on
+    stderr, so against the merge `head_tree` carried the warning and
+    `tree == head_tree` read UNEQUAL on a tree identical to HEAD: the clean-tree no-op
+    became a snapshot ref parking nothing, created on every non-destructive rollback.
+
+    Only a test that demands `None` can catch a comparison corrupted on one side. The
+    ref it wrongly creates is well-formed and its commit is real — there is nothing
+    malformed downstream for another assertion to trip over.
+
+    Ablation target: put the `rev-parse <head>^{tree}` read back on `_git` and restore
+    its `head_tree.strip()`, and this fails alone, on the ref name where None was
+    expected — `test_snapshot_worktree_parks_a_dirty_tree_under_host_noise` stays
+    green, since a dirty tree differs from HEAD's under either read. Reverting
+    `write-tree` reddens this row as well, for a different reason; that test's record
+    carries the measurement."""
+    repo = project.project
+    make_git_noisy(repo)
+    ref_name = "refs/attempt-preserve-dirty/run-clean-noisy"
+
+    assert verify.snapshot_worktree(repo, ref_name, baseline_untracked=[]) is None
+
+    assert verify.ref_exists(repo, ref_name) is False  # and no ref was created
 
 
 def test_engine_written_is_keyword_only_on_all_dev_verifiers():

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -2530,6 +2530,99 @@ def test_rev_parse_head_failure_still_carries_git_stderr(tmp_path):
     assert "not a git repository" in str(excinfo.value)
 
 
+def test_untracked_files_reads_stdout_alone_under_host_noise(project):
+    """REAL-GIT axis: the reddening comes from git's own rc-0 stderr
+    (`make_git_noisy`), not a synthetic line. Against `_git`'s merge that warning
+    splits off as a phantom untracked path on a PRISTINE tree, and this probe's
+    contract is what a plain `git clean -fd` would remove — so the phantom is a
+    ROLLBACK CANDIDATE. Silent, on every host whose git config warns.
+
+    Both halves matter: the empty set proves no phantom, and the second proves the
+    fix did not simply blank the probe.
+
+    Ablation target: put `untracked_files` back on `_git` (the merge) and this fails
+    alone, on a set carrying the warning — the four sibling #442 rows added with it
+    (`commits_above`, `prune_preserve_refs`, `worktree_list`, `capture_diff`) stay
+    green, since each site is converted separately."""
+    repo = project.project
+    make_git_noisy(repo)
+
+    assert verify.untracked_files(repo) == set()  # pristine tree, no phantom
+
+    (repo / "new.txt").write_text("real untracked\n")
+    assert verify.untracked_files(repo) == {"new.txt"}  # and it still sees real ones
+
+
+def test_commits_above_reads_stdout_alone_under_host_noise(project):
+    """REAL-GIT axis, same `make_git_noisy` shape. Against the merge the warning is
+    a phantom SHA, handed to `preserve_commits` as an attempt commit — and the
+    docstring's "Empty when HEAD is at or behind baseline" stops holding. Silent.
+
+    `rev_parse_head` is the oracle here because it already reads stdout alone
+    (converted with the same helper), so the baseline it hands back is clean.
+
+    Ablation target: put `commits_above` back on `_git` and this fails alone, on
+    `["warning: ignoring unknown core.fsyncMethod value …"]` where `[]` was
+    expected."""
+    repo = project.project
+    make_git_noisy(repo)
+    baseline = verify.rev_parse_head(repo)
+
+    assert verify.commits_above(repo, baseline) == []  # HEAD at baseline
+
+    (repo / "impl.txt").write_text("work\n")
+    git(repo, "add", "-A")
+    git(repo, "commit", "-q", "-m", "attempt work")
+
+    assert verify.commits_above(repo, baseline) == [verify.rev_parse_head(repo)]
+
+
+def _inject_git_stderr(monkeypatch, line: str) -> None:
+    """Prepend `line` to the stderr of every git spawn verify.py makes, leaving the
+    return code and stdout untouched — the house `monkeypatch.setattr(verify.subprocess,
+    "run", …)` seam (see `test_capture_diff_timeout_becomes_git_error`), wrapping the
+    real `subprocess.run` rather than scripting it.
+
+    A synthetic shape is used only where the real `core.fsyncMethod` warning CANNOT
+    redden the row; each caller's docstring says why. Bytes and `None` stderr pass
+    through untouched, so a `binary=True` spawn is not corrupted into a type error."""
+    real_run = verify.subprocess.run
+
+    def noisy_run(cmd, **kwargs):
+        proc = real_run(cmd, **kwargs)
+        if not isinstance(proc.stderr, str):
+            return proc
+        return verify.subprocess.CompletedProcess(
+            proc.args, proc.returncode, proc.stdout, line + proc.stderr
+        )
+
+    monkeypatch.setattr(verify.subprocess, "run", noisy_run)
+
+
+def test_capture_diff_untracked_leg_reads_stdout_alone(project, monkeypatch):
+    """SEAM axis, deliberately — the real warning cannot redden this row, and a test
+    that cannot redden is not evidence. Measured at git 2.55.0: the phantom rel that
+    the `core.fsyncMethod` warning splits off reaches
+    `git diff --no-index -- /dev/null "<phantom>"`, which exits **1** ("could not
+    access") with EMPTY stdout — and rc 1 is exactly the code this caller already
+    tolerates as "the files differ", so nothing is appended and the patch is
+    unchanged. #442's claim that the phantom "becomes a file that cannot be opened"
+    and corrupts the patch does not hold for that shape.
+
+    The injected line is instead the name of a file that IS tracked and unmodified,
+    so it can never legitimately appear in `ls-files --others` output. Pre-fix that
+    rel is real on disk, `diff --no-index` succeeds against it, and the patch gains
+    an add-from-empty `new file mode` hunk for an already-tracked file.
+
+    Ablation target: put the untracked leg back on `_git` (the merge) and this fails
+    alone, on a patch carrying that hunk for `src.txt` where `""` was expected."""
+    repo = project.project
+    baseline = verify.rev_parse_head(repo)
+    _inject_git_stderr(monkeypatch, "src.txt\n")
+
+    assert verify.capture_diff(repo, baseline) == ""
+
+
 def test_commit_paths_refuses_to_stage_a_glob_neighbour(project):
     """`commit_paths` promises "exactly `paths` (and nothing else)". Unescaped, a
     configured artifacts dir carrying `[` also stages the operator's unrelated
@@ -3446,6 +3539,34 @@ def test_prune_preserve_refs_continues_past_undeletable_ref(project):
     assert isinstance(excinfo.value, verify.PrunePreserveError)
     assert excinfo.value.deleted == ["attempt-preserve/run-1"]
     assert len(excinfo.value.failed) == 1 and "run-0" in excinfo.value.failed[0]
+
+
+def test_prune_preserve_refs_survives_host_noise(project):
+    """REAL-GIT axis (#442): `make_git_noisy` gives the sandbox a git that warns on
+    stderr at rc 0, which is the normal path on a host whose git config the
+    orchestrator does not control. Against `_git`'s stdout+stderr merge the warning
+    enters `_prune_refs`' ref list, lands in the `refs[keep:]` tail and is handed to
+    `delete_branch`, which fails — so retention is WEDGED with a PrunePreserveError
+    on every such host. The loud member of the family.
+
+    The absence of the raise is the assertion, not `pytest.raises`: pre-fix this is
+    the row that blows up. The kept refs are then re-read through `branch_exists`,
+    because "did not raise" alone would also hold for a prune that deleted nothing.
+
+    Ablation target: put `_prune_refs`' listing back on `_git` (the merge) and this
+    fails alone, on the PrunePreserveError naming the warning line as an undeletable
+    ref — the four sibling #442 rows stay green."""
+    repo = project.project
+    make_git_noisy(repo)
+    for i in range(4):
+        _dated_commit(repo, f"attempt {i}", f"2026-01-0{i + 1}T12:00:00")
+        git(repo, "branch", "-f", f"attempt-preserve/run-{i}")
+
+    deleted = verify.prune_preserve_refs(repo, 2)
+
+    assert sorted(deleted) == ["attempt-preserve/run-0", "attempt-preserve/run-1"]
+    assert verify.branch_exists(repo, "attempt-preserve/run-2")
+    assert verify.branch_exists(repo, "attempt-preserve/run-3")
 
 
 def _dirty_ref(repo, name):

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -12,6 +12,7 @@ from conftest import (
     MISSING_TOOL_CMD,
     fault_read_text,
     git,
+    make_git_noisy,
     spec_path,
     write_spec,
     write_sprint,
@@ -2462,6 +2463,71 @@ def test_worktree_clean_ignores_stderr_chatter_on_success(project, monkeypatch):
     assert verify.worktree_clean(project.project)
     (project.project / "stray.txt").write_text("real change\n")
     assert not verify.worktree_clean(project.project)  # a genuine change still shows
+
+
+# ------------------------------------------ probes that return git's text (#442)
+#
+# The rest of the family #441 documented and did not widen to. A real git config
+# does the reddening here rather than a synthetic stderr, so the row stands on
+# git's own behavior: `make_git_noisy` sets an unknown VALUE for a known KEY,
+# which warns on stderr at rc 0 — the normal path on a host whose git config the
+# orchestrator does not control.
+
+
+def test_rev_parse_head_reads_stdout_alone_under_host_noise(project):
+    """A warning-suffixed "sha" is not a sha. It reaches `same_commit` comparisons
+    and the baselines persisted in run state, so a resume grades a warning-carrying
+    string against a clean one and reads "moved" — silent, with a plausible-looking
+    value.
+
+    The third assertion is not implied by the first: equality alone would also hold
+    if the conftest oracle were corrupted the same way, and it reads stdout alone.
+
+    Ablation target: put `rev_parse_head` back on `_git` (the stdout+stderr merge)
+    and this fails alone, on a return carrying the warning — while
+    `test_last_commit_for_reads_stdout_alone_under_host_noise` and
+    `test_current_branch_reads_stdout_alone_under_host_noise` stay green, since each
+    site is converted separately."""
+    repo = project.project
+    warning = make_git_noisy(repo)
+
+    head = verify.rev_parse_head(repo)
+
+    assert head == git(repo, "rev-parse", "HEAD")  # conftest git() = stdout.strip()
+    assert len(head) == 40 and all(c in "0123456789abcdef" for c in head)
+    assert warning not in head
+
+
+def test_last_commit_for_reads_stdout_alone_under_host_noise(project):
+    """Same shape as its `rev-parse` sibling, one caller further out: this sha backs
+    an operator-park record's provenance (operatoractions.py), which is written into
+    the very commit it rides and so cannot be re-derived later.
+
+    Ablation target: put `last_commit_for` back on `_git` and this fails alone."""
+    repo = project.project
+    warning = make_git_noisy(repo)
+
+    sha = verify.last_commit_for(repo, repo / "src.txt")
+
+    assert sha == git(repo, "log", "-n", "1", "--format=%H", "--", "src.txt")
+    assert len(sha) == 40 and all(c in "0123456789abcdef" for c in sha)
+    assert warning not in sha
+
+
+def test_rev_parse_head_failure_still_carries_git_stderr(tmp_path):
+    """The other direction of the split: reading stdout alone for the VALUE must not
+    cost the ERROR path its diagnostic. git puts "not a git repository" on stderr, so
+    a message built from stdout alone would name the directory and say nothing about
+    why — which is the whole content of this failure.
+
+    Ablation target: in `rev_parse_head`, swap the raise's `detail` back to `out`
+    (leaving `_git_out` and the `return out` in place) and this fails alone, on an
+    empty message — while `test_rev_parse_head_reads_stdout_alone_under_host_noise`
+    stays green. That disjointness is what proves this is not a restatement of it."""
+    with pytest.raises(verify.GitError) as excinfo:
+        verify.rev_parse_head(tmp_path)
+
+    assert "not a git repository" in str(excinfo.value)
 
 
 def test_commit_paths_refuses_to_stage_a_glob_neighbour(project):

--- a/tests/test_verify_worktree.py
+++ b/tests/test_verify_worktree.py
@@ -84,6 +84,37 @@ def test_worktree_add_list_remove(project, tmp_path):
     assert wt.resolve() not in [p.resolve() for p in verify.worktree_list(repo)]
 
 
+def test_worktree_list_reads_stdout_alone(project, monkeypatch):
+    """SEAM axis, deliberately — unlike its `current_branch` neighbour above, this row
+    cannot be reddened by the real host noise, and a test that cannot redden is not
+    evidence. `make_git_noisy`'s warning does not start with `"worktree "`, so the
+    `startswith` filter screens it out and the parse is correct BY ACCIDENT; #442's
+    claim that this probe gains "an unparseable extra record" does not hold for that
+    shape (measured at git 2.55.0). The synthetic stderr line is chosen to survive the
+    filter, which is exactly what the filter cannot promise about every future advisory.
+
+    The filter stays in place as a second, independent screen; this asserts the read
+    no longer DEPENDS on it.
+
+    Ablation target: put `worktree_list` back on `_git` (the stdout+stderr merge) and
+    this fails alone, on a `/phantom` path appended to the list — the four sibling #442
+    rows in tests/test_verify.py stay green, since each site is converted separately."""
+    repo = project.project
+    real_run = verify.subprocess.run
+
+    def noisy_run(cmd, **kwargs):
+        proc = real_run(cmd, **kwargs)
+        if not isinstance(proc.stderr, str):  # a binary=True spawn passes through
+            return proc
+        return verify.subprocess.CompletedProcess(
+            proc.args, proc.returncode, proc.stdout, "worktree /phantom\n" + proc.stderr
+        )
+
+    monkeypatch.setattr(verify.subprocess, "run", noisy_run)
+
+    assert [p.resolve() for p in verify.worktree_list(repo)] == [repo.resolve()]
+
+
 def test_worktree_add_create_defaults_to_head(project, tmp_path):
     """create=True with no `base` cuts the branch from HEAD (git's own default)
     instead of passing None into git and crashing."""

--- a/tests/test_verify_worktree.py
+++ b/tests/test_verify_worktree.py
@@ -6,7 +6,7 @@ helpers carry no engine wiring yet — they are the plumbing Phase 3 builds on.
 """
 
 import pytest
-from conftest import git
+from conftest import git, make_git_noisy
 
 from bmad_loop import verify
 
@@ -22,6 +22,27 @@ def commit(repo, name, content="x\n", msg="work"):
 
 def test_current_branch(project):
     assert verify.current_branch(project.project) == "main"
+
+
+def test_current_branch_reads_stdout_alone_under_host_noise(project):
+    """git exits 0 while still writing an advisory to stderr, so against `_git`'s
+    stdout+stderr merge the branch name comes back with the warning appended (#442).
+    `make_git_noisy` sets an unknown VALUE for a known config KEY, which is exactly
+    that shape and not an error path.
+
+    The substring assertion is not implied by the equality: it is what distinguishes
+    "the value is clean" from "the oracle is corrupted the same way".
+
+    Ablation target: put `current_branch` back on `_git` (the merge) and this fails
+    alone — the two sibling rows in tests/test_verify.py stay green, since each site
+    is converted separately."""
+    repo = project.project
+    warning = make_git_noisy(repo)
+
+    branch = verify.current_branch(repo)
+
+    assert branch == "main"
+    assert warning not in branch
 
 
 def test_branch_exists(project):


### PR DESCRIPTION
Closes #442

## Problem

`verify._git` returns `(rc, (stdout + stderr).strip())`. That merge is right for the ~45 callers
that only check `rc` and spend the text on a `raise GitError(f"…: {out}")`, where stderr is the
informative half. It is wrong for every caller that reads the text as the **answer**, because git
writes advisories to stderr while still exiting 0 — an unknown `core.fsyncMethod` value, a
`core.fsmonitor` hook that cannot exec, a stale-index advisory, `core.hooksPath` pointing at a
missing directory. Against the merged stream those are indistinguishable from data.

This is not an error path. It is the normal path on any host whose git config the orchestrator does
not control — a host-config property, and one an operator never sees reported as a failure.

Measured reproduction (git 2.55.0):

```console
$ git init -q r && cd r && git commit -qm init --allow-empty
$ git config core.fsyncMethod bmad-loop-not-a-method   # an unknown VALUE for a known KEY
$ git rev-parse HEAD; echo "rc=$?"
c2ccf69e07134d2cbdeb928cc1c0196ad0897484
rc=0
$ git rev-parse HEAD 2>&1 >/dev/null                   # …and the same invocation's stderr
warning: ignoring unknown core.fsyncMethod value 'bmad-loop-not-a-method'
```

`git ls-files --others --exclude-standard`, `git rev-list HEAD..HEAD`, `git status --porcelain`,
`git write-tree`, `git commit-tree`, `git stash create` and `git for-each-ref` all behave the same
way: rc 0, the real answer (or nothing) on stdout, the warning on stderr.

#441 (for #423) fixed the two most dangerous instances — `worktree_clean` and `path_tracked`, both
emptiness reads — inline, and deliberately did not widen to the rest of the family it documented.
This PR is that rest.

## Fix

**`src/bmad_loop/verify.py`** — one new helper plus thirteen conversions in eleven functions.

`_git_out(repo, *args, env=None) -> (rc, stdout.strip(), (stdout + stderr).strip())`. A sibling
helper rather than thirteen inline `_run_git` spawns, for two reasons: the split becomes
**structural** instead of per-caller discipline, so a future probe cannot pick the merged form by
accident; and the third element is what keeps error messages byte-identical — every converted
`raise` still carries stderr. It spawns through the same `_run_git` chokepoint (AGENTS.md hard
invariant), and `tests/test_portability_guard.py` stays green on the added sequence-form argv.

| function | site | what the text is |
| --- | --- | --- |
| `rev_parse_head` | `rev-parse HEAD` | the sha |
| `last_commit_for` | `log -n 1 --format=%H` | the sha |
| `current_branch` | `rev-parse --abbrev-ref HEAD` | the branch name |
| `untracked_files` | `ls-files --others` | one record per line |
| `commits_above` | `rev-list <baseline>..HEAD` | one sha per line |
| `_prune_refs` | `for-each-ref` | one ref per line |
| `worktree_list` | `worktree list --porcelain` | records |
| `capture_diff` | `ls-files --others` (untracked leg) | one rel per line |
| `snapshot_worktree` | `write-tree` | the tree sha |
| `snapshot_worktree` | `rev-parse <head>^{tree}` | the tree sha |
| `snapshot_worktree` | `commit-tree` | the snapshot sha |
| `safe_rollback` | `stash create` | the snapshot sha |
| `commit_paths` | `status --porcelain -- <specs>` | an emptiness test |

**Deliberately left alone.** `_git` keeps the merge for its ~45 rc-only callers, and `_git_raw`
keeps returning stdout verbatim for `-z` output, whose records can begin with a space that
`.strip()` would corrupt. `_git_env`'s remaining calls on the snapshot path are rc-only and stay
as they are.

**The one merged READ deliberately kept:** `safe_rollback`'s `"did not match" not in out`
tolerance, below the preserve restore. It inspects text on the **error** path, where git's
"pathspec … did not match" lands on stderr — stdout alone can never contain it, so the substring
would stop matching and a benign empty preserve dir would raise. That is asserted rather than
assumed, by inverse ablation: convert that one line to read the stdout half and
`test_safe_rollback_tolerates_empty_preserve_dir` fails with
`GitError: git checkout df775e44178a -- _bmad-output failed:` — note the empty diagnostic after
the colon, which is git having put all of it, "did not match" included, on stderr. A comment on
the line records this so the next sweep does not "finish the job".

## Scope note

Not in this diff:

- `_git` itself and its ~45 rc-only call sites. They are correct as they are.
- The non-git `stdout + stderr` merges elsewhere in the tree — `plugins/bus.py`,
  `verify.run_verify_commands`, the Unity plugin scripts. Different surface, out of scope for #442.
- No new issues were filed during phases 1–3 of this work; nothing was deferred out of it.

## Visible behavior diffs

On a host whose git warns at rc 0:

- `rev_parse_head`, `last_commit_for` and `current_branch` return the value instead of the value
  with a warning appended. The sha probes feed `same_commit()` comparisons and the baselines
  persisted in run state, so before this a resume graded a warning-carrying string against a clean
  one and read "moved".
- `untracked_files` stops reporting a phantom rollback candidate on a pristine tree, and
  `commits_above` stops handing `preserve_commits` a phantom sha.
- Three call paths stop raising: `PrunePreserveError` from preserve-ref retention (the phantom
  entered the ref list, landed in the `refs[keep:]` tail and was handed to `delete_branch`),
  `GitError` from `snapshot_worktree`, and `GitError` from `commit_paths` on an unchanged path set
  (where its contract returns `None`).
- `snapshot_worktree` is worth naming on its own: since #340 that recovery ref is a **gate**, not
  a safety net — a plain rollback refuses to reset past work it could not park — so a noisy host
  had no working rollback at all.
- `safe_rollback` stops attempting a restore from a non-ref after the reset. On a clean tree
  `stash create` emits empty stdout with the warning on stderr, so against the merge `snapshot`
  became a non-empty non-ref and the restore ran `git checkout 'warning: …' -- <dir>` — **after**
  `git reset --hard` had already run. Destructive first, then loud.

On a quiet git, nothing changes at all. Error messages are unchanged everywhere: every converted
`raise` still interpolates the merged text.

## Honesty callout

Two of the thirteen were **not** reproducibly corrupted by the measured warning shape, and #442's
text is wrong about both:

- `worktree_list` — #442 says the parse gains "an unparseable extra record". It does not. The parse
  keeps only lines starting with `"worktree "`, which screens the warning out. Correct by accident
  of the filter shape.
- `capture_diff`'s untracked leg — #442 says the phantom "becomes a file that cannot be opened" and
  corrupts the patch. Measured, `git diff --no-index -- /dev/null "<phantom>"` exits **1** ("could
  not access") with **0 bytes** of stdout, and rc 1 is exactly the code the loop already tolerates
  as "the files differ", so nothing is appended. Correct by accident too.

Both are converted **defensively**, so the reads stand on the split rather than on that accident,
and `worktree_list` keeps its `startswith` filter as a second, independent screen. Their tests
therefore cannot use the real warning; they use the house
`monkeypatch.setattr(verify.subprocess, "run", …)` seam with a synthetic stderr line chosen to
survive each filter, and each docstring says which axis it uses and why. Stating this because a
reviewer who re-measures will find it, and finding it unstated costs more than stating it.

## Testing

`tests/conftest.py` gains `make_git_noisy` — the suite's first host-noise dimension, a plain
function rather than a fixture per `docs/testing.md`. It sets an unknown value for a known key, so
git warns at rc 0.

Fourteen new tests. One line of ablation evidence each, from the phase commits — every ablation run
against a `cp` backup and restored byte-identical, never `git checkout`:

| test | ablation → result |
| --- | --- |
| `test_rev_parse_head_reads_stdout_alone_under_host_noise` | site back on `_git` → FAILED alone: `assert "c2ccf69e…not-a-method'" == 'c2ccf69e0713…'` |
| `test_last_commit_for_reads_stdout_alone_under_host_noise` | site back on `_git` → FAILED alone, same shape |
| `test_current_branch_reads_stdout_alone_under_host_noise` | site back on `_git` → FAILED alone: `assert "main\nwarnin…" == 'main'`. The pre-existing `test_current_branch` passed throughout — which is why the new row is needed |
| `test_rev_parse_head_failure_still_carries_git_stderr` | swap the raise's `detail` back to `out`, keeping `_git_out` → FAILED: the message trails off empty after the colon, git's whole diagnostic gone |
| `test_untracked_files_reads_stdout_alone_under_host_noise` | site back on `_git` → 1 failed, 4 passed: `assert {"warning: ig…"} == set()` |
| `test_commits_above_reads_stdout_alone_under_host_noise` | site back on `_git` → 1 failed, 4 passed: `assert ["warning: ig…"] == []` |
| `test_prune_preserve_refs_survives_host_noise` | site back on `_git` → 1 failed, 4 passed: `PrunePreserveError: … could not delete warning: ignoring unknown core.fsyncMethod value '…'` |
| `test_worktree_list_reads_stdout_alone` | site back on `_git` → 1 failed, 4 passed: "Left contains one more item: `PosixPath('/phantom')`" |
| `test_capture_diff_untracked_leg_reads_stdout_alone` | site back on `_git` → 1 failed, 4 passed: a `new file mode 100644` hunk synthesized for the already-**tracked** `src.txt` |
| `test_snapshot_worktree_parks_a_dirty_tree_under_host_noise` | `commit-tree` back on `_git_env` → FAILED alone: `update-ref … fatal: df3963370a71…warning: …: not a valid SHA1` |
| `test_snapshot_worktree_still_noops_on_a_clean_tree_under_host_noise` | `rev-parse ^{tree}` back on `_git` → FAILED alone: a preserve ref where `None` was due. (`write-tree` back on `_git_env` reddens **both** snapshot rows — a corrupt `tree` cannot equal a clean `head_tree`, so the no-op stops returning early; the overlap is recorded in the tests rather than hidden.) |
| `test_safe_rollback_restores_a_preserve_dir_under_host_noise` | `stash create` back on `_git` → FAILED with `git checkout warning: ign -- _bmad-output/… : fatal: invalid reference: warning: …` |
| `test_safe_rollback_degrades_on_a_clean_tree_under_host_noise` | same ablation → FAILED alongside it |
| `test_commit_paths_noops_on_unchanged_paths_under_host_noise` | site back on `_git` → FAILED alone: `GitError: git commit failed: … nothing to commit, working tree clean / warning: …` |

Plus the fixture's own anti-vacuity guard, `test_make_git_noisy_produces_rc_zero_stderr`, which
exists because `core.fsyncMethod` only arrived in **git 2.36**: below that the key is merely
unknown, git ignores it in silence, and every dependent row would pass with the bug fully restored.
The helper measures the premise instead of predicting it and **skips**, naming the version it saw
(`git version X does not warn at rc 0 for an unknown core.fsyncMethod value`) — same argument as
`needs_strict_codec`. Ablated both ways: delete the `git config` line and the dependent rows report
`4 skipped, 0 passed`, none of them a false green; delete the probe as well, so nothing masks the
dead premise, and it is `4 failed`. Deleting the probe **alone** reddens nothing while the host git
still warns, which is the point rather than a gap — the probe is what turns a future silent git
into skips instead of false greens.

Two further pieces of ablation hygiene, recorded because they are easy to get wrong here:

- A **full** revert of a phase-1 commit cannot grade a test that asserts on an error *message* — it
  restores a single `out` that is already the merged text, so the assertion still holds. All the
  value-read ablations above are surgical, one site at a time.
- The two synthetic-shape rows (`worktree_list`, `capture_diff`) were re-run with the **real**
  warning substituted for the injection, against the **unfixed** code: **2 passed**. That pass is
  the evidence the synthetic shape is necessary and the honesty callout above is measured rather
  than guessed.

Finally, `test_prune_preserve_dirty_refs_keep_zero_never_runs_git` is hardened in this PR because
this diff narrowed it: the `for-each-ref` listing moved to `_git_out` while the deletes still route
via `_git`, so the `_git`-only guard stopped watching every git path the `keep <= 0` early return
skips. It patches both helpers now. The discriminating ablation — early return deleted **and** no
dirty ref present, so the listing runs and nothing is deleted — fails on the hardened form
(caught at the `for-each-ref` argv) and **passes** on the old `_git`-only form. That pass is the
hole, measured rather than argued.

## Gates

`uv run pytest -q -n logical` → 5515 passed, 50 skipped, 5 xfailed · `uv run pyright` → 0 errors ·
`trunk fmt` clean · `trunk check --all --no-fix` → 256 files, no issues ·
`uv run --no-project python scripts/release.py check` → version-sync ok.
