### PR TITLE
ci: bound and retry the tmux install instead of wedging the job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,51 +33,51 @@ jobs:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
 
-      - name: Install tmux (for generic_tmux integration tests)
-        # Bounds the step even if every attempt below stalls: the job cap is 15
-        # minutes and a wedged install used to consume all of it.
-        timeout-minutes: 7
+      - name: Ensure tmux (for generic_tmux integration tests)
+        # Bounded above the fallback's worst case (~260s) so the loop always
+        # reaches the final `tmux -V` instead of being cancelled mid-attempt.
+        timeout-minutes: 6
         run: |
-          # Two distinct failure modes, both measured on this runner fleet.
+          # The ubuntu-24.04 runner image already ships tmux. Measured on this
+          # workflow's own run: "tmux is already the newest version
+          # (3.4-1ubuntu0.1) ... 0 upgraded, 0 newly installed". The apt work this
+          # step used to do unconditionally therefore installed nothing, while
+          # taking the full risk of the network to do it:
           #
-          # 1. `apt-get update` EXITS NON-ZERO when a third-party repo baked into
-          #    the runner image (e.g. dl.google.com/chrome) serves a stale index
-          #    (Hash Sum mismatch). Harmless here — the Ubuntu archive lists still
-          #    refresh — so its status is discarded.
-          # 2. `apt-get update` NEVER EXITS. Measured on py3.11 (run 32230727567):
-          #    the azure mirror was Ign'd, apt fell back to archive.ubuntu.com, and
-          #    the `noble-security InRelease` fetch produced no further output for
-          #    14 minutes until the job cap killed the job — with `Install the
-          #    project` and `Run tests` never reached, so the code under review
-          #    never ran at all. Three attempts wedged the same way while the
-          #    py3.12/3.13/3.14 legs installed tmux in 8-12s in the same run.
+          #   `apt-get update` produced no output for 14 minutes on `test (py3.11)`
+          #   (run 32230727567) until the 15-minute job cap killed the job, with
+          #   `Install the project` and `Run tests` never reached — so the code
+          #   under review never ran and the red was uninformative. It wedged that
+          #   way four times. `|| true` cannot catch it: a command that never exits
+          #   has no exit status to discard. apt's own Acquire timeouts did not
+          #   fire during the stall either.
           #
-          # `|| true` cannot catch (2): a command that never exits has no exit
-          # status to discard. Neither can apt's own Acquire timeouts — the default
-          # 120s did not fire during that 14-minute stall, so the outer `timeout` is
-          # the bound that actually holds. The Acquire options are still set so the
-          # ordinary case fails fast instead of burning the full 60s, and the retry
-          # then gets a fresh connection (often a different mirror).
-          #
-          # `tmux -V` remains the assertion: if all three attempts fail, tmux is
-          # absent and the job fails loudly rather than skipping the tmux tests.
-          # `dpkg --configure -a` on retry: the only breakage `timeout` can itself
-          # cause is a kill during unpack, which leaves dpkg half-configured and
-          # would fail every later attempt with "dpkg was interrupted".
-          for attempt in 1 2 3; do
-            [ "$attempt" -eq 1 ] || { sleep 5; sudo dpkg --configure -a || true; }
-            sudo timeout -k 10 60 apt-get update \
+          # So ask first, and touch the network only if the answer is no. What
+          # follows is a fallback for an image that stops shipping tmux, not the
+          # normal path: every call is bounded by `timeout` (the bound that
+          # actually holds here) and retried once. `tmux -V` remains the
+          # assertion, so a genuine failure fails the job loudly rather than
+          # silently skipping the tmux integration tests.
+          if tmux -V; then
+            exit 0
+          fi
+          echo "::warning::tmux absent from the runner image; falling back to apt"
+          for attempt in 1 2; do
+            if [ "$attempt" -gt 1 ]; then
+              sleep 5
+              # The one breakage `timeout` can itself cause is a kill during
+              # unpack, which would fail every later attempt with "dpkg was
+              # interrupted". Bounded too — it is recovery, not a reason to hang.
+              sudo timeout -k 5 20 dpkg --configure -a || true
+            fi
+            sudo timeout -k 5 45 apt-get update \
               -o Acquire::Retries=3 \
               -o Acquire::http::Timeout=20 \
               -o Acquire::https::Timeout=20 || true
-            if sudo timeout -k 10 60 apt-get install -y \
-              -o Acquire::Retries=3 \
-              -o Acquire::http::Timeout=20 \
-              -o Acquire::https::Timeout=20 \
-              tmux; then
+            if sudo timeout -k 5 60 apt-get install -y tmux; then
               break
             fi
-            echo "::warning::tmux install attempt ${attempt} failed; retrying"
+            echo "::warning::tmux install attempt ${attempt} failed"
           done
           tmux -V
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,15 +34,51 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install tmux (for generic_tmux integration tests)
+        # Bounds the step even if every attempt below stalls: the job cap is 15
+        # minutes and a wedged install used to consume all of it.
+        timeout-minutes: 7
         run: |
