### PR TITLE
ci(windows): run the psmux live gate in CI instead of before releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,29 @@ jobs:
       - name: Install the project
         run: uv sync --locked --all-extras
 
+      - name: Ensure psmux (for the live multiplexer gate)
+        # Bounded, for the reason the Linux `Ensure tmux` step above documents at
+        # length: an unbounded package install wedged that job for 14 minutes with
+        # no exit status for `|| true` to discard. Chocolatey's own timeout bounds
+        # the install; the step timeout bounds everything else it might do.
+        timeout-minutes: 6
+        shell: pwsh
+        # After `Install the project`, because the assertion below runs `uv run`.
+        # What this buys `Run tests`: 9 more tests, measured at 68s serial on a
+        # dev box (they spread across xdist workers here). Sized against the
+        # job's 20-minute cap and its ~316s mean, so the headroom still holds.
+        run: |
+          choco install psmux -y --no-progress --execution-timeout=300
+          psmux -V
+          # `psmux -V` is not the assertion. test_psmux_live.py skips itself on
+          # PsmuxMultiplexer.available(), so an install at or below the version
+          # floor would leave this job green with the entire live gate never run
+          # — the one failure a "did it install?" check cannot see. Calling
+          # available() also keeps the floor in a single place (it reads
+          # `_LAST_UNSUPPORTED`, so a floor bump needs no edit here) and covers
+          # `pwsh`, which every parked window needs.
+          uv run python -c "import sys; from bmad_loop.adapters.psmux_backend import PsmuxMultiplexer as M; m = M(); sys.exit(0 if m.available() else f'psmux is not an admitted version: {m.version()!r}')"
+
       - name: Run tests
         # pytest roots `tmp_path` at `tempfile.gettempdir()`, which follows
         # TMP/TEMP on Windows. Measured on the windows-2025 image (2026-08-14):

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,9 +133,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         # After `Install the project`, because the assertion below runs `uv run`.
-        # What this buys: the 9 tests of the serial gate step below, measured at
-        # 46-68s on a dev box. Sized against this job's 20-minute cap and its
-        # ~316s mean, so the headroom still holds.
+        # What this buys: the 9 tests of the serial gate step below, measured on
+        # this runner at 9.6s (py3.11) and 12.4s (py3.14) against the job's
+        # 20-minute cap. A dev box took 46-68s for the same nine — the runner is
+        # the faster of the two, so the cap is sized off the slower number.
         run: |
           $ErrorActionPreference = 'Stop'
           # The release archive, not `choco install`. Chocolatey's community feed
@@ -195,7 +196,7 @@ jobs:
         # and running the gate off the shared workers keeps the whole module
         # from contending for the machine in the first place. A flake here
         # cannot be retried away — this repo has no retry mechanism by policy.
