### PR TITLE
fix(sanitize): close three egress-guard gaps in diagnose/probe-adapter (#202, #481, #512)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,10 +44,11 @@ breaking changes may land in a minor release.
   report and its `--json` document verbatim: `max_lines=5` over a 5000-character line still emitted
   all 5000. Each line is now bounded, and a line that is cut ends with `… (N more chars redacted)`,
   the same convention as the existing line-count marker. **This is a visible output change** for any
-  line that long. A cut that would land inside a credential-shaped token retracts to that token's
-  start and drops it whole: cutting mid-token could otherwise leave a prefix too short for the
-  egress guard's entropy rule to recognize, turning a fail-closed refusal into an emission carrying
-  part of the credential. `probe.SCHEMA_VERSION` is unchanged: no field is removed or renamed and no type
+  line that long. A cut that would land inside anything the egress guard flags — a credential-shaped
+  token, or a URL credential whose match ends at the `@` — retracts out of it and drops it whole:
+  cutting mid-construct could otherwise leave a fragment that keeps the sensitive part while no
+  longer tripping the rule, turning a fail-closed refusal into an emission carrying part of the
+  credential. `probe.SCHEMA_VERSION` is unchanged: no field is removed or renamed and no type
   changes, and the meaning of the value was already "the CLI's scrubbed output, capped" — adding a
   second axis to an already-documented lossy cap is the same class of value, not a new one.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,16 @@ breaking changes may land in a minor release.
 
 ### Changed
 
+- **`probe-adapter` now bounds how long a single scrubbed line can be (#481).** `scrub_text` capped
+  how many lines it emitted but never how long one of them could be, so a single very long line —
+  from a foreign CLI's `--version`/`--help`, or from a log tail — reached the `probe-adapter`
+  report and its `--json` document verbatim: `max_lines=5` over a 5000-character line still emitted
+  all 5000. Each line is now bounded, and a line that is cut ends with `… (N more chars redacted)`,
+  the same convention as the existing line-count marker. **This is a visible output change** for any
+  line that long. `probe.SCHEMA_VERSION` is unchanged: no field is removed or renamed and no type
+  changes, and the meaning of the value was already "the CLI's scrubbed output, capped" — adding a
+  second axis to an already-documented lossy cap is the same class of value, not a new one.
+
 - **Files the orchestrator replaces by name now land at `0600`.** Those writes pass
   `follow_symlinks=False`, and that mode deliberately carries nothing over from the target — not
   its permission bits, not its xattrs — so the new contents arrive at `mkstemp`'s private default.
@@ -67,6 +77,26 @@ breaking changes may land in a minor release.
   it cannot read.
 
 ### Fixed
+
+- **The egress self-check now sees Windows→WSL UNC home paths (#512).** `diagnose` and
+  `probe-adapter` re-scan their own rendered bytes before emitting and refuse to emit at all on a
+  hit, but the absolute-home-path rule knew only forward-slash spellings — so a path reached through
+  the Windows→WSL UNC bridge (`\\wsl.localhost\<distro>\home\<user>`, the legacy `\\wsl$\...`, the
+  extended-length `\\?\UNC\...` folding) was invisible to it, including through the `--json` render,
+  where every backslash is doubled. **No released version leaked such a path**: since #485
+  `collect_env` reduces the project path to a boolean and no `EnvInfo` field carries it. What was
+  wrong was the claim — the `diagnostics` module docstring described the backstop as fail-closed
+  without qualification — and that docstring is corrected in the same change to say what the guard
+  is, a shape re-scan of the rendered bytes, and what stays outside it: a home spelling it does not
+  know, or a username that is not this process's.
+
+- **The `diagnose` policy snapshot's verbatim-key invariant is now enforced (#202).** The snapshot
+  emits dict keys unredacted, which is correct only while no policy section is a free-keyed table
+  — the one user-keyed table, `plugins.settings`, is intercepted before it reaches the
+  passthrough. Nothing enforced that property, and a value-level check could not: a newly declared
+  free-keyed section defaults to an empty dict, so such a check stays green while the hazard is
+  live. A test now fails at declaration time, the moment such a section appears, and the reason is
+  written down at the passthrough. No behavior change.
 
 - **The zero-token OpenCode live smoke skips stale or broken shims (#294).** Its availability
   gate now requires `opencode --version` to succeed before starting a server; runnable installs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,10 @@ breaking changes may land in a minor release.
   report and its `--json` document verbatim: `max_lines=5` over a 5000-character line still emitted
   all 5000. Each line is now bounded, and a line that is cut ends with `… (N more chars redacted)`,
   the same convention as the existing line-count marker. **This is a visible output change** for any
-  line that long. `probe.SCHEMA_VERSION` is unchanged: no field is removed or renamed and no type
+  line that long. A cut that would land inside a credential-shaped token retracts to that token's
+  start and drops it whole: cutting mid-token could otherwise leave a prefix too short for the
+  egress guard's entropy rule to recognize, turning a fail-closed refusal into an emission carrying
+  part of the credential. `probe.SCHEMA_VERSION` is unchanged: no field is removed or renamed and no type
   changes, and the meaning of the value was already "the CLI's scrubbed output, capped" — adding a
   second axis to an already-documented lossy cap is the same class of value, not a new one.
 

--- a/src/bmad_loop/diagnostics.py
+++ b/src/bmad_loop/diagnostics.py
@@ -433,6 +433,26 @@ def _scrub_policy(obj: Any) -> Any:
                     k for k in (str(x) for x in value) if sanitize.looks_like_identifier(k)
                 )
             else:
+                # Keys pass through VERBATIM here, deliberately — unlike
+                # `sanitize._scrub`, which scrubs keys as well as values. The
+                # warrant is what this snapshot IS: `Policy.to_dict()` is
+                # `asdict()` over frozen dataclasses, so every key is a
+                # compile-time field name — developer-authored, non-PII, and the
+                # point of the dump (a reader diagnosing a run needs to see
+                # `max_review_cycles`, not `<redacted:str>`). The one user-keyed
+                # table, `plugins.settings`, never reaches this branch:
+                # `_POLICY_KEYSET_KEYS` intercepts it above and reduces it to its
+                # identifier-gated plugin-id keyset (#186).
+                #
+                # That rests on an invariant nothing else stated until #202: NO
+                # policy section has a free-keyed table. Add one — say an
+                # `adapter.overrides` keyed by binary path — and its keys ship
+                # verbatim in a dump meant to be shareable.
+                # `test_no_policy_section_has_a_free_keyed_table`
+                # (tests/test_diagnostics.py) enforces it over the field TYPES, so
+                # it fires when such a table is declared rather than when a user
+                # first populates it; route a new one through `_POLICY_KEYSET_KEYS`
+                # or `_POLICY_COUNT_KEYS` rather than widening that test.
                 out[key] = _scrub_policy(value)
         return out
     if isinstance(obj, (list, tuple)):

--- a/src/bmad_loop/diagnostics.py
+++ b/src/bmad_loop/diagnostics.py
@@ -18,7 +18,13 @@ directly; every value that could carry content is dropped, reduced to a boolean,
 otherwise survive verbatim), or scrubbed. Unknown/future fields default to a
 ``scrub_json`` pass, never raw. As a final backstop the rendered bytes are run
 through :func:`sanitize.guard` — the fail-closed egress self-check shared with
-``probe-adapter`` since #199. A stray pseudonymized original (a
+``probe-adapter`` since #199. That backstop re-scans the rendered bytes for known
+*shapes* — email, URL credentials, credential-shaped tokens, the absolute-home
+spellings in both separator forms (#512 added the backslash WSL-UNC one), and *this
+process's* username — and refuses to emit on a hit; it is not a proof of absence, since
+a home spelling it does not know, or a username that is not this process's (the Linux
+account behind a WSL UNC path), passes it untouched. Per-field routing is the primary
+defense and the guard is defense in depth. A stray pseudonymized original (a
 per-field routing gap — the value is in the legend, so its safe alias is known)
 is **repaired** by substituting the alias, re-verified, and disclosed in the
 dump itself — a "Backstop repairs" section in the markdown report, an optional
@@ -269,7 +275,9 @@ def collect_env(project: Path) -> EnvInfo:
     The project *path* itself is never emitted: it is a redaction hazard — the
     redactor leaves the Linux username in a ``\\\\wsl.localhost\\...\\home\\<user>\\...``
     path standing (it compares against the *Windows* account), and ``collect_env``
-    has no pseudonymizer to alias it against — so the boolean is what ships. Same
+    has no pseudonymizer to alias it against — so the boolean is what ships, and since
+    #512 that shape trips the egress guard, which refuses the whole dump rather than
+    passing it. Same
     reason ``sys.executable`` is absent despite naming the exact mismatch: the venv
     path carries the project name past the redactor."""
     from .adapters.multiplexer import fold_version, get_multiplexer

--- a/src/bmad_loop/probe.py
+++ b/src/bmad_loop/probe.py
@@ -245,8 +245,16 @@ def run_version_help(binary: str, timeout_s: float = 10) -> FlagFinding:
     return FlagFinding(
         binary=binary,
         found=True,
-        version=sanitize.scrub_text(version, max_lines=5) if version else None,
-        help=sanitize.scrub_text(help_txt, max_lines=80) if help_txt else None,
+        version=(
+            sanitize.scrub_text(version, max_lines=5, max_chars=sanitize.SCRUB_TEXT_MAX_CHARS)
+            if version
+            else None
+        ),
+        help=(
+            sanitize.scrub_text(help_txt, max_lines=80, max_chars=sanitize.SCRUB_TEXT_MAX_CHARS)
+            if help_txt
+            else None
+        ),
     )
 
 
@@ -792,7 +800,9 @@ def _log_tail(log_file: Path, max_lines: int = 20) -> str | None:
     if not text.strip():
         return None
     lines = text.splitlines()[-max_lines:]
-    return sanitize.scrub_text("\n".join(lines), max_lines=max_lines)
+    return sanitize.scrub_text(
+        "\n".join(lines), max_lines=max_lines, max_chars=sanitize.SCRUB_TEXT_MAX_CHARS
+    )
 
 
 # ------------------------------------------------------------------ rendering

--- a/src/bmad_loop/sanitize.py
+++ b/src/bmad_loop/sanitize.py
@@ -212,6 +212,15 @@ def _truncate_line(line: str, max_chars: int) -> str:
     it still truncates at exactly ``max_chars``; a ``ghp_``-prefixed token is
     matched at its start and still trips the guard once clipped, so it is not
     retracted either and the refusal is preserved with no content dropped (#481).
+
+    What this does NOT cover, deliberately: the guard's rules keyed on values
+    only the CALLER knows. ``assert_no_leak`` is consulted here without its
+    ``extra`` argument, so a caller-supplied sensitive value is not considered,
+    and the hazard patterns need six characters, so a standalone username at the
+    guard's five-character floor is matched by neither. Splitting one of those
+    still costs the guard its verdict. Closing that needs the caller's values
+    threaded into this function, which is tracked separately (#654) rather than
+    widened into #481 — this bounds the cap to the guard's STATIC rules.
     """
     if len(line) <= max_chars:
         return line

--- a/src/bmad_loop/sanitize.py
+++ b/src/bmad_loop/sanitize.py
@@ -96,8 +96,26 @@ _URL_CRED_RE = re.compile(r"https?://[^/\s]*:[^/@\s]+@")
 # Widening the drive-letter arm to `[\\/]` buys only the mixed-separator oddity
 # `C:\Users/alice` — and any string carrying a separator at all is rejected by
 # looks_like_identifier upstream and redacted before it can reach here.
-# tests/test_sanitize.py::test_assert_no_leak_fires pins each arm.
-_ABS_HOME_RE = re.compile(r"/home/|/Users/|/root/|[A-Za-z]:\\{1,2}Users\\{1,2}", re.I)
+#
+# The backslash `home`/`root` arm is for the Windows→WSL UNC bridge (#512):
+# `\\wsl.localhost\<distro>\home\<user>`, the legacy `\\wsl$\...`, and the
+# extended-length `\\?\UNC\wsl.localhost\...` folding all reach a POSIX home
+# directory whose separators are BACKSLASHES, so none of the forward-slash arms
+# can see them. That shape needs a path rule for a second reason: the identifier
+# at risk is the *Linux* username, while the username rule in assert_no_leak
+# compares `getpass.getuser()` — the *Windows* account — so on a native-Windows
+# interpreter reaching a distro path, no other rule can fire on the name that
+# matters. The arm anchors on the home segment rather than the `wsl` host
+# because a host anchor misses `\\?\UNC\wsl.localhost\...` entirely: the
+# `?\UNC\` segment sits between the leading backslashes and `wsl`. `Users` is
+# deliberately NOT in this arm — it stays behind the drive-letter arm above,
+# which is the bound the preceding paragraph justifies.
+# tests/test_sanitize.py::test_assert_no_leak_fires pins each arm;
+# ::test_assert_no_leak_home_rule_is_not_any_absolute_path pins the other
+# direction, since a hit makes diagnose refuse to emit at all.
+_ABS_HOME_RE = re.compile(
+    r"/home/|/Users/|/root/|[A-Za-z]:\\{1,2}Users\\{1,2}|\\{1,2}(?:home|root)\\{1,2}", re.I
+)
 
 _REDACTED_STR = "<redacted:str>"
 _REDACTED_SECRET = "<redacted:secret>"  # nosec B105 - redaction marker, not a credential

--- a/src/bmad_loop/sanitize.py
+++ b/src/bmad_loop/sanitize.py
@@ -88,7 +88,12 @@ _SECRET_RUN_MIN = 32  # length of contiguous alnum run that triggers the entropy
 _SECRET_ENTROPY_MIN = 3.5  # bits/char; pure hex ~4.0, base64 ~6.0, prose/slug well below
 
 # Token shape used by assert_no_leak to re-scan rendered output for secrets.
-_LEAK_TOKEN_RE = re.compile(r"[A-Za-z0-9._/+-]{6,}")
+# The single-character form is derived from the same class, not re-spelled, so a
+# change to one cannot silently desynchronize scrub_text's cut from what the
+# guard treats as one token.
+_LEAK_TOKEN_CHARS = r"[A-Za-z0-9._/+-]"  # nosec B105 - a regex character class, not a credential
+_LEAK_TOKEN_RE = re.compile(rf"{_LEAK_TOKEN_CHARS}{{6,}}")
+_LEAK_TOKEN_CHAR_RE = re.compile(_LEAK_TOKEN_CHARS)
 _URL_CRED_RE = re.compile(r"https?://[^/\s]*:[^/@\s]+@")
 # The same bytes reach assert_no_leak either as raw text (the markdown report)
 # or as JSON text (the --json document), and json.dumps DOUBLES a backslash —
@@ -176,6 +181,45 @@ def looks_like_secret(s: str) -> bool:
     return len(longest) >= _SECRET_RUN_MIN and _shannon_entropy(longest) >= _SECRET_ENTROPY_MIN
 
 
+def _truncate_line(line: str, max_chars: int) -> str:
+    """One line clipped to ``max_chars``, never in a way that blinds the guard.
+
+    The naive cut is at ``max_chars``. That is unsafe when it lands INSIDE a
+    token :func:`assert_no_leak` would have flagged: the entropy arm of
+    :func:`looks_like_secret` needs a contiguous alnum run of ``_SECRET_RUN_MIN``,
+    so clipping a 36-char high-entropy credential to 30 characters leaves a
+    credential prefix in the output that the guard no longer recognizes — turning
+    a fail-closed refusal into an emission. The cut therefore retracts to the
+    start of the split token, dropping it WHOLE, but only when the split actually
+    costs the guard its verdict.
+
+    That last condition is what keeps the cap from over-firing: ``"x" * 5000`` is
+    one 5000-char token, but it is not credential-shaped either whole or clipped,
+    so it still truncates at exactly ``max_chars``. The known-prefix arm
+    (``ghp_`` …) is anchored at the token's start and survives clipping, so it
+    needs no retraction either — the entropy arm is the one at risk (#481).
+    """
+    if len(line) <= max_chars:
+        return line
+    cut = max_chars
+    # Only a cut with a token character on BOTH sides splits a token; one landing
+    # on a delimiter already leaves every token whole.
+    if (
+        cut > 0
+        and _LEAK_TOKEN_CHAR_RE.match(line[cut])
+        and _LEAK_TOKEN_CHAR_RE.match(line[cut - 1])
+    ):
+        start = cut
+        while start > 0 and _LEAK_TOKEN_CHAR_RE.match(line[start - 1]):
+            start -= 1
+        end = cut
+        while end < len(line) and _LEAK_TOKEN_CHAR_RE.match(line[end]):
+            end += 1
+        if looks_like_secret(line[start:end]) and not looks_like_secret(line[start:cut]):
+            cut = start
+    return line[:cut] + f"… ({len(line) - cut} more chars redacted)"
+
+
 def scrub_text(s: str, *, max_lines: int | None = None, max_chars: int | None = None) -> str:
     """Sanitize free text (a CLI's ``--help`` / ``--version`` / a log tail).
 
@@ -184,10 +228,12 @@ def scrub_text(s: str, *, max_lines: int | None = None, max_chars: int | None = 
     then optionally cap the line count and each line's length.
 
     ``max_chars`` bounds each line's **content** at ``max_chars``; a truncated
-    line is emitted as ``max_chars`` characters plus the
-    ``… (N more chars redacted)`` marker, so its total length is
-    ``max_chars + len(marker)``. That overshoot is the same off-by-one
-    ``max_lines`` already has — ``max_lines=5`` emits six lines, five kept plus
+    line is emitted as at most ``max_chars`` characters plus the
+    ``… (N more chars redacted)`` marker, so its total length is at most
+    ``max_chars + len(marker)`` — "at most" because a cut that would split a
+    credential-shaped token retracts to that token's start rather than emit a
+    guard-invisible prefix of it (see :func:`_truncate_line`). That overshoot is
+    the same off-by-one ``max_lines`` already has — ``max_lines=5`` emits six lines, five kept plus
     the marker line — and it is deliberate (#481): a marker made to fit inside
     the budget would have to be a bare ellipsis, which does not say that
     redaction happened. The line-count marker is never itself char-truncated.
@@ -211,14 +257,7 @@ def scrub_text(s: str, *, max_lines: int | None = None, max_chars: int | None = 
         line_marker = [f"… ({dropped} more lines redacted)"]
         lines = lines[:max_lines]
     if max_chars is not None:
-        lines = [
-            (
-                line
-                if len(line) <= max_chars
-                else line[:max_chars] + f"… ({len(line) - max_chars} more chars redacted)"
-            )
-            for line in lines
-        ]
+        lines = [_truncate_line(line, max_chars) for line in lines]
     return "\n".join(lines + line_marker)
 
 

--- a/src/bmad_loop/sanitize.py
+++ b/src/bmad_loop/sanitize.py
@@ -88,13 +88,17 @@ _SECRET_RUN_MIN = 32  # length of contiguous alnum run that triggers the entropy
 _SECRET_ENTROPY_MIN = 3.5  # bits/char; pure hex ~4.0, base64 ~6.0, prose/slug well below
 
 # Token shape used by assert_no_leak to re-scan rendered output for secrets.
-# The single-character form is derived from the same class, not re-spelled, so a
-# change to one cannot silently desynchronize scrub_text's cut from what the
-# guard treats as one token.
-_LEAK_TOKEN_CHARS = r"[A-Za-z0-9._/+-]"  # nosec B105 - a regex character class, not a credential
-_LEAK_TOKEN_RE = re.compile(rf"{_LEAK_TOKEN_CHARS}{{6,}}")
-_LEAK_TOKEN_CHAR_RE = re.compile(_LEAK_TOKEN_CHARS)
+_LEAK_TOKEN_RE = re.compile(r"[A-Za-z0-9._/+-]{6,}")
 _URL_CRED_RE = re.compile(r"https?://[^/\s]*:[^/@\s]+@")
+# The guard constructs whose match can straddle a truncation point AND whose
+# leading fragment would still be sensitive once the rest is clipped away.
+# `scrub_text`'s cut retracts out of these -- see `_truncate_line`. This sits
+# beside assert_no_leak's rule list deliberately: a rule added there needs an
+# entry here only if a PREFIX of its match stays sensitive. `_EMAIL_RE` is absent
+# because scrub_text redacts emails BEFORE it truncates, so none survives to be
+# split; `_ABS_HOME_RE` is absent because a fragment too short to match `/home/`
+# no longer carries the home tree the rule names.
+_TRUNCATION_HAZARD_RES = (_LEAK_TOKEN_RE, _URL_CRED_RE)
 # The same bytes reach assert_no_leak either as raw text (the markdown report)
 # or as JSON text (the --json document), and json.dumps DOUBLES a backslash —
 # `C:\Users\alice` is serialized as `C:\\Users\\alice`. Matching only the raw
@@ -184,39 +188,48 @@ def looks_like_secret(s: str) -> bool:
 def _truncate_line(line: str, max_chars: int) -> str:
     """One line clipped to ``max_chars``, never in a way that blinds the guard.
 
-    The naive cut is at ``max_chars``. That is unsafe when it lands INSIDE a
-    token :func:`assert_no_leak` would have flagged: the entropy arm of
-    :func:`looks_like_secret` needs a contiguous alnum run of ``_SECRET_RUN_MIN``,
-    so clipping a 36-char high-entropy credential to 30 characters leaves a
-    credential prefix in the output that the guard no longer recognizes — turning
-    a fail-closed refusal into an emission. The cut therefore retracts to the
-    start of the split token, dropping it WHOLE, but only when the split actually
-    costs the guard its verdict.
+    The naive cut is at ``max_chars``. That is unsafe when it lands INSIDE
+    something :func:`assert_no_leak` would have flagged, because the fragment it
+    leaves behind can keep the sensitive part while no longer tripping the rule
+    — turning a fail-closed refusal into an emission. Two shapes reach here:
 
-    That last condition is what keeps the cap from over-firing: ``"x" * 5000`` is
-    one 5000-char token, but it is not credential-shaped either whole or clipped,
-    so it still truncates at exactly ``max_chars``. The known-prefix arm
-    (``ghp_`` …) is anchored at the token's start and survives clipping, so it
-    needs no retraction either — the entropy arm is the one at risk (#481).
+    * a credential-shaped token, where the entropy arm of
+      :func:`looks_like_secret` needs a contiguous alnum run of
+      ``_SECRET_RUN_MIN``, so clipping a 36-character token to 30 leaves a
+      credential prefix the guard no longer recognizes; and
+    * a URL credential, whose match ends at the ``@`` — clip that off and
+      ``_URL_CRED_RE`` stops matching while the password prefix still ships.
+
+    Rather than special-case either, the cut retracts out of any
+    ``_TRUNCATION_HAZARD_RES`` match it splits whose whole trips the guard while
+    its surviving prefix does not, using :func:`assert_no_leak` itself as the
+    oracle. Deferring to the guard is what keeps this general: it is the same
+    verdict the rendered bytes are judged by, so a rule added there is covered
+    here without a second implementation of what "sensitive" means.
+
+    That verdict test is also what keeps the cap from over-firing. ``"x" * 5000``
+    is a single 5000-character token, but it trips no rule whole OR clipped, so
+    it still truncates at exactly ``max_chars``; a ``ghp_``-prefixed token is
+    matched at its start and still trips the guard once clipped, so it is not
+    retracted either and the refusal is preserved with no content dropped (#481).
     """
     if len(line) <= max_chars:
         return line
     cut = max_chars
-    # Only a cut with a token character on BOTH sides splits a token; one landing
-    # on a delimiter already leaves every token whole.
-    if (
-        cut > 0
-        and _LEAK_TOKEN_CHAR_RE.match(line[cut])
-        and _LEAK_TOKEN_CHAR_RE.match(line[cut - 1])
-    ):
-        start = cut
-        while start > 0 and _LEAK_TOKEN_CHAR_RE.match(line[start - 1]):
-            start -= 1
-        end = cut
-        while end < len(line) and _LEAK_TOKEN_CHAR_RE.match(line[end]):
-            end += 1
-        if looks_like_secret(line[start:end]) and not looks_like_secret(line[start:cut]):
-            cut = start
+    # Retracting out of one hazard can land the cut inside an earlier one, so
+    # iterate to a fixed point. `cut` only ever decreases, so this terminates.
+    changed = True
+    while changed:
+        changed = False
+        for pattern in _TRUNCATION_HAZARD_RES:
+            for match in pattern.finditer(line):
+                if (
+                    match.start() < cut < match.end()
+                    and assert_no_leak(match.group())
+                    and not assert_no_leak(line[match.start() : cut])
+                ):
+                    cut = match.start()
+                    changed = True
     return line[:cut] + f"… ({len(line) - cut} more chars redacted)"
 
 

--- a/src/bmad_loop/sanitize.py
+++ b/src/bmad_loop/sanitize.py
@@ -61,6 +61,13 @@ from typing import Any, Iterable, Iterator
 _IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 _IDENTIFIER_MAX = 80
 
+# Per-line character bound for :func:`scrub_text`. Real ``--version``/``--help``
+# lines from the coding CLIs this probes run well under ~120 characters, so 200
+# is roughly 2x headroom over legitimate output while still bounding an
+# adversarial or corrupted one. Public because `probe.py` passes it explicitly
+# rather than relying on a hidden default.
+SCRUB_TEXT_MAX_CHARS = 200
+
 _EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
 
 # Known credential token shapes — provider prefixes plus the JWT header. These
@@ -169,22 +176,50 @@ def looks_like_secret(s: str) -> bool:
     return len(longest) >= _SECRET_RUN_MIN and _shannon_entropy(longest) >= _SECRET_ENTROPY_MIN
 
 
-def scrub_text(s: str, *, max_lines: int | None = None) -> str:
+def scrub_text(s: str, *, max_lines: int | None = None, max_chars: int | None = None) -> str:
     """Sanitize free text (a CLI's ``--help`` / ``--version`` / a log tail).
 
     Less aggressive than :func:`scrub_json` — help text is the CLI's own and
     flag lines must survive — so we only redact the home dir and any emails,
-    then optionally cap the line count.
+    then optionally cap the line count and each line's length.
+
+    ``max_chars`` bounds each line's **content** at ``max_chars``; a truncated
+    line is emitted as ``max_chars`` characters plus the
+    ``… (N more chars redacted)`` marker, so its total length is
+    ``max_chars + len(marker)``. That overshoot is the same off-by-one
+    ``max_lines`` already has — ``max_lines=5`` emits six lines, five kept plus
+    the marker line — and it is deliberate (#481): a marker made to fit inside
+    the budget would have to be a bare ellipsis, which does not say that
+    redaction happened. The line-count marker is never itself char-truncated.
+    Composing both caps bounds the whole result at
+    ``max_lines * (max_chars + len(char marker)) + len(line marker)``.
+
+    Passing either cap normalizes line endings and drops a trailing newline
+    (``splitlines``/``join``); passing neither is a byte-identical passthrough
+    of the redaction step.
     """
     s = redact_home(s)
     s = _EMAIL_RE.sub(_REDACTED_EMAIL, s)
-    if max_lines is not None:
-        lines = s.splitlines()
-        if len(lines) > max_lines:
-            dropped = len(lines) - max_lines
-            lines = lines[:max_lines] + [f"… ({dropped} more lines redacted)"]
-        s = "\n".join(lines)
-    return s
+    if max_lines is None and max_chars is None:
+        return s
+    lines = s.splitlines()
+    # Held aside, not appended yet: the line-count marker is a report of what the
+    # line cap removed, so char-truncating it would redact the redaction notice.
+    line_marker: list[str] = []
+    if max_lines is not None and len(lines) > max_lines:
+        dropped = len(lines) - max_lines
+        line_marker = [f"… ({dropped} more lines redacted)"]
+        lines = lines[:max_lines]
+    if max_chars is not None:
+        lines = [
+            (
+                line
+                if len(line) <= max_chars
+                else line[:max_chars] + f"… ({len(line) - max_chars} more chars redacted)"
+            )
+            for line in lines
+        ]
+    return "\n".join(lines + line_marker)
 
 
 def _is_word_boundary(ch: str) -> bool:

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -970,10 +970,19 @@ def test_scrub_policy_passes_unknown_section_keys_verbatim():
     snapshot, and redacting them would cost the reader the dump's whole index) and
     is the exact hazard `test_no_policy_section_has_a_free_keyed_table` guards. It
     is not an endorsement: if `_scrub_policy` is ever changed to scrub keys, this
-    test is expected to change with it rather than to stand in the way (#202)."""
-    snapshot = {"future": {HOME_PATH: {"model": "x"}}}
+    test is expected to change with it rather than to stand in the way (#202).
+
+    The passthrough is KEYS ONLY, and the value row below is what says so."""
+    snapshot = {"future": {HOME_PATH: {"model": HOME_PATH}}}
     scrubbed = diagnostics._scrub_policy(snapshot)
     assert list(scrubbed["future"]) == [HOME_PATH]
+    # Keys only. An unknown section's VALUES still go through the standard gate,
+    # so the same home path IS redacted one level down. This row is load-bearing
+    # against the shape of fix a reader reaches for when they want the keys kept:
+    # flattening the else-branch's `_scrub_policy(value)` recursion to a bare
+    # `value` keeps every other assertion here green while turning the whole
+    # branch into a leak, so without it this test would characterize one.
+    assert scrubbed["future"][HOME_PATH]["model"] == "<redacted:str>"
     # The contrast that makes the passthrough a deliberate divergence rather than
     # an oversight: the shared value gate would not have let this key through.
     assert HOME_PATH not in sanitize.scrub_json(snapshot)["future"]

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -7,9 +7,13 @@ none of them, while still preserving the diagnostic *structure*.
 
 from __future__ import annotations
 
+import dataclasses
 import json
 import re
 import sys
+import types
+import typing
+from collections.abc import Mapping
 from pathlib import Path
 
 import pytest
@@ -17,6 +21,7 @@ import pytest
 from bmad_loop import diagnostics, sanitize
 from bmad_loop.journal import Journal, save_state
 from bmad_loop.model import Phase, RunState, SessionRecord, StoryTask, TokenUsage
+from bmad_loop.policy import Policy
 
 # Labelled canaries planted across the run dir. NONE may appear in the dump.
 EMAIL = "victim.canary@example.com"
@@ -861,6 +866,117 @@ def test_state_root_path_is_redacted_in_the_dump(project, tmp_path, monkeypatch)
         with pytest.raises(diagnostics.LeakDetected) as exc:
             _render_json_over(monkeypatch, {"events_dir": planted})
         assert "absolute-home-path" in exc.value.rules
+
+
+# ------------------------------------- the _scrub_policy key invariant (#202)
+#
+# `_scrub_policy` emits dict KEYS verbatim (the else-branch passthrough), unlike
+# `sanitize._scrub`, which scrubs keys as well as values. That is safe only while
+# no policy section is a free-keyed table. These pin the invariant so the rule is
+# discoverable from a failure rather than only from the comment beside the code.
+
+
+def _policy_free_keyed_fields(dc, prefix="", seen=frozenset()):
+    """Dotted paths of every Mapping-typed field in ``dc``'s dataclass tree.
+
+    `policy.py` uses `from __future__ import annotations`, so `field.type` is a
+    STRING and only `typing.get_type_hints` gives back a comparable type."""
+    if dc in seen:  # defensive: the policy tree is a DAG today, not a cycle
+        return
+    seen = seen | {dc}
+    hints = typing.get_type_hints(dc)
+    for fld in dataclasses.fields(dc):
+        yield from _classify_policy_type(hints[fld.name], f"{prefix}{fld.name}", seen)
+
+
+def _classify_policy_type(tp, path, seen):
+    """Walk one resolved annotation, yielding ``path`` when it is a free-keyed
+    table. `get_origin` covers the subscripted `dict[str, X]` case; the bare
+    `dict`/`Mapping` case falls through to `tp` itself."""
+    origin = typing.get_origin(tp)
+    args = typing.get_args(tp)
+    if origin in (typing.Union, types.UnionType):
+        for arg in args:
+            yield from _classify_policy_type(arg, path, seen)
+        return
+    base = origin or tp
+    if isinstance(base, type) and issubclass(base, Mapping):
+        # A free-keyed table: report it and stop. Descending into its value type
+        # would report the same field twice for `dict[str, dict[str, Any]]`.
+        yield path
+        return
+    if dataclasses.is_dataclass(base):
+        yield from _policy_free_keyed_fields(base, f"{path}.", seen)
+        return
+    for arg in args:  # tuple[X, ...] / list[X] could nest a policy dataclass
+        yield from _classify_policy_type(arg, f"{path}[]", seen)
+
+
+def test_no_policy_section_has_a_free_keyed_table():
+    """The invariant `_scrub_policy`'s key passthrough rests on: no policy section
+    is a free-keyed table, so every key in a diagnose dump is a compile-time field
+    name rather than user data. `plugins.settings` is the sole exception and is
+    intercepted by `_POLICY_KEYSET_KEYS` before it can reach the passthrough.
+
+    This walks the field TYPES, and that is the load-bearing half of the pair. A
+    newly added free-keyed section — `adapter.overrides: dict[str, str]` keyed by
+    binary path, say — defaults to an EMPTY dict, so `Policy().to_dict()` yields
+    none of its keys and the value-level twin
+    (`test_every_policy_snapshot_key_is_identifier_shaped`) stays green while the
+    hazard is live. At declaration time the type is the only evidence there is,
+    and this test is what reads it.
+
+    The assertion is an EXACT set rather than a subset for the same reason: a
+    subset check is satisfied by a tree that grew a table, which is precisely the
+    event it would exist to catch.
+
+    When this fails, a new table was added. Either route it through
+    `_POLICY_KEYSET_KEYS` / `_POLICY_COUNT_KEYS` in `diagnostics.py` so its keys
+    are reduced before they ship, or establish that its keys cannot carry user
+    data. Do not simply widen the expected set (#202)."""
+    assert set(_policy_free_keyed_fields(Policy)) == {"plugins.settings"}
+
+
+def test_every_policy_snapshot_key_is_identifier_shaped():
+    """Every key the policy snapshot actually ships is a machine slug, never PII
+    — the value-level companion to the type-level check above (#202)."""
+    offenders: list[str] = []
+
+    def walk(obj, path):
+        if isinstance(obj, dict):
+            for key, value in obj.items():
+                if not sanitize.looks_like_identifier(str(key)):
+                    offenders.append(f"{path}.{key}")
+                walk(value, f"{path}.{key}")
+        elif isinstance(obj, (list, tuple)):
+            for item in obj:
+                walk(item, f"{path}[]")
+
+    # Belt to `test_no_policy_section_has_a_free_keyed_table`'s braces: this
+    # catches a field NAME that is not slug-shaped, where a leading-underscore
+    # private field is the realistic case (`sanitize._IDENTIFIER_RE` requires the
+    # first character to be alphanumeric). It cannot catch an empty-by-default
+    # free-keyed table — there are no keys to walk — which is why the type-level
+    # test is the load-bearing one and this cannot replace it.
+    walk(Policy().to_dict(), "policy")
+    assert offenders == []
+
+
+def test_scrub_policy_passes_unknown_section_keys_verbatim():
+    """Characterization of the else-branch: an unknown section's keys are emitted
+    VERBATIM — even a home path — while `sanitize.scrub_json` redacts the same key.
+
+    This pins the CURRENT, deliberate behavior (field names are the point of the
+    snapshot, and redacting them would cost the reader the dump's whole index) and
+    is the exact hazard `test_no_policy_section_has_a_free_keyed_table` guards. It
+    is not an endorsement: if `_scrub_policy` is ever changed to scrub keys, this
+    test is expected to change with it rather than to stand in the way (#202)."""
+    snapshot = {"future": {HOME_PATH: {"model": "x"}}}
+    scrubbed = diagnostics._scrub_policy(snapshot)
+    assert list(scrubbed["future"]) == [HOME_PATH]
+    # The contrast that makes the passthrough a deliberate divergence rather than
+    # an oversight: the shared value gate would not have let this key through.
+    assert HOME_PATH not in sanitize.scrub_json(snapshot)["future"]
 
 
 # The pure guard-mechanics tests (hard-rule refusal, repair tally, cyclic

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -753,6 +753,37 @@ def test_run_capture_replaces_undecodable_banner_bytes(tmp_path):
     assert "before" in out and "after" in out
 
 
+def test_run_version_help_bounds_line_length(monkeypatch):
+    """A single absurdly long banner line is bounded in both fields (#481)."""
+    # The WIRING test: `scrub_text` having the parameter proves nothing if the
+    # call site does not pass it.
+    monkeypatch.setattr(probe.shutil, "which", lambda _binary: "/usr/bin/fakecli")
+    monkeypatch.setattr(probe, "_run_capture", lambda _argv, _timeout_s: "y" * 5000)
+
+    finding = probe.run_version_help("fakecli")
+
+    max_chars = sanitize.SCRUB_TEXT_MAX_CHARS
+    marker = f"… ({5000 - max_chars} more chars redacted)"
+    for value in (finding.version, finding.help):
+        assert value is not None
+        assert len(value) == max_chars + len(marker)
+        assert "more chars redacted" in value
+
+
+def test_log_tail_bounds_line_length(tmp_path):
+    """A log whose tail is one 5000-char line is bounded too (#481)."""
+    log_file = tmp_path / "session.log"
+    log_file.write_text("z" * 5000 + "\n", encoding="utf-8")
+
+    out = probe._log_tail(log_file)
+
+    max_chars = sanitize.SCRUB_TEXT_MAX_CHARS
+    marker = f"… ({5000 - max_chars} more chars redacted)"
+    assert out is not None
+    assert len(out) == max_chars + len(marker)
+    assert "more chars redacted" in out
+
+
 # ------------------------------------------------------ liveness (#294)
 
 

--- a/tests/test_sanitize.py
+++ b/tests/test_sanitize.py
@@ -1,5 +1,6 @@
 """The crown-jewel PII case table for the probe sanitizer."""
 
+import json
 import re
 
 import pytest
@@ -231,6 +232,17 @@ def test_assert_no_leak_clean_text():
         ("path /Users/alice/x", "absolute-home-path"),
         ("path /root/x", "absolute-home-path"),
         ("path C:/Users/alice/x", "absolute-home-path"),
+        # The Windows→WSL UNC bridge (#512). These are NOT redundant with the
+        # `/home/` row above: the bridge spelling is BACKSLASH-separated, so no
+        # forward-slash arm can see it, and the identifier it carries is the
+        # *Linux* username — which assert_no_leak's username rule cannot match,
+        # because that rule compares `getpass.getuser()`, the *Windows* account.
+        # The path rule is therefore the only rule that can fire on this shape.
+        # The last row pins the `root` half of the same arm.
+        (r"path \\wsl.localhost\Ubuntu-24.04\home\u\p", "absolute-home-path"),
+        (r"path \\wsl$\Ubuntu\home\alice\proj", "absolute-home-path"),
+        (r"path \\?\UNC\wsl.localhost\Ubuntu\home\a", "absolute-home-path"),
+        (r"path \\wsl.localhost\Ubuntu\root\proj", "absolute-home-path"),
         ("key ghp_CANARYxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx01", "secret"),
     ],
 )
@@ -238,7 +250,37 @@ def test_assert_no_leak_fires(text, rule):
     assert rule in sanitize.assert_no_leak(text)
 
 
-@pytest.mark.parametrize("text", ["path D:/data/alice/x", "path /var/lib/alice/x"])
+def test_assert_no_leak_sees_wsl_unc_through_the_json_render():
+    """#512's literal reproduction, asserted on BOTH encodings.
+
+    The same bytes reach the guard as raw text (the markdown report) and as JSON
+    text (the ``--json`` document), and ``json.dumps`` DOUBLES every backslash —
+    the historic trap documented at ``src/bmad_loop/cli.py:3737-3750``. The two
+    encodings fail for different reasons, so a test that checked only one would
+    pass while the shipped ``--json`` document still leaked.
+    """
+    raw = r"\\wsl.localhost\Ubuntu-24.04\home\u\p"
+    assert "absolute-home-path" in sanitize.assert_no_leak(raw)
+
+    rendered = json.dumps({"env": {"raw_project": raw}})
+    assert r"\\\\wsl.localhost" in rendered  # the doubling actually happened
+    assert "absolute-home-path" in sanitize.assert_no_leak(rendered)
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "path D:/data/alice/x",
+        "path /var/lib/alice/x",
+        # Backslash negatives bound the #512 arm: it names *home* trees, not any
+        # UNC path and not any backslash. A share that is not a home tree, a
+        # plain drive path, and the two ordinary words that contain the literal
+        # substrings `home` and `root` must all stay clean.
+        r"path \\server\share\data\alice\x",
+        r"path D:\data\alice\x",
+        "note homeroom and rootkit are ordinary words",
+    ],
+)
 def test_assert_no_leak_home_rule_is_not_any_absolute_path(text):
     """The rule names *home* directories, and firing is fail-closed — diagnose
     refuses to emit. Matching every absolute path would turn an ordinary dump

--- a/tests/test_sanitize.py
+++ b/tests/test_sanitize.py
@@ -150,6 +150,46 @@ def test_scrub_text_max_chars_bounds_a_single_long_line():
     assert "more chars redacted" in out
 
 
+def test_scrub_text_max_chars_never_leaves_a_guard_invisible_secret_prefix():
+    """The cap must not blind the egress guard it feeds (#481).
+
+    `looks_like_secret`'s entropy arm needs a contiguous alnum run of
+    `_SECRET_RUN_MIN`, so a cut landing inside a 36-char credential would leave 30
+    characters of it in the emitted bytes as a run too short for the guard to
+    recognize — converting a fail-closed refusal into an emission that carries a
+    credential prefix. The straddling token is dropped WHOLE instead.
+    """
+    token = "aZ3kQ9mX7pL2vB8nR4tY6wS1cD5eF0gHjK7m"
+    line = "word " * 34 + token + " tail"  # the token begins at offset 170
+    assert line.index(token) == 170
+    # Without the cap the guard fires and the caller refuses to write at all.
+    assert "secret" in sanitize.assert_no_leak(line)
+
+    out = sanitize.scrub_text(line, max_chars=200)
+    # Not merely "below the entropy threshold" — no part of the credential ships.
+    assert token[:30] not in out
+    assert not any(token[i : i + 6] in out for i in range(len(token) - 6))
+    assert "more chars redacted" in out
+
+
+def test_scrub_text_max_chars_retraction_is_conditional():
+    """The retraction fires only when the split would cost the guard its verdict,
+    not on every token the cut happens to land in — otherwise the cap would throw
+    away diagnostic text to solve a problem these two cases do not have.
+
+    A `ghp_`-prefixed token is matched at its START, so a clipped one still fires
+    and the refusal survives with no content dropped; `"x" * 5000` is a single
+    5000-char token that is not credential-shaped whole OR clipped."""
+    max_chars = 200
+    ghp = "ghp_" + "B7kR2mQ9xL4vN8pT6wY1cS5dF0gHjK3n"
+    out = sanitize.scrub_text("word " * 34 + ghp + " tail", max_chars=max_chars)
+    assert "secret" in sanitize.assert_no_leak(out)  # still fail-closed
+    assert out.startswith("word " * 34 + ghp[:30])  # and nothing was retracted
+
+    plain = sanitize.scrub_text("x" * 5000, max_chars=max_chars)
+    assert plain == "x" * max_chars + f"… ({5000 - max_chars} more chars redacted)"
+
+
 def test_scrub_text_without_max_chars_is_byte_identical():
     # `diagnostics.py` calls with neither cap (the mux `version()` probe and
     # `os_release`); their output must not change shape.

--- a/tests/test_sanitize.py
+++ b/tests/test_sanitize.py
@@ -126,6 +126,37 @@ def test_scrub_text_max_lines_truncates():
     assert "more lines redacted" in out
 
 
+def test_scrub_text_max_chars_truncates_each_line():
+    max_chars = 40
+    text = "\n".join(["short one", "x" * 5000, "short two"])
+    out = sanitize.scrub_text(text, max_chars=max_chars)
+    lines = out.split("\n")
+    assert len(lines) == 3  # per-line truncation must not drop lines
+    assert lines[0] == "short one"  # short lines survive byte-for-byte
+    assert lines[2] == "short two"
+    marker = f"… ({5000 - max_chars} more chars redacted)"
+    assert lines[1] == "x" * max_chars + marker
+    assert len(lines[1]) == max_chars + len(marker)  # the documented bound
+    assert "more chars redacted" in out
+
+
+def test_scrub_text_max_chars_bounds_a_single_long_line():
+    # #481's core case. `max_lines` alone can never bound this input, because one
+    # line is already under the line cap — that is the whole of the issue.
+    max_chars = sanitize.SCRUB_TEXT_MAX_CHARS
+    out = sanitize.scrub_text("x" * 5000, max_lines=5, max_chars=max_chars)
+    marker = f"… ({5000 - max_chars} more chars redacted)"
+    assert len(out) == max_chars + len(marker)
+    assert "more chars redacted" in out
+
+
+def test_scrub_text_without_max_chars_is_byte_identical():
+    # `diagnostics.py` calls with neither cap (the mux `version()` probe and
+    # `os_release`); their output must not change shape.
+    text = "first line\r\nsecond line\r\n"
+    assert sanitize.scrub_text(text) == text  # no normalization, no lost newline
+
+
 def test_scrub_event_payload_is_scrub_json(home):
     payload = {"session_id": "s-1", "cwd": f"{home}/proj", "n": 5}
     out = sanitize.scrub_event_payload(payload)

--- a/tests/test_sanitize.py
+++ b/tests/test_sanitize.py
@@ -150,25 +150,44 @@ def test_scrub_text_max_chars_bounds_a_single_long_line():
     assert "more chars redacted" in out
 
 
-def test_scrub_text_max_chars_never_leaves_a_guard_invisible_secret_prefix():
+@pytest.mark.parametrize(
+    "sensitive,line,rule",
+    [
+        # A bare high-entropy credential. `looks_like_secret`'s entropy arm needs a
+        # contiguous alnum run of `_SECRET_RUN_MIN`, so a 30-character survivor of a
+        # 36-character token is invisible to the guard.
+        (
+            "aZ3kQ9mX7pL2vB8nR4tY6wS1cD5eF0gHjK7m",
+            "word " * 34 + "aZ3kQ9mX7pL2vB8nR4tY6wS1cD5eF0gHjK7m" + " tail",
+            "secret",
+        ),
+        # A URL credential. `_URL_CRED_RE`'s match ENDS at the `@`, so a cut that
+        # clips the `@` away silences the rule while the password prefix still
+        # ships — a different rule from the row above, reached the same way.
+        (
+            "correcthorsebatterystaple",
+            "word " * 34 + "https://bob:correcthorsebatterystaple@localhost/x",
+            "url-credentials",
+        ),
+    ],
+)
+def test_scrub_text_max_chars_never_leaves_a_guard_invisible_fragment(sensitive, line, rule):
     """The cap must not blind the egress guard it feeds (#481).
 
-    `looks_like_secret`'s entropy arm needs a contiguous alnum run of
-    `_SECRET_RUN_MIN`, so a cut landing inside a 36-char credential would leave 30
-    characters of it in the emitted bytes as a run too short for the guard to
-    recognize — converting a fail-closed refusal into an emission that carries a
-    credential prefix. The straddling token is dropped WHOLE instead.
+    Truncation is unsafe wherever the cut lands inside something `assert_no_leak`
+    would have flagged: the fragment keeps the sensitive part while no longer
+    tripping the rule, converting a fail-closed refusal into an emission. The rows
+    are deliberately different RULES, because the hazard is a property of cutting
+    a guard construct in half and not of any one rule — a third shape belongs here
+    as another row rather than as another special case in `_truncate_line`.
     """
-    token = "aZ3kQ9mX7pL2vB8nR4tY6wS1cD5eF0gHjK7m"
-    line = "word " * 34 + token + " tail"  # the token begins at offset 170
-    assert line.index(token) == 170
-    # Without the cap the guard fires and the caller refuses to write at all.
-    assert "secret" in sanitize.assert_no_leak(line)
+    # Uncapped, the guard fires and the caller refuses to write at all.
+    assert rule in sanitize.assert_no_leak(line)
 
     out = sanitize.scrub_text(line, max_chars=200)
-    # Not merely "below the entropy threshold" — no part of the credential ships.
-    assert token[:30] not in out
-    assert not any(token[i : i + 6] in out for i in range(len(token) - 6))
+    # Not merely "below the rule's threshold" — no part of it ships at all.
+    assert sensitive[:12] not in out
+    assert not any(sensitive[i : i + 6] in out for i in range(len(sensitive) - 6))
     assert "more chars redacted" in out
 
 

--- a/tests/test_sanitize.py
+++ b/tests/test_sanitize.py
@@ -274,6 +274,18 @@ def test_assert_no_leak_clean_text():
         (r"path \\wsl$\Ubuntu\home\alice\proj", "absolute-home-path"),
         (r"path \\?\UNC\wsl.localhost\Ubuntu\home\a", "absolute-home-path"),
         (r"path \\wsl.localhost\Ubuntu\root\proj", "absolute-home-path"),
+        # The arm names a `home`/`root` TREE, not the WSL bridge specifically, so
+        # an ordinary drive path or a plain share carrying that segment fires too.
+        # Reviewers have read that breadth as an over-match and proposed anchoring
+        # the arm on the WSL prefix and its distro segment; these rows record why
+        # it is deliberate. It is the breadth the untouched POSIX arms have always
+        # had — `/home/build` and `/root/data` fire — and the first row's own
+        # FORWARD-slash spelling, `D:/home/build`, already fired before #512 via
+        # the `/home/` arm. An arm anchored on the WSL prefix would leave
+        # `D:\home\build` clean while `D:/home/build` fires, which is the
+        # separator asymmetry that IS #512, reintroduced one level down.
+        (r"path D:\home\build", "absolute-home-path"),
+        (r"path \\server\share\root\data", "absolute-home-path"),
         ("key ghp_CANARYxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx01", "secret"),
     ],
 )


### PR DESCRIPTION
Three holes in one egress path — `sanitize` → `diagnose`/`probe-adapter`. Each is a bound or an
invariant that was believed to hold and did not, which is why they ship together rather than
separately: two of the three are corrections to a *claim* about that path, and fixing one while
leaving the others standing would leave the module still asserting more than it enforces.

## Problem

**#512 — the egress self-check's home-path rule was blind to backslashes.** `diagnose` and
`probe-adapter` re-scan their own rendered bytes before emitting and refuse to emit at all on a
hit. Every arm of `sanitize._ABS_HOME_RE` was forward-slash except the drive-letter one, so a path
reached through the Windows→WSL UNC bridge was invisible to it: `\\wsl.localhost\<distro>\home\<user>\...`,
the legacy `\\wsl$\...`, and the extended-length `\\?\UNC\wsl.localhost\...` folding — each also
after `json.dumps`, which doubles every backslash. All were confirmed returning `[]` from
`assert_no_leak` before this change. The forward-slash spelling (`//wsl.localhost/.../home/...`) was
already caught, subsumed by the `/home/` arm; that asymmetry was the whole bug.

*What was NOT reachable:* a leak. Since #485 `collect_env` reduces the project path to a boolean
(`win32_on_wsl_path`) and no `EnvInfo` field carries the path, so no released version emitted one.
*What WAS live:* the claim. The `diagnostics` module docstring described the backstop as
fail-closed without qualification, and for this shape the backstop provably could not fire. The
username rule cannot cover the shape either — it compares `getpass.getuser()`, the *Windows*
account, while the identifier at risk in a distro path is the *Linux* username. Two independent
causes, one outcome.

**#481 — `scrub_text` bounded line count but not line length.** `max_lines` capped how many lines
were emitted and nothing capped how long one could be, so a single very long line passed through
regardless: `len(scrub_text("x" * 5000, max_lines=5))` was 5000.

*What WAS reachable:* live output. A `--version`/`--help` line or a log-tail line from a foreign
CLI reached `probe-adapter`'s report and its `--json` document at whatever length the CLI chose.
*What was NOT reachable:* un-redacted content. The redaction pass still ran over that line; what
was missing was a bound on volume, so the failure mode is an unbounded document and the broken
table alignment #481 names, not a PII escape.

**#202 — the policy snapshot's verbatim-key invariant was enforced nowhere.** `_scrub_policy`
emits dict keys unredacted, which is correct only while no policy section is a free-keyed table —
so that every key it passes through is a compile-time dataclass field name rather than user data.
`plugins.settings`, the one user-keyed table, is intercepted by `_POLICY_KEYSET_KEYS` before it
reaches the passthrough.

*What was NOT reachable:* anything, today. The property holds right now; no section is free-keyed.
*What WAS live:* that nothing would notice it breaking. Neither a test nor a comment recorded it,
and a value-level check cannot substitute — a newly declared free-keyed section defaults to an
empty dict, so `Policy().to_dict()` yields none of its keys and a value walk stays green while the
hazard is live.

## Fix

- **`src/bmad_loop/sanitize.py`** — a backslash `home`/`root` arm on `_ABS_HOME_RE`
  (`|\\{1,2}(?:home|root)\\{1,2}`), mirroring the POSIX arms and reusing the existing `\\{1,2}`
  treatment so the `--json` render is covered. It anchors on the home segment, not the `wsl` host,
  because a host anchor misses `\\?\UNC\wsl.localhost\...` — the `?\UNC\` segment sits between the
  leading backslashes and `wsl`. `Users` is deliberately left out; it stays behind the drive-letter
  arm. Also `SCRUB_TEXT_MAX_CHARS = 200` and an optional `max_chars=` parameter on `scrub_text`;
  passing neither cap stays a byte-identical passthrough of the redaction step (no
  `splitlines`/`join`), which `diagnostics.py` depends on at its two uncapped call sites.
  Truncation runs through `_truncate_line`, which retracts a cut out of any guard construct it
  would split. Without that, the cap blinds the egress guard it feeds: `scrub_text` redacts only
  home paths and emails, and the guard runs over the ALREADY-truncated bytes, so a cut landing
  inside something `assert_no_leak` would have flagged leaves a fragment that keeps the sensitive
  part while no longer tripping the rule. Two rules are reachable that way — a credential-shaped
  token (the entropy arm of `looks_like_secret` needs a contiguous alnum run of `_SECRET_RUN_MIN`,
  so a 36-char token clipped to 30 goes unrecognized) and a URL credential (`_URL_CRED_RE`'s match
  ends at the `@`, so clipping the `@` silences it while the password prefix ships). Rather than
  special-case either, `_truncate_line` defers to `assert_no_leak` itself: it retracts out of a
  `_TRUNCATION_HAZARD_RES` match whose whole trips the guard while its surviving prefix does not.
  That keeps it general — a rule added to the guard is covered without a second implementation of
  what "sensitive" means. The verdict test is also what stops the cap over-firing: `"x" * 5000`
  (one huge token that trips no rule whole or clipped) and a `ghp_`-prefixed token (matched at its
  start, still trips the guard once clipped) both still truncate at exactly `max_chars`.
- **`src/bmad_loop/probe.py`** — three call sites wired to `max_chars=sanitize.SCRUB_TEXT_MAX_CHARS`:
  `--version` (`probe.py:249`), `--help` (`probe.py:254`), and the log tail (`probe.py:803`).
- **`src/bmad_loop/diagnostics.py`** — two module-docstring corrections replacing the unqualified
  fail-closed claim with what the guard actually is (a *shape* re-scan of the rendered bytes,
  fail-closed on a hit) and what falls outside it; plus a comment at the `_scrub_policy` key
  passthrough recording the invariant and why key-scrubbing was not the answer. No runtime change
  in this file.
- **`tests/test_sanitize.py`, `tests/test_probe.py`, `tests/test_diagnostics.py`** — the case rows
  and tests listed under Testing.

## Scope note

Nothing was folded in beyond the three filed issues. Deliberately left alone:

- **`diagnostics.py:303` (`os_release=sanitize.scrub_text(platform.release())`)** is a fifth
  `scrub_text` caller and is still unbounded. Left that way on purpose: it is the kernel release
  string from the Python stdlib, not foreign-CLI output, so #481's premise — that the value comes
  from a subprocess whose output the orchestrator does not control — does not hold there.
- **`adapters/multiplexer.fold_version`** stays independent of `scrub_text`, per #481's own
  guidance. Its `VERSION_MAX_CHARS` is a terminal-column budget for a table cell, not a redaction
  budget, so it keeps its bare `…`. (`diagnostics.py:298` composes the two and is already bounded
  downstream by it.)
- **`_scrub_policy` still passes keys through verbatim**, deliberately, per #202's own analysis.
  The third option — scrubbing keys through `looks_like_identifier` — would redact legitimate field
  names and lose the property that makes the snapshot worth shipping: a reader diagnosing a run
  needs to see `max_review_cycles`, not `<redacted:str>`.

Filed during review: **#654** — the truncation retraction defers to `assert_no_leak`, but consults it
without its `extra` argument and behind hazard patterns with a six-character minimum, so the guard's
rules keyed on values only the CALLER knows are outside it: a caller-supplied sensitive value, and a
standalone username at the guard's five-character floor. (A SIX-character username *is* caught today,
verified — the gap is exactly five.) Closing it means threading the caller's values into `scrub_text`,
a signature and layering change rather than a bound fix, so it is filed rather than folded in. The
`_truncate_line` docstring records the limit, so the cap is documented as covering the guard's STATIC
rules and no more.

Also filed earlier and left open for separate treatment: **leaves #652 open** — the `_POLICY_*`
sets match bare key names at any nesting depth, so a future `settings`/`env`/`extra_args` key in an
unrelated section would be reduced by the wrong rule. That is an interception over-reach, not a
leak, and out of scope here.

## Visible behavior diffs

Exactly one:

- A `--version`, `--help` or log-tail line longer than `SCRUB_TEXT_MAX_CHARS` (200) now ends with
  `… (N more chars redacted)` in `bmad-loop probe-adapter` output and in its `--json` document.
  A truncated line's total length is **at most** `max_chars + len(marker)` — the marker sits
  outside the budget, mirroring the off-by-one `max_lines` already has (`max_lines=5` emits six
  lines, five kept plus the marker line). That is deliberate: a marker made to fit inside the
  budget would have to be a bare ellipsis, which #481 rejected because it does not say that
  redaction happened. "At most" rather than exactly: a cut that would split a credential-shaped
  token retracts to that token's start, so such a line ends shorter and the token is dropped whole
  rather than emitted as a guard-invisible prefix.

Non-diffs a reader might expect and will not get:

- **`probe.SCHEMA_VERSION` is unchanged** (stays `2`). Per `machine.py:8-10`, evolution is
  additive-only and a bump is for removing or renaming a field, changing a type, or changing the
  meaning of a value. No field is removed or renamed and no type changes; the meaning of
  `version`/`help` was already "the CLI's scrubbed output, capped" — `max_lines=5` has always
  truncated it — so adding a second axis to an already-documented lossy cap is the same class of
  value, not a new one.
- **`diagnose` output is unchanged.** Its two `scrub_text` call sites pass no caps, and the
  no-cap path is a byte-identical passthrough.
- **#202 changes no behavior at all** — one comment and three tests. `_scrub_policy`,
  `_POLICY_COUNT_KEYS`, `_POLICY_BOOL_KEYS` and `_POLICY_KEYSET_KEYS` are untouched.

## What this does NOT claim

The egress guard is a shape-based re-scan of known hazards and a defense-in-depth layer *behind*
per-field routing — not a proof. A home-path spelling it does not know, or a username that is not
this process's, is still outside it. `diagnose` output is not now provably PII-free, and this
change does not make the guard catch every home-path spelling. Stating that boundary is the point
of #512; restating the overclaim here would reproduce the bug in a new place.

## Testing

New coverage, by issue:

- **#512** — `tests/test_sanitize.py`: four new rows on `test_assert_no_leak_fires` (the two WSL
  bridge spellings, the `\\?\UNC\` folding, and a `root` row pinning the other half of the arm);
  `test_assert_no_leak_sees_wsl_unc_through_the_json_render`, which asserts both encodings and
  checks that `json.dumps` actually doubled the backslashes; and three new negative rows on
  `test_assert_no_leak_home_rule_is_not_any_absolute_path` (a non-home UNC share, a plain drive
  path, and the ordinary words `homeroom`/`rootkit`) bounding the arm against over-matching, which
  matters because a hit is fail-closed in both directions — it makes `diagnose` refuse to emit.
  Added in review: two POSITIVE rows (`D:\home\build`, `\\server\share\root\data`) pinning that
  the arm names a `home`/`root` TREE and not the WSL bridge specifically — the same breadth the
  untouched POSIX arms have always had, and the bound a reviewer proposed narrowing.
- **#481** — `tests/test_sanitize.py`: `test_scrub_text_max_chars_truncates_each_line` (T1),
  `test_scrub_text_max_chars_bounds_a_single_long_line` (T2),
  `test_scrub_text_without_max_chars_is_byte_identical` (T3). `tests/test_probe.py`:
  `test_run_version_help_bounds_line_length` (T4), `test_log_tail_bounds_line_length` (T5).
  Added in review: `test_scrub_text_max_chars_never_leaves_a_guard_invisible_fragment` (T6),
  parametrized over BOTH reachable guard rules (a bare high-entropy credential and a URL
  credential), asserting no part of either ships, and
  `test_scrub_text_max_chars_retraction_is_conditional` (T7), which pins that the retraction does
  NOT fire for the two shapes that do not need it — otherwise the cap would throw away diagnostic
  text to solve a problem they do not have.
- **#202** — `tests/test_diagnostics.py`: `test_no_policy_section_has_a_free_keyed_table`,
  `test_every_policy_snapshot_key_is_identifier_shaped`,
  `test_scrub_policy_passes_unknown_section_keys_verbatim` — the last now also asserts that the
  unknown section's VALUES still go through the standard gate, added in review because the
  original proved only the key passthrough and stayed green over a branch with the value gate
  removed.

Ablation evidence, one line per new guard, quoted from what each phase actually reported:

- **#512, axis A (under-match)** — deleted only the new alternation: *"5 failed, 74 passed — T1's
  four new bridge rows and T2 FAILED; the negative test stayed green."*
- **#512, axis B (over-match)** — widened the arm to a bare `\\{1,2}`: *"2 failed, 77 passed — the
  two backslash negatives FAILED; T1/T2 stayed green."*
- **#512, axis B′ (extra, unprompted)** — stripped the arm's backslash delimiters to a bare
  `(?:home|root)`: *"The `homeroom`/`rootkit` negative FAILED."* Run because neither A nor B
  reddens that row, confirming it carries weight rather than riding along.
- **#481, axis A (predicate)** — deleted only the per-line truncation branch, keeping the
  parameter: *"T1, T2, T4, T5 FAILED (`assert 5000 == (200 + 28)`); T3 and the pre-existing
  `test_scrub_text_max_lines_truncates` stayed green — 4 failed, 128 passed. Restored: 132 passed."*
- **#481, axis B (wiring)** — removed only the `max_chars=` argument from the three call sites:
  *"T4 and T5 FAILED; T1, T2, T3 stayed green — 2 failed, 130 passed. Restored: 132 passed."*
- **#481, axis C (the no-op guarantee)** — defaulted `max_chars` so the split/join runs uncapped:
  *"T3 alone FAILED (CRLF normalized, trailing newline lost) — 1 failed, 131 passed."*
- **#202, axis A (the load-bearing contrast)** — added `overrides: dict[str, str]` to `MuxPolicy`:
  *"`test_no_policy_section_has_a_free_keyed_table` FAILED ("Extra items in the left set:
  'mux.overrides'") while `test_every_policy_snapshot_key_is_identifier_shaped` PASSED."* That
  contrast is the entire warrant for the type-level test: the new table's default is empty, so the
  value-level walk saw nothing to object to.
- **#202, axis B** — added `_cache: str = ""` to `MuxPolicy`:
  *"`test_every_policy_snapshot_key_is_identifier_shaped` FAILED ("assert ['policy.mux._cache'] ==
  []"); the type-level test passed."*
- **#202, axis C** — changed the passthrough to `out[sanitize._scrub_str(key)]`:
  *"`test_scrub_policy_passes_unknown_section_keys_verbatim` FAILED ("'<redacted:str>' !=
  '/home/canaryuser/secret/proj'")."*

Added in review, one line per guard landed answering a bot finding:

- **#481, the truncation retraction, axis A (mechanism)** — disabled it entirely
  (`_TRUNCATION_HAZARD_RES = ()`): *"BOTH T6 rows FAILED — 2 failed, 85 deselected."*
- **#481, axis B (the generalization)** — reverted the hazard set to the first fix's token-only
  scope (`(_LEAK_TOKEN_RE,)`): *"ONLY the url-credentials row FAILED; the secret row PASSED — 1
  failed, 1 passed."* The two axes redden DISJOINT sets, which is the proof the generalization
  carries weight the token-only fix did not, rather than restating it.
- **#512, the breadth rows** — applied the reviewer's own proposal, anchoring the arm on the WSL
  prefix and distro segment: *"exactly the two new rows FAILED (`assert 'absolute-home-path' in
  []`) while all four WSL bridge rows and every negative row stayed green — 2 failed, 82 passed."*
- **#202, the value-gate row** — flattened the else-branch recursion to `out[key] = value`:
  *"`test_scrub_policy_passes_unknown_section_keys_verbatim` FAILED (`assert
  '/home/canaryuser/secret/proj' == '<redacted:str>'`) — and the pre-existing key assertion above
  it PASSED, which is the proof the original test would have stayed green over a leaking branch."*

Phase 2's axes A and B redden overlapping rather than disjoint sets — B's {T4, T5} is a subset of
A's {T1, T2, T4, T5}. Full disjointness is unreachable for a wiring test that asserts observable
output, since deleting the predicate must also break the end-to-end assertion. The separation that
carries the proof is present in both directions anyway: T1/T2 redden under A only, so the predicate
has witnesses independent of the call sites; T4/T5 redden under B while T1/T2 stay green, so the
call sites have witnesses that fail for wiring reasons alone with the predicate fully intact.

Sources restored from `cp` backups after every axis — never `git checkout` — and each phase
confirmed green again before committing.

Gates on the final tree, all four green:

| Gate | Result |
| --- | --- |
| `uv run pytest -q -n logical` | 6016 passed, 50 skipped |
| `uv run pyright` | 0 errors, 0 warnings, 0 informations |
| `trunk fmt` | clean (stable — no reflow on re-run) |
| `trunk check --no-fix --all` | 258 files checked, no issues |

`--no-fix` is not optional here: ruff's F401 autofix deletes the load-bearing
`# noqa: F401 — re-export` in `diagnostics.py` and breaks `cmd_diagnose`'s except clause.

Closes #202, closes #512, closes #481


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Limited scrubbed diagnostic lines to a safe character length while preserving redaction markers.
  - Prevented truncation from exposing partial credentials or URL credentials.
  - Improved detection of sensitive Windows and WSL UNC home paths, including escaped forms.
  - Applied consistent limits to version/help output and log tails.
  - Clarified diagnostic egress scanning and rendered-output boundaries.

- **Tests**
  - Added coverage for truncation, credential protection, redaction behavior, UNC path detection, and policy-key safety.
  - Verified that unrestricted text remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