-          # `apt-get update` can exit non-zero when an unrelated third-party
-          # repo baked into the runner image (e.g. dl.google.com/chrome) serves
-          # a stale index (Hash Sum mismatch). That must not fail our build —
-          # the Ubuntu archive lists still refresh, so tmux installs cleanly.
-          # `tmux -V` then asserts tmux is actually present, so a genuine
-          # install failure still fails the job loudly.
-          sudo apt-get update -o Acquire::Retries=3 || true
-          sudo apt-get install -y tmux
+          # Two distinct failure modes, both measured on this runner fleet.
+          #
+          # 1. `apt-get update` EXITS NON-ZERO when a third-party repo baked into
+          #    the runner image (e.g. dl.google.com/chrome) serves a stale index
+          #    (Hash Sum mismatch). Harmless here — the Ubuntu archive lists still
+          #    refresh — so its status is discarded.
+          # 2. `apt-get update` NEVER EXITS. Measured on py3.11 (run 32230727567):
+          #    the azure mirror was Ign'd, apt fell back to archive.ubuntu.com, and
+          #    the `noble-security InRelease` fetch produced no further output for
+          #    14 minutes until the job cap killed the job — with `Install the
+          #    project` and `Run tests` never reached, so the code under review
+          #    never ran at all. Three attempts wedged the same way while the
+          #    py3.12/3.13/3.14 legs installed tmux in 8-12s in the same run.
+          #
+          # `|| true` cannot catch (2): a command that never exits has no exit
+          # status to discard. Neither can apt's own Acquire timeouts — the default
+          # 120s did not fire during that 14-minute stall, so the outer `timeout` is
+          # the bound that actually holds. The Acquire options are still set so the
+          # ordinary case fails fast instead of burning the full 60s, and the retry
+          # then gets a fresh connection (often a different mirror).
+          #
+          # `tmux -V` remains the assertion: if all three attempts fail, tmux is
+          # absent and the job fails loudly rather than skipping the tmux tests.
+          # `dpkg --configure -a` on retry: the only breakage `timeout` can itself
+          # cause is a kill during unpack, which leaves dpkg half-configured and
+          # would fail every later attempt with "dpkg was interrupted".
+          for attempt in 1 2 3; do
+            [ "$attempt" -eq 1 ] || { sleep 5; sudo dpkg --configure -a || true; }
+            sudo timeout -k 10 60 apt-get update \
+              -o Acquire::Retries=3 \
+              -o Acquire::http::Timeout=20 \
+              -o Acquire::https::Timeout=20 || true
+            if sudo timeout -k 10 60 apt-get install -y \
+              -o Acquire::Retries=3 \
+              -o Acquire::http::Timeout=20 \
+              -o Acquire::https::Timeout=20 \
+              tmux; then
+              break
+            fi
+            echo "::warning::tmux install attempt ${attempt} failed; retrying"
+          done
           tmux -V
 
       - name: Install the project


### PR DESCRIPTION
## The bug

The Linux `test` job's tmux step guarded `apt-get update` with `|| true`. That
handles a non-zero exit. The failure actually hitting the job is the other one:
**`apt-get update` does not exit at all**, and `|| true` has no exit status to
discard.

Measured on run `32230727567`, job `test (py3.11)` — from the job log:

```
08:04:27 Get:5 https://archive.ubuntu.com/ubuntu noble-security InRelease [126 kB]
08:18:54 ##[error]The operation was canceled.
```

**No output for 14 minutes** until the 15-minute job cap killed it. `Install the
project` and `Run tests` never started, so the code under review never ran — the
red was uninformative. It wedged that way four times in a row. apt's own
`Acquire::*::Timeout` (default 120s) did **not** fire during the stall, so a tuned
apt option would not have helped either.

## The finding that changed the fix

The first iteration of this PR added bounds and retries around the apt calls. Its
own CI run then answered a question the PR had not thought to ask:

```
tmux is already the newest version (3.4-1ubuntu0.1).
0 upgraded, 0 newly installed, 0 to remove and 1 not upgraded.
```

**The ubuntu-24.04 runner image already ships tmux.** This step has never
installed anything. It was taking the full risk of the network for a no-op — and
that risk is what kept killing the job. The retry loop made that survivable, but
it also made every Linux leg pay a 60s timeout (measured on all four legs) to
discover there was nothing to do.

## The fix

Ask first. `tmux -V` up front short-circuits the entire step, so the normal path
touches the network zero times. apt becomes a **fallback** for an image that stops
shipping tmux — announced with a `::warning::`, bounded by `timeout` (the bound
that actually holds here), and retried once. The closing `tmux -V` is still the
assertion, so a genuine absence fails the job loudly rather than silently skipping
the tmux integration tests.

Also bounds `dpkg --configure -a`, and sizes the step cap **above** the fallback's
worst case rather than under it: with `--kill-after`, the retry loop's worst case
was 430s against a 420s cap, so the final `tmux -V` could have been cancelled
instead of reached. It is now 260s against a 360s cap.

## Verification

`trunk check` (actionlint/yamllint/prettier) clean. The `run:` script was extracted
verbatim from the YAML and executed under `bash -e` against stubbed
`sudo`/`apt-get`/`dpkg`/`tmux`:

| scenario | result |
| --- | --- |
| tmux present (the real runner) | `rc=0`, 0s, **apt never invoked** — empty call trace |
| tmux absent, apt healthy | `rc=0`, falls back, one `update` + one `install` |
| tmux absent, install fails once | `rc=0`, retries with bounded `dpkg --configure -a`, succeeds |
| tmux absent, install always fails | 2 attempts, then `tmux -V` fails → **job fails loudly** |
| tmux absent, `update` hangs (`sleep 600`) | `rc=0` at 45s — `timeout` killed the hang, install proceeded |

Ablation, the same hang against the **original** step: it never returns. The trace
stops at `update`, `install` is never reached, and an external 25s bound had to
kill it — the CI failure above, reproduced and then closed.

Workflow-only change; no CHANGELOG entry, matching the existing `ci:` commits.