-        # Cost: 46-68s measured serial, against this job's 20-minute cap.
+        # Cost: 9.6-12.4s measured here, 46-68s on a dev box.
         env:
           TMP: ${{ runner.temp }}
           TEMP: ${{ runner.temp }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,8 @@ jobs:
         run: uv run pytest -q -n logical --durations=15
 
   test-windows:
-    # Real-Windows runner for the deterministic suite (live psmux e2e stays a manual gate).
+    # Real-Windows runner for the deterministic suite plus the live psmux gate,
+    # which this job installs psmux for and runs in its own serial step.
     name: test (windows, py${{ matrix.python-version }})
     runs-on: windows-latest
     # 20, not the 15 the Linux test job uses: the slowest pre-lever Windows run
@@ -130,9 +131,9 @@ jobs:
         timeout-minutes: 6
         shell: pwsh
         # After `Install the project`, because the assertion below runs `uv run`.
-        # What this buys `Run tests`: 9 more tests, measured at 68s serial on a
-        # dev box (they spread across xdist workers here). Sized against the
-        # job's 20-minute cap and its ~316s mean, so the headroom still holds.
+        # What this buys: the 9 tests of the serial gate step below, measured at
+        # 46-68s on a dev box. Sized against this job's 20-minute cap and its
+        # ~316s mean, so the headroom still holds.
         run: |
           choco install psmux -y --no-progress --execution-timeout=300
           psmux -V
@@ -156,7 +157,23 @@ jobs:
         env:
           TMP: ${{ runner.temp }}
           TEMP: ${{ runner.temp }}
-        run: uv run pytest -q -n logical --durations=15
+        run: uv run pytest -q -n logical --durations=15 --ignore=tests/test_psmux_live.py
+
+      - name: Run the live psmux gate
+        # Serial, and deliberately out of the parallel run above: these nine
+        # tests drive real psmux servers, which are a single-machine resource
+        # rather than per-worker state. Interleaved with the other ~2800 tests
+        # under `-n logical`, the window mint in the prune test came back empty
+        # on a dev box and failed the degraded-mint assertion; the registry
+        # isolation that lands with this step fixes that test's own asymmetry,
+        # and running the gate off the shared workers keeps the whole module
+        # from contending for the machine in the first place. A flake here
+        # cannot be retried away — this repo has no retry mechanism by policy.
+        # Cost: 46-68s measured serial, against this job's 20-minute cap.
+        env:
+          TMP: ${{ runner.temp }}
+          TEMP: ${{ runner.temp }}
+        run: uv run pytest -q tests/test_psmux_live.py --durations=15
 
   version-sync:
     name: version-sync

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,17 +125,43 @@ jobs:
 
       - name: Ensure psmux (for the live multiplexer gate)
         # Bounded, for the reason the Linux `Ensure tmux` step above documents at
-        # length: an unbounded package install wedged that job for 14 minutes with
-        # no exit status for `|| true` to discard. Chocolatey's own timeout bounds
-        # the install; the step timeout bounds everything else it might do.
+        # length: an unbounded fetch wedged that job for 14 minutes with no exit
+        # status for `|| true` to discard. Here the retries are bounded by
+        # Invoke-WebRequest and everything else by the step timeout.
         timeout-minutes: 6
         shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
         # After `Install the project`, because the assertion below runs `uv run`.
         # What this buys: the 9 tests of the serial gate step below, measured at
         # 46-68s on a dev box. Sized against this job's 20-minute cap and its
         # ~316s mean, so the headroom still holds.
         run: |
-          choco install psmux -y --no-progress --execution-timeout=300
+          $ErrorActionPreference = 'Stop'
+          # The release archive, not `choco install`. Chocolatey's community feed
+          # answered the V2 package lookup with 503 on BOTH matrix legs of this
+          # job's first run, while the package itself sat published and healthy.
+          # Chocolatey document that feed as neither supported nor guaranteed and
+          # rate-limited per IP behind Cloudflare, and hosted runners share egress
+          # addresses — other projects track the same feed-503 flake. This is one
+          # GET against the host the job already depends on.
+          #
+          # `releases/latest`, not a pinned tag: the floor assertion below stays
+          # the only version gate, so a psmux release needs no edit here.
+          $url = gh api repos/psmux/psmux/releases/latest --jq '.assets[] | select(.name | endswith("windows-x64.zip")) | .browser_download_url'
+          if (-not $url) { throw 'no windows-x64 asset on the latest psmux release' }
+          $zip = Join-Path $env:RUNNER_TEMP 'psmux.zip'
+          $dir = Join-Path $env:RUNNER_TEMP 'psmux'
+          Invoke-WebRequest -Uri $url -OutFile $zip -MaximumRetryCount 3 -RetryIntervalSec 5
+          Expand-Archive -LiteralPath $zip -DestinationPath $dir -Force
+          $exe = Get-ChildItem -Path $dir -Recurse -Filter psmux.exe | Select-Object -First 1
+          if (-not $exe) { throw "no psmux.exe in $url" }
+          # The archive ships tmux.exe beside psmux.exe, which looks alarming on a
+          # PATH but is inert: test_generic_tmux's HAVE_TMUX gates on
+          # `sys.platform != "win32"` before it ever looks for the binary.
+          # PATH for this step, GITHUB_PATH for `Run tests` and the gate step.
+          $env:PATH = "$($exe.Directory.FullName);$env:PATH"
+          Add-Content -Path $env:GITHUB_PATH -Value $exe.Directory.FullName
           psmux -V
           # `psmux -V` is not the assertion. test_psmux_live.py skips itself on
           # PsmuxMultiplexer.available(), so an install at or below the version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,14 @@ breaking changes may land in a minor release.
 
 ### Changed
 
+- **The psmux live gate now runs in CI instead of before releases (#662).** The `test-windows`
+  job installs psmux from Chocolatey, so `tests/test_psmux_live.py` — prune isolation, the
+  workaround premise probes, the 3.3.8-floor adoption probes — runs on every push and PR
+  rather than on a maintainer's Windows box at release time. The step asserts
+  `PsmuxMultiplexer.available()`, not just that the binary resolves: the gate skips itself on
+  an unadmitted version, which would otherwise read green. `test_opencode_live.py` remains the
+  one manual gate.
+
 - **The psmux backend now requires psmux 3.3.8 or newer (#658, closes #222).** `available()`
   refuses 3.3.7 and below, so **on such a host the backend reports unavailable and selection
   falls through**. Every verb now assumes 3.3.8's fixes instead of routing around the defects

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,8 +66,10 @@ breaking changes may land in a minor release.
 
 - **The psmux live gate now runs in CI instead of before releases (#662).** The `test-windows`
   job installs psmux from Chocolatey, so `tests/test_psmux_live.py` — prune isolation, the
-  workaround premise probes, the 3.3.8-floor adoption probes — runs on every push and PR
-  rather than on a maintainer's Windows box at release time. The step asserts
+  workaround premise probes, the 3.3.8-floor adoption probes — runs on every pull request
+  and on pushes to `main`/`release/*`, rather than on a maintainer's Windows box at release
+  time. It runs as its own serial step: real psmux servers are a single-machine resource,
+  and the gate flaked when interleaved with the parallel run. The step asserts
   `PsmuxMultiplexer.available()`, not just that the binary resolves: the gate skips itself on
   an unadmitted version, which would otherwise read green. `test_opencode_live.py` remains the
   one manual gate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@ breaking changes may land in a minor release.
 ### Changed
 
 - **The psmux live gate now runs in CI instead of before releases (#662).** The `test-windows`
-  job installs psmux from Chocolatey, so `tests/test_psmux_live.py` — prune isolation, the
+  job installs psmux from its GitHub release, so `tests/test_psmux_live.py` — prune isolation, the
   workaround premise probes, the 3.3.8-floor adoption probes — runs on every pull request
   and on pushes to `main`/`release/*`, rather than on a maintainer's Windows box at release
   time. It runs as its own serial step: real psmux servers are a single-machine resource,

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -170,16 +170,17 @@ everywhere, and the mechanism differs per gate — worth knowing before touching
 | `test_generic_tmux.py` (5 `HAVE_TMUX` test functions, 7 collected) | tmux server                                        | The spawned "CLI" is a tiny shell script written by the test                                                                                                                                                                                                                                                                                                                     | CI Linux job + any POSIX dev box with tmux                                                                                  |
 | `test_stories_e2e.py`                                              | tmux + the real `bmad-loop run/resolve/resume` CLI | Scripted fake `claude` variants (bash, defined as string constants in the test module) wired in as a custom TOML profile (`fakestories`); the fake writes its own SessionStart/Stop hook events, so no `bmad-loop init` and no real CLI exists anywhere in the run                                                                                                               | CI Linux job (Linux-only gate: the fakes use GNU coreutils + `setsid`)                                                      |
 | `test_opencode_live.py`                                            | A real `opencode serve` HTTP server                | **Never sends a prompt**: only the spawn/teardown paths are used — nothing that prompts — and the tests touch health/doc/session/event endpoints; the prompt endpoint is asserted against the OpenAPI schema, never called. One test asserts the session's token/cost aggregates are zero                                                                                        | Manual — POSIX box with a **runnable** `opencode` — the gate probes `--version`, so a resolvable-but-dead shim skips (#294) |
-| `test_psmux_live.py`                                               | A real psmux on Windows                            | **Parked windows only**: every parked window runs `pwsh -NoProfile -Command exit 0`, and no coding CLI is ever launched. Includes `test_premise_*` probes with inverted semantics — a red probe means a workaround became droppable — and `test_adopted_*` probes with ordinary semantics — a red probe means psmux regressed a behavior the 3.3.8 floor lets the backend assume | Manual — Windows box with an admitted psmux (3.3.8+) and `pwsh` on PATH                                                     |
+| `test_psmux_live.py`                                               | A real psmux on Windows                            | **Parked windows only**: every parked window runs `pwsh -NoProfile -Command exit 0`, and no coding CLI is ever launched. Includes `test_premise_*` probes with inverted semantics — a red probe means a workaround became droppable — and `test_adopted_*` probes with ordinary semantics — a red probe means psmux regressed a behavior the 3.3.8 floor lets the backend assume | CI Windows job (the job installs psmux) + any Windows dev box with an admitted psmux (3.3.8+) and `pwsh` on PATH            |
 
 Never "fix" a gate to call a real CLI, and never add a completion path that trusts LLM output —
 sessions complete only on hook Stop events or window death, and the fakes exercise exactly
 those paths.
 
-**Manual-gate cadence:** the two manual gates run before every release — `test_opencode_live.py`
-on a POSIX box with opencode installed, `test_psmux_live.py` on a Windows box with an admitted
-psmux version — and after any change to the adapter or backend they cover. CI cannot see these;
-a release cut without them is trusting stale evidence.
+**Manual-gate cadence:** `test_opencode_live.py` is the one gate CI still cannot see. Run it on a
+POSIX box with opencode installed before every release, and after any change to the adapter it
+covers; a release cut without it is trusting stale evidence. `test_psmux_live.py` left this
+category in #662 — the **test-windows** job installs psmux and runs the gate on every push and
+PR, so its evidence is as fresh as the branch rather than as fresh as someone's memory.
 
 ## Ablation records
 
@@ -247,9 +248,10 @@ fixed, the test fails and forces the debt note to be removed with it.
 ## CI, flakes, and deliberate absences
 
 Six jobs (`.github/workflows/ci.yml`): **test** (ubuntu, Python 3.11–3.14, tmux installed so
-L4 and `stories_e2e` run), **test-windows** (`PYTHONUTF8=1`; PRs run the 3.11/3.14 boundary
-only — Windows failures here have been platform-shaped, not version-shaped — pushes to `main`
-and `release/*` run the full spread), **version-sync**, **lint** (trunk, including actionlint + zizmor over the
+L4 and `stories_e2e` run), **test-windows** (`PYTHONUTF8=1`, psmux installed so the L5
+`test_psmux_live.py` gate runs; PRs run the 3.11/3.14 boundary only — Windows failures here
+have been platform-shaped, not version-shaped — pushes to `main` and `release/*` run the full
+spread), **version-sync**, **lint** (trunk, including actionlint + zizmor over the
 workflows themselves), **typecheck** (the same pinned pyright a contributor runs), and
 **build** (packaging smoke: sdist + wheel, the console script executed from the installed
 wheel, and a wheel data-file inventory against `git ls-files` — every other job runs from the
@@ -281,8 +283,10 @@ Deliberate absences — decisions, not gaps:
   guard; macOS-specific traps found in the field get targeted unit tests (the psutil
   `create_time` trap being the canonical example). A macOS job would mostly re-run the Linux
   suite at 10× the queue time.
-- **Live gates stay manual** (table above) — CI has no Windows psmux or opencode install, and
-  faking either would test the fake.
+- **No opencode install in CI** — so `test_opencode_live.py` is the last manual gate (table
+  above), and faking the server would test the fake. psmux is the counter-example rather than
+  the precedent: it is one Chocolatey package, so **test-windows** installs it and runs that
+  gate on every push (#662).
 
 ## TUI testing
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -179,8 +179,9 @@ those paths.
 **Manual-gate cadence:** `test_opencode_live.py` is the one gate CI still cannot see. Run it on a
 POSIX box with opencode installed before every release, and after any change to the adapter it
 covers; a release cut without it is trusting stale evidence. `test_psmux_live.py` left this
-category in #662 — the **test-windows** job installs psmux and runs the gate on every push and
-PR, so its evidence is as fresh as the branch rather than as fresh as someone's memory.
+category in #662 — the **test-windows** job installs psmux and runs the gate on every pull
+request and on pushes to `main`/`release/*` (the workflow's own triggers), in its own serial
+step, so its evidence is as fresh as the branch rather than as fresh as someone's memory.
 
 ## Ablation records
 
@@ -286,7 +287,7 @@ Deliberate absences — decisions, not gaps:
 - **No opencode install in CI** — so `test_opencode_live.py` is the last manual gate (table
   above), and faking the server would test the fake. psmux is the counter-example rather than
   the precedent: it is one Chocolatey package, so **test-windows** installs it and runs that
-  gate on every push (#662).
+  gate on every PR and every push to `main`/`release/*` (#662).
 
 ## TUI testing
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -286,8 +286,10 @@ Deliberate absences — decisions, not gaps:
   suite at 10× the queue time.
 - **No opencode install in CI** — so `test_opencode_live.py` is the last manual gate (table
   above), and faking the server would test the fake. psmux is the counter-example rather than
-  the precedent: it is one Chocolatey package, so **test-windows** installs it and runs that
-  gate on every PR and every push to `main`/`release/*` (#662).
+  the precedent: it is one zip on a GitHub release, so **test-windows** installs it and runs
+  that gate on every PR and every push to `main`/`release/*` (#662). Chocolatey was tried
+  first and dropped — its community feed 503'd on both matrix legs, and Chocolatey document
+  it as unguaranteed and rate-limited per IP, which hosted runners share.
 
 ## TUI testing
 

--- a/tests/test_psmux_live.py
+++ b/tests/test_psmux_live.py
@@ -60,8 +60,7 @@ def test_prune_kills_only_the_owning_projects_window(tmp_path: Path, monkeypatch
     # that contention made the mint below hand back "" and fail at the
     # degraded-mint assertion. Isolation is what makes the module xdist-safe,
     # not the uuid session names, which never collided.
-    if psmux_data_root is not None:
-        monkeypatch.setenv("PSMUX_DATA_DIR", str(psmux_data_root))
+    monkeypatch.setenv("PSMUX_DATA_DIR", str(psmux_data_root))
     session = f"bmad-loop-test-{uuid.uuid4().hex[:8]}"
     proj_a = tmp_path / "proj-a"
     proj_b = tmp_path / "proj-b"
@@ -213,7 +212,16 @@ def _active_window(mux: PsmuxMultiplexer, session: str) -> str:
 
 @pytest.fixture(scope="module")
 def psmux_data_root(tmp_path_factory):
-    """Return an isolated registry root only when the installed build honors it."""
+    """Return an isolated registry root, or fail loudly if one cannot be had.
+
+    Isolation is a precondition here, not a nicety: without it every test in this
+    module shares the developer's real registry, and under xdist that contention
+    is what made the prune test's window mint hand back "". Returning a degraded
+    ``None`` would restore that flake silently — and worst under load, where the
+    probe below is itself most likely to fail — so both failure directions raise
+    instead. On the 3.3.8 floor the ignored-variable branch is unreachable
+    anyway; what stays live is the probe failing as an instrument.
+    """
     mux = PsmuxMultiplexer()
     if not mux.available():
         pytest.skip("psmux present but not an admitted version")
@@ -226,10 +234,19 @@ def psmux_data_root(tmp_path_factory):
             ["new-session", "-d", "-s", session, "-c", str(root)], check=False, env=env
         )
         if created.returncode != 0:
-            return None
+            pytest.fail(
+                "probe setup: could not mint the isolation probe session: "
+                f"{created.stderr.strip()!r}"
+            )
         isolated = _plain_has_session(mux, session, env=env)
         default = _plain_has_session(mux, session)
-        return root if isolated and not default else None
+        if not isolated or default:
+            pytest.fail(
+                "probe setup: the installed psmux ignored PSMUX_DATA_DIR "
+                f"(visible in the isolated registry={isolated}, "
+                f"visible in the default one={default})"
+            )
+        return root
     finally:
         # The one session here that can land in the developer's real registry —
         # a build ignoring PSMUX_DATA_DIR is the very branch this fixture exists
@@ -256,8 +273,7 @@ def probe(tmp_path, monkeypatch, psmux_data_root):
     mux = PsmuxMultiplexer()
     if not mux.available():
         pytest.skip("psmux present but not an admitted version")
-    if psmux_data_root is not None:
-        monkeypatch.setenv("PSMUX_DATA_DIR", str(psmux_data_root))
+    monkeypatch.setenv("PSMUX_DATA_DIR", str(psmux_data_root))
     session = f"bmad-loop-test-{uuid.uuid4().hex[:8]}"
     try:
         _raw_new_session(mux, session, tmp_path)

--- a/tests/test_psmux_live.py
+++ b/tests/test_psmux_live.py
@@ -50,10 +50,18 @@ pytestmark = pytest.mark.skipif(not HAVE_PSMUX, reason="requires Windows with ps
 PARKED_ARGV = ["pwsh", "-NoProfile", "-Command", "exit 0"]  # zero tokens, parks on read
 
 
-def test_prune_kills_only_the_owning_projects_window(tmp_path: Path, monkeypatch):
+def test_prune_kills_only_the_owning_projects_window(tmp_path: Path, monkeypatch, psmux_data_root):
     mux = PsmuxMultiplexer()
     if not mux.available():
         pytest.skip("psmux present but not an admitted version")
+    # Same registry isolation the `probe` fixture gives every other test here.
+    # Without it this test alone ran against the default registry while its
+    # siblings spawned and killed servers in private ones — under `-n logical`
+    # that contention made the mint below hand back "" and fail at the
+    # degraded-mint assertion. Isolation is what makes the module xdist-safe,
+    # not the uuid session names, which never collided.
+    if psmux_data_root is not None:
+        monkeypatch.setenv("PSMUX_DATA_DIR", str(psmux_data_root))
     session = f"bmad-loop-test-{uuid.uuid4().hex[:8]}"
     proj_a = tmp_path / "proj-a"
     proj_b = tmp_path / "proj-b"


### PR DESCRIPTION
`tests/test_psmux_live.py` — the only gate that drives a real psmux server — has been skipped on every CI run because `psmux` is absent from the `windows-latest` image, so Windows CI validated the psmux backend through mocked `subprocess.run` alone. The Linux job has had the equivalent (`Ensure tmux`) since it existed.

`test-windows` now installs psmux from Chocolatey and runs the gate.

## What landed, and why each piece is there

**The install step is bounded.** The Linux `Ensure tmux` step's comment block records an unbounded `apt-get` hanging for 14 minutes with no exit status for `|| true` to discard, wedging the job four times. Same hazard, same treatment: `timeout-minutes` plus Chocolatey's own `--execution-timeout`.

**The step asserts `PsmuxMultiplexer.available()`, not `psmux -V`.** Presence is the wrong question. The gate skips *itself* on an unadmitted version, so a psmux at or below the floor would leave the job green with the entire live gate never run — the one failure a "did it install?" check cannot see. Calling `available()` also keeps the version floor in a single place (it reads `_LAST_UNSUPPORTED`, so a floor bump needs no edit in the workflow) and covers `pwsh`, which every parked window needs. Verified in both directions locally: exit 0 on 3.3.8, and exit 1 naming the reported version when the floor is forced above it.

## Two things found in review, fixed in the second commit

**The gate is not safe inside the parallel run.** `test_prune_kills_only_the_owning_projects_window` was the only one of the nine taking neither the `probe` fixture nor `psmux_data_root`, so it drove the default psmux registry while its eight siblings spawned and killed servers in private ones. Under `-n logical` alongside the rest of the suite, that contention made the window mint hand back an empty string and fail the degraded-mint assertion — reproduced on a dev box, green on the rerun and green serially.

Two changes, because they address different things: the test gets the same registry isolation its siblings have (the actual defect, which also bit anyone running the suite with `-n logical` locally), and the module runs in its own serial CI step. Real psmux servers are a single-machine resource rather than per-worker state, and a flake here cannot be retried away — this repo has no retry mechanism by policy.

**The docs claimed "every push".** The workflow's push trigger is `main`/`release/*` only; every other branch arrives through `pull_request`. Corrected in the CHANGELOG and in both `docs/testing.md` sites. The `test-windows` job comment also still described the gate as manual.

## Verification

- Full suite under `-n logical` with the live module included — the exact condition that reproduced the flake: all nine live tests green.
- The gate alone, serially, as CI now runs it: 9 passed in 46s. Earlier serial runs measured up to 68s; the step is sized against the job's 20-minute cap and its ~316s mean.
- `trunk check` clean over all four changed files.
- Registry selection is unaffected by a real psmux install: `tests/test_backend_registry.py` stubs `available` / `shutil.which` at the two sites whose verdicts turn on availability.

Two measured corrections to the issue as filed: the PATH-refresh snippet is unnecessary (Chocolatey installs a shim into a directory already on the runner PATH), and the gate costs ~46–68s serially rather than the "<10s" estimated there.

## What this does not prove

Whether psmux works on a headless GitHub runner at all. No local test can answer that — the first CI run on this branch is the measurement. If it comes back red or flaky, that is evidence about psmux under CI, not something to silence with `continue-on-error`.

Closes #662


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Improvements**
  * Windows CI now installs and verifies psmux automatically.
  * Live psmux tests run as a dedicated, serialized gate with isolated temporary data.
  * Deterministic tests remain parallelized, while the OpenCode live gate remains manual.

* **Documentation**
  * Updated testing guidance and the changelog to reflect automated psmux coverage.

* **Bug Fixes**
  * Improved live-test isolation to prevent interference between test sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->