### PR TITLE
fix(policy): enforce declared timeout and nudge minima

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ breaking changes may land in a minor release.
 
 ### Fixed
 
+- **Policy loading now enforces the declared timeout and result-less Stop nudge minima (#648).**
+  The valid `session_timeout_min = 1` and `stop_without_result_nudges = 0` boundaries remain
+  accepted, while smaller values now raise `PolicyError`.
+
 - **Reject mismatched TOML scalar types for every `limits.*` policy field (#278).**
   Quoted booleans and other coercible values now raise `PolicyError` instead of silently changing
   the configured limit or enabling a disabled behavior.

--- a/src/bmad_loop/policy.py
+++ b/src/bmad_loop/policy.py
@@ -805,10 +805,19 @@ def loads(text: str, plugin_schemas: dict[str, Any] | None = None) -> Policy:
         raise PolicyError(
             f"limits.max_followup_reviews must be >= 0: got {limits.max_followup_reviews}"
         )
+    if limits.session_timeout_min < 1:
+        raise PolicyError(
+            f"limits.session_timeout_min must be >= 1: got {limits.session_timeout_min}"
+        )
     if limits.git_timeout_s < 1:
         raise PolicyError(f"limits.git_timeout_s must be >= 1: got {limits.git_timeout_s}")
     if limits.teardown_grace_s < 0:
         raise PolicyError(f"limits.teardown_grace_s must be >= 0: got {limits.teardown_grace_s}")
+    if limits.stop_without_result_nudges < 0:
+        raise PolicyError(
+            "limits.stop_without_result_nudges must be >= 0: "
+            f"got {limits.stop_without_result_nudges}"
+        )
     if not 0.0 <= limits.cache_read_weight <= 1.0:
         raise PolicyError(
             f"limits.cache_read_weight must be between 0 and 1: got {limits.cache_read_weight}"

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -362,6 +362,63 @@ def test_zero_budget_rejected(tmp_path):
         policy.load(p)
 
 
+@pytest.mark.parametrize(
+    ("key", "minimum"),
+    [
+        pytest.param("session_timeout_min", 1, id="timeout-minimum"),
+        pytest.param("stop_without_result_nudges", 0, id="nudges-minimum"),
+    ],
+)
+def test_limits_schema_minimum_boundaries(key, minimum):
+    loaded = policy.loads(f"[limits]\n{key} = {minimum}\n")
+    assert getattr(loaded.limits, key) == minimum
+
+
+@pytest.mark.parametrize(
+    ("key", "value", "expected"),
+    [
+        pytest.param(
+            "session_timeout_min",
+            0,
+            "limits.session_timeout_min must be >= 1: got 0",
+            id="timeout-zero",
+        ),
+        pytest.param(
+            "session_timeout_min",
+            -1,
+            "limits.session_timeout_min must be >= 1: got -1",
+            id="timeout-negative-one",
+        ),
+        pytest.param(
+            "session_timeout_min",
+            -9,
+            "limits.session_timeout_min must be >= 1: got -9",
+            id="timeout-negative-nine",
+        ),
+        pytest.param(
+            "stop_without_result_nudges",
+            -1,
+            "limits.stop_without_result_nudges must be >= 0: got -1",
+            id="nudges-negative-one",
+        ),
+        pytest.param(
+            "stop_without_result_nudges",
+            -9,
+            "limits.stop_without_result_nudges must be >= 0: got -9",
+            id="nudges-negative-nine",
+        ),
+    ],
+)
+def test_limits_schema_minima_reject_below_minimum(key, value, expected):
+    """ABLATION A1: Delete only the `session_timeout_min` gate; the timeout rows
+    fail because invalid values load.
+    ABLATION A2: Delete only the `stop_without_result_nudges` gate; the nudge
+    rows fail because invalid values load."""
+    with pytest.raises(policy.PolicyError) as exc:
+        policy.loads(f"[limits]\n{key} = {value}\n")
+    assert str(exc.value) == expected
+
+
 def test_git_timeout_default_parse_and_template():
     import tomllib
 


### PR DESCRIPTION
## Summary

- Reject `limits.session_timeout_min` values below the declared minimum of `1`.
- Reject `limits.stop_without_result_nudges` values below the declared minimum of `0`.
- Preserve the valid `session_timeout_min = 1` and `stop_without_result_nudges = 0` boundaries.
- Add table-driven boundary/rejection coverage and single-gate ablation records.

This is the focused follow-up to merged prerequisite #587; its strict scalar validators remain unchanged.

Fixes #648

## Validation

Tested HEAD: `7cbc62450124caea36a4990db7e8e3c5bf5d7994`

- `uv sync --all-extras --locked` — passed
- `uv run pytest tests/test_policy.py tests/test_settings_schema.py -q` — 200 passed
- `uv run pytest -q -n auto --durations=15` — 5,956 passed, 50 skipped
- `uv run pyright` — 0 errors, 0 warnings
- `trunk check --all` — 258 files checked, no issues
- `uv run python scripts/release.py check` — passed
- `git diff --check` — passed
- `git diff --check origin/main...HEAD` — passed

Ablations performed separately on 2026-08-18 UTC:

- Removing only the timeout gate made all 3 timeout rejection rows fail because `PolicyError` was not raised; the source was restored byte-identically.
- Removing only the nudge gate made both nudge rejection rows fail for the same reason; the source was restored byte-identically.

Local validation was run on the current Linux workspace. Native Ubuntu/Windows claims are deferred to exact-head CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added stricter policy validation for session timeouts and stop-without-result nudges.
  * Values below the supported minimum now raise a clear policy validation error.
  * Minimum boundary values remain valid.

* **Documentation**
  * Documented the updated validation requirements in the unreleased changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->