### PR TITLE
fix(tui): responsive modal widths + compact small-height layout (#281)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -312,6 +312,22 @@ breaking changes may land in a minor release.
   rather than a declared failure, and relabelling it as a signature mismatch would bury it. This is
   message quality only — an error escaping here already unwound the composition it had started.
 
+- **A modal dialog on a terminal narrower than its declared width now shrinks to fit instead of
+  being clipped, so its action buttons stay reachable (#281).** The docked button row is
+  right-aligned, so the buttons were exactly what fell off the right edge — the horizontal twin of
+  the vertical defect #275/#280 fixed. `EscalationModal` needed 87 columns, so a standard
+  80-column terminal already clipped it outright; `DecisionModal` needed 83 and the bounded
+  confirms 61. Below 60 columns those buttons additionally render smaller and tighter, because
+  clamping the dialog alone still leaves a three-button row demanding 54 columns inside a content
+  region narrower than that.
+
+  On the other axis, below 20 rows a dialog now renders in a compact layout — collapsed padding,
+  no title margin, a one-row button row — rather than clipping its docked buttons and safety
+  warnings. `docs/tui-guide.md` accordingly documents a supported minimum terminal size, **39
+  columns × 9 rows**, which is a new user-facing contract; it is a floor for the dialogs
+  specifically, not for the dashboard behind them. At 60 columns and 20 rows and above the full
+  chrome renders exactly as it does today.
+
 ## [0.10.0] — 2026-08-14
 
 Much of this section is the `release/0.9.x` hotfix line brought forward onto `main` (#433).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -323,17 +323,18 @@ breaking changes may land in a minor release.
 
   On the other axis, below 20 rows a dialog now renders in a compact layout — collapsed padding,
   no title margin, a one-row button row — rather than clipping its docked buttons and safety
-  warnings. `docs/tui-guide.md` accordingly documents a supported minimum terminal size, **39
-  columns × 9 rows**, which is a new user-facing contract; it is a floor for the dialogs
-  specifically, not for the dashboard behind them, and it is the floor for a dialog's own chrome
-  rather than for the text it is handed. `EscalationModal` sets it and its height floor is
-  width-dependent, its docked warning wrapping to 9 rows at 39 columns but 6 at 80. Titles,
-  headers and paths dock outside the scrolling body, so a long enough one wraps and costs rows the
-  body cannot give back: a ~300-character deferred-work heading clips the close button, the
-  validate viewer grows with its document's spec folder (#629), and the spec viewer's `copy path`
-  button plus its action verbs simply do not fit 39 columns (#628). A standard 80 × 24 terminal
-  absorbs all of them. At 60 columns and 20 rows and above the full chrome renders
-  exactly as it does today.
+  warnings. `docs/tui-guide.md` accordingly records the terminal sizes these dialogs were measured
+  at — **39 columns × 9 rows** for a dialog's own chrome — stated as sizes measured to be
+  sufficient rather than as a supported minimum, and scoped to the dialogs, not the dashboard
+  behind them. `EscalationModal` sets that figure and it is width-dependent, its docked warning
+  wrapping to 9 rows at 39 columns but 6 at 80. Titles, headers and paths dock outside the
+  scrolling body, so a long enough one wraps and costs rows the body cannot give back: a
+  ~300-character deferred-work heading clips the close button, the validate viewer grows with its
+  document's spec folder (#629), and the spec viewer's `copy path` button plus its action verbs
+  simply do not fit 39 columns (#628). Nothing bounds that caller-supplied text, so no fixed size
+  is a minimum these dialogs will always meet; a standard 80 × 24 terminal absorbed every measured
+  example and the guide quotes it on those terms. At 60 columns and 20 rows and above the full
+  chrome renders exactly as it does today.
 
 ## [0.10.0] — 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -325,9 +325,11 @@ breaking changes may land in a minor release.
   no title margin, a one-row button row — rather than clipping its docked buttons and safety
   warnings. `docs/tui-guide.md` accordingly documents a supported minimum terminal size, **39
   columns × 9 rows**, which is a new user-facing contract; it is a floor for the dialogs
-  specifically, not for the dashboard behind them, and it excludes the spec viewer's
-  plan-checkpoint variant, whose four button labels are wider than a 39-column dialog can hold
-  (#628). At 60 columns and 20 rows and above the full chrome renders exactly as it does today.
+  specifically, not for the dashboard behind them, and it excludes the two viewers that dock
+  chrome which wraps — the validate-findings header needs one more row at 39 columns (#629), and
+  the spec viewer's `copy path` button plus its action verbs are wider than a 39-column dialog can
+  hold (#628). At 60 columns and 20 rows and above the full chrome renders exactly as it does
+  today.
 
 ## [0.10.0] — 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -325,8 +325,9 @@ breaking changes may land in a minor release.
   no title margin, a one-row button row — rather than clipping its docked buttons and safety
   warnings. `docs/tui-guide.md` accordingly documents a supported minimum terminal size, **39
   columns × 9 rows**, which is a new user-facing contract; it is a floor for the dialogs
-  specifically, not for the dashboard behind them. At 60 columns and 20 rows and above the full
-  chrome renders exactly as it does today.
+  specifically, not for the dashboard behind them, and it excludes the spec viewer's
+  plan-checkpoint variant, whose four button labels are wider than a 39-column dialog can hold
+  (#628). At 60 columns and 20 rows and above the full chrome renders exactly as it does today.
 
 ## [0.10.0] — 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -325,11 +325,14 @@ breaking changes may land in a minor release.
   no title margin, a one-row button row — rather than clipping its docked buttons and safety
   warnings. `docs/tui-guide.md` accordingly documents a supported minimum terminal size, **39
   columns × 9 rows**, which is a new user-facing contract; it is a floor for the dialogs
-  specifically, not for the dashboard behind them, and it excludes the two viewers that dock chrome
-  which wraps, whose floors move with what they display rather than being fixed — the
-  validate-findings header grows with the document's own spec folder (#629), and the spec viewer's
-  `copy path` button plus its action verbs are wider than a 39-column dialog can hold (#628). Both
-  fit a standard 80 × 24 terminal. At 60 columns and 20 rows and above the full chrome renders
+  specifically, not for the dashboard behind them, and it is the floor for a dialog's own chrome
+  rather than for the text it is handed. `EscalationModal` sets it and its height floor is
+  width-dependent, its docked warning wrapping to 9 rows at 39 columns but 6 at 80. Titles,
+  headers and paths dock outside the scrolling body, so a long enough one wraps and costs rows the
+  body cannot give back: a ~300-character deferred-work heading clips the close button, the
+  validate viewer grows with its document's spec folder (#629), and the spec viewer's `copy path`
+  button plus its action verbs simply do not fit 39 columns (#628). A standard 80 × 24 terminal
+  absorbs all of them. At 60 columns and 20 rows and above the full chrome renders
   exactly as it does today.
 
 ## [0.10.0] — 2026-08-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -325,11 +325,12 @@ breaking changes may land in a minor release.
   no title margin, a one-row button row — rather than clipping its docked buttons and safety
   warnings. `docs/tui-guide.md` accordingly documents a supported minimum terminal size, **39
   columns × 9 rows**, which is a new user-facing contract; it is a floor for the dialogs
-  specifically, not for the dashboard behind them, and it excludes the two viewers that dock
-  chrome which wraps — the validate-findings header needs one more row at 39 columns (#629), and
-  the spec viewer's `copy path` button plus its action verbs are wider than a 39-column dialog can
-  hold (#628). At 60 columns and 20 rows and above the full chrome renders exactly as it does
-  today.
+  specifically, not for the dashboard behind them, and it excludes the two viewers that dock chrome
+  which wraps, whose floors move with what they display rather than being fixed — the
+  validate-findings header grows with the document's own spec folder (#629), and the spec viewer's
+  `copy path` button plus its action verbs are wider than a 39-column dialog can hold (#628). Both
+  fit a standard 80 × 24 terminal. At 60 columns and 20 rows and above the full chrome renders
+  exactly as it does today.
 
 ## [0.10.0] — 2026-08-14
 

--- a/docs/tui-guide.md
+++ b/docs/tui-guide.md
@@ -27,7 +27,13 @@ option forms, the escalation and checkpoint viewers — are the tightest thing t
 TUI draws, and **39 columns × 9 rows** is the floor at which every one of them
 still shows its title, a row of body, and all of its docked action buttons. That
 is a floor for the dialogs specifically, not for the dashboard behind them,
-which simply shows fewer rows as the window shrinks. Below **60 columns or 20
+which simply shows fewer rows as the window shrinks. One dialog is outside that
+floor: the spec viewer's plan-checkpoint variant docks four buttons (`copy
+path`, `Approve & resume`, `Request replan`, `close`) whose labels alone are
+wider than a 39-column dialog's content region, so no amount of shrinking the
+button metrics makes them fit. It needs 77 columns — with one isolated
+59-column window where the narrow metrics happen to line up — and wrapping that
+row is tracked separately (#628). Below **60 columns or 20
 rows** the dialogs degrade to a compact layout rather than clipping: the dialog
 clamps to the screen width, the action buttons shrink and tighten, and vertically
 the padding, the title margin and the button-row margin collapse while the

--- a/docs/tui-guide.md
+++ b/docs/tui-guide.md
@@ -27,13 +27,19 @@ option forms, the escalation and checkpoint viewers — are the tightest thing t
 TUI draws, and **39 columns × 9 rows** is the floor at which every one of them
 still shows its title, a row of body, and all of its docked action buttons. That
 is a floor for the dialogs specifically, not for the dashboard behind them,
-which simply shows fewer rows as the window shrinks. One dialog is outside that
-floor: the spec viewer's plan-checkpoint variant docks four buttons (`copy
-path`, `Approve & resume`, `Request replan`, `close`) whose labels alone are
-wider than a 39-column dialog's content region, so no amount of shrinking the
-button metrics makes them fit. It needs 77 columns — with one isolated
-59-column window where the narrow metrics happen to line up — and wrapping that
-row is tracked separately (#628). Below **60 columns or 20
+which simply shows fewer rows as the window shrinks. Two viewers sit outside
+that floor, both because they dock chrome that wraps: wrapped lines are content,
+so the compact layout cannot collapse them the way it collapses padding. The
+validate-findings viewer's header wraps to five lines at 39 columns and so needs
+**one more row** — 39 × 10 — while a wider window that lets the header wrap less
+needs no extra row at all (#629). The spec viewer docks a `copy path` button
+alongside its action verbs,
+whose labels alone are wider than a 39-column dialog's content region, and it
+prints the full spec path above the body, so a path long enough to wrap can push
+the action row off a 9-row screen altogether. Its floor is therefore a function
+of the spec path and of which action verbs the caller supplies rather than a
+single number, and a standard **80 × 24** terminal shows either variant in full.
+Wrapping that row is tracked separately (#628). Below **60 columns or 20
 rows** the dialogs degrade to a compact layout rather than clipping: the dialog
 clamps to the screen width, the action buttons shrink and tighten, and vertically
 the padding, the title margin and the button-row margin collapse while the

--- a/docs/tui-guide.md
+++ b/docs/tui-guide.md
@@ -22,28 +22,37 @@ Linux, so tmux works there unchanged; native Windows awaits a Windows-capable ba
 `bmad-loop mux` shows which backend is selected and why, and the Settings editor's
 `mux.backend` (or the `BMAD_LOOP_MUX_BACKEND` env var) forces the choice per machine.
 
-**Minimum terminal size.** The modal dialogs — confirmations, the start/sweep
-option forms, the escalation and checkpoint viewers — are the tightest thing the
-TUI draws, and **39 columns × 9 rows** is the floor at which a dialog's own
-chrome still fits: its border, padding, title line and margins, a row of body,
-and the whole docked button row. That is a floor for the **dialogs**, not for
+**Terminal sizes, as measured.** The modal dialogs — confirmations, the
+start/sweep option forms, the escalation and checkpoint viewers — are the
+tightest thing the TUI draws. The figures below describe those **dialogs**, not
 the dashboard behind them, which simply shows fewer rows as the window shrinks.
-`EscalationModal` sets it, and its height floor is width-dependent because its
-docked warning wraps — 9 rows at 39 columns but only 6 at 80 — so a roomier
-window buys height as well as width.
+**39 columns × 9 rows** is the size at which a dialog's own chrome was measured
+to fit: its border, padding, title line and margins, a row of body, and the
+whole docked button row. `EscalationModal` is what sets it, and its height is
+width-dependent because its docked warning wraps — 9 rows at 39 columns but only
+6 at 80 — so a roomier window buys height as well as width.
 
-That floor covers the chrome, not the text a dialog is handed. Titles, headers,
-warnings and file paths are docked _outside_ the scrolling body, so each line
-they wrap to costs a row the body cannot give back, the body having floored at
-one row. A dialog showing long enough caller-supplied text therefore has no
-fixed minimum. Measured at 39 columns: a deferred-work heading of about 150
-characters still fits, while about 300 characters wraps to nine rows of title
-and pushes the close button off; the validate-findings viewer needs one extra
-row for a plain result and three when the document carries a long spec folder;
-and the spec viewer's `copy path` button alongside its action verbs is wider
-than a 39-column dialog can hold whatever the button metrics do, over and above
-a spec path that wraps. All of them fit a standard **80 × 24** terminal, which
-is the size to rely on wherever the content is not bounded (#628, #629).
+That is a measurement of the chrome, not of the text a dialog is handed, and it
+is not a size you can rely on. Titles, headers, warnings and file paths are
+docked _outside_ the scrolling body, so each line they wrap to costs a row the
+body cannot give back, the body having floored at one row. That text comes from
+the caller and **nothing bounds its length** — a deferred-work ledger title, a
+`spec:` folder, a spec path. A long enough value therefore consumes the frame
+and clips the docked controls at **any** fixed size, so no figure here — 39 × 9,
+80 × 24, or larger — is a minimum these dialogs will always meet. Bounding that
+text is tracked in #629, and the spec viewer's over-wide action row in #628.
+
+What the figures do say is that these sizes were sufficient for the dialogs as
+measured, at the content lengths the test suite exercises. Measured at 39
+columns: a deferred-work heading of about 150 characters still fits, while about
+300 characters wraps to nine rows of title and pushes the close button off; the
+validate-findings viewer needs one extra row for a plain result and three when
+the document carries a long spec folder; and the spec viewer's `copy path`
+button alongside its action verbs is wider than a 39-column dialog can hold
+whatever the button metrics do, over and above a spec path that wraps. A
+standard **80 × 24** terminal was sufficient for every one of those measured
+examples, which is why it is the size quoted wherever the content is unbounded —
+as one that worked for what was measured, not as one that cannot be overrun.
 
 Below **60 columns or 20 rows** the dialogs degrade to a compact layout rather
 than clipping: the dialog clamps to the screen width, the action buttons shrink

--- a/docs/tui-guide.md
+++ b/docs/tui-guide.md
@@ -29,17 +29,18 @@ still shows its title, a row of body, and all of its docked action buttons. That
 is a floor for the dialogs specifically, not for the dashboard behind them,
 which simply shows fewer rows as the window shrinks. Two viewers sit outside
 that floor, both because they dock chrome that wraps: wrapped lines are content,
-so the compact layout cannot collapse them the way it collapses padding. The
-validate-findings viewer's header wraps to five lines at 39 columns and so needs
-**one more row** — 39 × 10 — while a wider window that lets the header wrap less
-needs no extra row at all (#629). The spec viewer docks a `copy path` button
-alongside its action verbs,
-whose labels alone are wider than a 39-column dialog's content region, and it
-prints the full spec path above the body, so a path long enough to wrap can push
-the action row off a 9-row screen altogether. Its floor is therefore a function
-of the spec path and of which action verbs the caller supplies rather than a
-single number, and a standard **80 × 24** terminal shows either variant in full.
-Wrapping that row is tracked separately (#628). Below **60 columns or 20
+so the compact layout cannot collapse them the way it collapses padding. Neither
+has a fixed minimum — each one's floor moves with what it is being asked to
+show — and a standard **80 × 24** terminal displays both in full. The
+validate-findings viewer's header carries the run mode and the spec folder, and
+that folder is user-controlled, so how far it wraps is a property of the
+document: a plain result needs one row more than the floor at 39 columns, and a
+long spec folder needs three (#629). The spec viewer docks a `copy path` button
+alongside its action verbs, whose labels alone are wider than a 39-column
+dialog's content region, and it prints the full spec path above the body, so a
+path long enough to wrap can push the action row off a 9-row screen altogether;
+its floor follows that path and the action verbs the caller supplies (#628).
+Below **60 columns or 20
 rows** the dialogs degrade to a compact layout rather than clipping: the dialog
 clamps to the screen width, the action buttons shrink and tighten, and vertically
 the padding, the title margin and the button-row margin collapse while the

--- a/docs/tui-guide.md
+++ b/docs/tui-guide.md
@@ -24,31 +24,32 @@ Linux, so tmux works there unchanged; native Windows awaits a Windows-capable ba
 
 **Minimum terminal size.** The modal dialogs — confirmations, the start/sweep
 option forms, the escalation and checkpoint viewers — are the tightest thing the
-TUI draws, and **39 columns × 9 rows** is the floor at which every one of them
-still shows its title, a row of body, and all of its docked action buttons. That
-is a floor for the dialogs specifically, not for the dashboard behind them,
-which simply shows fewer rows as the window shrinks. Two viewers sit outside
-that floor, both because they dock chrome that wraps: wrapped lines are content,
-so the compact layout cannot collapse them the way it collapses padding. Neither
-has a fixed minimum — each one's floor moves with what it is being asked to
-show — and a standard **80 × 24** terminal displays both in full. The
-validate-findings viewer's header carries the run mode and the spec folder, and
-that folder is user-controlled, so how far it wraps is a property of the
-document: a plain result needs one row more than the floor at 39 columns, and a
-long spec folder needs three (#629). The spec viewer docks a `copy path` button
-alongside its action verbs, whose labels alone are wider than a 39-column
-dialog's content region, and it prints the full spec path above the body, so a
-path long enough to wrap can push the action row off a 9-row screen altogether;
-its floor follows that path and the action verbs the caller supplies (#628).
-Below **60 columns or 20
-rows** the dialogs degrade to a compact layout rather than clipping: the dialog
-clamps to the screen width, the action buttons shrink and tighten, and vertically
-the padding, the title margin and the button-row margin collapse while the
-buttons render one row tall instead of three. At 60 columns and 20 rows and above
-you get the full chrome, unchanged. The height floor is width-dependent where a
-dialog docks a wrapping warning — the escalation viewer needs 9 rows at 39
-columns but only 6 at 80 — so a roomier window buys height as well as width
-(#281).
+TUI draws, and **39 columns × 9 rows** is the floor at which a dialog's own
+chrome still fits: its border, padding, title line and margins, a row of body,
+and the whole docked button row. That is a floor for the **dialogs**, not for
+the dashboard behind them, which simply shows fewer rows as the window shrinks.
+`EscalationModal` sets it, and its height floor is width-dependent because its
+docked warning wraps — 9 rows at 39 columns but only 6 at 80 — so a roomier
+window buys height as well as width.
+
+That floor covers the chrome, not the text a dialog is handed. Titles, headers,
+warnings and file paths are docked _outside_ the scrolling body, so each line
+they wrap to costs a row the body cannot give back, the body having floored at
+one row. A dialog showing long enough caller-supplied text therefore has no
+fixed minimum. Measured at 39 columns: a deferred-work heading of about 150
+characters still fits, while about 300 characters wraps to nine rows of title
+and pushes the close button off; the validate-findings viewer needs one extra
+row for a plain result and three when the document carries a long spec folder;
+and the spec viewer's `copy path` button alongside its action verbs is wider
+than a 39-column dialog can hold whatever the button metrics do, over and above
+a spec path that wraps. All of them fit a standard **80 × 24** terminal, which
+is the size to rely on wherever the content is not bounded (#628, #629).
+
+Below **60 columns or 20 rows** the dialogs degrade to a compact layout rather
+than clipping: the dialog clamps to the screen width, the action buttons shrink
+and tighten, and vertically the padding, the title margin and the button-row
+margin collapse while the buttons render one row tall instead of three. At 60
+columns and 20 rows and above you get the full chrome, unchanged (#281).
 
 Over a slow or high-latency link (SSH, Tailscale), a 60fps update stream can't
 drain in time and partial frames paint over old ones. Launch with

--- a/docs/tui-guide.md
+++ b/docs/tui-guide.md
@@ -22,6 +22,21 @@ Linux, so tmux works there unchanged; native Windows awaits a Windows-capable ba
 `bmad-loop mux` shows which backend is selected and why, and the Settings editor's
 `mux.backend` (or the `BMAD_LOOP_MUX_BACKEND` env var) forces the choice per machine.
 
+**Minimum terminal size.** The modal dialogs — confirmations, the start/sweep
+option forms, the escalation and checkpoint viewers — are the tightest thing the
+TUI draws, and **39 columns × 9 rows** is the floor at which every one of them
+still shows its title, a row of body, and all of its docked action buttons. That
+is a floor for the dialogs specifically, not for the dashboard behind them,
+which simply shows fewer rows as the window shrinks. Below **60 columns or 20
+rows** the dialogs degrade to a compact layout rather than clipping: the dialog
+clamps to the screen width, the action buttons shrink and tighten, and vertically
+the padding, the title margin and the button-row margin collapse while the
+buttons render one row tall instead of three. At 60 columns and 20 rows and above
+you get the full chrome, unchanged. The height floor is width-dependent where a
+dialog docks a wrapping warning — the escalation viewer needs 9 rows at 39
+columns but only 6 at 80 — so a roomier window buys height as well as width
+(#281).
+
 Over a slow or high-latency link (SSH, Tailscale), a 60fps update stream can't
 drain in time and partial frames paint over old ones. Launch with
 `bmad-loop tui --low-frame-rate` to cap Textual to 15fps and disable

--- a/src/bmad_loop/tui/screens/modals.py
+++ b/src/bmad_loop/tui/screens/modals.py
@@ -38,6 +38,14 @@ class BaseDialog(ModalScreen):
     }
     BaseDialog #dialog {
         width: 64;
+        /* the clamp lives on the SHARED rule on purpose: the five subclasses that
+           widen the dialog (Decision 86, Escalation 90, DeferredEntry/Validate/
+           TextOutput 96, SpecReview 100) override only `width`, never `max-width`,
+           so this one declaration covers all ten and a subclass cannot silently
+           opt out of it. Without it a fixed column count is laid out wider than a
+           narrow terminal and the right-hand side — i.e. the docked button row,
+           which is align-horizontal: right — is clipped off-screen (#281). */
+        max-width: 100%;
         /* height is intentionally auto (not a definite %). Two-tier by design:
            list-heavy modals (Decision/Escalation/StartRun/...) override #dialog
            with a definite height + a 1fr body; the bounded modals (Confirm/
@@ -63,7 +71,30 @@ class BaseDialog(ModalScreen):
     BaseDialog .buttons Button {
         margin-left: 2;
     }
+    /* Clamping #dialog is not enough on its own: Textual's Button is
+       `width: auto; min-width: 16` and the rule above adds a 2-column margin per
+       button, so a three-button row demands 3*16 + 3*2 = 54 columns while a
+       dialog clamped to a 50-column terminal only has 50 - 2 (thick border)
+       - 4 (padding `1 2`) = 44 columns of content — the row still overflows and
+       the right-most button is clipped. Dropping the floor lets each button size
+       to its own label instead. Scoped to `-narrow` so terminals 60 columns and
+       wider keep today's button sizing byte-for-byte. */
+    BaseDialog.-narrow .buttons Button {
+        min-width: 4;
+        margin-left: 1;
+    }
     """
+
+    # Textual applies the matching breakpoint class to the Screen itself on
+    # resize, and BaseDialog IS a ModalScreen — so `-narrow` lands on the dialog
+    # screen and CSS can select `BaseDialog.-narrow ...`. `-narrow` therefore
+    # means "the terminal is under 60 columns". 60 is where an un-narrowed
+    # three-button row (3 * Textual's `min-width: 16` + 3 * `margin-left: 2`
+    # = 54) still fits a clamped dialog's content region (60 - 2 border
+    # - 4 padding = 54). Declaring this here scopes it to dialogs: the App and
+    # DashboardScreen leave their breakpoints at the default, so the dashboard
+    # is unaffected.
+    HORIZONTAL_BREAKPOINTS = [(0, "-narrow"), (60, "-wide")]
 
     BINDINGS = [Binding("escape", "cancel", "cancel")]
 

--- a/src/bmad_loop/tui/screens/modals.py
+++ b/src/bmad_loop/tui/screens/modals.py
@@ -137,9 +137,12 @@ class BaseDialog(ModalScreen):
     # the full chrome. Every figure above is a CHROME measurement, taken with
     # short titles: a title, header, warning or path is docked outside the
     # scrolling body, so a long enough one wraps and costs rows this layout
-    # cannot reclaim — the body is already at its 1-row minimum. Those dialogs
-    # have no fixed floor; docs/tui-guide.md says so and names 80x24 as the size
-    # to rely on instead (#628, #629).
+    # cannot reclaim — the body is already at its 1-row minimum. Nothing bounds
+    # that caller-supplied text, so a long enough value clips the docked controls
+    # at ANY fixed size and those dialogs have no floor to state. That is why
+    # docs/tui-guide.md gives its figures as sizes measured to be sufficient for
+    # the content it exercised rather than as a minimum — 80x24 included
+    # (#628, #629).
     VERTICAL_BREAKPOINTS = [(0, "-short"), (20, "-tall")]
 
     BINDINGS = [Binding("escape", "cancel", "cancel")]

--- a/src/bmad_loop/tui/screens/modals.py
+++ b/src/bmad_loop/tui/screens/modals.py
@@ -134,7 +134,12 @@ class BaseDialog(ModalScreen):
     # #body). The compact layout has to engage before anything clips, not at the
     # moment it does, so the threshold is above 14 rather than on it. It is also
     # below the 24 rows of a default terminal, so an ordinary window still gets
-    # the full chrome.
+    # the full chrome. Every figure above is a CHROME measurement, taken with
+    # short titles: a title, header, warning or path is docked outside the
+    # scrolling body, so a long enough one wraps and costs rows this layout
+    # cannot reclaim — the body is already at its 1-row minimum. Those dialogs
+    # have no fixed floor; docs/tui-guide.md says so and names 80x24 as the size
+    # to rely on instead (#628, #629).
     VERTICAL_BREAKPOINTS = [(0, "-short"), (20, "-tall")]
 
     BINDINGS = [Binding("escape", "cancel", "cancel")]

--- a/src/bmad_loop/tui/screens/modals.py
+++ b/src/bmad_loop/tui/screens/modals.py
@@ -83,6 +83,35 @@ class BaseDialog(ModalScreen):
         min-width: 4;
         margin-left: 1;
     }
+    /* The vertical twin. Before any body content a dialog spends 10 rows of
+       chrome: 2 border (1 per side — every Textual border STYLE is exactly one
+       cell, so `thick` -> `round` would save nothing), 2 padding, 1 title,
+       1 title margin-bottom, 1 .buttons margin-top and 3 for the button row
+       (Textual's Button is `border: tall`, so a one-line label is 3 rows).
+       `max-height: 90%` then turns those 10 rows into a per-modal terminal-height
+       floor of 12-14. Under `-short` the chrome collapses to 4 rows — padding
+       0 1, no title margin, no button margin, a 1-row borderless button — and
+       max-height goes to 100% so the dialog may use the last row. The `#dialog`
+       BORDER IS DELIBERATELY KEPT: it is the only thing separating the dialog
+       from the dashboard rendered behind a ModalScreen, and the 2 rows it costs
+       are not needed to clear the floor. Nothing here sets a definite `height`
+       — that would balloon the bounded tier, see
+       test_short_confirm_modal_stays_compact — and nothing here touches `width`,
+       which is the `-narrow` axis above. */
+    BaseDialog.-short #dialog {
+        max-height: 100%;
+        padding: 0 1;
+    }
+    BaseDialog.-short .title {
+        margin-bottom: 0;
+    }
+    BaseDialog.-short .buttons {
+        margin-top: 0;
+    }
+    BaseDialog.-short .buttons Button {
+        height: 1;
+        border: none;
+    }
     """
 
     # Textual applies the matching breakpoint class to the Screen itself on
@@ -95,6 +124,18 @@ class BaseDialog(ModalScreen):
     # DashboardScreen leave their breakpoints at the default, so the dashboard
     # is unaffected.
     HORIZONTAL_BREAKPOINTS = [(0, "-narrow"), (60, "-wide")]
+
+    # Same mechanism on the other axis: `-short` means "the terminal is under 20
+    # rows". 20 is chosen to sit clear of the tallest measured pre-fix frame
+    # floor — the height at which every docked control of a modal is fully
+    # on-screen: ConfirmModal 12, StartSweep 13, StoryCheckpoint 13, and 14 for
+    # ConfirmModal WITH a warning (the ConfirmResumeModal case, whose
+    # double-drive warning gates a destructive confirm and is docked outside
+    # #body). The compact layout has to engage before anything clips, not at the
+    # moment it does, so the threshold is above 14 rather than on it. It is also
+    # below the 24 rows of a default terminal, so an ordinary window still gets
+    # the full chrome.
+    VERTICAL_BREAKPOINTS = [(0, "-short"), (20, "-tall")]
 
     BINDINGS = [Binding("escape", "cancel", "cancel")]
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -144,21 +144,51 @@ async def until(pilot, condition, timeout: float = 10.0) -> None:
         waited += 0.05
 
 
-async def ready(pilot, selector: str):
+async def ready(pilot, selector: str, timeout: float = 10.0):
     """Wait until a modal widget is mounted *and* laid out on-screen, then return it.
 
     A screen-type `until` returns the instant push_screen swaps app.screen — before
     the modal's children mount (query NoMatches) or receive a layout region (click
     OutOfBounds, region still 0). Gating on a real on-screen region makes the
     following query_one / click / value-set safe on slow CI runners. A modal's
-    widgets mount and lay out together, so one gate covers every field in it."""
+    widgets mount and lay out together, so one gate covers every field in it.
+
+    That gate alone stopped being enough once BaseDialog grew breakpoints (#281).
+    The breakpoint class is on the screen by the time the first widget has a
+    region — but the stylesheet reapply it triggers is still QUEUED, so the first
+    laid-out pass carries the un-classed metrics and the real layout arrives a
+    frame later. Measured on StoryCheckpointModal at 45 columns, the docked row
+    reads Textual's default `Button min-width: 16` on that first pass
+    (x=5/23/41, each 16 wide, so the last ends at column 57 — off a 45-column
+    screen) and the `-narrow` metrics (14/10/7) on the next.
+
+    So this also pumps the queue until the screen's layout stops moving. It is
+    the message pump, not a sleep, that does the work: the pending reapply is a
+    message, and each `pause` drains it. Requiring the regions to repeat lets a
+    slow runner take as many frames as it needs. Everything downstream — a
+    reachability assert, a `scroll_visible` target, a click coordinate — is then
+    computed against the settled layout rather than a doomed intermediate one.
+    Under load this is worth 2-3 failures per 25 runs on the tests it covers."""
 
     def _hit():
         hits = pilot.app.screen.query(selector)
         node = hits.first() if hits else None
         return node if node is not None and node.region.area > 0 else None
 
-    await until(pilot, lambda: _hit() is not None)
+    await until(pilot, lambda: _hit() is not None, timeout)
+
+    def _layout():
+        return tuple(w.region for w in pilot.app.screen.query("*"))
+
+    previous, stable, waited = None, 0, 0.0
+    while stable < 3:
+        if waited >= timeout:
+            raise AssertionError("screen layout never settled")
+        await pilot.pause(0.05)
+        waited += 0.05
+        current = _layout()
+        stable = stable + 1 if current == previous else 0
+        previous = current
     return _hit()
 
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1483,6 +1483,100 @@ async def test_settings_binding_opens_editor(project):
         await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
 
 
+# ---- #281 modal dialogs shrink to fit narrow terminals (horizontal axis)
+#
+# Measured minimum terminal WIDTH at which every docked button is fully
+# on-screen — before this fix / after it: DecisionModal 83 -> 12,
+# EscalationModal 87 -> 39, ConfirmModal 61 -> 22, StartSweepModal 61 -> 20,
+# StoryCheckpointModal 61 -> 37. EscalationModal's 87 means a standard
+# 80-column terminal clipped it.
+
+
+async def test_decision_modal_clamps_to_narrow_terminal(project):
+    """A 50-column terminal is narrower than DecisionModal's declared width: 86.
+    `max-width: 100%` on the shared BaseDialog #dialog rule clamps it to the
+    screen, so the docked skip button is reachable instead of being laid out past
+    the right edge (#281). The width assertion pins the clamp; the reachability
+    assertion is what the user actually feels."""
+    app = BmadLoopApp(project.project)
+    async with app.run_test(size=(50, 30)) as pilot:
+        await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
+        app.push_screen(DecisionModal(_long_decision()))
+        await until(pilot, lambda: isinstance(app.screen, DecisionModal))
+        await ready(pilot, "#body")
+        # clamped to the terminal, not laid out at its declared 86 columns
+        assert app.screen.query_one("#dialog").region.width == 50
+        assert _on_screen(app, app.screen.query_one("#cancel", Button))
+
+
+async def test_escalation_modal_three_buttons_reachable_when_narrow(project):
+    """The three-button escalation row at 45 columns — the case the clamp alone
+    does NOT fix, so this is the test that earns the `-narrow` rule.
+
+    At 45 columns the clamped dialog has 45 - 2 (thick border) - 4 (padding) = 39
+    columns of content, while Textual's default `Button min-width: 16` plus
+    BaseDialog's `margin-left: 2` demands 3*16 + 3*2 = 54 for three buttons — the
+    row overflows and the right-most button is clipped. Measured: with the clamp
+    but WITHOUT `BaseDialog.-narrow .buttons Button`, this modal still needs 58
+    columns. So this test covers the `-narrow` rule, not merely `max-width` —
+    deleting that rule must redden this test, and T1 does not cover it."""
+    app = BmadLoopApp(project.project)
+    async with app.run_test(size=(45, 30)) as pilot:
+        await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
+        app.push_screen(
+            EscalationModal(
+                story_key="e-1-s",
+                title="t",
+                description="d",
+                blocking="b",
+                sentinel_kind="",
+                resolution_ready=True,
+                engine_live=False,
+                restore_recorded=True,
+            )
+        )
+        await until(pilot, lambda: isinstance(app.screen, EscalationModal))
+        await ready(pilot, "#body")
+        for bid in ("#act-resolve", "#act-rearm", "#cancel"):
+            assert _on_screen(app, app.screen.query_one(bid, Button)), bid
+
+
+async def test_story_checkpoint_three_buttons_reachable_when_narrow(project):
+    """The other three-button row, same 45-column bound as the escalation case:
+    measured at 57 columns with the clamp alone, so this too rests on `-narrow`."""
+    app = BmadLoopApp(project.project)
+    async with app.run_test(size=(45, 30)) as pilot:
+        await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
+        app.push_screen(
+            StoryCheckpointModal(
+                story_key="e-1-s",
+                title="t",
+                commit="abc123",
+                verify_line="v",
+                tokens="0",
+            )
+        )
+        await until(pilot, lambda: isinstance(app.screen, StoryCheckpointModal))
+        await ready(pilot, "#body")
+        for bid in ("#act-continue", "#act-stop", "#cancel"):
+            assert _on_screen(app, app.screen.query_one(bid, Button)), bid
+
+
+async def test_wide_terminal_dialog_width_unchanged(project):
+    """The clamp must not shrink a dialog that already fits: at 120 columns a
+    ConfirmModal still lays out at its declared 64, and 120 is above the 60-column
+    `-narrow` breakpoint so the button row keeps today's sizing. Guards the fix
+    against becoming a visible regression for normal-width terminals (#281)."""
+    app = BmadLoopApp(project.project)
+    async with app.run_test(size=(120, 30)) as pilot:
+        await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
+        app.push_screen(ConfirmModal("t", "body"))
+        await until(pilot, lambda: isinstance(app.screen, ConfirmModal))
+        await ready(pilot, "#body")
+        assert app.screen.query_one("#dialog").region.width == 64
+        assert "-narrow" not in app.screen.classes  # the breakpoint did not engage
+
+
 # ------------------------------------------------------------- run control
 
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1857,30 +1857,44 @@ async def test_spec_review_modal_operable_on_a_standard_terminal(project, action
             assert _on_screen(app, app.screen.query_one(selector)), selector
 
 
-async def test_validate_findings_modal_clears_the_floor_one_row_higher(project):
-    """The other documented exception: this modal needs 39x10, not 39x9 (#629).
+_LONG_SPEC_FOLDER = "docs/specs/epics/epic-1/stories/generated/very-long-folder-name"
 
-    Its `.title` is `widgets.validate_header(doc)` — a multi-line header docked
-    outside the scrolling `#findings` body — and at 39 columns it wraps to five
-    rows, which puts the button row at y=9 on a screen whose rows are 0-8. The
-    `-short` rules cannot buy that back: they collapse padding and margins, and
-    this cost is content. One more row clears it.
 
-    The 10 is specific to the document built here, since a header that wraps to
-    more lines costs more rows, so this asserts the size works rather than
-    treating 10 as the modal's universal floor. 39 is held fixed so the test
-    still runs in the narrow band the wrap depends on."""
+@pytest.mark.parametrize(
+    ("kwargs", "size"),
+    [
+        ({}, (_MIN_COLS, _MIN_ROWS + 1)),
+        ({"stories_on": True, "spec_folder": _LONG_SPEC_FOLDER}, (_MIN_COLS, _MIN_ROWS + 3)),
+        ({"stories_on": True, "spec_folder": _LONG_SPEC_FOLDER}, (80, 24)),
+    ],
+    ids=["plain-39x10", "long-spec-folder-39x12", "long-spec-folder-80x24"],
+)
+async def test_validate_findings_modal_floor_moves_with_its_header(project, kwargs, size):
+    """The other documented exception, and its floor is content-dependent (#629).
+
+    `.title` is `widgets.validate_header(doc)`, docked outside the scrolling
+    `#findings` body, so every line it wraps to costs the button row a row that
+    `-short` cannot buy back — collapsing padding and margins does not shrink
+    content. At 39 columns a plain document's header wraps to 5 rows and puts
+    the button row at y=9 on a screen whose rows are 0-8, so it needs 10.
+
+    But the header also carries `spec: <spec_folder>`, and that path is
+    user-controlled (widgets.py:582-585). A 63-character folder takes the header
+    to 7 rows and the floor with it: `#ok` is still clipped at BOTH 39x10 and
+    39x11, and only clears at 39x12. So the three cases here pin the dependence
+    itself rather than a single minimum — which is why docs/tui-guide.md
+    describes this floor as content-dependent and quotes the standard 80x24
+    terminal, the last case, which absorbs either header."""
+    cols, rows = size
     app = BmadLoopApp(project.project)
-    async with app.run_test(size=(_MIN_COLS, _MIN_ROWS + 1)) as pilot:
+    async with app.run_test(size=(cols, rows)) as pilot:
         await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
         modal = ValidateFindingsModal(
-            make_validate_document([("bmad-config", "problem", "a finding", None)])
+            make_validate_document([("bmad-config", "problem", "a finding", None)], **kwargs)
         )
         app.push_screen(modal)
         await until(pilot, lambda: app.screen is modal)
         await ready(pilot, "#findings")
-        assert "-narrow" in app.screen.classes
-        assert "-short" in app.screen.classes
         assert _on_screen(app, app.screen.query_one("#ok"))
 
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1623,8 +1623,8 @@ async def test_wide_terminal_dialog_width_unchanged(project):
 # ConfirmModal-with-a-warning 14 -> 5, StartSweepModal 13 -> 4,
 # StoryCheckpointModal 13 -> 4, EscalationModal 12 -> 6, DecisionModal 9 -> 4.
 # EscalationModal's floor is width-dependent because its #hint warning wraps:
-# at 39 columns (phase 1's narrowest supported width) it is 15 -> 9, which is
-# the 39x9 joint minimum documented in docs/tui-guide.md.
+# at 39 columns (phase 1's narrowest measured width) it is 15 -> 9, which is the
+# 39x9 pair docs/tui-guide.md records as measured, not as a minimum.
 
 
 async def test_compact_layout_makes_a_short_terminal_usable(project):
@@ -1689,29 +1689,30 @@ async def test_tall_terminal_dialog_height_unchanged(project):
         assert app.screen.query_one("#dialog").region.height == 11
 
 
-# ---- #281 the documented 39x9 minimum, where BOTH breakpoints are engaged
+# ---- #281 the measured 39x9 pair, where BOTH breakpoints are engaged
 #
 # Everything above exercises one axis at a time. This is the corner where
-# `-narrow` and `-short` apply together, and it is the only test of the number
-# docs/tui-guide.md publishes as a user-facing contract — so a rule that is
-# correct on each axis alone but wrong at the intersection reddens here and
-# nowhere else. It is also what keeps the published floor honest: the claim is
-# asserted for every dialog it covers, so a modal cannot quietly stop meeting it.
+# `-narrow` and `-short` apply together, and it is the only test of the pair
+# docs/tui-guide.md records — so a rule that is correct on each axis alone but
+# wrong at the intersection reddens here and nowhere else. It also keeps the
+# published figure honest: it is asserted for every dialog it covers, so a modal
+# cannot quietly stop meeting the size the guide says it was measured at.
 #
-# What the floor covers is a dialog's own CHROME, not the text it is handed, and
-# the cases below are parametrised with short titles for exactly that reason.
+# What was measured is a dialog's own CHROME, not the text it is handed, and the
+# cases below are parametrised with short titles for exactly that reason.
 # Titles, headers, warnings and paths dock OUTSIDE the scrolling body, so every
 # line they wrap to costs a row the body cannot give back — it floors at 1 — and
 # the `-short`/`-narrow` rules cannot shrink content the way they shrink padding.
-# So any dialog handed long enough caller-supplied text has no fixed minimum.
-# Measured at 39 columns: a ~150-character deferred-work heading still fits 9
-# rows, ~300 characters wraps to 9 rows of title and clips the close button; the
-# validate header grows with its document's spec folder; the spec viewer's
-# `copy path` plus its action verbs overflow 39 columns outright. That is one
-# family with three faces, not three defects — tracked in #628 (row too wide)
-# and #629 (docked wrapping text steals rows). The tests below pin the bounded
-# case here, each unbounded case at a size measured to work, and 80x24 as the
-# size to rely on when the content is not bounded.
+# Nothing bounds that caller-supplied text, so a dialog handed a long enough
+# value has no floor to state at all. Measured at 39 columns: a ~150-character
+# deferred-work heading still fits 9 rows, ~300 characters wraps to 9 rows of
+# title and clips the close button; the validate header grows with its
+# document's spec folder; the spec viewer's `copy path` plus its action verbs
+# overflow 39 columns outright. That is one family with three faces, not three
+# defects — tracked in #628 (row too wide) and #629 (docked wrapping text steals
+# rows). The tests below pin the bounded case here, each unbounded case at a
+# size measured to work, and 80x24 as a size that was sufficient for the
+# examples measured — not one an unbounded value cannot overrun.
 
 _MIN_COLS, _MIN_ROWS = 39, 9
 
@@ -1790,9 +1791,10 @@ def _minimum_size_case(name: str, project):
 
 
 @pytest.mark.parametrize("case", _MIN_SIZE_CASES)
-async def test_documented_minimum_terminal_size_keeps_dialogs_operable(project, case):
-    """At the published 39x9 floor every covered dialog still shows its title, a
-    row of body and all of its docked controls (#281).
+async def test_measured_terminal_size_keeps_dialogs_operable(project, case):
+    """At the 39x9 pair the guide records as measured, every covered dialog still
+    shows its title, a row of body and all of its docked controls (#281). Short
+    titles, so this pins the chrome; caller text is unbounded and has no floor.
 
     Both breakpoint classes are asserted present first, so the test fails loudly
     if a future threshold change means this size no longer exercises the compact
@@ -1831,8 +1833,10 @@ async def test_documented_minimum_terminal_size_keeps_dialogs_operable(project, 
     ids=["gate", "plan-checkpoint"],
 )
 async def test_spec_review_modal_operable_on_a_standard_terminal(project, actions, controls):
-    """The spec viewer is the one dialog outside the 39x9 floor, so pin what it
-    does guarantee: a standard 80x24 terminal shows either action row in full.
+    """The spec viewer is the one dialog outside the measured 39x9 pair, so pin
+    what WAS measured: a standard 80x24 terminal shows either action row in full
+    at the path length used here. That is sufficiency for this case, not a size
+    the dialog will meet for every spec path — nothing bounds one (#629).
 
     It has no single floor to pin instead. Two things push it around, and one of
     them is not a width at all: the docked `copy path` button plus the caller's
@@ -1890,7 +1894,8 @@ async def test_validate_findings_modal_floor_moves_with_its_header(project, kwar
     39x11, and only clears at 39x12. So the three cases here pin the dependence
     itself rather than a single minimum — which is why docs/tui-guide.md
     describes this floor as content-dependent and quotes the standard 80x24
-    terminal, the last case, which absorbs either header."""
+    terminal, the last case, which absorbed both headers measured here. A longer
+    folder would move it again; nothing bounds one (#629)."""
     cols, rows = size
     app = BmadLoopApp(project.project)
     async with app.run_test(size=(cols, rows)) as pilot:
@@ -1910,8 +1915,8 @@ async def test_validate_findings_modal_floor_moves_with_its_header(project, kwar
 
 @pytest.mark.parametrize("chars", [150, 300], ids=["fits-the-floor", "overflows-the-floor"])
 async def test_long_docked_title_still_fits_a_standard_terminal(project, chars):
-    """The third face of the same family, and the guarantee the guide falls back
-    on: 80x24 absorbs a docked title no 39-column screen could.
+    """The third face of the same family, and the size the guide falls back on:
+    80x24 absorbed a docked title no 39-column screen could — at these lengths.
 
     `DeferredEntryModal` renders the ledger heading as the docked `.title`,
     outside the scrolling `#entry`, and `parse_ledger` does not bound that text.
@@ -1920,7 +1925,9 @@ async def test_long_docked_title_still_fits_a_standard_terminal(project, chars):
     screen — `#entry` is already at its one-row minimum and has nothing left to
     give. Both lengths are asserted at 80x24 rather than at 39 columns, because
     the point is the fallback size, not another content-specific minimum that a
-    longer heading would falsify (#629)."""
+    longer heading would falsify (#629). A longer heading falsifies 80x24 too —
+    `parse_ledger` bounds nothing — which is why the guide states 80x24 as
+    sufficient for the lengths measured here rather than as a size to rely on."""
     app = BmadLoopApp(project.project)
     async with app.run_test(size=(80, 24)) as pilot:
         await until(pilot, lambda: isinstance(app.screen, DashboardScreen))

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1341,9 +1341,16 @@ async def test_confirm_modal_scrolls_long_body(project):
 async def test_start_sweep_and_checkpoint_buttons_reachable(project):
     """On a short terminal the bounded modals keep their docked action buttons
     on-screen: the body scrolls to absorb the overflow instead of pushing the
-    button row off the bottom. The height (14) sits just above the frame floor —
-    a thick-bordered dialog with a title and a 3-row button row needs ~13 rows
-    before any body content — so the assertion isolates the body-scroll fix."""
+    button row off the bottom. The height (14) sits just above the frame floor,
+    so the assertion isolates the body-scroll fix.
+
+    The frame floor is not a chrome count and it is not one number. The chrome is
+    10 rows — 2 border, 2 padding, 1 title, 1 title margin, 1 button-row margin
+    and 3 for the button row, Textual's Button being `border: tall`. `#dialog` is
+    then capped at `max-height: 90%`, which turns those 10 rows into a per-modal
+    TERMINAL-height floor of 12-14: ConfirmModal 12, StartSweep 13,
+    StoryCheckpoint 13, ConfirmModal-with-a-warning 14. 14 was chosen because it
+    clears the 13-row floor of the two modals this test drives (#281 measured)."""
     app = BmadLoopApp(project.project)
     async with app.run_test(size=(64, 14)) as pilot:
         await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
@@ -1575,6 +1582,81 @@ async def test_wide_terminal_dialog_width_unchanged(project):
         await ready(pilot, "#body")
         assert app.screen.query_one("#dialog").region.width == 64
         assert "-narrow" not in app.screen.classes  # the breakpoint did not engage
+
+
+# ---- #281 modal dialogs degrade to a compact layout on short terminals
+#      (vertical axis)
+#
+# Measured minimum terminal HEIGHT at which a modal's title, one row of body and
+# every docked control (buttons + any docked warning) are fully on-screen —
+# before this fix / after it, at 90-100 columns: ConfirmModal 12 -> 4,
+# ConfirmModal-with-a-warning 14 -> 5, StartSweepModal 13 -> 4,
+# StoryCheckpointModal 13 -> 4, EscalationModal 12 -> 6, DecisionModal 9 -> 4.
+# EscalationModal's floor is width-dependent because its #hint warning wraps:
+# at 39 columns (phase 1's narrowest supported width) it is 15 -> 9, which is
+# the 39x9 joint minimum documented in docs/tui-guide.md.
+
+
+async def test_compact_layout_makes_a_short_terminal_usable(project):
+    """The payoff test for the vertical axis: at 8 rows a ConfirmModal with a
+    docked warning is fully operable.
+
+    8 is well BELOW this exact modal's pre-fix floor of 14 rows (measured at 64
+    columns, the same modal and body), so a green assertion here cannot be
+    explained by a roomy terminal — it is the `-short` compact layout doing the
+    work. Post-fix the same modal bottoms out at 5 rows. The warning is included
+    on purpose: it gates a destructive confirm (ConfirmResumeModal inherits it),
+    is docked outside #body, and is what pushes this modal's floor above the
+    other bounded modals'."""
+    app = BmadLoopApp(project.project)
+    async with app.run_test(size=(64, 8)) as pilot:
+        await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
+        app.push_screen(ConfirmModal("t", "line\n" * 80, warning="w"))
+        await until(pilot, lambda: isinstance(app.screen, ConfirmModal))
+        await ready(pilot, "#body")
+        assert _on_screen(app, app.screen.query_one("#ok", Button))
+        assert _on_screen(app, app.screen.query_one("#cancel", Button))
+        assert _on_screen(app, app.screen.query_one("#warning", Static))
+
+
+async def test_short_breakpoint_engages_only_below_the_threshold(project):
+    """Pins the mechanism itself, so deleting `VERTICAL_BREAKPOINTS` fails loudly
+    instead of drifting the layout: Textual puts the matching class on the Screen,
+    and BaseDialog IS a ModalScreen, so `-short`/`-tall` land on the dialog screen
+    where the CSS selects them. 19 and 20 are the two sides of the threshold."""
+    app = BmadLoopApp(project.project)
+    async with app.run_test(size=(64, 19)) as pilot:
+        await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
+        app.push_screen(ConfirmModal("t", "Stop the run?"))
+        await until(pilot, lambda: isinstance(app.screen, ConfirmModal))
+        await ready(pilot, "#body")
+        assert "-short" in app.screen.classes
+        assert "-tall" not in app.screen.classes
+
+    app = BmadLoopApp(project.project)
+    async with app.run_test(size=(64, 40)) as pilot:
+        await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
+        app.push_screen(ConfirmModal("t", "Stop the run?"))
+        await until(pilot, lambda: isinstance(app.screen, ConfirmModal))
+        await ready(pilot, "#body")
+        assert "-tall" in app.screen.classes
+        assert "-short" not in app.screen.classes
+
+
+async def test_tall_terminal_dialog_height_unchanged(project):
+    """The compact rules must not leak upward. At 40 rows a one-line confirm lays
+    out at exactly 11 — 2 border + 2 padding + 1 title + 1 title margin + 1 body
+    + 1 button-row margin + 3 button — which is what it measures both with and
+    without this fix. `test_short_confirm_modal_stays_compact` does NOT cover
+    this: it asserts `< 12`, and a leaked `-short` (which takes this dialog to 5)
+    would satisfy that bound too. The equality is the point."""
+    app = BmadLoopApp(project.project)
+    async with app.run_test(size=(64, 40)) as pilot:
+        await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
+        app.push_screen(ConfirmModal("t", "Stop the run?"))
+        await until(pilot, lambda: isinstance(app.screen, ConfirmModal))
+        await ready(pilot, "#body")
+        assert app.screen.query_one("#dialog").region.height == 11
 
 
 # ------------------------------------------------------------- run control

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1901,6 +1901,10 @@ async def test_validate_findings_modal_floor_moves_with_its_header(project, kwar
         app.push_screen(modal)
         await until(pilot, lambda: app.screen is modal)
         await ready(pilot, "#findings")
+        # the header is the thing that moves this floor, so assert it too: a
+        # regression that clipped it would otherwise leave #ok reachable and
+        # pass
+        assert _on_screen(app, app.screen.query(".title").first())
         assert _on_screen(app, app.screen.query_one("#ok"))
 
 
@@ -1933,6 +1937,9 @@ async def test_long_docked_title_still_fits_a_standard_terminal(project, chars):
         app.push_screen(modal)
         await until(pilot, lambda: app.screen is modal)
         await ready(pilot, "#entry")
+        # the wrapped heading is what costs the rows here, so a clipped title is
+        # the regression this test exists to catch, not just an unreachable #ok
+        assert _on_screen(app, app.screen.query(".title").first())
         assert _on_screen(app, app.screen.query_one("#ok"))
 
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1689,6 +1689,201 @@ async def test_tall_terminal_dialog_height_unchanged(project):
         assert app.screen.query_one("#dialog").region.height == 11
 
 
+# ---- #281 the documented 39x9 minimum, where BOTH breakpoints are engaged
+#
+# Everything above exercises one axis at a time. This is the corner where
+# `-narrow` and `-short` apply together, and it is the only test of the number
+# docs/tui-guide.md publishes as a user-facing contract — so a rule that is
+# correct on each axis alone but wrong at the intersection reddens here and
+# nowhere else. It is also what keeps the published floor honest: the claim is
+# asserted for every dialog it covers, so a modal cannot quietly stop meeting it.
+#
+# Two dialogs are documented exceptions and deliberately absent from this table,
+# each with its own test below. The spec viewer docks `copy path` alongside its
+# action verbs, so its labels alone overflow a 39-column dialog whatever the
+# button metrics do (#628). The validate viewer's header is docked outside the
+# scrolling body and wraps, and each wrapped line costs the button row a row
+# (#629). Both are the same shape of defect: chrome docked outside the body,
+# which the `-short`/`-narrow` rules cannot shrink because it is content, not
+# padding.
+
+_MIN_COLS, _MIN_ROWS = 39, 9
+
+_MIN_SIZE_CASES = (
+    "confirm",
+    "confirm-warning",
+    "start-run",
+    "start-sweep",
+    "decision",
+    "deferred-entry",
+    "story-checkpoint",
+    "escalation",
+    "text-output",
+)
+
+
+def _minimum_size_case(name: str, project):
+    """(modal, docked controls that must stay reachable, its scrolling body).
+
+    The controls are the ones docked OUTSIDE the body — buttons plus any warning
+    docked beside them — because those are what the doc promises stay on-screen.
+    `DecisionModal`'s per-option `opt-N` buttons are deliberately not listed:
+    they live inside the scrolling `#body` and are reached by scrolling, which
+    test_decision_modal_scrolls_when_content_long already covers."""
+    if name == "confirm":
+        return ConfirmModal("t", "line\n" * 80), ("#ok", "#cancel"), "#body"
+    if name == "confirm-warning":
+        # the docked warning gates a destructive confirm (ConfirmResumeModal
+        # inherits it), so losing it off-screen is a safety defect, not cosmetic
+        return (
+            ConfirmModal("t", "line\n" * 80, warning="w"),
+            ("#ok", "#cancel", "#warning"),
+            "#body",
+        )
+    if name == "start-run":
+        return StartRunModal(project.project), ("#ok", "#cancel"), "#fields"
+    if name == "start-sweep":
+        return StartSweepModal(), ("#ok", "#cancel"), "#body"
+    if name == "decision":
+        return DecisionModal(_long_decision()), ("#cancel",), "#body"
+    if name == "deferred-entry":
+        item = data.DeferredItem(
+            id="DW-1",
+            title="a deferred item",
+            status="open",
+            done=False,
+            severity="high",
+            body="line\n" * 40,
+        )
+        return DeferredEntryModal(item), ("#ok",), "#entry"
+    if name == "story-checkpoint":
+        return (
+            StoryCheckpointModal(
+                story_key="e-1-s", title="t", commit="abc123", verify_line="v", tokens="0"
+            ),
+            ("#act-continue", "#act-stop", "#cancel"),
+            "#body",
+        )
+    if name == "escalation":
+        return (
+            EscalationModal(
+                story_key="e-1-s",
+                title="t",
+                description="d",
+                blocking="b",
+                sentinel_kind="",
+                resolution_ready=True,
+                engine_live=False,
+                restore_recorded=True,
+            ),
+            ("#act-resolve", "#act-rearm", "#cancel", "#hint"),
+            "#body",
+        )
+    assert name == "text-output", name
+    return TextOutputModal("validate", 0, "out\n" * 40), ("#ok",), "#output"
+
+
+@pytest.mark.parametrize("case", _MIN_SIZE_CASES)
+async def test_documented_minimum_terminal_size_keeps_dialogs_operable(project, case):
+    """At the published 39x9 floor every covered dialog still shows its title, a
+    row of body and all of its docked controls (#281).
+
+    Both breakpoint classes are asserted present first, so the test fails loudly
+    if a future threshold change means this size no longer exercises the compact
+    layout at all — otherwise the assertions below could pass for the wrong
+    reason, on a dialog that simply never engaged either rule."""
+    app = BmadLoopApp(project.project)
+    async with app.run_test(size=(_MIN_COLS, _MIN_ROWS)) as pilot:
+        await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
+        modal, controls, body = _minimum_size_case(case, project)
+        app.push_screen(modal)
+        await until(pilot, lambda: app.screen is modal)
+        await ready(pilot, body)
+        assert "-narrow" in app.screen.classes, case
+        assert "-short" in app.screen.classes, case
+        assert _on_screen(app, app.screen.query(".title").first()), case
+        assert app.screen.query_one(body).region.height >= 1, case
+        for selector in controls:
+            assert _on_screen(app, app.screen.query_one(selector)), f"{case} {selector}"
+
+
+@pytest.mark.parametrize(
+    ("actions", "controls"),
+    [
+        (
+            [("resume", "Approve & resume", "primary")],
+            ("#copy-path", "#act-resume", "#cancel"),
+        ),
+        (
+            [
+                ("approve", "Approve & resume", "primary"),
+                ("replan", "Request replan", "warning"),
+            ],
+            ("#copy-path", "#act-approve", "#act-replan", "#cancel"),
+        ),
+    ],
+    ids=["gate", "plan-checkpoint"],
+)
+async def test_spec_review_modal_operable_on_a_standard_terminal(project, actions, controls):
+    """The spec viewer is the one dialog outside the 39x9 floor, so pin what it
+    does guarantee: a standard 80x24 terminal shows either action row in full.
+
+    It has no single floor to pin instead. Two things push it around, and one of
+    them is not a width at all: the docked `copy path` button plus the caller's
+    action verbs overflow a 39-column dialog horizontally, AND the full spec path
+    printed above the body wraps, so a long path costs rows and can drop the
+    action row off the bottom of a 9-row screen (measured: a 59-character path
+    puts the row at y=9 on a 9-row screen, while a short one leaves it at y=8).
+    Its floor is therefore a function of the path and the verbs, which is why
+    docs/tui-guide.md quotes this size rather than a minimum, and why wrapping
+    the row is tracked in #628 instead of being pinned here.
+
+    Asserting a size that WORKS, rather than that a narrower one fails, keeps the
+    contract pinned without freezing the defect: fixing #628 cannot redden it."""
+    app = BmadLoopApp(project.project)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
+        modal = SpecReviewModal(
+            title="review the spec",
+            subtitle="epic-1 story-2",
+            spec_path=project.project / "spec.md",
+            spec_text="line\n" * 40,
+            actions=actions,
+        )
+        app.push_screen(modal)
+        await until(pilot, lambda: app.screen is modal)
+        await ready(pilot, "#spec")
+        for selector in controls:
+            assert _on_screen(app, app.screen.query_one(selector)), selector
+
+
+async def test_validate_findings_modal_clears_the_floor_one_row_higher(project):
+    """The other documented exception: this modal needs 39x10, not 39x9 (#629).
+
+    Its `.title` is `widgets.validate_header(doc)` — a multi-line header docked
+    outside the scrolling `#findings` body — and at 39 columns it wraps to five
+    rows, which puts the button row at y=9 on a screen whose rows are 0-8. The
+    `-short` rules cannot buy that back: they collapse padding and margins, and
+    this cost is content. One more row clears it.
+
+    The 10 is specific to the document built here, since a header that wraps to
+    more lines costs more rows, so this asserts the size works rather than
+    treating 10 as the modal's universal floor. 39 is held fixed so the test
+    still runs in the narrow band the wrap depends on."""
+    app = BmadLoopApp(project.project)
+    async with app.run_test(size=(_MIN_COLS, _MIN_ROWS + 1)) as pilot:
+        await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
+        modal = ValidateFindingsModal(
+            make_validate_document([("bmad-config", "problem", "a finding", None)])
+        )
+        app.push_screen(modal)
+        await until(pilot, lambda: app.screen is modal)
+        await ready(pilot, "#findings")
+        assert "-narrow" in app.screen.classes
+        assert "-short" in app.screen.classes
+        assert _on_screen(app, app.screen.query_one("#ok"))
+
+
 # ------------------------------------------------------------- run control
 
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1698,14 +1698,20 @@ async def test_tall_terminal_dialog_height_unchanged(project):
 # nowhere else. It is also what keeps the published floor honest: the claim is
 # asserted for every dialog it covers, so a modal cannot quietly stop meeting it.
 #
-# Two dialogs are documented exceptions and deliberately absent from this table,
-# each with its own test below. The spec viewer docks `copy path` alongside its
-# action verbs, so its labels alone overflow a 39-column dialog whatever the
-# button metrics do (#628). The validate viewer's header is docked outside the
-# scrolling body and wraps, and each wrapped line costs the button row a row
-# (#629). Both are the same shape of defect: chrome docked outside the body,
-# which the `-short`/`-narrow` rules cannot shrink because it is content, not
-# padding.
+# What the floor covers is a dialog's own CHROME, not the text it is handed, and
+# the cases below are parametrised with short titles for exactly that reason.
+# Titles, headers, warnings and paths dock OUTSIDE the scrolling body, so every
+# line they wrap to costs a row the body cannot give back — it floors at 1 — and
+# the `-short`/`-narrow` rules cannot shrink content the way they shrink padding.
+# So any dialog handed long enough caller-supplied text has no fixed minimum.
+# Measured at 39 columns: a ~150-character deferred-work heading still fits 9
+# rows, ~300 characters wraps to 9 rows of title and clips the close button; the
+# validate header grows with its document's spec folder; the spec viewer's
+# `copy path` plus its action verbs overflow 39 columns outright. That is one
+# family with three faces, not three defects — tracked in #628 (row too wide)
+# and #629 (docked wrapping text steals rows). The tests below pin the bounded
+# case here, each unbounded case at a size measured to work, and 80x24 as the
+# size to rely on when the content is not bounded.
 
 _MIN_COLS, _MIN_ROWS = 39, 9
 
@@ -1895,6 +1901,38 @@ async def test_validate_findings_modal_floor_moves_with_its_header(project, kwar
         app.push_screen(modal)
         await until(pilot, lambda: app.screen is modal)
         await ready(pilot, "#findings")
+        assert _on_screen(app, app.screen.query_one("#ok"))
+
+
+@pytest.mark.parametrize("chars", [150, 300], ids=["fits-the-floor", "overflows-the-floor"])
+async def test_long_docked_title_still_fits_a_standard_terminal(project, chars):
+    """The third face of the same family, and the guarantee the guide falls back
+    on: 80x24 absorbs a docked title no 39-column screen could.
+
+    `DeferredEntryModal` renders the ledger heading as the docked `.title`,
+    outside the scrolling `#entry`, and `parse_ledger` does not bound that text.
+    At 39 columns a ~150-character heading still clears the floor, but ~300
+    characters wraps to nine rows of title and pushes `#ok` off a nine-row
+    screen — `#entry` is already at its one-row minimum and has nothing left to
+    give. Both lengths are asserted at 80x24 rather than at 39 columns, because
+    the point is the fallback size, not another content-specific minimum that a
+    longer heading would falsify (#629)."""
+    app = BmadLoopApp(project.project)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await until(pilot, lambda: isinstance(app.screen, DashboardScreen))
+        modal = DeferredEntryModal(
+            data.DeferredItem(
+                id="DW-1",
+                title=("word " * 200)[:chars].strip(),
+                status="open",
+                done=False,
+                severity="high",
+                body="line\n" * 40,
+            )
+        )
+        app.push_screen(modal)
+        await until(pilot, lambda: app.screen is modal)
+        await ready(pilot, "#entry")
         assert _on_screen(app, app.screen.query_one("#ok"))
 
 


### PR DESCRIPTION
Closes #281.

Follow-up to #280 (which fixed the #275 vertical-overflow defect). Two limitations flagged in that
review and deliberately deferred are both landed here: one commit per axis, then a test-harness fix
the gate turned up (see _Testing_), then the changelog entry.

## Problem

**Horizontal — the same "control unreachable" bug #275/#280 fixed, on the other axis.** Every modal
declared a fixed column count with no clamp (`BaseDialog` 64; `DecisionModal` 86, `EscalationModal`
90, `DeferredEntryModal`/`ValidateFindingsModal`/`TextOutputModal` 96, `SpecReviewModal` 100), so on
a terminal narrower than the declared width the dialog was laid out wider than the screen. The
docked button row is `align-horizontal: right`, so the action buttons were exactly what fell off the
right edge — unreachable, precisely as #275's buttons were unreachable below the fold.

Measured minimum terminal **width** at which every docked button of a modal is fully on-screen,
before this PR:

| modal                  | before | after |
| ---------------------- | -----: | ----: |
| `DecisionModal`        |     83 |  ≤ 12 |
| `EscalationModal`      |     87 |    39 |
| `ConfirmModal`         |     61 |    22 |
| `StartSweepModal`      |     61 |    20 |
| `StoryCheckpointModal` |     61 |    37 |

`EscalationModal` needing 87 columns is the headline: a standard 80-column terminal already clipped
it.

**Vertical — the frame floor.** Before any body content a dialog spends **10 rows of chrome**: 2
border (1 per side), 2 padding, 1 title, 1 title `margin-bottom`, 1 `.buttons` `margin-top`, and 3
for the button row (Textual's `Button` is `border: tall`, so a one-line label is 3 rows). `#dialog`
is then capped at `max-height: 90%`, and that cap is what turns 10 rows of chrome into a per-modal
**terminal-height floor of 12–14 rows** — `ConfirmModal` 12, `StartSweepModal` 13,
`StoryCheckpointModal` 13, and 14 for a `ConfirmModal` carrying a docked warning (the
`ConfirmResumeModal` case). Below that the docked action row was pushed off the bottom regardless of
the body scrolling #280 added. (`DecisionModal` measured 9 rather than 12–14 because it overrides
`#dialog` with a definite height, so the 90% cap does not compose the same way.)

The two halves are the same defect: a fixed frame laid out against a screen that may be smaller than
it, with the docked controls — the things a user must reach to act — on the side that gets cut.

## Fix

**`src/bmad_loop/tui/screens/modals.py`** — CSS and two breakpoint declarations, no Python behavior
change.

_Width clamp._ `max-width: 100%` is one declaration on the **shared** `BaseDialog #dialog` rule
rather than ten per-subclass edits. That is deliberate, not shorthand: the five subclasses that
widen the dialog set only `width` and never `max-width`, so a single clamp on the shared rule covers
all ten modals and — the part that matters for the next subclass — a subclass **cannot silently opt
out** of it by setting the property it already sets.

_The clamp alone is not sufficient._ Textual's `Button` is `width: auto; min-width: 16`, and
`BaseDialog` adds `margin-left: 2` per button, so a three-button docked row demands 3×16 + 3×2 = 54
columns — while a dialog clamped to a 50-column terminal has 50 − 2 (thick border) − 4 (padding
`1 2`) = 44 columns of content. The row still overflows and the right-most button is still clipped.
Measured with the clamp only: `EscalationModal` still needed 58 columns, `StoryCheckpointModal` 57.
`BaseDialog.-narrow .buttons Button { min-width: 4; margin-left: 1 }` drops the floor so each button
sizes to its own label.

_Compact small-height layout._ Under `BaseDialog.-short` the 10 rows of chrome collapse to 4 —
`padding: 0 1`, no title `margin-bottom`, no `.buttons` `margin-top`, and a 1-row borderless button
row — with `max-height` lifted to 100% so the dialog may use the last row. Nothing there sets a
definite `height` (that would balloon the bounded tier) and nothing touches `width` (that is the
other axis).

_Both breakpoints are Textual's own mechanism._ `HORIZONTAL_BREAKPOINTS = [(0, "-narrow"),
(60, "-wide")]` and `VERTICAL_BREAKPOINTS = [(0, "-short"), (20, "-tall")]` are declared **on
`BaseDialog`**. Textual applies the matching class to the `Screen`, and `BaseDialog` _is_ a
`ModalScreen`, so the class lands where `BaseDialog.-narrow …` / `BaseDialog.-short …` can select
it. Scoping the declaration to `BaseDialog` is what keeps this off the dashboard: `BmadLoopApp` and
`DashboardScreen` leave their breakpoints at the default and are not touched by this PR.

The thresholds are derived, not picked. 60 columns is where an un-narrowed 54-column button row
still fits a clamped dialog's content region (60 − 2 border − 4 padding = 54). 20 rows sits clear
above the tallest measured pre-fix floor (14) so the compact layout engages _before_ anything clips
rather than at the moment it does, and below the 24 rows of a default terminal so an ordinary window
keeps the full chrome.

**`docs/tui-guide.md`** — records the terminal sizes these dialogs were measured at (see below).

**`tests/test_tui_app.py`** — seven new tests, plus a settle step in the shared `ready()` gate that
the breakpoints turned out to require (see _Testing_), plus a docstring correction on the
pre-existing `test_start_sweep_and_checkpoint_buttons_reachable`, which repeated the issue's "~13
rows of chrome" claim. No assertion in that test changed.

## Scope note

The issue's inventory was incomplete and its arithmetic imprecise. This PR corrects both.

- **The inventory.** #281 named `DecisionModal` (86), `EscalationModal` (90) and "~64" for three
  others. The "~64" is not three separate widths — it is `BaseDialog`'s inherited default, which
  those three never override. And four wider modals the issue never named have the same defect:
  `SpecReviewModal` (100), `DeferredEntryModal` (96), `ValidateFindingsModal` (96) and
  `TextOutputModal` (96). Because the clamp lives on the shared rule they are covered at **no extra
  diff cost** — which is the concrete payoff of the shared-rule choice over per-subclass edits.
- **The arithmetic.** "~13 rows of chrome" is not a chrome count and it is not one number. The
  chrome is 10; the 90% cap turns it into a per-modal 12–14.
- **The proposed "thinner border" saves zero rows.** Every Textual border _style_ occupies exactly
  one cell per side, so `thick` → `round` is a no-op. Instead the `-short` layout reclaims its rows
  from padding, the two margins and the button row's own border — and the `#dialog` border is
  **deliberately kept**: it is the only thing separating the dialog from the dashboard rendered
  behind a `ModalScreen`, and the floor is already clear without the 2 rows it costs.

## Visible behavior diffs

- **Narrow terminals** — a dialog narrower than its declared width shrinks to fit the screen instead
  of being clipped, so its docked action buttons stay on-screen and reachable.
- **Below 60 columns** — the docked buttons additionally render with a smaller minimum width (4
  rather than Textual's 16) and tighter spacing (`margin-left: 1` rather than 2).
- **Below 20 rows** — the compact layout engages: collapsed padding, no title margin, no button-row
  margin, a one-row button row, `max-height: 100%`.
- **At or above both breakpoints, rendering is unchanged from today.** This is pinned explicitly, on
  both axes: `test_wide_terminal_dialog_width_unchanged` asserts a `ConfirmModal` at 120 columns
  still lays out at exactly 64 and that `-narrow` did not engage, and
  `test_tall_terminal_dialog_height_unchanged` asserts a one-line confirm at 40 rows lays out at
  exactly 11 rows — the same 11 it measures without this fix.
- **`docs/tui-guide.md` now records the terminal sizes these dialogs were measured at, stated as
  measured sufficiency and NOT as a supported minimum:** **39 columns × 9 rows** is the size at
  which a dialog's own **chrome** was measured to fit — border, padding, title line and margins, a
  row of body, and the whole docked button row. The figures describe the **dialogs**, not the
  dashboard behind them (which simply shows fewer rows as the window shrinks). It is
  `EscalationModal` that sets that number, and it is width-dependent because its `#hint` warning
  wraps: 9 rows at 39 columns, 6 at 80. Full non-compact chrome appears at 60 × 20 and above.
- **No fixed size is a floor these dialogs will always meet, and review is what established that.**
  Four rounds returned the same family in four shapes — a stated minimum claiming more than had
  been measured — so the guide no longer states a minimum at all. Titles, headers, warnings and
  paths dock *outside* the scrolling body, so each line they wrap to costs a row the body cannot
  give back: it is already at its 1-row minimum, and `-short` collapses padding, not content. That
  text is caller-supplied and **nothing bounds its length** — a ledger title, a `spec:` folder, a
  spec path — so a long enough value consumes the frame and clips the docked controls at **any**
  fixed size. Measured at 39 columns:
  * deferred-work heading — 72 chars → 3 title rows, reachable; 150 → 5 rows, reachable; **300 → 9
    rows, close button clipped**; 600 → 18 rows.
  * validate viewer — plain document clears at 39 × 10; a 63-character spec folder needs 39 × 12
    (still clipped at both 10 and 11).
  * spec viewer — `copy path` plus its action verbs exceed 39 columns outright, whatever the button
    metrics do, on top of a spec path that wraps.

  **80 × 24 was sufficient for every one of those measured examples**, so that is the size the guide
  quotes where content is unbounded, and what the tests pin — as a size that worked for what was
  measured, not one an unbounded value cannot overrun. A longer heading or path would falsify 80 × 24
  the same way it falsifies 39 × 9, and the guide now says so. None of this is fixed here: bounding
  docked text or wrapping an action row changes what these dialogs render and needs its own tests,
  which would widen a #281 layout fix well past its scope. Tracked in #628 (action row too wide) and
  #629 (docked wrapping text steals rows — retitled to the family and given the deferred-entry
  measurements). Documented rather than papered over: no figure was quietly restated to make it true.

**The floor moved down a long way, and what is written down is what was measured** — not a size
users can rely on wherever content is unbounded. This PR does not claim modal dialogs are usable at
any terminal size, and it does not make the dashboard layout responsive; the dashboard was not
touched.

## Testing

`5714 passed, 50 skipped`; `pyright` 0 errors; `trunk fmt` and `trunk check` clean.

The final review round reworded every place this branch stated a size — the guide, the
`modals.py` breakpoint comment, the changelog entry, the test docstrings and this body — from a
guaranteed minimum to measured sufficiency, and renamed
`test_documented_minimum_terminal_size_keeps_dialogs_operable` to
`test_measured_terminal_size_keeps_dialogs_operable` so the name does not restate the claim the
prose retracted. No CSS, breakpoint value, assertion or behavior changed in that round, so the four
ablation axes below are unaffected by it and were not re-run.

### A flake this gate caught, and the fix for it

Running the suite under `-n logical` **failed**
`test_story_checkpoint_three_buttons_reachable_when_narrow`, which passed standalone. That is a real
defect these breakpoints introduce into the test harness, so it is fixed here.

Cause: `ready()` returns as soon as the queried widget has a laid-out region. The breakpoint class
is already on the screen by then — but the stylesheet reapply it triggers is still **queued**, so
the first laid-out pass carries the un-classed metrics and the real layout arrives a frame later.
Instrumented at 45 columns, the checkpoint button row measures Textual's default `min-width: 16` on
that first pass (x = 5/23/41, each 16 wide, so the last ends at column 57 — off a 45-column screen)
and the `-narrow` metrics (14/10/7) on the next. The layout always converges correctly; the
assertion was simply read one frame early. So this is a test-harness race, **not** a defect in the
fix itself.

**The first attempt at this was wrong, and a repeated run refuted it.** I first fixed only the new
narrow tests, on the reasoning that the five pre-existing modal tests which now sit below the 20-row
breakpoint — and so are laid out under `-short` too — kept enough slack at 64–90 columns to be
safe. A third repeat run then failed the pre-existing
`test_decision_modal_scrolls_when_content_long` (90×16) at `assert _on_screen(app, opt8)`: it calls
`scroll_visible()` on an option, which computes a scroll target against the doomed first-pass
layout, and the relayout then moves the option back out of view. Slack was not the protection I
assumed, and the exposure is not confined to the new tests.

So the fix moved to the root instead: **`ready()` now pumps the message queue until the screen's
layout stops moving** (regions repeating three times), and every call site inherits it — a smaller
diff than patching assertions one by one, and it covers scroll targets and click coordinates, not
just reachability asserts. It is the pump, not a sleep, that does the work: the pending reapply is a
message and each pause drains it; requiring the regions to repeat lets a slow runner take as many
frames as it needs, and a screen that never settles raises rather than proceeding.

Measured on the test that exposed it, under CPU load: **2 failures in 25 runs before, 0 in 25
after.** Four repeats of the full suite under `-n logical` are green.

### The tests

Seven new tests in `tests/test_tui_app.py`. Every ablation below was restored from a `cp` backup and
the restore verified byte-identical — never `git checkout`. All four axes were **re-run after** the
`ready()` change, since altering when assertions are measured invalidates evidence gathered before
it; all four reproduce the original result exactly.

**Horizontal axis (phase 1)**

| # | test | asserts |
| - | ---- | ------- |
| T1 | `test_decision_modal_clamps_to_narrow_terminal` | at 50 columns `#dialog.region.width == 50` (not its declared 86) and `#cancel` is on-screen |
| T2 | `test_escalation_modal_three_buttons_reachable_when_narrow` | at 45 columns all three of `#act-resolve`, `#act-rearm`, `#cancel` are on-screen — the case the clamp alone does **not** fix (measured: still needs 58 columns with the clamp only) |
| T3 | `test_story_checkpoint_three_buttons_reachable_when_narrow` | same 45-column bound for `#act-continue`, `#act-stop`, `#cancel` (measured: 57 columns with the clamp only) |
| T4 | `test_wide_terminal_dialog_width_unchanged` | at 120 columns `#dialog.region.width == 64` and `-narrow` is absent — the no-regression guard |

The width clamp and the narrow button row are **separate ablation axes, and they redden different
tests** — which is why both T1 and T2/T3 exist:

- **Axis A — dropped `max-width: 100%`:** T1, T2 and T3 red; T4 green.
- **Axis B — dropped only `BaseDialog.-narrow .buttons Button`, clamp left in place:** T2 and T3
  red; **T1 green** and T4 green. T1 alone would therefore not have caught a missing `-narrow` rule.

**Vertical axis (phase 2)**

| # | test | asserts |
| - | ---- | ------- |
| T5 | `test_compact_layout_makes_a_short_terminal_usable` | at 64×8 a `ConfirmModal` **with a docked warning** has `#ok`, `#cancel` and `#warning` all on-screen — 8 rows is well below this exact modal's pre-fix floor of 14, so a green result cannot be explained by a roomy terminal |
| T6 | `test_short_breakpoint_engages_only_below_the_threshold` | the mechanism itself: at 19 rows `-short` is on the screen and `-tall` is not; at 40 rows the reverse — both sides of the threshold |
| T7 | `test_tall_terminal_dialog_height_unchanged` | at 40 rows a one-line confirm is **exactly** 11 rows tall — the no-regression guard |

Same shape, same conclusion:

- **Axis A — dropped `VERTICAL_BREAKPOINTS`:** T5 and T6 red; T7 green.
- **Axis B — dropped only the four `BaseDialog.-short` CSS rules, breakpoints left in place:** **T5
  red alone**; **T6 green** — the class is still applied, it just selects nothing. That is exactly
  why T6 is a separate test from T5.

**Ablations that did not redden what one might expect, and why that is correct:** **no ablation
reddened T4 or T7.** Those two are the no-change guards — they pin that a wide/tall terminal renders
as it does today, so removing the fix is precisely the condition under which they _should_ stay
green. They fail in the other direction (a leaked `-narrow`/`-short`), which is the regression they
exist to catch; T7's assertion is an equality rather than a `< 12` bound for that reason, since a
leaked `-short` takes that dialog to 5 rows and would satisfy a bound.

All six pre-existing modal tests constrained by these thresholds stayed green, unmodified.

## Not in this PR

The dashboard's own layout. The breakpoints are declared on `BaseDialog` only; `BmadLoopApp` and
`DashboardScreen` keep the framework defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TUI dialogs now adapt to narrow and short terminals.
  * Dialogs preserve reachable action buttons with tighter controls and compact layouts on smaller screens.
  * Full dialog styling remains available at 60×20 and above.

* **Bug Fixes**
  * Improved modal sizing to prevent controls from being cut off on constrained terminals.

* **Documentation**
  * Added guidance on terminal-size behavior, breakpoints, and content-dependent sizing, including 39×9 as a measured sufficient size rather than a guaranteed minimum.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


