### PR TITLE
fix(sweep): anchor the bundle name and key regexes with \Z (#330)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -376,30 +376,17 @@ breaking changes may land in a minor release.
   example and the guide quotes it on those terms. At 60 columns and 20 rows and above the full
   chrome renders exactly as it does today.
 
-- **A deferred-work bundle whose name ends in a newline is now rejected at triage instead of
-  becoming a directory (#330).** Both of the sweep module's regexes ended in `$`, which in Python
-  matches at the end of the string _or_ just before a single trailing newline, and every call site
-  uses `.match()`, which anchors only the start. So a triage result naming a bundle `fix-it\n`
-  validated clean, and that name is used raw from there — nothing sanitizes it — as the
-  `run_dir/bundles/<name>/` path segment and as the `dw-<name>` story key that lands in run state
-  and the journal. On Linux it silently created a directory whose name ends in a newline; on native
-  Windows a control character in a path segment is invalid, so the sweep failed at bundle start.
-  The bundle-key regex had the same hole with a quieter consequence — `.` does not match a newline,
-  so a key of `dw-foo\n` matched and reconstructed the name as `foo`, and a degraded bundle's intent
-  was regenerated under that different directory without a word in the journal. Both patterns now
-  anchor with `\Z`.
-
-  What flips is narrow: a name or key ending in exactly one bare LF, with nothing after it, moves
-  from accepted to rejected. `\r\n`, `\n\n`, a bare `\r`, a trailing space and any interior newline
-  were already rejected, and every well-formed name and key parses exactly as it did before. Three
-  further effects follow. The validation error text interpolates the pattern, so it now reads
-  `...{1,39}\Z` where it read `...{1,39}$`. A cached `triage.json` carrying a newline-suffixed name
-  now fails its reload re-validation, which degrades rather than crashes: the run journals
-  `sweep-triage-reload-failed` and runs a fresh triage. And a run state persisted by a pre-fix build
-  whose task key ends in a newline is no longer recognised as a bundle by the in-flight-finish or
-  stranded-bundle scans, so such a task becomes inert instead of being re-driven — under a silently
-  different name, which is what the old behavior actually did. This closes the trailing-newline hole
-  in the sweep module only; it does not make a bundle name safe as a path segment in general.
+- **A deferred-work bundle whose name or key ends in a newline is now rejected instead of becoming a
+  directory (#330).** Both sweep regexes anchored with `$`, which in Python also matches just before
+  a single trailing newline, and every call site uses `.match()`. So a bundle named `fix-it\n`
+  validated clean and was used unsanitized as both the `run_dir/bundles/<name>/` path segment —
+  invalid on native Windows — and the `dw-<name>` story key, while a key of `dw-foo\n` silently
+  rebuilt a degraded bundle's intent under the different directory `foo`. Both patterns now anchor
+  with `\Z`. Only a name or key ending in exactly one bare LF flips to rejected; `\r\n`, `\n\n`, a
+  bare `\r`, a trailing space and any interior newline already were. A cached triage carrying such a
+  name now re-runs instead of crashing, and a pre-fix run-state task keyed that way becomes inert
+  rather than re-driven under a silently different name. Sweep-scoped: a bundle name is still not
+  guaranteed safe as a path segment.
 
 ## [0.10.0] — 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -376,6 +376,31 @@ breaking changes may land in a minor release.
   example and the guide quotes it on those terms. At 60 columns and 20 rows and above the full
   chrome renders exactly as it does today.
 
+- **A deferred-work bundle whose name ends in a newline is now rejected at triage instead of
+  becoming a directory (#330).** Both of the sweep module's regexes ended in `$`, which in Python
+  matches at the end of the string _or_ just before a single trailing newline, and every call site
+  uses `.match()`, which anchors only the start. So a triage result naming a bundle `fix-it\n`
+  validated clean, and that name is used raw from there — nothing sanitizes it — as the
+  `run_dir/bundles/<name>/` path segment and as the `dw-<name>` story key that lands in run state
+  and the journal. On Linux it silently created a directory whose name ends in a newline; on native
+  Windows a control character in a path segment is invalid, so the sweep failed at bundle start.
+  The bundle-key regex had the same hole with a quieter consequence — `.` does not match a newline,
+  so a key of `dw-foo\n` matched and reconstructed the name as `foo`, and a degraded bundle's intent
+  was regenerated under that different directory without a word in the journal. Both patterns now
+  anchor with `\Z`.
+
+  What flips is narrow: a name or key ending in exactly one bare LF, with nothing after it, moves
+  from accepted to rejected. `\r\n`, `\n\n`, a bare `\r`, a trailing space and any interior newline
+  were already rejected, and every well-formed name and key parses exactly as it did before. Three
+  further effects follow. The validation error text interpolates the pattern, so it now reads
+  `...{1,39}\Z` where it read `...{1,39}$`. A cached `triage.json` carrying a newline-suffixed name
+  now fails its reload re-validation, which degrades rather than crashes: the run journals
+  `sweep-triage-reload-failed` and runs a fresh triage. And a run state persisted by a pre-fix build
+  whose task key ends in a newline is no longer recognised as a bundle by the in-flight-finish or
+  stranded-bundle scans, so such a task becomes inert instead of being re-driven — under a silently
+  different name, which is what the old behavior actually did. This closes the trailing-newline hole
+  in the sweep module only; it does not make a bundle name safe as a path segment in general.
+
 ## [0.10.0] — 2026-08-14
 
 Much of this section is the `release/0.9.x` hotfix line brought forward onto `main` (#433).

--- a/src/bmad_loop/sweep.py
+++ b/src/bmad_loop/sweep.py
@@ -34,11 +34,11 @@ TRIAGE_KEY = "sweep-triage"
 TRIAGE_WORKFLOW = "deferred-sweep-triage"
 MIGRATE_KEY = "sweep-migrate"
 MIGRATE_WORKFLOW = "deferred-sweep-migrate"
-BUNDLE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]{1,39}$")
+BUNDLE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]{1,39}\Z")
 # the inverse of SweepEngine._bundle_key: "dw-<name>" (cycle 1) / "dw<N>-<name>".
 # A cycle-1 key always has "-" straight after "dw", so the cycle group matches
 # empty and the split stays unambiguous even for a bundle named "2fix".
-BUNDLE_KEY_RE = re.compile(r"^dw(\d*)-(.+)$")
+BUNDLE_KEY_RE = re.compile(r"^dw(\d*)-(.+)\Z")
 DECISION_EFFECTS = ("build", "close", "keep-open")
 
 

--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -45,6 +45,7 @@ from bmad_loop.policy import (
     VerifyPolicy,
 )
 from bmad_loop.sweep import (
+    BUNDLE_KEY_RE,
     Bundle,
     Decision,
     DecisionOption,
@@ -209,6 +210,77 @@ def test_validate_triage_bad_fields():
     assert "needs intent" in joined
     assert "at least 2 options" in joined
     assert "recommendation" in joined
+
+
+# --------------------------------- trailing newline in an identifier (#330)
+#
+# The other axis from the free-text block below. A bundle name and a bundle key
+# are identifiers: the name becomes a path segment (run_dir/bundles/<name>/) and
+# a story key, with no sanitizer on either path, so unlike free text they are
+# gated. `$` matches before a trailing newline and every call site uses
+# `.match()`, so one bare LF slipped through both patterns until `\Z` closed it.
+
+
+def test_validate_triage_rejects_a_trailing_newline_in_bundle_name():
+    rj = triage_result(
+        ["DW-1"],
+        bundles=[{"name": "fix-it\n", "dw_ids": ["DW-1"], "intent": "do x"}],
+    )
+
+    plan, errors = validate_triage(rj, {"DW-1"})
+
+    assert plan is None
+    # The error text assertion is load-bearing, not decoration: validate_triage
+    # returns None whenever *any* error is present, so a bare `plan is None`
+    # would pass for reasons unrelated to the name. Do not simplify it away.
+    joined = "; ".join(errors)
+    assert repr("fix-it\n") in joined
+    assert "invalid" in joined
+
+
+def test_validate_triage_rejects_a_trailing_newline_in_option_bundle_name():
+    rj = triage_result(
+        ["DW-1"],
+        decisions=[
+            {
+                "id": "DW-1",
+                "question": "renegotiate?",
+                "options": [
+                    {
+                        "key": "1",
+                        "label": "build it",
+                        "effect": "build",
+                        "intent": "do x",
+                        "bundle_name": "fix-it\n",
+                    },
+                    {"key": "2", "label": "keep", "effect": "keep-open"},
+                ],
+                "recommendation": "1",
+            }
+        ],
+    )
+
+    plan, errors = validate_triage(rj, {"DW-1"})
+
+    assert plan is None
+    # Same reason as above: `plan is None` alone would pass on any unrelated
+    # error, so the option's own message is what pins the second call site.
+    assert "bad bundle_name" in "; ".join(errors)
+
+
+def test_bundle_key_re_refuses_a_trailing_newline():
+    # The hazard this records: before the `\Z` anchor, "dw-foo\n" *matched* with
+    # group(2) == "foo", because `.` does not match a newline. _ensure_bundle_intent
+    # rebuilds the intent path from that reconstructed name, so a degraded bundle
+    # keyed "dw-foo\n" silently regenerated its intent under the different
+    # directory "foo", without a word in the journal. That is why this test exists.
+    assert BUNDLE_KEY_RE.match("dw-foo\n") is None
+    assert BUNDLE_KEY_RE.match("dw2-foo\n") is None
+
+    # Well-formed keys still round-trip through the inverse of _bundle_key.
+    assert BUNDLE_KEY_RE.match("dw-foo").groups() == ("", "foo")
+    assert BUNDLE_KEY_RE.match("dw2-foo").groups() == ("2", "foo")
+    assert BUNDLE_KEY_RE.match("dw-c2-foo").group(2) == "c2-foo"
 
 
 # --------------------------------- line breaks in ledger-bound text (#305)


### PR DESCRIPTION
Closes #330.

## Problem

`sweep.py` has exactly two module-level regexes and both ended in `$`:

```python
BUNDLE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]{1,39}$")   # sweep.py:37
BUNDLE_KEY_RE  = re.compile(r"^dw(\d*)-(.+)$")              # sweep.py:41
```

In Python, `$` without `re.MULTILINE` matches at the end of the string **or just before a single trailing newline**, and every call site of both patterns uses `.match()`, which anchors only the start. Neither end was actually closed, so one trailing LF slipped through patterns written to reject it. The two regexes then failed in two different ways.

**`BUNDLE_NAME_RE` — a raw path segment and a raw story key.** A bundle name of `"fix-it\n"` passed `validate_triage` with `errors == []`, at both the `bundles[].name` site and a decision option's `bundle_name`. Nothing sanitizes the name after that — `safe_segment` does not appear in `sweep.py` at all — so it is used verbatim in two places:

- as a filesystem segment in `run_dir/bundles/<name>/intent.md` (path built at `sweep.py:1300`, reached from `sweep.py:686-687`), whose `mkdir(parents=True)` silently creates a directory whose name ends in a newline on Linux; on native Windows a control character in a path segment is invalid, so the sweep fails at bundle start;
- as the `dw-<name>` story key (`sweep.py:672-673`), which lands in run state and the journal.

**`BUNDLE_KEY_RE` — a silent rename.** Same hole, quieter consequence. Because `.` does not match `\n`, `BUNDLE_KEY_RE.match("dw-foo\n")` *succeeded* with `group(2) == "foo"`. `_ensure_bundle_intent` (`sweep.py:1322`, `sweep.py:1337`) rebuilds the intent path from that reconstructed name, so a degraded bundle keyed `"dw-foo\n"` had its intent regenerated under the different directory `foo`, with nothing in the journal to say so.

## Fix

- **`src/bmad_loop/sweep.py`** — change only the trailing anchor of both regexes from `$` to `\Z`, which in Python means end-of-string with no newline exemption. The leading `^` and everything between are untouched. The fix is in the pattern rather than at the call sites: switching the five `.match()` calls to `fullmatch` would work too, but it moves the safety off the pattern, where one future `.match()` reopens the hole.
- **`tests/test_sweep.py`** — three tests plus the `BUNDLE_KEY_RE` import (see Testing).
- **`CHANGELOG.md`** — one `### Fixed` entry under `## [Unreleased]`, in its own commit.

## Scope note

**Why both regexes in one PR.** They are the only two regexes in the module and they are one defect class — the same `$`-with-`.match()` mistake, discovered together. The maintainer's review comment on #330 asks for exactly this: the `BUNDLE_KEY_RE` hole is a verified amendment to the issue and is to be `\Z`-anchored in the same PR.

**Deliberately left out:**

- No `safe_segment` call added to `_write_intent`. That is a real, separate defect on the same "`Bundle.name` is used raw as a path segment" axis — a bundle named `con`, `nul`, `aux`, `prn`, `com1`–`com9` or `lpt1`–`lpt9` passes `BUNDLE_NAME_RE` both before and after this PR and is still an invalid directory on native Windows. Filed as #637; this PR leaves #637 open.
- No widening of `_warn_stranded_bundles` (or `_finish_inflight_bundles`) to recognise pre-existing newline-carrying keys — see the last bullet under Visible behavior diffs.
- The same `$`-with-`.match()` class elsewhere in the repo — `policy.py`, `decisions.py:34`, `sprintstatus.py:18-25` — is untouched. Out of scope here per the same review comment.

## Visible behavior diffs

The complete delta, deliberately not overstated:

- **`BUNDLE_NAME_RE`:** a name ending in exactly one bare LF, with nothing after it, flips from accepted to rejected. Nothing else changes. `"fix-it\r\n"`, `"fix-it\n\n"`, `"fix-it\r"`, `"fix-it "` and any interior newline were **already** rejected before this change.
- **`BUNDLE_KEY_RE`:** `"dw-<name>\n"` and `"dw<N>-<name>\n"` flip from matching to not matching. Every well-formed key parses exactly as before, including `"dw-c2-foo"` → `("", "c2-foo")`.
- **Error text.** The validation message at `sweep.py:143` interpolates `BUNDLE_NAME_RE.pattern`, so it now reads `...{1,39}\Z` where it read `...{1,39}$`.
- **Cached triage.** A `triage.json` is re-validated on reload (`sweep.py:970`). A cached plan carrying a newline-suffixed bundle name now fails that re-validation. It degrades gracefully rather than crashing: the run journals `sweep-triage-reload-failed` and runs a fresh triage.
- **Pre-existing run state.** Stated plainly rather than hidden: a run state persisted *before* this change whose task key ends in a newline is no longer recognised as a bundle by `_finish_inflight_bundles` (`sweep.py:575`) or `_warn_stranded_bundles` (`sweep.py:600`) — both narrow together. Such a task becomes inert instead of being re-driven. The pre-change behavior was not correct either: it re-drove the bundle under a silently different name. After this change no such key can be created at all.

**This PR claims exactly that and no more.** It closes the trailing-newline hole in `sweep.py` only. It does **not** make `Bundle.name` safe as a path segment, it does **not** fix the `$`-with-`.match()` family repo-wide, and it does **not** close the Windows path hazard — the reserved-basename residue in #637 is exactly why.

## Testing

Three tests in `tests/test_sweep.py`:

- **T1** `test_validate_triage_rejects_a_trailing_newline_in_bundle_name`
- **T2** `test_validate_triage_rejects_a_trailing_newline_in_option_bundle_name`
- **T3** `test_bundle_key_re_refuses_a_trailing_newline`

T1 and T2 assert the error text, not just `plan is None` — `validate_triage` returns `None` whenever *any* error is present, so a bare `plan is None` would pass for reasons unrelated to the name.

**Ablation, re-run on this branch head.** Each axis reverts exactly one anchor back to `$`, leaving the other at `\Z`, restoring from a `cp` backup between axes:

- **Axis A** — `BUNDLE_NAME_RE` (`sweep.py:37`) back to `$`: `2 failed, 1 passed`. **T1 and T2 reddened, T3 stayed green.** Both failures landed on the intended `assert plan is None` — T1 on `TriagePlan(... Bundle(name='fix-it\n', ...))`, T2 on a plan whose decision option carried the newline-suffixed `bundle_name`. Neither was a collection or fixture error.
- **Axis B** — `BUNDLE_KEY_RE` (`sweep.py:41`) back to `$`: `1 failed, 2 passed`. **T3 reddened, T1 and T2 stayed green.** The failure landed on the intended assertion, `assert BUNDLE_KEY_RE.match("dw-foo\n") is None`, which returned `<re.Match object; span=(0, 6), match='dw-foo'>`.

**The two axes reddened disjoint sets — {T1, T2} and {T3}.** That disjointness is the proof: each anchor is independently load-bearing, neither test is riding on the other's fix.

After restoring both anchors: `tests/test_sweep.py` `121 passed`, and the tree was clean with no `.bak` left behind.

**Gates**, all green on the final tree:

| Gate | Result |
| --- | --- |
| `uv run pytest -q` | 5771 passed, 50 skipped |
| `uv run pyright` | 0 errors, 0 warnings, 0 informations |
| `trunk fmt` | no issues (no reflow of the CHANGELOG entry) |
| `trunk check --all` | 257 files checked, no issues |
