### PR TITLE
test: de-flake the two open TUI flakes (#360, #581) and the template-copy race

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -25,8 +25,8 @@ and every negative assertion proven by ablation.**
   (the `non-linux` extra carries no environment marker, and CI syncs `--all-extras`), so
   xdist's `auto` resolves to the _physical_ core count — half the vCPUs on the hosted
   runners. CI passes `-n logical` in both test jobs for that reason. A test that fails only
-  under xdist load is a flake, which is a bug — #360 is the open instance. Live/E2E modules skip themselves when their host requirements are
-  absent — selection is in-file, never in config.
+  under xdist load is a flake, which is a bug. Live/E2E modules skip themselves when their
+  host requirements are absent — selection is in-file, never in config.
 - Only builtin pytest marks appear: `parametrize`, `skipif`, `usefixtures`, and exactly one
   `xfail(strict=True)` (a pinned known defect, see [Ablation records](#ablation-records)).
   **No custom markers, deliberately**: a marker registry is a second selection mechanism that
@@ -258,11 +258,10 @@ source tree, so packaging breaks were invisible until this job existed).
 **Zero-retry flaky policy.** There is no retry mechanism anywhere: no `--reruns`, no retry
 plugin — `pytest-rerunfailures` was removed from the environment precisely because an installed
 retry plugin is an invitation to paper over a real flake. **A flake is a bug**: it gets an
-issue (#360 and #581 are the open instances), a diagnosis, and a deterministic fix — never a
-rerun loop. The main defense is the **frozen-clock pattern, mandatory for time-dependent
-tests**: no unit or seam test sleeps toward a deadline (the real-process gates use short
-settle polls, which is different from waiting out a production timeout). Two sanctioned
-shapes:
+issue, a diagnosis, and a deterministic fix — never a rerun loop. The main defense is the
+**frozen-clock pattern, mandatory for time-dependent tests**: no unit or seam test sleeps
+toward a deadline (the real-process gates use short settle polls, which is different from
+waiting out a production timeout). Two sanctioned shapes:
 
 1. A scoped `_Clock` shim over a mutable dict, monkeypatched in as the module-under-test's
    `time` reference; a scripted watcher callback advances the dict past the deadline

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -446,6 +446,16 @@ def _project_template(
     git(root, "config", "user.email", "test@test")
     git(root, "config", "user.name", "test")
     git(root, "config", "core.fsync", "none")  # cheapen commits; old git ignores unknown keys
+    # `git commit` ends by spawning `git maintenance run --auto --quiet --detach`
+    # (traced on git 2.55). That child DETACHES, so it outlives the commit and this
+    # fixture both, and it writes under `.git/objects/` in the template while later
+    # tests are already copytree-ing it: `objects/maintenance.lock` is listed by
+    # scandir, unlinked by the detached child, and gone by the time copy2 opens it,
+    # failing one arbitrary test on `[Errno 2]` for a file nothing asked for. Disable
+    # the writer rather than teach the copy to tolerate it — an `ignore=` pattern on
+    # the copy would also silently skip a lock that did matter. The copies inherit
+    # this via the copied .git/config, so what they commit cannot re-arm it either.
+    git(root, "config", "maintenance.auto", "false")
     git(root, "add", "-A")
     git(root, "commit", "-q", "-m", "initial")
     return root

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -69,8 +69,11 @@ def test_template_leaves_no_detached_git_maintenance_writing_into_the_copies(pro
     Ablation target: delete the `maintenance.auto` line from `_project_template`
     and this row fails alone, naming the spawned `git maintenance run` in the
     assertion message. The trace-recorded-the-commit assertion is the anti-vacuity
-    guard — without it a git built without trace2, or any typo in the env var,
-    would write no events and the row would pass for having observed nothing."""
+    guard: `spawned` reads empty both when no child ran and when the trace parsed
+    into nothing we recognize, so a trace2 event or field rename would otherwise
+    leave this row green for having observed nothing. It does not guard an absent
+    trace — a git without trace2, or a mistyped env var, writes no file at all and
+    the read below raises `FileNotFoundError`, which is loud on its own."""
     repo = project.project
     (repo / "src.txt").write_text("changed\n")
     subprocess.run(["git", "-C", str(repo), "add", "-A"], check=True, capture_output=True)

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -14,6 +14,8 @@ therefore pinned here, one fact per row.
 
 from __future__ import annotations
 
+import json
+import os
 import subprocess
 
 import conftest
@@ -46,6 +48,55 @@ def test_template_drops_sample_hooks_but_keeps_hooks_dir_and_exclude(project):
     assert list(hooks.glob("*.sample")) == []
     assert hooks.is_dir()
     assert (git_dir / "info" / "exclude").is_file()
+
+
+def test_template_leaves_no_detached_git_maintenance_writing_into_the_copies(project, tmp_path):
+    """No background git process may outlive a commit into the sandbox.
+
+    `git commit` normally ends by spawning `git maintenance run --auto --quiet
+    --detach`. Detached, it outlives the command that started it and keeps writing
+    under `.git/objects/` — and the template it writes into is exactly what
+    `project` copytrees for every test. `objects/maintenance.lock` gets listed by
+    scandir, unlinked by that child, then opened by copy2 and is already gone, so
+    one arbitrary unrelated test dies at fixture setup on `[Errno 2]`. It reddens a
+    different test each time and only on whichever interpreter leg loses the race,
+    which is the flake signature this suite treats as a bug.
+
+    Graded on the behavior, not on the config key: reading back
+    `maintenance.auto` would pass on a git that had stopped honouring it. This
+    commits into a real copy under GIT_TRACE2 and pins the child list instead.
+
+    Ablation target: delete the `maintenance.auto` line from `_project_template`
+    and this row fails alone, naming the spawned `git maintenance run` in the
+    assertion message. The trace-recorded-the-commit assertion is the anti-vacuity
+    guard — without it a git built without trace2, or any typo in the env var,
+    would write no events and the row would pass for having observed nothing."""
+    repo = project.project
+    (repo / "src.txt").write_text("changed\n")
+    subprocess.run(["git", "-C", str(repo), "add", "-A"], check=True, capture_output=True)
+
+    trace = tmp_path / "trace2.json"
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "-q", "-m", "second"],
+        check=True,
+        capture_output=True,
+        env={**os.environ, "GIT_TRACE2_EVENT": str(trace)},
+    )
+
+    events = []
+    for line in trace.read_text(encoding="utf-8", errors="replace").splitlines():
+        try:
+            events.append(json.loads(line))
+        except ValueError:  # trace2 writes one JSON object per line; skip any partial
+            continue
+
+    # Anti-vacuity: the trace really did observe this commit.
+    assert any(
+        e.get("event") == "cmd_name" and e.get("name") == "commit" for e in events
+    ), f"GIT_TRACE2 recorded no commit; nothing was actually observed: {events}"
+
+    spawned = [" ".join(e.get("argv") or []) for e in events if e.get("event") == "child_start"]
+    assert not [c for c in spawned if "maintenance" in c or "gc" in c], spawned
 
 
 def test_make_git_noisy_produces_rc_zero_stderr(project):

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -79,11 +79,18 @@ def test_template_leaves_no_detached_git_maintenance_writing_into_the_copies(pro
     subprocess.run(["git", "-C", str(repo), "add", "-A"], check=True, capture_output=True)
 
     trace = tmp_path / "trace2.json"
+    # `GIT_CONFIG_COUNT=0` drops any inherited command-scope `GIT_CONFIG_KEY_n`
+    # pair, which outranks `.git/config` exactly as `git -c` does. Measured: an
+    # ambient `maintenance.auto=true` re-arms the spawn straight through the
+    # fixture's own `false` and reddens this row, and an ambient `false` would
+    # hold it green with the fixture line ablated — the vacuity this row exists
+    # to refuse. Scoped to this one probe, not to the suite-wide env fixtures,
+    # which shadow only the variables they must on purpose.
     subprocess.run(
         ["git", "-C", str(repo), "commit", "-q", "-m", "second"],
         check=True,
         capture_output=True,
-        env={**os.environ, "GIT_TRACE2_EVENT": str(trace)},
+        env={**os.environ, "GIT_TRACE2_EVENT": str(trace), "GIT_CONFIG_COUNT": "0"},
     )
 
     events = []

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1024,6 +1024,15 @@ async def test_poll_skips_while_another_holds_the_lock(project):
     # Regression: exclusive=True cannot stop a running thread worker, so the
     # screen lock must make a second poll bail instead of mutating shared ctx
     # (two threads feeding ctx.log's pyte stream crashed the TUI).
+    #
+    # Ablation target: delete the `if not self._poll_lock.acquire(blocking=False):
+    # return` guard from `_poll` *and* neutralize its paired
+    # `finally: self._poll_lock.release()` to `pass` — one guard, both halves,
+    # not two gates. Dropping only the acquire makes every other tick release a
+    # lock it never took, reddening the whole file on `RuntimeError: release
+    # unlocked lock` instead. With both gone this test fails alone on
+    # `assert ctx.entries == before` — the probe thread runs the body and
+    # appends the checkpoint entry.
     root = project.project
     run_dir = make_run(root, "20260611-100000-aaaa", alive=True)
     write_numbered_log(run_dir, "story-1", count=30)
@@ -1044,9 +1053,26 @@ async def test_poll_skips_while_another_holds_the_lock(project):
         # while waiting on call_from_thread(_apply).
         await until(pilot, lambda: screen._poll_lock.acquire(blocking=False))
         try:
+            gen = screen._generation
             before = list(ctx.entries)
             journal.append("checkpoint", log_task="story-1", log_pos=0)  # new entry on disk
-            worker = screen._poll(ctx, screen._generation, False, None)
+            # Run the undecorated body as our own thread worker, in a group of
+            # our own. Calling the @work-decorated _poll enters group "poll" on
+            # this same node, and the next 1s interval tick's poll cancels that
+            # group on arrival (add_worker -> cancel_group), marking this worker
+            # CANCELLED — so worker.wait() raced the tick and raised
+            # WorkerCancelled on slow Windows runners (#581). A private group is
+            # never a cancel_group candidate, so this awaits to completion;
+            # thread=True keeps it a real second thread entering the guarded body
+            # while the lock is held, which is the point of the test.
+            # exit_on_error=False surfaces a body exception as WorkerFailed at
+            # the await instead of tearing the app down mid-test.
+            worker = screen.run_worker(
+                lambda: DashboardScreen._poll.__wrapped__(screen, ctx, gen, False, None),
+                thread=True,
+                group="poll-probe-581",
+                exit_on_error=False,
+            )
             await worker.wait()
             assert ctx.entries == before  # guarded body never ran
         finally:

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1391,11 +1391,14 @@ async def test_decision_modal_scrolls_when_content_long(project):
         # `scroll_visible` only queues the scroll. It runs straight through to
         # the container's `Widget.scroll_to`, which defers the offset write via
         # `call_after_refresh`: an InvokeLater the pump forwards to the screen,
-        # where it lands on `Screen._callbacks` and is drained only by the
-        # screen's *idle* handler. `pilot.pause()` does not synchronize on that
-        # drain — its barrier covers messages queued at call time, and it then
-        # calls `_on_timer_update`, which relayouts whatever scroll state
-        # exists right then. Lose that one idle hop and `scroll_y` is still 0,
+        # where it lands on `Screen._callbacks`. Draining that queue always
+        # costs a later pump hop. The screen's idle handler drains it, but only
+        # once the screen is clean — a dirty one resumes the update timer and
+        # returns — and `_on_timer_update` only `call_next`s the drain rather
+        # than running it. So `pilot.pause()` does not synchronize on the
+        # write: its barrier covers messages queued at call time, and the
+        # `_on_timer_update` it ends with relayouts whatever scroll state
+        # exists right then. Lose that hop and `scroll_y` is still 0,
         # so the relayout reflows the old offset and `region` keeps its
         # pre-scroll geometry, putting the option below the fold (#360). Gate
         # on the write landing — `body.scroll_y` is the one observable here not

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1392,15 +1392,15 @@ async def test_decision_modal_scrolls_when_content_long(project):
         # the container's `Widget.scroll_to`, which defers the offset write via
         # `call_after_refresh`: an InvokeLater the pump forwards to the screen,
         # where it lands on `Screen._callbacks` and is drained only by the
-        # screen's *idle* handler. `pilot.pause()` never waits for that drain —
-        # its barrier covers messages queued at call time, and it then calls
-        # `_on_timer_update`, which relayouts whatever scroll state exists right
-        # then. Lose that one idle hop and `scroll_y` is still 0, so the
-        # relayout reflows the old offset and `region` keeps its pre-scroll
-        # geometry, putting the option below the fold (#360). Gate on the write
-        # landing — `body.scroll_y` is the one observable here not read through
-        # the compositor map — then let the relayout it triggers settle before
-        # reading a region.
+        # screen's *idle* handler. `pilot.pause()` does not synchronize on that
+        # drain — its barrier covers messages queued at call time, and it then
+        # calls `_on_timer_update`, which relayouts whatever scroll state
+        # exists right then. Lose that one idle hop and `scroll_y` is still 0,
+        # so the relayout reflows the old offset and `region` keeps its
+        # pre-scroll geometry, putting the option below the fold (#360). Gate
+        # on the write landing — `body.scroll_y` is the one observable here not
+        # read through the compositor map — then let the relayout it triggers
+        # settle before reading a region.
         await until(pilot, lambda: body.scroll_y > 0)
         await settle(pilot)
         assert _on_screen(app, opt8)

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -150,6 +150,35 @@ async def until(pilot, condition, timeout: float = 10.0) -> None:
         waited += 0.05
 
 
+async def settle(pilot, timeout: float = 10.0) -> None:
+    """Pump the message queue until the screen's layout stops moving.
+
+    It is the message pump, not a sleep, that does the work: a pending stylesheet
+    reapply, a deferred scroll, a resize of a widget the scroll just exposed —
+    each is a message, and each `pause` drains a round. Requiring the regions to
+    repeat lets a slow runner take as many frames as it needs, and a screen that
+    never settles raises rather than proceeding.
+
+    `ready()` calls this once the modal is mounted (#281). Call it again after
+    anything that moves the layout, before reading a region or a click
+    coordinate: a widget's `region` is served from the compositor map while
+    that map is valid, and a scroll does not invalidate it — so the region
+    holds the old geometry until the screen's next relayout runs (#360)."""
+
+    def _layout():
+        return tuple(w.region for w in pilot.app.screen.query("*"))
+
+    previous, stable, waited = None, 0, 0.0
+    while stable < 3:
+        if waited >= timeout:
+            raise AssertionError("screen layout never settled")
+        await pilot.pause(0.05)
+        waited += 0.05
+        current = _layout()
+        stable = stable + 1 if current == previous else 0
+        previous = current
+
+
 async def ready(pilot, selector: str, timeout: float = 10.0):
     """Wait until a modal widget is mounted *and* laid out on-screen, then return it.
 
@@ -168,13 +197,11 @@ async def ready(pilot, selector: str, timeout: float = 10.0):
     (x=5/23/41, each 16 wide, so the last ends at column 57 — off a 45-column
     screen) and the `-narrow` metrics (14/10/7) on the next.
 
-    So this also pumps the queue until the screen's layout stops moving. It is
-    the message pump, not a sleep, that does the work: the pending reapply is a
-    message, and each `pause` drains it. Requiring the regions to repeat lets a
-    slow runner take as many frames as it needs. Everything downstream — a
-    reachability assert, a `scroll_visible` target, a click coordinate — is then
-    computed against the settled layout rather than a doomed intermediate one.
-    Under load this is worth 2-3 failures per 25 runs on the tests it covers."""
+    So this also `settle`s the screen before returning, so that everything
+    downstream — a reachability assert, a `scroll_visible` target, a click
+    coordinate — is computed against the settled layout rather than a doomed
+    intermediate one. Under load that is worth 2-3 failures per 25 runs on the
+    tests it covers."""
 
     def _hit():
         hits = pilot.app.screen.query(selector)
@@ -182,19 +209,7 @@ async def ready(pilot, selector: str, timeout: float = 10.0):
         return node if node is not None and node.region.area > 0 else None
 
     await until(pilot, lambda: _hit() is not None, timeout)
-
-    def _layout():
-        return tuple(w.region for w in pilot.app.screen.query("*"))
-
-    previous, stable, waited = None, 0, 0.0
-    while stable < 3:
-        if waited >= timeout:
-            raise AssertionError("screen layout never settled")
-        await pilot.pause(0.05)
-        waited += 0.05
-        current = _layout()
-        stable = stable + 1 if current == previous else 0
-        previous = current
+    await settle(pilot, timeout)
     return _hit()
 
 
@@ -1373,7 +1388,21 @@ async def test_decision_modal_scrolls_when_content_long(project):
         # screen, then click it — the whole point of the scroll fix.
         opt8 = app.screen.query_one("#opt-8", Button)
         opt8.scroll_visible(animate=False)
-        await pilot.pause()
+        # `scroll_visible` only queues the scroll. It runs straight through to
+        # the container's `Widget.scroll_to`, which defers the offset write via
+        # `call_after_refresh`: an InvokeLater the pump forwards to the screen,
+        # where it lands on `Screen._callbacks` and is drained only by the
+        # screen's *idle* handler. `pilot.pause()` never waits for that drain —
+        # its barrier covers messages queued at call time, and it then calls
+        # `_on_timer_update`, which relayouts whatever scroll state exists right
+        # then. Lose that one idle hop and `scroll_y` is still 0, so the
+        # relayout reflows the old offset and `region` keeps its pre-scroll
+        # geometry, putting the option below the fold (#360). Gate on the write
+        # landing — `body.scroll_y` is the one observable here not read through
+        # the compositor map — then let the relayout it triggers settle before
+        # reading a region.
+        await until(pilot, lambda: body.scroll_y > 0)
+        await settle(pilot)
         assert _on_screen(app, opt8)
         await pilot.click("#opt-8")
         await until(pilot, lambda: bool(chosen))


### PR DESCRIPTION
## What

Three test-harness de-flakes — the two open TUI flakes plus a `tests/conftest.py` fixture race — and retirement of the `docs/testing.md` lines naming open flake instances.

## Why

Fixes #360
Fixes #581

Every guard already held; only the awaiting was wrong, so no production code changes. The docs' enumeration has gone stale twice (#529 → #553) — this also retires the `:28` residual PR #594 left behind while closing #553, without reopening it.

## How

- #581: run the poll probe's undecorated body as our own thread worker, in a private group the 1s tick's `cancel_group` cannot match.
- #360: gate on `body.scroll_y > 0`, then settle the layout (loop extracted verbatim from `ready()`), replacing one bare `pilot.pause()`.
- `conftest`: `git commit` spawns a detached `git maintenance run --auto` that outlives the template fixture and unlinks `.git/objects/maintenance.lock` mid-`copytree`. Disabled at source; it reddened `test (py3.13)` on this PR's first CI run.
- Docs: drop the numbers at both sites; the tracker is the source of truth.

## Testing

Deterministic probes, not run counts: injecting a tick reproduces #581's cancel race on demand; a 0.15 s stall on `Screen._invoke_and_clear_callbacks` reddens #360 10/10 pre-fix and none post; `GIT_TRACE2` pins the daemon. Each fix ablates to one attributable failure. `pytest -q -n logical` (6062 passed, 50 skipped), `pyright` and `trunk check --all` clean.

## Changelog

n/a — tests and docs only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interface test stability by waiting for widgets and layouts to settle before validation.
  * Fixed a polling lock regression test to avoid timing-related race conditions.
  * Prevented background Git maintenance processes from modifying copied project templates during tests.

* **Tests**
  * Added coverage verifying commits do not spawn detached Git maintenance or garbage-collection processes.

* **Documentation**
  * Clarified testing guidance while preserving existing testing policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->