### PR TITLE
fix: catch unresolvable restore-patch and spec-folder paths (#560)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -230,6 +230,16 @@ breaking changes may land in a minor release.
   Quoted booleans and other coercible values now raise `PolicyError` instead of silently changing
   the configured limit or enabling a disabled behavior.
 
+- **Unresolvable restore-patch and spec-folder paths no longer bypass their own rejection
+  message (#560).** `_resolve_restore_patch` (`cli --restore-patch`) and
+  `relativize_spec_folder` (`--spec`, `[stories] source`) each called `.resolve()` outside the
+  exception type their local handler caught, so a host that cannot canonicalize the path (a dead
+  UNC provider, `WinError 64`; a symlink loop on the 3.11/3.12 floor) fell through to a generic,
+  unscoped error instead of the specific one the rest of the function reports. The restore-patch
+  path now returns the same rejected-latch shape as its sibling checks; the spec-folder path
+  degrades to the shared lexical fallback like every other `platform_util.resolve_or_lexical`
+  consumer.
+
 - **Attempt-owned spec-only retries no longer demand a false manual rollback (#123).** A
   bound plain attempt whose only residue is its lifecycle flip is restored to its pre-attempt
   lifecycle status and proven Git-clean before retry. A resolved re-drive may instead retain an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,20 +45,12 @@ breaking changes may land in a minor release.
 - **An unresolvable restore-patch or spec-folder path is now a named refusal, not a bare
   `[Errno ...]` (#560).** `_resolve_restore_patch` (`cli --restore-patch`) and
   `relativize_spec_folder` (`--spec`, `[stories] source`) each called `.resolve()` outside the
-  exception type their local handler caught, so a host that cannot canonicalize the path (a dead
-  UNC provider, `WinError 64`; a symlink loop on the 3.11/3.12 floor) left the function by a route
-  it does not describe. The restore-patch half is a rejection, and now returns the sibling
-  rejected-latch shape — naming the path and pointing at `bmad-loop validate` — where the fault
-  used to surface as a bare `[Errno ...]` from the top-level backstop. The spec-folder half now
-  refuses on the same terms, raising `stories.StoriesError` with both operands named, which the
-  `--dry-run` preview reports before exiting 1. Only the canonicalization leg refuses — a spec
-  folder that simply lies outside the project tree still comes back verbatim, because an external
-  spec folder is a supported layout. Degrading the uncertain leg to the raw absolute spelling was
-  the first shape and is wrong at the sink: `BMAD_LOOP_SPEC_FOLDER`, the dev prompt,
-  `RunState.spec_folder` and the post-session verification all take the string as given, and only
-  a project-_relative_ answer is anchored on the live workspace root — so under
-  `isolation = "worktree"` an absolute one would point a story's reads and writes at the main
-  checkout instead of its own unit worktree.
+  exception type their handler caught, so a host that cannot canonicalize the path — a dead UNC
+  provider (`WinError 64`), a symlink loop on the 3.11/3.12 floor — escaped by a route neither
+  describes. Both now refuse by name and point at `bmad-loop validate`: the restore patch returns
+  its sibling rejected-latch shape, the spec folder raises `stories.StoriesError`, and `--dry-run`
+  reports it before exiting 1. A spec folder that merely lies outside the project tree still comes
+  back verbatim — that is a supported layout, and only the canonicalization leg refuses.
 
 ## [0.11.0] — 2026-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -237,8 +237,9 @@ breaking changes may land in a minor release.
   UNC provider, `WinError 64`; a symlink loop on the 3.11/3.12 floor) fell through to a generic,
   unscoped error instead of the specific one the rest of the function reports. The restore-patch
   path now returns the same rejected-latch shape as its sibling checks; the spec-folder path
-  degrades to the shared lexical fallback like every other `platform_util.resolve_or_lexical`
-  consumer.
+  widens its own handler to the `(OSError, RuntimeError, ValueError)` house guard and keeps the
+  path verbatim, the answer `verify._stories_relpaths` already gives for the same folder — a
+  location the host cannot canonicalize must not be rebased onto the project root.
 
 - **Attempt-owned spec-only retries no longer demand a false manual rollback (#123).** A
   bound plain attempt whose only residue is its lifecycle flip is restored to its pre-attempt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,18 +42,23 @@ breaking changes may land in a minor release.
   now pin to the calling pane via `TMUX_PANE`, and answer `None` without spawning when that value
   is absent or not pane-shaped.
 
-- **Unresolvable restore-patch and spec-folder paths no longer escape their own handler (#560).**
-  `_resolve_restore_patch` (`cli --restore-patch`) and `relativize_spec_folder` (`--spec`,
-  `[stories] source`) each called `.resolve()` outside the exception type their local handler
-  caught, so a host that cannot canonicalize the path (a dead UNC provider, `WinError 64`; a
-  symlink loop on the 3.11/3.12 floor) left the function by a route it does not describe. The
-  restore-patch half is a rejection, and now returns the sibling rejected-latch shape — naming the
-  path and pointing at `bmad-loop validate` — where the fault used to surface as a bare
-  `[Errno ...]` from the top-level backstop. The spec-folder half rejects nothing and reports
-  nothing: it widens its own handler to the `(OSError, RuntimeError, ValueError)` house guard —
-  the guard `verify._stories_relpaths` already puts around the same relativization of the same
-  folder — and keeps the path verbatim, because a location the host cannot canonicalize must not
-  be rebased onto the project root.
+- **An unresolvable restore-patch or spec-folder path is now a named refusal, not a bare
+  `[Errno ...]` (#560).** `_resolve_restore_patch` (`cli --restore-patch`) and
+  `relativize_spec_folder` (`--spec`, `[stories] source`) each called `.resolve()` outside the
+  exception type their local handler caught, so a host that cannot canonicalize the path (a dead
+  UNC provider, `WinError 64`; a symlink loop on the 3.11/3.12 floor) left the function by a route
+  it does not describe. The restore-patch half is a rejection, and now returns the sibling
+  rejected-latch shape — naming the path and pointing at `bmad-loop validate` — where the fault
+  used to surface as a bare `[Errno ...]` from the top-level backstop. The spec-folder half now
+  refuses on the same terms, raising `stories.StoriesError` with both operands named, which the
+  `--dry-run` preview reports before exiting 1. Only the canonicalization leg refuses — a spec
+  folder that simply lies outside the project tree still comes back verbatim, because an external
+  spec folder is a supported layout. Degrading the uncertain leg to the raw absolute spelling was
+  the first shape and is wrong at the sink: `BMAD_LOOP_SPEC_FOLDER`, the dev prompt,
+  `RunState.spec_folder` and the post-session verification all take the string as given, and only
+  a project-_relative_ answer is anchored on the live workspace root — so under
+  `isolation = "worktree"` an absolute one would point a story's reads and writes at the main
+  checkout instead of its own unit worktree.
 
 ## [0.11.0] — 2026-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,19 @@ breaking changes may land in a minor release.
   now pin to the calling pane via `TMUX_PANE`, and answer `None` without spawning when that value
   is absent or not pane-shaped.
 
+- **Unresolvable restore-patch and spec-folder paths no longer escape their own handler (#560).**
+  `_resolve_restore_patch` (`cli --restore-patch`) and `relativize_spec_folder` (`--spec`,
+  `[stories] source`) each called `.resolve()` outside the exception type their local handler
+  caught, so a host that cannot canonicalize the path (a dead UNC provider, `WinError 64`; a
+  symlink loop on the 3.11/3.12 floor) left the function by a route it does not describe. The
+  restore-patch half is a rejection, and now returns the sibling rejected-latch shape — naming the
+  path and pointing at `bmad-loop validate` — where the fault used to surface as a bare
+  `[Errno ...]` from the top-level backstop. The spec-folder half rejects nothing and reports
+  nothing: it widens its own handler to the `(OSError, RuntimeError, ValueError)` house guard —
+  the guard `verify._stories_relpaths` already puts around the same relativization of the same
+  folder — and keeps the path verbatim, because a location the host cannot canonicalize must not
+  be rebased onto the project root.
+
 ## [0.11.0] — 2026-08-19
 
 ### Added
@@ -229,17 +242,6 @@ breaking changes may land in a minor release.
 - **Reject mismatched TOML scalar types for every `limits.*` policy field (#278).**
   Quoted booleans and other coercible values now raise `PolicyError` instead of silently changing
   the configured limit or enabling a disabled behavior.
-
-- **Unresolvable restore-patch and spec-folder paths no longer bypass their own rejection
-  message (#560).** `_resolve_restore_patch` (`cli --restore-patch`) and
-  `relativize_spec_folder` (`--spec`, `[stories] source`) each called `.resolve()` outside the
-  exception type their local handler caught, so a host that cannot canonicalize the path (a dead
-  UNC provider, `WinError 64`; a symlink loop on the 3.11/3.12 floor) fell through to a generic,
-  unscoped error instead of the specific one the rest of the function reports. The restore-patch
-  path now returns the same rejected-latch shape as its sibling checks; the spec-folder path
-  widens its own handler to the `(OSError, RuntimeError, ValueError)` house guard and keeps the
-  path verbatim, the answer `verify._stories_relpaths` already gives for the same folder — a
-  location the host cannot canonicalize must not be rebased onto the project root.
 
 - **Attempt-owned spec-only retries no longer demand a false manual rollback (#123).** A
   bound plain attempt whose only residue is its lifecycle flip is restored to its pre-attempt

--- a/src/bmad_loop/cli.py
+++ b/src/bmad_loop/cli.py
@@ -2451,9 +2451,10 @@ def _resolve_restore_patch(
         patch = verify.resolve_restore_path(raw, project).resolve()
     except (OSError, RuntimeError) as e:
         return None, (
-            f"cannot canonicalize the restore patch path {raw!r}: {e}, so whether it "
-            "lies inside or outside the project tree cannot be determined, and the "
-            "restore cannot be latched"
+            f"cannot canonicalize the restore patch path {raw!r}: {e} — whether it "
+            "lies inside or outside the project tree cannot be determined, so the "
+            "restore cannot be latched. Run `bmad-loop validate` for what this host "
+            "is doing."
         )
     # Same trusted-roots shape as the frontmatter reconcile's spec_within_roots:
     # bmad-build-auto saves the patch under implementation_artifacts, and artifact

--- a/src/bmad_loop/cli.py
+++ b/src/bmad_loop/cli.py
@@ -1917,8 +1917,17 @@ def _dry_run_stories(
     _warn_preflight_would_abort(paths, pol, require_stories=True)
     folder = stories_mod.resolve_spec_folder(paths.project, spec_folder)
     # The real dispatch always uses the project-relative folder (the engine
-    # relativizes it); render the identical string here so dry-run and run agree.
-    rel = stories_mod.relativize_spec_folder(paths.project, spec_folder)
+    # relativizes it); render the identical string here so dry-run and run agree —
+    # including the refusal, which is the one answer `run` would not survive. No
+    # `(spec folder: ...)` suffix like the sibling below: the reason already names
+    # the spec folder and the project root, and on this leg `folder` is only
+    # `spec_folder` re-spelled (the raise is reachable from the absolute branch
+    # alone), so the suffix would print the same path a third time.
+    try:
+        rel = stories_mod.relativize_spec_folder(paths.project, spec_folder)
+    except stories_mod.StoriesError as e:
+        print(f"stories mode: {e}", file=sys.stderr)
+        return 1
     try:
         rows = stories_mod.story_rows(folder, selector=args.story, max_stories=args.max_stories)
     except stories_mod.StoriesError as e:

--- a/src/bmad_loop/cli.py
+++ b/src/bmad_loop/cli.py
@@ -2444,8 +2444,17 @@ def _resolve_restore_patch(
         return None, err
     # `.resolve()` on top of the shared normalizer: this is the one consumer that
     # feeds a containment check (spec_within_roots), which needs `..`/symlinks
-    # collapsed. The resolved absolute path is what gets latched.
-    patch = verify.resolve_restore_path(raw, project).resolve()
+    # collapsed. The resolved absolute path is what gets latched, so this stays a
+    # bare `.resolve()` rather than `resolve_or_lexical`: a degraded, non-canonical
+    # answer here could pass containment on the wrong directory.
+    try:
+        patch = verify.resolve_restore_path(raw, project).resolve()
+    except (OSError, RuntimeError) as e:
+        return None, (
+            f"cannot canonicalize the restore patch path {raw!r}: {e}, so whether it "
+            "lies inside or outside the project tree cannot be determined, and the "
+            "restore cannot be latched"
+        )
     # Same trusted-roots shape as the frontmatter reconcile's spec_within_roots:
     # bmad-build-auto saves the patch under implementation_artifacts, and artifact
     # dirs configured OUTSIDE the project tree are a supported layout — a bare

--- a/src/bmad_loop/stories.py
+++ b/src/bmad_loop/stories.py
@@ -30,6 +30,7 @@ import yaml
 
 from . import deferredwork
 from .frontmatter import read_frontmatter, status_of
+from .platform_util import resolve_or_lexical
 
 # Fixed-name discovery, like SPEC.md / .memlog.md — never listed in companions.
 STORIES_FILENAME = "stories.yaml"
@@ -480,7 +481,7 @@ def relativize_spec_folder(project: Path, spec_folder: str) -> str:
     raw = Path(spec_folder)
     if raw.is_absolute():
         try:
-            return raw.resolve().relative_to(project.resolve()).as_posix()
+            return resolve_or_lexical(raw).relative_to(resolve_or_lexical(project)).as_posix()
         except ValueError:
             return raw.as_posix()  # outside the project tree — leave absolute
     return raw.as_posix()

--- a/src/bmad_loop/stories.py
+++ b/src/bmad_loop/stories.py
@@ -472,22 +472,38 @@ def resolve_spec_folder(project: Path, spec_folder: str) -> Path:
 def relativize_spec_folder(project: Path, spec_folder: str) -> str:
     """The project-relative posix form of ``spec_folder`` — what the orchestrator
     actually dispatches (``BMAD_LOOP_SPEC_FOLDER`` / the ``Spec folder:`` prompt).
+    The one place this lives so the engine's real dispatch and the CLI dry-run
+    render the identical folder string.
 
-    An absolute path inside the project tree is rebased to the project root;
-    anything else is kept verbatim (the contract allows an absolute spec folder,
-    though we never author one) — including an in-tree one on a host that cannot
-    canonicalize either side, whose location is not knowable here. The one place
-    this lives so the engine's real dispatch and the CLI dry-run render the
-    identical folder string."""
+    Three answers and one refusal. A relative spelling is kept verbatim; an
+    absolute one inside the project tree is rebased onto the root; an absolute one
+    genuinely outside it is kept verbatim too — an external spec folder is a
+    supported layout (``[stories] source``), though we never author one. A host
+    that cannot canonicalize either operand raises :class:`StoriesError`
+    (#552/#560) instead of answering: the location is unknowable, and every sink
+    takes the string as given — ``BMAD_LOOP_SPEC_FOLDER``, the dev prompt,
+    ``RunState.spec_folder`` and the post-session verification all consume it
+    verbatim, and ``StoriesEngine._stories_folder`` anchors only a *relative*
+    answer on the live workspace root. Handing back an unverified absolute path
+    would therefore skip the anchor entirely and point an isolated story's reads
+    and writes at the main checkout; refusing costs a run that could not have been
+    dispatched correctly anyway."""
     raw = Path(spec_folder)
     if not raw.is_absolute():
         return raw.as_posix()
     try:
         return raw.resolve().relative_to(project.resolve()).as_posix()
-    except (OSError, RuntimeError, ValueError):
-        # Outside the project tree, or a host that cannot canonicalize either side
-        # (#552/#560) — an uncertain location must not be rebased.
+    except ValueError:
+        # Both sides canonicalized and simply share no prefix: genuinely outside
+        # the project tree, which the contract allows — keep it verbatim.
         return raw.as_posix()
+    except (OSError, RuntimeError) as e:
+        raise StoriesError(
+            f"cannot canonicalize the spec folder {spec_folder!r} against the project "
+            f"root {str(project)!r}: {e} — whether it lies inside or outside the "
+            "project tree cannot be determined, so no run can safely dispatch it. "
+            "Run `bmad-loop validate` for what this host is doing."
+        ) from e
 
 
 def is_plan_halt_leg(spec_checkpoint: bool, state: StoryState) -> bool:

--- a/src/bmad_loop/stories.py
+++ b/src/bmad_loop/stories.py
@@ -30,7 +30,6 @@ import yaml
 
 from . import deferredwork
 from .frontmatter import read_frontmatter, status_of
-from .platform_util import resolve_or_lexical
 
 # Fixed-name discovery, like SPEC.md / .memlog.md — never listed in companions.
 STORIES_FILENAME = "stories.yaml"
@@ -476,15 +475,19 @@ def relativize_spec_folder(project: Path, spec_folder: str) -> str:
 
     An absolute path inside the project tree is rebased to the project root;
     anything else is kept verbatim (the contract allows an absolute spec folder,
-    though we never author one). The one place this lives so the engine's real
-    dispatch and the CLI dry-run render the identical folder string."""
+    though we never author one) — including an in-tree one on a host that cannot
+    canonicalize either side, whose location is not knowable here. The one place
+    this lives so the engine's real dispatch and the CLI dry-run render the
+    identical folder string."""
     raw = Path(spec_folder)
-    if raw.is_absolute():
-        try:
-            return resolve_or_lexical(raw).relative_to(resolve_or_lexical(project)).as_posix()
-        except ValueError:
-            return raw.as_posix()  # outside the project tree — leave absolute
-    return raw.as_posix()
+    if not raw.is_absolute():
+        return raw.as_posix()
+    try:
+        return raw.resolve().relative_to(project.resolve()).as_posix()
+    except (OSError, RuntimeError, ValueError):
+        # Outside the project tree, or a host that cannot canonicalize either side
+        # (#552/#560) — an uncertain location must not be rebased.
+        return raw.as_posix()
 
 
 def is_plan_halt_leg(spec_checkpoint: bool, state: StoryState) -> bool:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2613,6 +2613,47 @@ def test_resolve_restore_patch_outside_project_rejected(tmp_path, monkeypatch, c
     assert task.phase == Phase.ESCALATED and task.restore_patch is None  # not re-armed
 
 
+def test_resolve_restore_patch_unresolvable_rejected(tmp_path, monkeypatch, capsys):
+    """A restore patch path whose `.resolve()` faults (WinError 64 on a dead UNC
+    provider, or a symlink loop on the 3.11/3.12 floor, #560) escaped this
+    function's own try/except (scoped to `bmadconfig.BmadConfigError`) and fell
+    through to `main()`'s generic backstop, which reports a bare `[Errno ...]`
+    string instead of naming the restore-patch path or what failed. Pin the
+    specific message this function now returns, matching its other three
+    rejection reasons."""
+    from bmad_loop.journal import load_state
+    from bmad_loop.model import Phase
+
+    spec = tmp_path / "spec.md"
+    spec.write_text("---\nstatus: blocked\n---\n", encoding="utf-8")
+    _write_bmad_config(tmp_path)
+    run_dir = _escalated_run(tmp_path, "r1", spec_file=str(spec))
+    called: list = []
+    monkeypatch.setattr(cli, "_resume_paused_run", lambda proj, rd: called.append(rd) or 0)
+    patch = tmp_path / "whatever.patch"
+    refuse_to_resolve(monkeypatch, patch)
+
+    rc = cli.main(
+        [
+            "resolve",
+            "--project",
+            str(tmp_path),
+            "r1",
+            "--no-interactive",
+            "--restore-patch",
+            str(patch),
+            "--resume",
+        ]
+    )
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "cannot canonicalize the restore patch path" in err
+    assert UNRESOLVABLE in err
+    assert called == []  # never resumed
+    task = load_state(run_dir).tasks["s1"]
+    assert task.phase == Phase.ESCALATED and task.restore_patch is None  # not re-armed
+
+
 def test_resolve_restore_patch_in_outside_project_artifacts_allowed(tmp_path, monkeypatch):
     """Artifact dirs configured OUTSIDE the project tree are a supported layout
     (bmadconfig keeps them absolute; verify special-cases them throughout), and

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2619,8 +2619,23 @@ def test_resolve_restore_patch_unresolvable_rejected(tmp_path, monkeypatch, caps
     function's own try/except (scoped to `bmadconfig.BmadConfigError`) and fell
     through to `main()`'s generic backstop, which reports a bare `[Errno ...]`
     string instead of naming the restore-patch path or what failed. Pin the
-    specific message this function now returns, matching its other three
-    rejection reasons."""
+    specific message this function now returns, in the shape its five sibling
+    rejection reasons use.
+
+    Measured ablation (delete the `except (OSError, RuntimeError)` arm from
+    `_resolve_restore_patch`, leaving the bare `.resolve()`): this row fails, at
+    `assert f"cannot canonicalize the restore patch path {str(patch)!r}" in err`.
+    Only the two message assertions carry it. The unguarded `OSError` reaches
+    `main()`'s generic `except Exception` backstop, which prints `error: {e}` to
+    stderr and returns `ExitCode.FAILURE` — so ablated, `rc == 1`,
+    `UNRESOLVABLE in err`, `called == []` and both halves of the
+    phase/restore_patch assertion still pass; measured `err` is exactly
+    `error: [Errno 0] stubbed: the provider is registered but not serving`, and
+    with only those two message lines commented out the ablated row goes GREEN.
+    `UNRESOLVABLE in err` can never discriminate this regression — the guard
+    interpolates `{e}` and the backstop prints `{e}` bare, so it is the same
+    substring on both sides. Loosening the message assertion to it would make
+    this row a false green."""
     from bmad_loop.journal import load_state
     from bmad_loop.model import Phase
 
@@ -2647,8 +2662,81 @@ def test_resolve_restore_patch_unresolvable_rejected(tmp_path, monkeypatch, caps
     )
     assert rc == 1
     err = capsys.readouterr().err
-    assert "cannot canonicalize the restore patch path" in err
+    assert f"cannot canonicalize the restore patch path {str(patch)!r}" in err
     assert UNRESOLVABLE in err
+    assert "Run `bmad-loop validate` for what this host is doing." in err
+    assert called == []  # never resumed
+    task = load_state(run_dir).tasks["s1"]
+    assert task.phase == Phase.ESCALATED and task.restore_patch is None  # not re-armed
+
+
+def test_resolve_restore_patch_unresolvable_from_resolution_json_rejected(
+    tmp_path, monkeypatch, capsys
+):
+    """The same `.resolve()` guard, reached from the OTHER caller. `cmd_resolve`
+    validates an explicit `--restore-patch` flag BEFORE the interactive session,
+    but a `restore_patch` the agent recorded in resolution.json only exists once
+    that session has written it — so this arm cannot be hoisted, and its abort
+    lands after a whole agent conversation. The sibling flag-arm row above cannot
+    stand in for it: that row passes `--no-interactive`, which short-circuits the
+    resolution.json read (`if raw is None and args.interactive`), leaving `raw`
+    None so `if not raw: return None, None` fires and the guarded `.resolve()` is
+    never reached from this side. `ran == ["s1"]` is what pins that difference —
+    an identity assertion for the row, not a guard assertion (see below). The
+    patch here is a real file under the configured implementation_artifacts root,
+    i.e. an otherwise-honorable restore whose only defect is that this host cannot
+    canonicalize its path.
+
+    Measured ablation (delete the `except (OSError, RuntimeError)` arm from
+    `_resolve_restore_patch`, leaving the bare `.resolve()`): this row fails, at
+    `assert f"cannot canonicalize the restore patch path {str(patch)!r}" in err`.
+    Only the two message assertions carry it — with just those two lines removed
+    the ablated row goes GREEN. The unguarded `OSError` unwinds `cmd_resolve` into
+    `main()`'s generic `except Exception` backstop, which prints `error: {e}` to
+    stderr and returns `ExitCode.FAILURE`, so ablated `rc == 1`, `ran == ["s1"]`
+    (the session had already run), `UNRESOLVABLE in err`, `called == []` and both
+    halves of the phase/restore_patch assertion all still pass; measured `err` is
+    exactly `error: [Errno 0] stubbed: the provider is registered but not
+    serving`. As in the flag-arm row, `UNRESOLVABLE in err` can never discriminate
+    this regression — the guard interpolates `{e}` and the backstop prints `{e}`
+    bare, so it is the same substring on both sides."""
+    from bmad_loop import resolve
+    from bmad_loop.journal import load_state
+    from bmad_loop.model import Phase
+
+    spec = tmp_path / "spec.md"
+    spec.write_text("---\nstatus: blocked\n---\n", encoding="utf-8")
+    _write_bmad_config(tmp_path)
+    patch = tmp_path / "artifacts" / "attempt.patch"  # a legitimate restore target
+    patch.parent.mkdir(parents=True)
+    patch.write_text("diff", encoding="utf-8")
+    run_dir = _escalated_run(tmp_path, "r1", spec_file=str(spec))
+    ran: list = []
+
+    def fake_session(adapter, project, rd, story_key, *, model=""):
+        # the resolve agent records a restore_patch in its output marker
+        ran.append(story_key)
+        marker = resolve.resolution_path(rd, story_key)
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text(json.dumps({"restore_patch": str(patch)}), encoding="utf-8")
+        return True
+
+    monkeypatch.setattr(cli, "_make_adapters", lambda *a, **k: {"dev": object()})
+    monkeypatch.setattr(resolve, "build_context", lambda *a, **k: None)
+    monkeypatch.setattr(resolve, "run_session", fake_session)
+    called: list = []
+    monkeypatch.setattr(cli, "_resume_paused_run", lambda proj, rd: called.append(rd) or 0)
+    refuse_to_resolve(monkeypatch, patch)
+
+    # interactive is the default, and is required: this arm reads the marker the
+    # session writes, so --no-interactive would short-circuit it before the guard
+    rc = cli.main(["resolve", "--project", str(tmp_path), "r1", "--resume"])
+    assert rc == 1
+    assert ran == ["s1"]  # the session really ran: this abort is post-session
+    err = capsys.readouterr().err
+    assert f"cannot canonicalize the restore patch path {str(patch)!r}" in err
+    assert UNRESOLVABLE in err
+    assert "Run `bmad-loop validate` for what this host is doing." in err
     assert called == []  # never resumed
     task = load_state(run_dir).tasks["s1"]
     assert task.phase == Phase.ESCALATED and task.restore_patch is None  # not re-armed

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5899,6 +5899,43 @@ def test_dry_run_stories_relativizes_absolute_folder(project, capsys):
     assert f"Spec folder: {abs_folder}" not in out  # not the raw absolute path
 
 
+def test_dry_run_stories_unresolvable_absolute_folder_refused(project, monkeypatch, capsys):
+    """`relativize_spec_folder` reaches the CLI only here, and the refusal it
+    now raises (#560) is the one answer the dry-run cannot render: an absolute
+    `--spec` inside the project whose `.resolve()` faults has no knowable
+    location, so there is no folder string to preview. Print the reason and exit
+    1, in the shape of its `story_rows` sibling just below — minus that sibling's
+    `(spec folder: ...)` suffix, which would be a third printing of a path the
+    reason already names twice (this leg is reachable only from the absolute
+    branch, where `folder` is `spec_folder` re-spelled).
+
+    Measured ablations:
+    - B3 (delete the `try`/`except stories_mod.StoriesError` around the
+      `relativize_spec_folder` call in `cli._dry_run_stories`): FAILS at `assert
+      cli._dry_run(project, pol, args, True, abs_folder) == 1` — the
+      `StoriesError` propagates out of `_dry_run` uncaught, so the row errors on
+      that line and the two stderr assertions are never reached. That line alone
+      carries this row.
+    - B1 (collapse `relativize_spec_folder` back to one degrade arm): FAILS on
+      the same line with `assert 0 == 1`, and the captured stdout is the
+      regression itself — a rendered `BMAD_LOOP_SPEC_FOLDER=<absolute path into
+      the main checkout>` previewed as runnable.
+    - B2 (blanket raise): green — this row travels the `OSError` leg, which B2
+      leaves refusing."""
+    _setup_stories_fixture(project, [_stories_entry("1")])
+    abs_folder = str(project.project / STORIES_SPEC_FOLDER)
+    pol = policy_mod.loads("")
+    args = argparse.Namespace(spec=abs_folder, epic=None, story=None, max_stories=None)
+    refuse_to_resolve(monkeypatch, Path(abs_folder))
+
+    assert cli._dry_run(project, pol, args, True, abs_folder) == 1
+
+    cap = capsys.readouterr()
+    assert f"stories mode: cannot canonicalize the spec folder {abs_folder!r}" in cap.err
+    assert "Run `bmad-loop validate` for what this host is doing." in cap.err
+    assert "linear schedule" not in cap.out  # no preview of a folder we cannot place
+
+
 # --------------- `bmad-loop mux`: backend listing + persisted choice (issue #87) ----
 
 

--- a/tests/test_stories.py
+++ b/tests/test_stories.py
@@ -4,7 +4,7 @@ import re
 from pathlib import Path
 
 import pytest
-from conftest import fault_read_text, refuse_to_resolve
+from conftest import UNRESOLVABLE, fault_read_text, refuse_to_resolve
 
 from bmad_loop import stories
 
@@ -596,67 +596,87 @@ def test_story_rows_missing_manifest_raises(tmp_path):
 
 
 def test_relativize_spec_folder_rebases_absolute_path_in_project(tmp_path):
+    """CONTROL for the whole section, not an ablation row: the healthy path. Both
+    `.resolve()` calls answer, they agree on a shared prefix, and the result is
+    project-relative — so a red neighbour below is evidence about a refusal leg,
+    never about rebasing itself. Measured green under B1, B2 and B3."""
     project = tmp_path / "proj"
     spec_folder = project / "specs" / "s1"
     spec_folder.mkdir(parents=True)
     assert stories.relativize_spec_folder(project, str(spec_folder)) == "specs/s1"
 
 
-def test_relativize_spec_folder_survives_unresolvable_project_root(tmp_path, monkeypatch, capsys):
+def test_relativize_spec_folder_refuses_unresolvable_project_root(tmp_path, monkeypatch):
     """The project root's own `.resolve()` faulting (WinError 64 from a
     registered-but-not-serving UNC provider, or a symlink loop on the 3.11/3.12
     floor, #560) escaped the `except ValueError` that used to be the whole guard
-    around this pair of `.resolve()` calls. The widened tuple catches it and the
-    raw absolute spelling is kept: a host that cannot canonicalize one side
-    cannot say where the folder is, and an uncertain location must not be
-    rebased onto the project root.
+    around this pair of `.resolve()` calls. Catching it must not mean answering
+    it: a host that cannot canonicalize one side cannot say where the folder is,
+    and every sink downstream takes the string as given — `BMAD_LOOP_SPEC_FOLDER`,
+    the dev prompt, `RunState.spec_folder`, post-session verification — while
+    `StoriesEngine._stories_folder` anchors only a *relative* answer on the live
+    workspace root. Degrading to the raw absolute spelling therefore trades a loud
+    abort for an isolated story that silently reads and writes the main checkout,
+    so this leg refuses instead.
 
-    Ablation A1 (#560): narrow the arm back to `except ValueError` and this
-    reddens — the OSError escapes the function.
-    Ablation A2 (the PR's first shape): restore
-    `resolve_or_lexical(raw).relative_to(resolve_or_lexical(project))` and this
-    reddens too, on its first assertion — that pair degrades the refused operand
-    to a lexical spelling and rebases anyway, answering `specs/s1` for a folder
-    it could not locate."""
+    Measured ablations:
+    - B1 (collapse the split back to one degrade arm,
+      `except (OSError, RuntimeError, ValueError): return raw.as_posix()`): FAILS
+      at `with pytest.raises(stories.StoriesError)` — `Failed: DID NOT RAISE
+      StoriesError`. That line alone carries the row; the five assertions after it
+      are never reached.
+    - B2 (widen the raise arm to the whole tuple): green. B2 changes only the
+      `ValueError` leg, which this row does not travel — the outside-the-tree row
+      at the end of this section is the one that catches it.
+    - B3 (delete the `cli._dry_run_stories` handler): green — no CLI here."""
     project = tmp_path / "proj"
     spec_folder = project / "specs" / "s1"
     spec_folder.mkdir(parents=True)
     refuse_to_resolve(monkeypatch, project)
 
-    rel = stories.relativize_spec_folder(project, str(spec_folder))
+    with pytest.raises(stories.StoriesError) as excinfo:
+        stories.relativize_spec_folder(project, str(spec_folder))
 
-    assert rel == spec_folder.as_posix()  # kept where it was, not rebased
-    # The degrade note belongs to the observation surface, not to a value the
-    # engine dispatches on every story.
-    assert capsys.readouterr().err == ""
+    msg = str(excinfo.value)
+    assert f"cannot canonicalize the spec folder {str(spec_folder)!r}" in msg
+    assert f"project root {str(project)!r}" in msg
+    assert UNRESOLVABLE in msg  # the refusing OSError's own text, interpolated
+    assert "Run `bmad-loop validate` for what this host is doing." in msg
+    assert isinstance(excinfo.value.__cause__, OSError)  # `raise ... from e`
 
 
-def test_relativize_spec_folder_survives_unresolvable_spec_folder(tmp_path, monkeypatch, capsys):
+def test_relativize_spec_folder_refuses_unresolvable_spec_folder(tmp_path, monkeypatch):
     """Same arm, the other operand: `refuse_to_resolve` matches on the exact
     `str()` spelling, so refusing the project root above leaves `raw.resolve()`
     answering normally and vice versa. Without this row a regression that
-    restored only the `raw` side would still pass the project-root row.
+    re-degraded only the `raw` side would still pass the project-root row.
 
-    Ablations A1 and A2 both redden it, for the same two reasons recorded
-    above — A1 by letting the OSError escape, A2 by answering `specs/s1`."""
+    Measured ablations: identical to the project-root row above — B1 FAILS at
+    `with pytest.raises(stories.StoriesError)` (`DID NOT RAISE StoriesError`),
+    B2 green, B3 green."""
     project = tmp_path / "proj"
     spec_folder = project / "specs" / "s1"
     spec_folder.mkdir(parents=True)
     refuse_to_resolve(monkeypatch, spec_folder)
 
-    rel = stories.relativize_spec_folder(project, str(spec_folder))
+    with pytest.raises(stories.StoriesError) as excinfo:
+        stories.relativize_spec_folder(project, str(spec_folder))
 
-    assert rel == spec_folder.as_posix()
-    assert capsys.readouterr().err == ""
+    msg = str(excinfo.value)
+    assert f"cannot canonicalize the spec folder {str(spec_folder)!r}" in msg
+    assert f"project root {str(project)!r}" in msg
+    assert UNRESOLVABLE in msg
+    assert "Run `bmad-loop validate` for what this host is doing." in msg
+    assert isinstance(excinfo.value.__cause__, OSError)
 
 
 def _symlinked_project_root(tmp_path: Path) -> Path:
     """A project root reached through a symlink, so its lexical and canonical
     spellings really are different strings.
 
-    The two rows above cannot see a mixed-spelling answer on their own: measured
-    here, `tmp_path.resolve() == tmp_path`, so a degraded (lexical) operand and a
-    canonical one are the same text and every combination returns `specs/s1`.
+    The two rows above cannot see a mixed-spelling message on their own: measured
+    here, `tmp_path.resolve() == tmp_path`, so a raw operand and a dereferenced one
+    are the same text and every spelling assertion passes either way.
     Follows `test_bmadconfig.py`'s `worktree_isolation_conflict` symlink row,
     including its skip for a Windows host without SeCreateSymbolicLink."""
     target = tmp_path / "target"
@@ -674,8 +694,8 @@ def test_relativize_spec_folder_symlinked_root_still_rebases_when_healthy(tmp_pa
     """CONTROL for the two symlinked rows below, not an ablation row: reaching
     the root through a symlink does not by itself stop the rebase. Both
     `.resolve()` calls answer, they agree on the canonical spelling, and the
-    result is project-relative. Measured green under every ablation below — it
-    is here so a red neighbour cannot be blamed on the symlink itself."""
+    result is project-relative. Measured green under B1, B2 and B3 — it is here
+    so a red neighbour cannot be blamed on the symlink itself."""
     root = _symlinked_project_root(tmp_path)
     spec_folder = root / "specs" / "s1"
     spec_folder.mkdir(parents=True)
@@ -683,68 +703,84 @@ def test_relativize_spec_folder_symlinked_root_still_rebases_when_healthy(tmp_pa
     assert stories.relativize_spec_folder(root, str(spec_folder)) == "specs/s1"
 
 
-def test_relativize_spec_folder_symlinked_root_project_refused_keeps_raw_spelling(
-    tmp_path, monkeypatch, capsys
-):
-    """The project-root operand refused on a host where the two spellings differ.
-    The value returned is the *raw* spelling the caller passed, not the canonical
-    one — `stories_engine._stories_folder` consumes this string verbatim, so a
-    silently re-spelled answer would move where a story reads and writes.
+def test_relativize_spec_folder_symlinked_root_project_refused_raises(tmp_path, monkeypatch):
+    """The project-root operand refused on a host where a path's raw and
+    canonical spellings really are different strings. The refusal quotes the
+    *raw* spelling the caller passed, never the dereferenced one: the message is
+    the only place an operator learns which path to fix, and both the engine and
+    the dry-run consume that same raw string, so a silently re-spelled one would
+    name a directory nobody configured.
 
-    Ablation A1 (#560) reddens this row. Ablation A2 reddens only its stderr
-    assertion: the PR's shape returns the same absolute string here (one operand
-    canonical, one lexical, so `relative_to` fails and both fall to the same
-    arm), and is caught only by the degrade note it prints. The row that catches
-    A2 on its *return value* is the parent-escape row below."""
+    Measured ablations:
+    - B1: FAILS at `with pytest.raises(stories.StoriesError)` (`DID NOT RAISE
+      StoriesError`) — that line carries the row.
+    - B2: green (the `ValueError` leg is untravelled here). B3: green.
+
+    The `not in msg` line is INERT under all three: nothing in this change
+    canonicalizes the operands before interpolating them, so no mandated ablation
+    can redden it. It is a forward guard on the message shape — the one assertion
+    the two non-symlinked rows above cannot make, since `tmp_path.resolve() ==
+    tmp_path` there — and not what carries the row."""
     root = _symlinked_project_root(tmp_path)
     spec_folder = root / "specs" / "s1"
     spec_folder.mkdir(parents=True)
     canonical = spec_folder.resolve()
     refuse_to_resolve(monkeypatch, root)
 
-    rel = stories.relativize_spec_folder(root, str(spec_folder))
+    with pytest.raises(stories.StoriesError) as excinfo:
+        stories.relativize_spec_folder(root, str(spec_folder))
 
-    assert rel == spec_folder.as_posix()
-    assert Path(rel).is_absolute()
-    assert rel != canonical.as_posix(), "the raw spelling, not the dereferenced one"
-    assert capsys.readouterr().err == ""
+    msg = str(excinfo.value)
+    assert f"cannot canonicalize the spec folder {str(spec_folder)!r}" in msg
+    assert "Run `bmad-loop validate` for what this host is doing." in msg
+    assert f"{str(canonical)!r}" not in msg, "the raw spelling, not the dereferenced one"
 
 
-def test_relativize_spec_folder_symlinked_root_spec_folder_refused_keeps_raw_spelling(
-    tmp_path, monkeypatch, capsys
-):
-    """The spec-folder operand refused, same symlinked host. Ablations as for the
-    project-root row above: A1 reddens the whole row, A2 only its stderr
-    assertion."""
+def test_relativize_spec_folder_symlinked_root_spec_folder_refused_raises(tmp_path, monkeypatch):
+    """The spec-folder operand refused, same symlinked host — the pairing the
+    project-root row above cannot cover, for the reason its own sibling states.
+
+    Measured ablations exactly as for that row: B1 FAILS at `with
+    pytest.raises(stories.StoriesError)` (`DID NOT RAISE StoriesError`), B2 and
+    B3 green, and the `not in msg` line is INERT under all three (a forward guard
+    on the message shape, not what carries the row)."""
     root = _symlinked_project_root(tmp_path)
     spec_folder = root / "specs" / "s1"
     spec_folder.mkdir(parents=True)
     canonical = root.resolve() / "specs" / "s1"
     refuse_to_resolve(monkeypatch, spec_folder)
 
-    rel = stories.relativize_spec_folder(root, str(spec_folder))
+    with pytest.raises(stories.StoriesError) as excinfo:
+        stories.relativize_spec_folder(root, str(spec_folder))
 
-    assert rel == spec_folder.as_posix()
-    assert Path(rel).is_absolute()
-    assert rel != canonical.as_posix(), "the raw spelling, not the dereferenced one"
-    assert capsys.readouterr().err == ""
+    msg = str(excinfo.value)
+    assert f"cannot canonicalize the spec folder {str(spec_folder)!r}" in msg
+    assert "Run `bmad-loop validate` for what this host is doing." in msg
+    assert f"{str(canonical)!r}" not in msg, "the raw spelling, not the dereferenced one"
 
 
 def test_relativize_spec_folder_never_answers_a_parent_escaping_path(tmp_path, monkeypatch):
-    """A `..`-spelled spec folder with both operands refused. This is the row the
-    rework exists for: `relative_to` strips a *textual* prefix, so two lexical
-    (un-dereferenced) operands can leave the `..` standing and yield a
-    "relative" path that climbs out of the root it is relative to.
+    """A `..`-spelled spec folder with both operands refused. Written for the
+    degrade era, where it was the proof that no answer climbed out of the root it
+    claimed to be relative to: `relative_to` strips a *textual* prefix, so two
+    un-dereferenced operands could leave the `..` standing, and
+    `StoriesEngine._stories_folder` would then join `../proj/specs/s1` against the
+    unit worktree — a sibling directory nobody configured.
 
-    The harm is at the sink: `stories_engine._stories_folder` joins a relative
-    answer against `workspace.root`, which during an isolated story is the unit
-    worktree — so `../proj/specs/s1` names a sibling of the worktree that nobody
-    configured, and the story reads a directory that does not exist.
+    Restated, not silently repurposed: under the refusal there is no answer to
+    inspect, so what this row pins now is that the parent-escaping shape is
+    *unreachable* — the leg returns nothing at all. Its first assertion stays the
+    control showing a healthy host collapses the `..` and rebases normally, so the
+    refusal below cannot be blamed on the `..` being unusual.
 
-    Ablation A2 reddens this row on its return value: the PR's shape answers
-    `../proj/specs/s1`. Ablation A1 reddens it too, by letting the OSError
-    escape. Nothing here relies on the `..` being *unusual* — the first
-    assertion is the control showing a healthy host collapses it."""
+    Measured ablations:
+    - B1: FAILS at `with pytest.raises(stories.StoriesError)` (`DID NOT RAISE
+      StoriesError`). Note what B1 actually returns here — `raw.as_posix()`, the
+      absolute `.../proj/../proj/specs/s1` — and NOT the leading-`..` string this
+      row was originally written against: that shape belonged to the
+      rebase-anyway degrade the PR had already retired. B1 is caught by the
+      missing raise, not by an escaping answer.
+    - B2: green. B3: green."""
     project = tmp_path / "proj"
     (project / "specs" / "s1").mkdir(parents=True)
     spelled_up = project / ".." / project.name / "specs" / "s1"
@@ -754,23 +790,29 @@ def test_relativize_spec_folder_never_answers_a_parent_escaping_path(tmp_path, m
     assert stories.relativize_spec_folder(project, str(spelled_up)) == "specs/s1"
 
     refuse_to_resolve(monkeypatch, project, spelled_up)
-    rel = stories.relativize_spec_folder(project, str(spelled_up))
 
-    assert not rel.startswith(".."), "a relative answer must not climb out of the root"
-    assert Path(rel).is_absolute()
-    assert rel == spelled_up.as_posix()
+    with pytest.raises(stories.StoriesError) as excinfo:
+        stories.relativize_spec_folder(project, str(spelled_up))
+
+    assert "Run `bmad-loop validate` for what this host is doing." in str(excinfo.value)
 
 
 def test_relativize_spec_folder_outside_project_tree_stays_absolute(tmp_path):
-    """The `ValueError` leg of the same arm, which no row covered before: an
-    absolute spec folder genuinely outside the project tree, on a host that
-    canonicalizes both sides without complaint. The contract allows an absolute
-    spec folder (we never author one), so it is kept verbatim.
+    """The `ValueError` leg — and the proof this change is a SPLIT and not a
+    blanket raise. An absolute spec folder genuinely outside the project tree, on
+    a host that canonicalizes both sides without complaint: an external spec
+    folder is a supported layout (`[stories] source`, `policy.py`), so it is kept
+    verbatim and must stay that way.
 
-    Ablation A3: drop `ValueError` from the caught tuple and this reddens
-    alone — every other row in this section faults with `OSError` or does not
-    fault at all, so A1 and A2, which both still catch `ValueError`, leave it
-    green."""
+    Measured ablations:
+    - B2 (widen the raise arm to `(OSError, RuntimeError, ValueError)`): this row
+      FAILS ALONE, at `rel = stories.relativize_spec_folder(project,
+      str(outside))` — the call itself raises `StoriesError: cannot canonicalize
+      the spec folder ...: '...' is not in the subpath of '...'`, so neither
+      assertion below is reached. Every other row in this section faults with
+      `OSError` or does not fault at all, which is why B2 reddens nothing else.
+    - B1: green — the collapsed degrade still returns the absolute path, so only
+      B2 can pin this contract. B3: green."""
     project = tmp_path / "proj"
     project.mkdir()
     outside = tmp_path / "elsewhere" / "s1"

--- a/tests/test_stories.py
+++ b/tests/test_stories.py
@@ -4,7 +4,7 @@ import re
 from pathlib import Path
 
 import pytest
-from conftest import UNRESOLVABLE, fault_read_text, refuse_to_resolve
+from conftest import fault_read_text, refuse_to_resolve
 
 from bmad_loop import stories
 
@@ -603,12 +603,21 @@ def test_relativize_spec_folder_rebases_absolute_path_in_project(tmp_path):
 
 
 def test_relativize_spec_folder_survives_unresolvable_project_root(tmp_path, monkeypatch, capsys):
-    """The project root's own `.resolve()` faulting (WinError 64 on a dead UNC
-    provider, or a symlink loop on the 3.11/3.12 floor, #560) escaped this
-    function's try/except, which caught only `ValueError` around a bare
-    `.resolve()` on both sides. `relativize_spec_folder` degrades to the
-    lexical path instead now, like every other consumer of the shared
-    canonicalization helper."""
+    """The project root's own `.resolve()` faulting (WinError 64 from a
+    registered-but-not-serving UNC provider, or a symlink loop on the 3.11/3.12
+    floor, #560) escaped the `except ValueError` that used to be the whole guard
+    around this pair of `.resolve()` calls. The widened tuple catches it and the
+    raw absolute spelling is kept: a host that cannot canonicalize one side
+    cannot say where the folder is, and an uncertain location must not be
+    rebased onto the project root.
+
+    Ablation A1 (#560): narrow the arm back to `except ValueError` and this
+    reddens — the OSError escapes the function.
+    Ablation A2 (the PR's first shape): restore
+    `resolve_or_lexical(raw).relative_to(resolve_or_lexical(project))` and this
+    reddens too, on its first assertion — that pair degrades the refused operand
+    to a lexical spelling and rebases anyway, answering `specs/s1` for a folder
+    it could not locate."""
     project = tmp_path / "proj"
     spec_folder = project / "specs" / "s1"
     spec_folder.mkdir(parents=True)
@@ -616,14 +625,20 @@ def test_relativize_spec_folder_survives_unresolvable_project_root(tmp_path, mon
 
     rel = stories.relativize_spec_folder(project, str(spec_folder))
 
-    assert rel == "specs/s1"  # degraded (lexical) project root still contains it
-    assert UNRESOLVABLE in capsys.readouterr().err
+    assert rel == spec_folder.as_posix()  # kept where it was, not rebased
+    # The degrade note belongs to the observation surface, not to a value the
+    # engine dispatches on every story.
+    assert capsys.readouterr().err == ""
 
 
 def test_relativize_spec_folder_survives_unresolvable_spec_folder(tmp_path, monkeypatch, capsys):
-    """Same guard, the other operand: a regression that restored the bare
-    `raw.resolve()` `resolve_or_lexical` replaced would still pass the project-root
-    variant above, since that one only injects the failure into `project`."""
+    """Same arm, the other operand: `refuse_to_resolve` matches on the exact
+    `str()` spelling, so refusing the project root above leaves `raw.resolve()`
+    answering normally and vice versa. Without this row a regression that
+    restored only the `raw` side would still pass the project-root row.
+
+    Ablations A1 and A2 both redden it, for the same two reasons recorded
+    above — A1 by letting the OSError escape, A2 by answering `specs/s1`."""
     project = tmp_path / "proj"
     spec_folder = project / "specs" / "s1"
     spec_folder.mkdir(parents=True)
@@ -631,5 +646,137 @@ def test_relativize_spec_folder_survives_unresolvable_spec_folder(tmp_path, monk
 
     rel = stories.relativize_spec_folder(project, str(spec_folder))
 
-    assert rel == "specs/s1"
-    assert UNRESOLVABLE in capsys.readouterr().err
+    assert rel == spec_folder.as_posix()
+    assert capsys.readouterr().err == ""
+
+
+def _symlinked_project_root(tmp_path: Path) -> Path:
+    """A project root reached through a symlink, so its lexical and canonical
+    spellings really are different strings.
+
+    The two rows above cannot see a mixed-spelling answer on their own: measured
+    here, `tmp_path.resolve() == tmp_path`, so a degraded (lexical) operand and a
+    canonical one are the same text and every combination returns `specs/s1`.
+    Follows `test_bmadconfig.py`'s `worktree_isolation_conflict` symlink row,
+    including its skip for a Windows host without SeCreateSymbolicLink."""
+    target = tmp_path / "target"
+    target.mkdir()
+    root = tmp_path / "p"
+    try:
+        root.symlink_to(target, target_is_directory=True)
+    except OSError as e:  # Windows without SeCreateSymbolicLink / developer mode
+        pytest.skip(f"cannot create a symlink here: {e}")
+    assert root.resolve() != root, "the two spellings really are different"
+    return root
+
+
+def test_relativize_spec_folder_symlinked_root_still_rebases_when_healthy(tmp_path):
+    """CONTROL for the two symlinked rows below, not an ablation row: reaching
+    the root through a symlink does not by itself stop the rebase. Both
+    `.resolve()` calls answer, they agree on the canonical spelling, and the
+    result is project-relative. Measured green under every ablation below — it
+    is here so a red neighbour cannot be blamed on the symlink itself."""
+    root = _symlinked_project_root(tmp_path)
+    spec_folder = root / "specs" / "s1"
+    spec_folder.mkdir(parents=True)
+
+    assert stories.relativize_spec_folder(root, str(spec_folder)) == "specs/s1"
+
+
+def test_relativize_spec_folder_symlinked_root_project_refused_keeps_raw_spelling(
+    tmp_path, monkeypatch, capsys
+):
+    """The project-root operand refused on a host where the two spellings differ.
+    The value returned is the *raw* spelling the caller passed, not the canonical
+    one — `stories_engine._stories_folder` consumes this string verbatim, so a
+    silently re-spelled answer would move where a story reads and writes.
+
+    Ablation A1 (#560) reddens this row. Ablation A2 reddens only its stderr
+    assertion: the PR's shape returns the same absolute string here (one operand
+    canonical, one lexical, so `relative_to` fails and both fall to the same
+    arm), and is caught only by the degrade note it prints. The row that catches
+    A2 on its *return value* is the parent-escape row below."""
+    root = _symlinked_project_root(tmp_path)
+    spec_folder = root / "specs" / "s1"
+    spec_folder.mkdir(parents=True)
+    canonical = spec_folder.resolve()
+    refuse_to_resolve(monkeypatch, root)
+
+    rel = stories.relativize_spec_folder(root, str(spec_folder))
+
+    assert rel == spec_folder.as_posix()
+    assert Path(rel).is_absolute()
+    assert rel != canonical.as_posix(), "the raw spelling, not the dereferenced one"
+    assert capsys.readouterr().err == ""
+
+
+def test_relativize_spec_folder_symlinked_root_spec_folder_refused_keeps_raw_spelling(
+    tmp_path, monkeypatch, capsys
+):
+    """The spec-folder operand refused, same symlinked host. Ablations as for the
+    project-root row above: A1 reddens the whole row, A2 only its stderr
+    assertion."""
+    root = _symlinked_project_root(tmp_path)
+    spec_folder = root / "specs" / "s1"
+    spec_folder.mkdir(parents=True)
+    canonical = root.resolve() / "specs" / "s1"
+    refuse_to_resolve(monkeypatch, spec_folder)
+
+    rel = stories.relativize_spec_folder(root, str(spec_folder))
+
+    assert rel == spec_folder.as_posix()
+    assert Path(rel).is_absolute()
+    assert rel != canonical.as_posix(), "the raw spelling, not the dereferenced one"
+    assert capsys.readouterr().err == ""
+
+
+def test_relativize_spec_folder_never_answers_a_parent_escaping_path(tmp_path, monkeypatch):
+    """A `..`-spelled spec folder with both operands refused. This is the row the
+    rework exists for: `relative_to` strips a *textual* prefix, so two lexical
+    (un-dereferenced) operands can leave the `..` standing and yield a
+    "relative" path that climbs out of the root it is relative to.
+
+    The harm is at the sink: `stories_engine._stories_folder` joins a relative
+    answer against `workspace.root`, which during an isolated story is the unit
+    worktree — so `../proj/specs/s1` names a sibling of the worktree that nobody
+    configured, and the story reads a directory that does not exist.
+
+    Ablation A2 reddens this row on its return value: the PR's shape answers
+    `../proj/specs/s1`. Ablation A1 reddens it too, by letting the OSError
+    escape. Nothing here relies on the `..` being *unusual* — the first
+    assertion is the control showing a healthy host collapses it."""
+    project = tmp_path / "proj"
+    (project / "specs" / "s1").mkdir(parents=True)
+    spelled_up = project / ".." / project.name / "specs" / "s1"
+
+    # control: on a host that can canonicalize, the `..` collapses and the
+    # folder rebases normally.
+    assert stories.relativize_spec_folder(project, str(spelled_up)) == "specs/s1"
+
+    refuse_to_resolve(monkeypatch, project, spelled_up)
+    rel = stories.relativize_spec_folder(project, str(spelled_up))
+
+    assert not rel.startswith(".."), "a relative answer must not climb out of the root"
+    assert Path(rel).is_absolute()
+    assert rel == spelled_up.as_posix()
+
+
+def test_relativize_spec_folder_outside_project_tree_stays_absolute(tmp_path):
+    """The `ValueError` leg of the same arm, which no row covered before: an
+    absolute spec folder genuinely outside the project tree, on a host that
+    canonicalizes both sides without complaint. The contract allows an absolute
+    spec folder (we never author one), so it is kept verbatim.
+
+    Ablation A3: drop `ValueError` from the caught tuple and this reddens
+    alone — every other row in this section faults with `OSError` or does not
+    fault at all, so A1 and A2, which both still catch `ValueError`, leave it
+    green."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    outside = tmp_path / "elsewhere" / "s1"
+    outside.mkdir(parents=True)
+
+    rel = stories.relativize_spec_folder(project, str(outside))
+
+    assert rel == outside.as_posix()
+    assert Path(rel).is_absolute()

--- a/tests/test_stories.py
+++ b/tests/test_stories.py
@@ -618,3 +618,18 @@ def test_relativize_spec_folder_survives_unresolvable_project_root(tmp_path, mon
 
     assert rel == "specs/s1"  # degraded (lexical) project root still contains it
     assert UNRESOLVABLE in capsys.readouterr().err
+
+
+def test_relativize_spec_folder_survives_unresolvable_spec_folder(tmp_path, monkeypatch, capsys):
+    """Same guard, the other operand: a regression that restored the bare
+    `raw.resolve()` `resolve_or_lexical` replaced would still pass the project-root
+    variant above, since that one only injects the failure into `project`."""
+    project = tmp_path / "proj"
+    spec_folder = project / "specs" / "s1"
+    spec_folder.mkdir(parents=True)
+    refuse_to_resolve(monkeypatch, spec_folder)
+
+    rel = stories.relativize_spec_folder(project, str(spec_folder))
+
+    assert rel == "specs/s1"
+    assert UNRESOLVABLE in capsys.readouterr().err

--- a/tests/test_stories.py
+++ b/tests/test_stories.py
@@ -4,7 +4,7 @@ import re
 from pathlib import Path
 
 import pytest
-from conftest import fault_read_text
+from conftest import UNRESOLVABLE, fault_read_text, refuse_to_resolve
 
 from bmad_loop import stories
 
@@ -590,3 +590,31 @@ def test_story_rows_limit_counts_dispatchable_not_done(tmp_path):
 def test_story_rows_missing_manifest_raises(tmp_path):
     with pytest.raises(stories.StoriesError, match=re.escape("no stories.yaml found")):
         stories.story_rows(tmp_path)
+
+
+# --------------------------------------------------------- relativize_spec_folder
+
+
+def test_relativize_spec_folder_rebases_absolute_path_in_project(tmp_path):
+    project = tmp_path / "proj"
+    spec_folder = project / "specs" / "s1"
+    spec_folder.mkdir(parents=True)
+    assert stories.relativize_spec_folder(project, str(spec_folder)) == "specs/s1"
+
+
+def test_relativize_spec_folder_survives_unresolvable_project_root(tmp_path, monkeypatch, capsys):
+    """The project root's own `.resolve()` faulting (WinError 64 on a dead UNC
+    provider, or a symlink loop on the 3.11/3.12 floor, #560) escaped this
+    function's try/except, which caught only `ValueError` around a bare
+    `.resolve()` on both sides. `relativize_spec_folder` degrades to the
+    lexical path instead now, like every other consumer of the shared
+    canonicalization helper."""
+    project = tmp_path / "proj"
+    spec_folder = project / "specs" / "s1"
+    spec_folder.mkdir(parents=True)
+    refuse_to_resolve(monkeypatch, project)
+
+    rel = stories.relativize_spec_folder(project, str(spec_folder))
+
+    assert rel == "specs/s1"  # degraded (lexical) project root still contains it
+    assert UNRESOLVABLE in capsys.readouterr().err


### PR DESCRIPTION
## What

Two `.resolve()` calls that raise outside the exception type their own handler catches, and the tests that pin what each one now does instead.

Fixes #560

| Site | Reached from | Before | Now |
| --- | --- | --- | --- |
| `cli._resolve_restore_patch` | `resolve --restore-patch`, and `resolution.json`'s `restore_patch` field | handler scoped to `bmadconfig.BmadConfigError`; the fault fell through to `main()`'s backstop as a bare `error: [Errno …]` | a named rejection in the shape its five sibling refusals use |
| `stories.relativize_spec_folder` | `--spec`, `[stories] source` | handler scoped to `ValueError`; the fault escaped the function and died at the same backstop | the handler **splits**: `ValueError` (genuinely outside the tree) still answers verbatim; `OSError` / `RuntimeError` raises `StoriesError` naming both operands |

**Note on the commit history.** The spec-folder half has three successive shapes on this branch, and a reader of the log will meet all three. Shape 2 — one widened `(OSError, RuntimeError, ValueError)` arm returning the raw absolute path — is what `d3be2627` and everything before it carried. A codex review raised it as a P1; the hazard was confirmed by measurement, and `a523a4a7`…`6e9c432a` replaced it with the split refusal. [The three shapes](#the-spec-folder-half-took-three-shapes) records what each one got wrong. Only the third is what this PR ships.

## Why

Residual sites from #552. The fault class is host-environmental, not operator error: a Windows host whose WSL UNC provider is registered but not serving answers `resolve()` with `ERROR_NETNAME_DELETED` (WinError 64), which CPython's non-strict `ntpath` allow-list does not absorb, so `resolve()` fails outright rather than degrading to its own lexical walk; a symlink loop on the 3.11/3.12 floor raises `RuntimeError` from the same call. Neither is `ValueError`, and neither is `BmadConfigError`.

The two halves want opposite answers, which is why they get different fixes.

## How

**The restore-patch half is a rejection.** `.resolve()` is wrapped and returns the sibling `(None, message)` rejected-latch shape:

> cannot canonicalize the restore patch path `'…'`: `[Errno …]` — whether it lies inside or outside the project tree cannot be determined, so the restore cannot be latched. Run `bmad-loop validate` for what this host is doing.

The em dash follows the function's own habit (four of its five sibling rejections already use it); the closer follows the three existing `cannot canonicalize` precedents — bmadconfig's artifact-path and project-root raises, and `platform_util`'s lexical-fallback note — because `validate` is where a host finding gets reported.

The `.resolve()` stays **bare**, deliberately. Its value feeds `verify.spec_within_roots`, a containment check that needs `..` and symlinks collapsed; a degraded, non-canonical answer there could pass containment on the wrong directory. This consumer needs canonical-or-refuse, so it refuses.

**The spec-folder half is a refusal too — split from the one leg it must not swallow.** The single handler becomes two arms:

```python
try:
    return raw.resolve().relative_to(project.resolve()).as_posix()
except ValueError:
    return raw.as_posix()           # genuinely outside the tree — a supported layout
except (OSError, RuntimeError) as e:
    raise StoriesError(...) from e  # the host cannot say where it is — refuse
```

The `ValueError` leg is a real answer: both operands canonicalized and simply share no prefix, which `[stories] source` allows (we never author one), so the path comes back verbatim. The canonicalize leg is not an answer at all, and catching the fault must not mean inventing one — **this value is dispatched, not observed.** Four sinks take the string exactly as given:

| Sink | Site |
| --- | --- |
| `BMAD_LOOP_SPEC_FOLDER` in the session env | `stories_engine.py:369` |
| the `Spec folder: …` line of the dev prompt | `stories_engine.py:410` |
| `RunState.spec_folder`, persisted and restored on resume | `stories_engine.py:115`, `runsetup.py:1278` |
| `verify.verify_dev_stories(spec_folder=…)` | `stories_engine.py:526` |

And `StoriesEngine._stories_folder` (`stories_engine.py:126-130`) anchors only a **relative** answer — `rel if rel.is_absolute() else self.workspace.root / rel`. Under `isolation = "worktree"` that root is also the session's cwd (`engine.py:4801`), i.e. the unit worktree. So an absolute answer skips the anchor entirely and points a story's reads and writes at the main checkout while cwd and git stay in the worktree: worktree isolation defeated, silently, on every story of the run. Refusing costs a run that could not have been dispatched correctly anyway.

The raise follows `bmadconfig.load_paths`' own `cannot canonicalize the project root …` refusal (`bmadconfig.py:181-189`) and this PR's restore-patch half, down to the `validate` closer. It is also how the nearest in-repo two-tier fallback idiom already reads: `engine._legacy_ledger_changed_before_harvest` and `engine._harvest_gate_exclude` both fall back once and then **refuse** (`return False` / `return ()`) — neither tier ever hands the uncertain value onward.

**Reach, stated honestly.** Only the spec-folder operand, and only an absolute one, can enter this window in production. The project-root operand is not reachable for a persistent fault: `bmadconfig.load_paths` (`bmadconfig.py:181-189`) already refuses typed on such a host before either the engine or the dry-run gets this far — measured identical pre-PR and post. The tests refuse the two operands independently because the *function* must hold for either, not because both are reachable.

**Callers.** `cli._dry_run_stories` is the only one that needed a new handler: it prints `stories mode: {e}` and returns 1, in the shape of its `story_rows` sibling just below — minus that sibling's `(spec folder: …)` suffix, which would print a path the reason already names twice (this leg is reachable only from the absolute branch, where `folder` is `spec_folder` re-spelled). The engine's call unwinds through `runsetup.compose_run`'s `except BaseException: … raise` into `main()`'s backstop, which already prints `error: {e}` and returns `ExitCode.FAILURE`.

**What an operator on such a host sees:**

| | Before this PR | Shape 2, in review (never released) | Now |
| --- | --- | --- | --- |
| `run` | rc 1, `error: [Errno …]` — no path named | the function answered the raw absolute path, which is what `run` would then dispatch | rc 1, `error: cannot canonicalize the spec folder '…' against the project root '…': [Errno …] — …`, closing on the `bmad-loop validate` pointer |
| `--dry-run` | rc 1, same bare `error: [Errno …]` (measured) | rc **0** (measured), rendering a runnable-looking preview with `BMAD_LOOP_SPEC_FOLDER=<absolute path into the main checkout>` | rc 1, `stories mode: cannot canonicalize the spec folder '…' …` |

The exit code is unchanged for users: 1 before, 1 now, with a message that names the path and what failed. The rc 0 column is an in-review shape that was never released.

## The spec-folder half took three shapes

**Shape 1 — `platform_util.resolve_or_lexical` on both calls.** Closes the #560 escape and opens a wider one, so it was removed. `resolve_or_lexical` degrades **per call**: one operand can canonicalize while the other falls back to its lexical spelling, and `relative_to` then subtracts a textual prefix across two different namings of one tree. Measured:

- on a symlinked project root, an **absolute** result in two of four host states;
- on a `..`-spelled folder with both sides refused, `../proj/specs/s1` — a "relative" answer that climbs out of the root it is relative to, a shape `resolve()` can never produce, and one that `_stories_folder` would join against the unit worktree to name a sibling directory nobody configured.

`bmadconfig.worktree_isolation_conflict` already documents this mixed-spelling window, for an *equality* comparison, and sits behind a raw-equality short-circuit. A prefix subtraction has nothing to sit behind. `platform_util`'s degrade helper stays at the observation surface its own docstring bounds it to.

**Shape 2 — one widened `(OSError, RuntimeError, ValueError)` arm, path kept verbatim.** Rejected in review (a codex P1, confirmed by measurement). Its analysis of shape 1 was right and its conclusion did not follow: **returning the raw path verbatim *is* returning an absolute answer.** Shape 1 was refused because two of its four host states put an absolute path in front of the four sinks above; shape 2 put one there in every canonicalize-fault state. Narrower trigger, same hazard — and it also spent the one thing the pre-PR code still had going for it, the loud abort, trading it for a silent wrong-tree dispatch (the dry-run measuring rc 0 above).

**Shape 3 — the split, above.** The `ValueError` leg keeps the only degrade that was ever a real answer. The canonicalize leg stops answering.

One supporting citation does not survive with shape 2, and is dropped rather than restated: `verify._stories_relpaths` (`verify.py:2496-2507`) was offered as the precedent for putting one shared guard around this same relativization of this same folder. It is the same expression, but not the same decision — it returns `()` on the degrade, which drops the proof-of-work exclude prefixes and thereby **widens a check inside the right tree**. This function chooses **which tree gets written**. Different blast radius; not a precedent for what to return here.

## Testing

Local gates on `6e9c432a`, Linux / CPython 3.13:

- `pytest -q -n logical` → **6129 passed, 53 skipped**
- `pyright` → **0 errors, 0 warnings, 0 informations**
- `trunk check --all --no-fix` → **258 files, no issues**

CI on `d3be2627` (the previous head) ran **all 10 jobs green** — the first CI run this branch has had, the earlier ones having sat unapproved at the fork gate: `test` on Linux py3.11–3.14 (py3.13: 6123 passed, 58 skipped) and on Windows py3.11 / py3.14 (5968 passed, 201 skipped, plus the 12-row live psmux gate), `lint (trunk)`, `typecheck (pyright)`, `build (packaging)`, `version-sync`. The runs on `d206cd34` and `6e9c432a` are in flight; no result is claimed for either here.

Per the repo's ablation doctrine, every row's docstring records the mutation that reddens it, measured rather than assumed.

**Spec-folder half** — nine rows (eight in `tests/test_stories.py`, one new in `tests/test_cli.py`), three ablations:

| Ablation | Mutation | Result |
| --- | --- | --- |
| B1 | collapse the split back to one degrade arm — `except (OSError, RuntimeError, ValueError): return raw.as_posix()`, i.e. shape 2 | the **five raises-rows** redden at `with pytest.raises(stories.StoriesError)` (`DID NOT RAISE`), and the **CLI row** reddens at `assert cli._dry_run(...) == 1` with `assert 0 == 1` |
| B2 | widen the raise arm to the whole `(OSError, RuntimeError, ValueError)` tuple | the outside-the-tree row reddens **alone**, at the call itself |
| B3 | delete the `try` / `except stories_mod.StoriesError` around the `relativize_spec_folder` call in `cli._dry_run_stories` | the new **CLI row alone** — the `StoriesError` propagates out of `_dry_run` uncaught |

**B1 and B2 redden disjoint sets, and that disjointness is the proof this is a split and not a blanket raise.** B1 on its own would be satisfied by raising on every leg; B2 is the ablation that says the `ValueError` leg must *not* raise, and the outside-the-tree row is the only row that can see it — every other row in the section faults with `OSError` or does not fault at all.

Under B1 the CLI row's captured stdout is the regression itself: a rendered `BMAD_LOOP_SPEC_FOLDER=<absolute path into the main checkout>`, previewed as runnable.

| Row (`tests/test_stories.py`) | What it is |
| --- | --- |
| `…_rebases_absolute_path_in_project` | CONTROL — the healthy path; green under B1, B2, B3, so a red neighbour is evidence about a refusal leg and never about rebasing |
| `…_refuses_unresolvable_project_root` | raises-row (B1). Also pins `__cause__` is the `OSError` (`raise … from e`) |
| `…_refuses_unresolvable_spec_folder` | raises-row (B1), the other operand — `refuse_to_resolve` matches the exact `str()` spelling, so refusing one leaves the other answering; without this row a regression that re-degraded only the `raw` side would still pass the project-root row |
| `…_symlinked_root_still_rebases_when_healthy` | CONTROL — green under B1, B2, B3, so a red neighbour cannot be blamed on the symlink itself |
| `…_symlinked_root_project_refused_raises` | raises-row (B1), plus the message-shape guard: the refusal quotes the **raw** spelling the caller passed, never the dereferenced one |
| `…_symlinked_root_spec_folder_refused_raises` | same, other operand |
| `…_never_answers_a_parent_escaping_path` | raises-row (B1); restated for the refusal, see below |
| `…_outside_project_tree_stays_absolute` | the `ValueError` leg — the only row B2 reddens, and the proof this change is a split |

The new CLI row, `test_dry_run_stories_unresolvable_absolute_folder_refused`, is the first test to reach `relativize_spec_folder` through the CLI at all. It carries B3 on its exit-code line and B1 on the same line.

Two details worth stating rather than burying:

- **The parent-escape row was restated, not silently repurposed.** It was written for the degrade era, as the proof that no answer climbed out of the root it claimed to be relative to; under the refusal there is no answer to inspect, so what it pins now is that the parent-escaping shape is *unreachable*. Its first assertion stays the control showing a healthy host collapses the `..`. Its docstring also records what B1 actually returns there — `raw.as_posix()`, the absolute `…/proj/../proj/specs/s1`, and **not** the leading-`..` string the row was originally written against; that shape belonged to shape 1, already retired. B1 is caught there by the missing raise, not by an escaping answer.
- **Two assertions are declared inert, in their own docstrings.** The `not in msg` spelling guards on the two symlinked raises-rows cannot be reddened by any of B1/B2/B3: nothing in this change canonicalizes the operands before interpolating them. They are forward guards on the message shape — the one assertion the two non-symlinked rows cannot make, since `tmp_path.resolve() == tmp_path` on this host makes a raw operand and a dereferenced one the same text — and they are not what carries their rows. That same measured fact is why `_symlinked_project_root` exists, and why it asserts up front that the two spellings really differ.

**Restore-patch half** (unchanged by the rework) — deleting the `except (OSError, RuntimeError)` arm reddens both rows, at the message assertion and nowhere else. Measured with the arm gone: `rc == 1`, `called == []`, the phase/`restore_patch` assertions and `UNRESOLVABLE in err` **all still pass**, because the unguarded `OSError` reaches `main()`'s generic `except Exception` backstop, which prints `error: {e}` and returns `ExitCode.FAILURE` — the same exit and the same `{e}` substring the guard itself produces. With only the two message assertions removed, the ablated rows go green. Loosening back to the bare substring would make them false greens, so both rows pin the interpolated path and the closer.

The second caller was uncovered and is now a row of its own. `cmd_resolve` reaches the same `.resolve()` from the `resolution.json` arm, and that arm cannot be hoisted above the interactive session — its abort lands after a whole agent conversation. The flag-arm row cannot stand in for it: `--no-interactive` short-circuits the marker read, leaving `raw` None so `if not raw: return None, None` fires and the guarded line is never reached from that side.

## What this does not establish

- **The fault is simulated, never reproduced.** `tests/conftest.py::refuse_to_resolve` monkeypatches `Path.resolve` to raise `OSError(0, …, None, 64)` for exactly the named paths. No real degraded host — no dead UNC provider, no symlink loop — was involved in any measurement here. The stub is scoped to named paths on purpose: a blanket one would break every unrelated resolve in the process, and a row asserting "the command survived" would then pass for reasons unrelated to the guard.
- **No degraded host was exercised, on any platform.** The Windows CI legs run the same monkeypatched stub the Linux ones do — a real dead UNC provider is not reachable from CI either.
- **Whether the symlinked rows ran on Windows is not established.** `_symlinked_project_root` skips where a symlink cannot be created — Windows without `SeCreateSymbolicLink` or developer mode — and CI invokes pytest with `-q` and no `-rs`, so the green run on `d3be2627` reported 201 Windows skips in total without naming them. Where those rows do skip, the ones that distinguish a raw spelling from a dereferenced one do not run, and the rest cannot see a mixed-spelling message. They are measured green on Linux, where the helper asserts up front that the two spellings really differ.
- **A degraded host is still not made to work.** `--restore-patch` on such a host refuses; a spec folder whose location the host cannot determine now refuses too. What changes is *when* and *how*: the run stops earlier, by name, naming both operands and pointing at `bmad-loop validate`, instead of dying to a bare `[Errno …]` — and instead of the in-review shape's silent dispatch into the wrong tree.
- **The project-root operand is not a production trigger.** `bmadconfig.load_paths` refuses it typed first, on the same host. The rows that refuse it pin a function-level contract, not a reachable path.
- **Scope is the two sites the issue names.** The two the issue flags for completeness — `data/plugins/unity/unity_seed_assets.py`'s `Path(__file__).resolve()` and `platform_util.atomic_write_text`'s resolve under `follow_symlinks=True` — are untouched here.

## Changelog

One entry under `## [Unreleased]` → `### Fixed`, restating the spec-folder half as a refusal and describing each half by what it actually does.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added actionable validation errors when restore-patch or spec-folder paths cannot be resolved.
  - Stories-mode dry runs now stop safely without rendering an invalid schedule.
  - Restore operations no longer resume or re-arm when patch-path containment cannot be verified.
  - Valid paths outside the project remain supported.
  - Improved handling of relative paths, symlinks, and paths that escape the project directory.

- **Documentation**
  - Added changelog details covering path validation, dry-run behavior, and supported external paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->