### PR TITLE
fix(sprintstatus): preserve board line endings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,13 @@ breaking changes may land in a minor release.
 
 ### Fixed
 
+- **Advancing a sprint board now preserves every authored line ending (#576).** A valid UTF-8
+  board keeps each CRLF, LF, bare-CR or mixed per-line terminator while the requested story,
+  conditional parent-epic and optional `last_updated` values still change. Previously the
+  read/write relay could translate the whole board to the platform line ending, producing
+  newline-only diff noise outside those intended value edits; parsed YAML content was not
+  corrupted.
+
 - **A `sweep --migrate` rewrite that drops a `gate:` token a pre-existing entry declared is now
   refused, instead of un-gating that story silently (#519).** Validation held the rewrite to each
   entry's id and status only, so losing the token passed, got committed, and the next dispatch ran

--- a/src/bmad_loop/sprintstatus.py
+++ b/src/bmad_loop/sprintstatus.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 import yaml
 
-from .platform_util import atomic_write_text
+from .platform_util import atomic_write_bytes
 
 EPIC_RE = re.compile(r"^epic-(\d+)$")
 RETRO_RE = re.compile(r"^epic-(\d+)-retrospective$")
@@ -186,8 +186,9 @@ def story_status(path: Path, key: str) -> str | None:
 # wherever the line happens to end. Both arms demand a trailing `\S`, so a line
 # carrying anything after the value that neither arm can account for — trailing
 # whitespace, no comment — is refused whole rather than silently rewritten
-# without it. (That refusal is why the line-ending relay in #576 cannot be fixed
-# by reading bytes alone: a surviving `\r` is trailing whitespace to both arms.)
+# without it. Line terminators are excluded before either scalar matcher runs
+# and carried separately per line, so CRLF's `\r` is never mistaken for trailing
+# scalar whitespace (#576).
 _QUOTED_VALUE_RE = re.compile(r"^(?P<val>['\"](?:.*\S)?)$")
 _UNQUOTED_VALUE_RE = re.compile(r"^(?P<val>\S(?:.*?\S)?)(?P<rest>[ \t]+#.*)?$")
 
@@ -215,10 +216,12 @@ def _set_mapping_value(lines: list[str], key: str, new_value: str) -> bool:
 
     A remainder neither arm can read leaves the line alone, exactly like a key
     that never matched — `advance` reports the unchanged status rather than
-    claiming a write it did not make."""
+    claiming a write it did not make. Each line's terminator is excluded from
+    the scalar match and then reattached exactly as authored (#576)."""
     key_pat = re.compile(rf"^(?P<indent>\s*){re.escape(key)}:(?P<gap>[ \t]+)(?P<body>\S.*)$")
     for i, line in enumerate(lines):
-        m = key_pat.match(line.rstrip("\n"))
+        stripped = line.rstrip("\r\n")
+        m = key_pat.match(stripped)
         if not m:
             continue
         body = m.group("body")
@@ -229,7 +232,7 @@ def _set_mapping_value(lines: list[str], key: str, new_value: str) -> bool:
         if vm.group("val") == new_value:
             return False  # already at target — idempotent no-op
         rest = vm.groupdict().get("rest") or ""
-        nl = "\n" if line.endswith("\n") else ""
+        nl = line[len(stripped) :]
         lines[i] = f"{m.group('indent')}{key}:{m.group('gap')}{new_value}{rest}" + nl
         return True
     return False
@@ -246,18 +249,23 @@ def advance(path: Path, story_key: str, target: str, *, now: str | None = None) 
     via line edits. Returns the story's status after the call (== `target` on a
     write), or None when nothing was eligible.
 
-    The rewrite is atomic (#379). This is a read-modify-rewrite of the board, and
-    a truncating `write_text` that faults partway through corrupts it SILENTLY:
-    YAML cut at a line boundary is still a valid mapping, just a smaller one, so
-    the epics past the tear cease to exist rather than raising. AGENTS.md makes
-    this the orchestrator's sole write path to sprint-status.yaml, so nothing
-    downstream would contradict the shortened board — the run would simply walk
-    off the end of the sprint. `atomic_write_text` keeps the file entire: either
-    the old contents or the whole new ones, never a prefix.
+    The rewrite is atomic and symlink-following (#379), and every existing CRLF,
+    LF, bare CR, or mixed per-line terminator is preserved (#576). The board is
+    read as raw UTF-8 bytes, each edited line carries its own terminator, and
+    `atomic_write_bytes` publishes the byte-exact result. This is a
+    read-modify-rewrite of the board, and a truncating write that faults partway
+    through corrupts it SILENTLY: YAML cut at a line boundary is still a valid
+    mapping, just a smaller one, so the epics past the tear cease to exist rather
+    than raising. AGENTS.md makes this the orchestrator's sole write path to
+    sprint-status.yaml, so nothing downstream would contradict the shortened
+    board — the run would simply walk off the end of the sprint. The atomic
+    helper keeps the file entire: either the old contents or the whole new ones,
+    never a prefix.
 
-    Symlinks are FOLLOWED (the helper's default), which is what the truncating
-    write did too — the board is an operator-curated file at a project-relative
-    path, and a repo that symlinks it somewhere must keep being a symlink.
+    Symlinks are FOLLOWED (the helper's default), which is what the old
+    truncating write did too — the board is an operator-curated file at a
+    project-relative path, and a repo that symlinks it somewhere must keep being
+    a symlink.
     """
     if not path.is_file():
         return None
@@ -271,7 +279,7 @@ def advance(path: Path, story_key: str, target: str, *, now: str | None = None) 
     ):
         return current  # already at or past target — never regress
 
-    text = path.read_text(encoding="utf-8")
+    text = path.read_bytes().decode("utf-8")
     lines = text.splitlines(keepends=True)
     # story_status() resolves keys via a full YAML parse, but _set_mapping_value
     # rewrites via a line regex that can't touch every shape it finds (quoted or
@@ -294,7 +302,7 @@ def advance(path: Path, story_key: str, target: str, *, now: str | None = None) 
         changed = _set_mapping_value(lines, "last_updated", now) or changed
 
     if changed:
-        atomic_write_text(path, "".join(lines))
+        atomic_write_bytes(path, "".join(lines).encode("utf-8"))
     return target
 
 

--- a/tests/test_sprintstatus_advance.py
+++ b/tests/test_sprintstatus_advance.py
@@ -4,8 +4,10 @@ import sys
 from pathlib import Path
 
 import pytest
+import yaml
 
 from bmad_loop import sprintstatus
+from bmad_loop.platform_util import atomic_write_bytes as real_atomic_write_bytes
 
 SPRINT = """\
 # Sprint status — do not hand-edit casually
@@ -198,14 +200,10 @@ def test_a_hash_inside_a_quoted_value_never_becomes_a_comment(tmp_path):
     ever a comment.
 
     Compares the full resulting TEXT, not its bytes. Full-content equality is the
-    point — a substring or a re-parse is blind to a fabricated comment — but
-    `advance` writes through `Path.write_text`, whose `newline=None` relays every
-    line ending in the board to `os.linesep`, so a byte comparison also asserts
-    line endings and fails on Windows for a reason that has nothing to do with
-    #366. That relay is real and known (#576); it is not this test's subject, and
-    pinning it here would put a second, accidental contract on the row that guards
-    the value/comment split. Reading back with universal newlines drops exactly
-    that difference and nothing else."""
+    point — a substring or a re-parse is blind to a fabricated comment — while
+    the dedicated #576 rows below own byte-exact line-ending preservation. Keeping
+    this oracle text-focused avoids putting a second, accidental contract on the
+    row that guards only the value/comment split."""
     p = tmp_path / "sprint-status.yaml"
     board = (
         'last_updated: 01-06-2026 10:00\ndevelopment_status:\n  3-2-x: "a # b"\n  3-3-y: backlog\n'
@@ -281,6 +279,118 @@ def test_a_line_with_trailing_whitespace_and_no_comment_is_refused(tmp_path):
         assert "".join(lines) == line
 
 
+# --------------------------------------------------- line-ending preservation (#576)
+
+
+def test_a_crlf_board_keeps_every_crlf_and_only_intended_values_change(tmp_path):
+    """POSIX oracle for the raw-read, CRLF matcher, and per-line emit sites."""
+    board = (
+        b"# Sprint status\r\n"
+        b"last_updated: 01-06-2026 10:00\r\n"
+        b"development_status:\r\n"
+        b"  epic-3: backlog\r\n"
+        b"  3-1-login: backlog\r\n"
+        b"  3-2-finished: done\r\n"
+    )
+    expected = board.replace(b"  epic-3: backlog\r\n", b"  epic-3: in-progress\r\n").replace(
+        b"  3-1-login: backlog\r\n", b"  3-1-login: in-progress\r\n"
+    )
+    p = tmp_path / "sprint-status.yaml"
+    p.write_bytes(board)
+
+    assert sprintstatus.advance(p, "3-1-login", "in-progress") == "in-progress"
+
+    actual = p.read_bytes()
+    assert actual == expected
+    assert b"\n" not in actual.replace(b"\r\n", b"")  # no bare LF was introduced
+    assert sprintstatus.story_status(p, "3-1-login") == "in-progress"
+    assert sprintstatus.load(p).epics[3] == "in-progress"
+
+
+def test_an_lf_board_keeps_every_lf_and_only_intended_values_change(tmp_path):
+    """Windows-CI oracle for the old translating text-writer half of #576."""
+    board = (
+        b"# Sprint status\n"
+        b"last_updated: 01-06-2026 10:00\n"
+        b"development_status:\n"
+        b"  epic-3: backlog\n"
+        b"  3-1-login: backlog\n"
+        b"  3-2-finished: done\n"
+    )
+    expected = board.replace(b"  epic-3: backlog\n", b"  epic-3: in-progress\n").replace(
+        b"  3-1-login: backlog\n", b"  3-1-login: in-progress\n"
+    )
+    p = tmp_path / "sprint-status.yaml"
+    p.write_bytes(board)
+
+    assert sprintstatus.advance(p, "3-1-login", "in-progress") == "in-progress"
+
+    actual = p.read_bytes()
+    assert actual == expected
+    assert b"\r" not in actual
+
+
+def test_a_mixed_ending_board_keeps_each_line_its_own_ending(tmp_path):
+    """POSIX oracle spanning the raw-read and per-line emit sites with all endings."""
+    board = (
+        b"last_updated: 01-06-2026 10:00\r\n"
+        b"development_status:\r\n"
+        b"  epic-3: backlog\n"
+        b"  3-1-login: backlog\r"
+        b"  3-2-untouched: backlog\r\n"
+    )
+    now = "22-06-2026 14:30"
+    expected = (
+        board.replace(
+            b"last_updated: 01-06-2026 10:00\r\n",
+            b"last_updated: 22-06-2026 14:30\r\n",
+        )
+        .replace(b"  epic-3: backlog\n", b"  epic-3: in-progress\n")
+        .replace(b"  3-1-login: backlog\r", b"  3-1-login: in-progress\r")
+    )
+    p = tmp_path / "sprint-status.yaml"
+    p.write_bytes(board)
+
+    assert sprintstatus.advance(p, "3-1-login", "in-progress", now=now) == "in-progress"
+
+    actual = p.read_bytes()
+    assert actual == expected
+    assert sprintstatus.story_status(p, "3-1-login") == "in-progress"
+    assert sprintstatus.load(p).epics[3] == "in-progress"
+    assert yaml.safe_load(actual.decode("utf-8"))["last_updated"] == now
+
+
+def test_advance_sends_bytes_to_the_atomic_writer(tmp_path, monkeypatch):
+    """All-platform oracle for the atomic-writer binding and payload type site."""
+    board = (
+        b"last_updated: 01-06-2026 10:00\r\n"
+        b"development_status:\r\n"
+        b"  epic-3: backlog\r\n"
+        b"  3-1-login: backlog\r\n"
+    )
+    p = tmp_path / "sprint-status.yaml"
+    p.write_bytes(board)
+    writes: list[bytes | str] = []
+
+    def record(path: Path, payload: bytes | str, *, follow_symlinks: bool = True) -> None:
+        writes.append(payload)
+        raw = payload if isinstance(payload, bytes) else payload.encode("utf-8")
+        real_atomic_write_bytes(path, raw, follow_symlinks=follow_symlinks)
+
+    # Wrap both names so the writer-choice ablation still reaches the payload
+    # assertion instead of escaping through whichever module binding it restores.
+    monkeypatch.setattr(sprintstatus, "atomic_write_bytes", record, raising=False)
+    monkeypatch.setattr(sprintstatus, "atomic_write_text", record, raising=False)
+
+    assert sprintstatus.advance(p, "3-1-login", "in-progress") == "in-progress"
+
+    assert len(writes) == 1
+    payload = writes[0]
+    assert isinstance(payload, bytes)
+    assert b"  epic-3: in-progress\r\n" in payload
+    assert b"  3-1-login: in-progress\r\n" in payload
+
+
 # ------------------------------------------------------------ atomic rewrite (#379)
 
 
@@ -323,10 +433,10 @@ def test_advance_write_failure_raises_and_leaves_the_board_entire(tmp_path, monk
     p = _write(tmp_path)
     before = p.read_bytes()
 
-    def boom(path, text, *, follow_symlinks=True):
+    def boom(path, data: bytes, *, follow_symlinks=True):
         raise OSError("no space left on device")
 
-    monkeypatch.setattr(sprintstatus, "atomic_write_text", boom)
+    monkeypatch.setattr(sprintstatus, "atomic_write_bytes", boom)
     with pytest.raises(OSError, match="no space left"):
         sprintstatus.advance(p, "3-2-digest-delivery", "in-progress")
 


### PR DESCRIPTION
## Problem

A one-story sprint-board edit passed every line ending through universal-newline translation. Parsed YAML content and the requested story, conditional parent-epic, and optional timestamp changes remained correct, but tracked boards could show whole-file newline-only diffs across platforms.

## Fix

Read raw bytes and decode them as UTF-8, carry each line's exact terminator through `_set_mapping_value`, then encode and publish the result with the atomic bytes helper. The established atomic-write behavior and default symlink following remain intact.

## Scope note

This adds no scope beyond #576: no lock or concurrency change, no line-ending normalization policy, no `load()` change, and no public API, config, or exit-code change. The merged #366 quote/comment behavior remains unchanged.

## Visible behavior diffs

Valid UTF-8 boards with CRLF, LF, bare-CR, or mixed endings retain their authored per-line terminators. Only the existing story, conditional parent-epic, and optional `last_updated` values change.

## Testing

- Focused current-head rows: T1-T5 plus the symlink-following contract passed, 6/6, after every restored mutation.
- Full suite: `5695 passed, 50 skipped` with `uv run pytest -q -n logical --durations=15`.
- Pyright: `0 errors, 0 warnings, 0 informations`.
- Trunk formatting: no issues in 3 modified files.
- Whole-repo Trunk lint: no issues in 257 files.
- Release check: version-sync and changelog checks passed.
- `git diff --check`: passed.
- A1 (`read_text`): T1/T3 failed 2/2 on byte equality because authored CRLF and mixed terminators became LF.
- A2 (LF-only matcher strip): T1 failed 1/1 because `advance()` returned `backlog` instead of editing the CRLF line.
- A3 (flat LF emit): T1/T3 failed 2/2 on edited-line byte equality.
- A4 (`atomic_write_text` with a string): T4 failed 1/1 because the captured payload was `str`, not `bytes`.

Closes #576


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Sprint board updates now preserve existing line endings, including CRLF, LF, bare CR, and mixed formats.
  - Updating story status, conditional epic values, and timestamps no longer reformats unrelated content.
  - Board files continue to be written safely while retaining their original UTF-8 formatting.

- **Documentation**
  - Added an Unreleased changelog entry describing line-ending preservation during sprint board updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->