### PR TITLE
fix(psmux): rebase switch_client's verdict on the exit code it can trust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,15 @@ breaking changes may land in a minor release.
 
 ### Fixed
 
-- **psmux: a hand-back that succeeded no longer reports as failed — or undoes itself
-  (#659).** `switch_client` decided whether a client moved from the session's
-  attached-client count, which a same-session move cannot change: the common return
-  path landed the client correctly, read no change, and answered "failed". With the
-  last-client fallback enabled — how `return_attached_client` always calls it — the
-  failed verdict then fired `switch-client -l`, dragging the operator into an unrelated
-  session, and the drag produced the very count change the correct move could not, so
-  the call reported success and cleared its return option. The `-t` verb now takes its
-  exit code as the verdict, gated on a client having been attached to this session, and
-  the fallback fires only when that verb actually failed. Measured on a live attached
-  client against psmux 3.3.8.
+- **psmux: a hand-back that succeeded no longer reports as failed — or undoes itself (#659).**
+  `switch_client` read its verdict off the session's attached-client count, which a same-session
+  move cannot change — and same-session is the common shape for the return path, so a correct
+  hand-back answered "failed". With the last-client fallback enabled (how
+  `return_attached_client` always calls it) that verdict then fired `switch-client -l`, relocating
+  the operator to an unrelated session; the relocation supplied the count change the correct move
+  could not, so the call reported success and cleared its return option. The `-t` verb now takes
+  its exit code as the verdict, gated on a client having been attached, and the fallback fires
+  only when that verb failed.
 
 ## [0.11.0] — 2026-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ breaking changes may land in a minor release.
   could not, so the call reported success and cleared its return option. The `-t` verb now takes
   its exit code as the verdict, gated on a client having been attached, and the fallback fires
   only when that verb failed.
+- **A sweep whose client has dropped no longer keeps prompting the empty window (#659).** On tmux,
+  `switch-client` spends one nonzero exit on both "that target is unreachable" and "there is no
+  client here at all", so a failed hand-back read as "the human is still in front of me" either
+  way; the session's attached-client count now separates them. `TerminalMultiplexer.switch_client`
+  answers a third value, `None`, for any move it cannot vouch for — that state, a timed-out verb,
+  and on psmux an unreadable gate count — which `return_attached_client` routes to `UNREACHABLE`:
+  the return option survives, but the sweep goes unattended instead of blocking a later `--repeat`
+  cycle on `input()`. `False` now carries the joint claim its caller always read it as. Out-of-tree
+  backends answering a plain bool still work; `detach_client` is unchanged.
 
 ## [0.11.0] — 2026-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ breaking changes may land in a minor release.
 
 ## [Unreleased]
 
+### Fixed
+
+- **psmux: a hand-back that succeeded no longer reports as failed — or undoes itself
+  (#659).** `switch_client` decided whether a client moved from the session's
+  attached-client count, which a same-session move cannot change: the common return
+  path landed the client correctly, read no change, and answered "failed". With the
+  last-client fallback enabled — how `return_attached_client` always calls it — the
+  failed verdict then fired `switch-client -l`, dragging the operator into an unrelated
+  session, and the drag produced the very count change the correct move could not, so
+  the call reported success and cleared its return option. The `-t` verb now takes its
+  exit code as the verdict, gated on a client having been attached to this session, and
+  the fallback fires only when that verb actually failed. Measured on a live attached
+  client against psmux 3.3.8.
+
 ## [0.11.0] — 2026-08-19
 
 ### Added

--- a/docs/adapter-authoring-guide.md
+++ b/docs/adapter-authoring-guide.md
@@ -107,16 +107,21 @@ seams of a full OS port are in
   binary's version string or `None` — **one bounded line**, folded with
   `fold_version()`; see [the porting guide](porting-to-a-new-os.md)).
 
-  **Both client verbs report effect, not dispatch.** They answer a bool the
-  parked-window return path trusts, so a backend with no real detach (herdr —
+  **Both client verbs report effect, not dispatch.** They answer what the
+  parked-window return path trusts — a bool from `detach_client`, a tri-state
+  from `switch_client` (see below) — so a backend with no real detach (herdr —
   only a manual chord releases its client) answers `False`. If your CLI's exit
   code already means "a client moved" you are done (tmux: `detach-client` fails
   with _no current client_); if it does not, **measure** what the verb is meant
   to change — psmux counts the session's attached clients across `detach_client`
   and the last-client fallback, and answers on the drop — and record what the
   measure cannot see in your degradation ledger. Where no measure is available,
-  answer `False` and record that gap in the ledger too. Check the ledger against
-  every verb before you trust one measure for all of them: psmux's drop is blind
+  answer `False` from `detach_client` and `None` from `switch_client`, and
+  record that gap in the ledger too — per _call_, though, never as the wiring: a
+  `switch_client` hard-coded to `None` pins the return path to `UNREACHABLE`, and
+  an attended sweep then stops prompting for good. Use the exit code wherever it
+  carries the effect. Check the ledger against every verb before you
+  trust one measure for all of them: psmux's drop is blind
   to a `switch_client` whose target sits in the same session, which is the common
   case for the return path, so that verb gates on the client count read _before_
   the call and takes the exit code as the verdict instead (#659). A fallback verb
@@ -124,14 +129,19 @@ seams of a full OS port are in
   "the primary could not be vouched for", or a hand-back that worked gets undone
   by its own fallback and the undo is read as the success.
   `tui.launch.return_attached_client` reads a failed `switch_client` as
-  `ATTENDED` — normally the client never left this window, so an attended sweep
-  keeps prompting; a False your backend answers for a move it could not _vouch_
-  for (a timed-out verb, an unreadable count) lands in the same bucket, which is
-  why the return option must survive a False: the parked trailer's retry is the
-  recovery — and a failed `detach_client` as `UNREACHABLE`, which is evidence of
-  nothing, so the sweep goes unattended and defers this cycle's decisions to
-  `bmad-loop decisions`. `False` is the safe answer either way; a vacuous `True`
-  is the one answer no backend may give — it announces a hand-back that never
+  `ATTENDED` — the client never left this window, so an attended sweep keeps
+  prompting — and a failed `detach_client` as `UNREACHABLE`, which is evidence
+  of nothing, so the sweep goes unattended and defers this cycle's decisions to
+  `bmad-loop decisions`. That makes `switch_client`'s `False` a **joint claim**:
+  no switch happened _and_ the client is still here. A move you cannot _vouch_
+  for is only its first half — a timed-out verb, an unreadable count, nothing
+  attached to move — so answer `None`, which routes to `UNREACHABLE`: the return
+  option survives and the sweep still stops prompting a window the client may
+  already have left. Do not reach for that surviving option as the recovery. The
+  parked trailer sits behind a blocking read, so it never runs while a `--repeat`
+  cycle is stuck on `input()` in the same window — which is exactly what an
+  `ATTENDED` the client has walked away from produces. A vacuous `True` remains
+  the one answer no backend may give: it announces a hand-back that never
   happened and sends the sweep unattended with the human still sitting there
   (#227).
 
@@ -197,9 +207,11 @@ whenever the content changes, which is exactly enough to drive the two log consu
 a tmux tee would (`generic._log_activity_key`'s stall re-arm and `probe`'s marker
 discovery). Its module docstring is a **degradation ledger** of every such
 divergence (sidecar options, poller `pipe_pane`, the no-op `detach_client` —
-which the widened seam now requires to answer `False`, not `None`, so the
+which #317's widening requires to answer `False`, not `None`, so the
 parked-return path reads it as `UNREACHABLE` and an attended sweep stops
-prompting into a window whose client only a manual chord can release — the attach
+prompting into a window whose client only a manual chord can release; that is a
+different widening from `switch_client`'s tri-state above, and `detach_client`
+is the verb that stays a bool — the attach
 argv, the advisory geometry, the protocol-version policy) — the reference for what
 "implement fresh" costs when the host has no tmux-shaped CLI. The operator-facing
 view — what a herdr _user_ notices and does — is

--- a/docs/adapter-authoring-guide.md
+++ b/docs/adapter-authoring-guide.md
@@ -124,8 +124,11 @@ seams of a full OS port are in
   "the primary could not be vouched for", or a hand-back that worked gets undone
   by its own fallback and the undo is read as the success.
   `tui.launch.return_attached_client` reads a failed `switch_client` as
-  `ATTENDED` — the client never left this window, so an attended sweep keeps
-  prompting — and a failed `detach_client` as `UNREACHABLE`, which is evidence of
+  `ATTENDED` — normally the client never left this window, so an attended sweep
+  keeps prompting; a False your backend answers for a move it could not _vouch_
+  for (a timed-out verb, an unreadable count) lands in the same bucket, which is
+  why the return option must survive a False: the parked trailer's retry is the
+  recovery — and a failed `detach_client` as `UNREACHABLE`, which is evidence of
   nothing, so the sweep goes unattended and defers this cycle's decisions to
   `bmad-loop decisions`. `False` is the safe answer either way; a vacuous `True`
   is the one answer no backend may give — it announces a hand-back that never

--- a/docs/adapter-authoring-guide.md
+++ b/docs/adapter-authoring-guide.md
@@ -128,9 +128,9 @@ seams of a full OS port are in
   belongs to the same audit — hang it on the primary verb's failure, never on
   "the primary could not be vouched for", or a hand-back that worked gets undone
   by its own fallback and the undo is read as the success.
-  `tui.launch.return_attached_client` reads a failed `switch_client` as
+  `tui.launch.return_attached_client` reads a `False` from `switch_client` as
   `ATTENDED` — the client never left this window, so an attended sweep keeps
-  prompting — and a failed `detach_client` as `UNREACHABLE`, which is evidence
+  prompting — and a `False` from `detach_client` as `UNREACHABLE`, which is evidence
   of nothing, so the sweep goes unattended and defers this cycle's decisions to
   `bmad-loop decisions`. That makes `switch_client`'s `False` a **joint claim**:
   no switch happened _and_ the client is still here. A move you cannot _vouch_

--- a/docs/adapter-authoring-guide.md
+++ b/docs/adapter-authoring-guide.md
@@ -112,11 +112,17 @@ seams of a full OS port are in
   only a manual chord releases its client) answers `False`. If your CLI's exit
   code already means "a client moved" you are done (tmux: `detach-client` fails
   with _no current client_); if it does not, **measure** what the verb is meant
-  to change — psmux counts the session's attached clients across the call and
-  answers on the drop — and record what the measure cannot see in your
-  degradation ledger (psmux's `Residue:` note: a switch _within_ one session
-  moves no client count, so it reads as no effect). Where no measure is
-  available, answer `False` and record that gap in the ledger too.
+  to change — psmux counts the session's attached clients across `detach_client`
+  and the last-client fallback, and answers on the drop — and record what the
+  measure cannot see in your degradation ledger. Where no measure is available,
+  answer `False` and record that gap in the ledger too. Check the ledger against
+  every verb before you trust one measure for all of them: psmux's drop is blind
+  to a `switch_client` whose target sits in the same session, which is the common
+  case for the return path, so that verb gates on the client count read _before_
+  the call and takes the exit code as the verdict instead (#659). A fallback verb
+  belongs to the same audit — hang it on the primary verb's failure, never on
+  "the primary could not be vouched for", or a hand-back that worked gets undone
+  by its own fallback and the undo is read as the success.
   `tui.launch.return_attached_client` reads a failed `switch_client` as
   `ATTENDED` — the client never left this window, so an attended sweep keeps
   prompting — and a failed `detach_client` as `UNREACHABLE`, which is evidence of

--- a/src/bmad_loop/adapters/multiplexer.py
+++ b/src/bmad_loop/adapters/multiplexer.py
@@ -315,18 +315,42 @@ class TerminalMultiplexer(ABC):
         instead (psmux counts the session's attached clients across the call).
         Callers that only want the terminal handed back may ignore the answer;
         the parked-window return path cannot — it clears its return option on a
-        True, and a vacuous one strands the human, while a False is positive
-        evidence that nobody is watching this window any more (see
+        True, and a vacuous one strands the human. It reads a False as
+        UNREACHABLE: on tmux that is positive evidence nobody is watching this
+        window any more, but off tmux the same False also covers an effect the
+        backend could not observe and a backend with no detach verb at all, so
+        the response is a policy for the uncertainty rather than proof (see
         tui.launch.return_attached_client)."""
 
     @abstractmethod
-    def switch_client(self, target: str, last_fallback: bool = False) -> bool:
+    def switch_client(self, target: str, last_fallback: bool = False) -> bool | None:
         """Switch the current client to ``target`` (optionally falling back to
-        the last client on failure). Returns True iff a switch happened — the
-        same effect-not-dispatch rule as :meth:`detach_client`, so a transport
-        failure returns False and a backend whose CLI cannot report the move
-        measures it or answers False. ``target`` is a :meth:`target` token or a
-        backend-native id."""
+        the last client on failure). ``target`` is a :meth:`target` token or a
+        backend-native id.
+
+        Three answers, because the parked-window return path asks two questions
+        of the one verb — did the switch happen, and is anyone still at this
+        terminal:
+
+        - ``True`` — a switch happened. Effect, not dispatch, the same rule as
+          :meth:`detach_client`.
+        - ``False`` — the **joint** claim: no switch happened *and* the client
+          is still here. The verb ran, refused, and moved nobody.
+          :func:`tui.launch.return_attached_client` reads it as ATTENDED and
+          keeps prompting this terminal, so do not answer it for the first half
+          alone.
+        - ``None`` — cannot vouch for the second half: the verb's answer never
+          arrived (a timed-out call), its effect was unobservable, or there was
+          no client here to move. That reads as UNREACHABLE — the sweep keeps
+          its return option but stops prompting, which is the safe way to be
+          wrong, since prompting into a window nobody is viewing blocks a
+          ``--repeat`` sweep on ``input()`` forever and the parked trailer's
+          retry cannot recover it (it sits behind that same blocking read).
+
+        A backend that never widened to the third state keeps working — a bool
+        is a valid answer and the seam only loses a distinction that backend
+        never drew. What no backend may do is answer ``False`` for a move it
+        merely could not confirm, or a vacuous ``True`` (#659)."""
 
     @abstractmethod
     def available(self) -> bool:

--- a/src/bmad_loop/adapters/psmux_backend.py
+++ b/src/bmad_loop/adapters/psmux_backend.py
@@ -27,9 +27,11 @@ still has to read back verbatim through the same listing parse, so
 ``set_session_option`` gates it on the same transportability rule (#320).
 ``detach-client`` and ``switch-client`` report dispatch, not effect: a
 nonzero exit is a real failure, but a zero one says only that the verb was
-sent, so both seam booleans are measured against the session's
-attached-client count instead of read off the exit code; see the ``client
-verbs: observed effect (#317)`` block. ``available()``
+sent, so neither seam boolean can be read off the exit code alone. The
+session's attached-client count supplies what the rc cannot — as a drop
+across ``detach-client`` and ``switch-client -l``, and as a gate on the
+targeted ``switch-client -t``, whose same-session move no drop can see
+(#659); see the ``client verbs: observed effect (#317)`` block. ``available()``
 additionally gates on the reported version — see ``_LAST_UNSUPPORTED``
 for what the floor buys and why it moves. ``has_session``
 is inherited unchanged, but one server per session gives it a residual the
@@ -776,39 +778,57 @@ class PsmuxMultiplexer(BaseTmuxBackend):
 
     # ------------------------------- client verbs: observed effect (#317)
     #
-    # psmux's client verbs report *dispatch*, not effect. The exit code is
-    # trustworthy in ONE direction only: a nonzero one is a real failure (an
-    # unreachable session server, a target that would not parse), but a zero one
-    # says the verb was sent, not that a client moved. ``detach-client`` exits 0
-    # with zero clients attached (and a flag-less detach is promoted server-side
-    # to detach-all); ``switch-client`` carries a server reply for ``-t`` on the
-    # supported build but still exits 0 with nothing to move, and ``-l``, which
-    # has no target form, carries none at all. Taking those exit codes as the
-    # seam's booleans is the rc-0 no-op (#228) reached through Python instead of
-    # a shell fallback, and it is what ``tui.launch.return_attached_client``
-    # would consume to decide a human has been handed their terminal back.
+    # psmux's client verbs report *dispatch*, not effect, and the seam's contract
+    # is effect: an unobservable move must answer False, never a vacuous True.
+    # The exit code is trustworthy in ONE direction for every verb — a nonzero
+    # one is a real failure (an unreachable session server, a target that would
+    # not parse) — so the verdict source is per verb, and there are two of them.
     #
-    # So the exit code is discarded and the effect is measured: count the
-    # clients attached to this session before and after the verb, and answer on
-    # the DELTA. Never on an absolute count — a ``-t`` read against a session
-    # whose server is gone answers from whichever server the fallback picks, so
-    # "zero attached" on its own proves nothing (#315). A drop cannot be
-    # manufactured that way: it needs two successful reads of the same session,
-    # the first of them nonzero.
+    # ``switch-client -t`` reads the exit code, gated on this session having had
+    # a client to move. The gate is what a bare rc cannot supply: the verb still
+    # exits 0 with nothing attached (pinned by
+    # test_premise_client_verbs_exit_zero_with_no_client_to_move), which is the
+    # rc-0 no-op (#228) reached through Python. With a client present the rc is
+    # the whole answer, because the target either resolved server-side and moved
+    # it (psmux/psmux#483) or failed loudly — pinned in the failure direction by
+    # test_adopted_switch_client_rejects_an_unresolvable_target, and measured with
+    # a real attached client only by hand (no CI box has one).
     #
-    # Unobservable answers False, never a vacuous True. For the detach that is
-    # safe in both directions — the caller's UNREACHABLE and RETURNED agree that
-    # nobody is left at this terminal, and the only cost is the parked trailer
-    # re-issuing a detach that no-ops. For the switch it is the conservative
-    # direction: the caller keeps prompting rather than reporting a terminal
-    # handed back that was not. Measuring rather than hardcoding is what lets a
-    # build that really does move the client report so with no change here.
+    # Two costs are taken deliberately here, since both are the kind that go
+    # unnoticed. The gate IS an absolute count, which the delta rule below
+    # forbids for good reason: the same server-fallback that makes "zero
+    # attached" meaningless (#315) can hand back a FOREIGN session's nonzero
+    # count, and a switch that exits 0 for its own reasons would then read as
+    # vouched-for. It is admitted only because the alternative — the delta — is
+    # blind to the same-session move this verb's main caller performs, and the
+    # damage directions are not equal: a wrong True here costs one unverified
+    # hand-back claim, where the delta cost a relocated human. And the rc rule
+    # assumes the admitted floor: psmux/psmux#483 lands in 3.3.8, so on a build
+    # forced past ``available()`` (an explicit backend override) a ``-t`` that
+    # moves nobody still exits 0 and is answered True.
     #
-    # Residue: a switch whose target pane lives in THIS session moves the client
-    # between windows without changing the session's attached count, so it reads
-    # as no effect. Reachable only when the return target was recorded from
-    # inside a control-session window; the caller then keeps prompting, which is
-    # the safe direction.
+    # ``switch-client -l`` and ``detach-client`` read the attached-client DELTA:
+    # count the clients on this session before and after, and answer on the drop.
+    # Neither can use rc — ``-l`` has no target form and carries no server reply
+    # at all, and ``detach-client`` exits 0 with zero clients attached (a
+    # flag-less detach is promoted server-side to detach-all). Never an absolute
+    # count: a read against a session whose server is gone answers from whichever
+    # server the fallback picks, so "zero attached" on its own proves nothing
+    # (#315). A drop cannot be manufactured that way — it needs two successful
+    # reads of the same session, the first of them nonzero.
+    #
+    # The delta is why ``-t`` could not stay on it (#659): a switch whose target
+    # lives in THIS session moves the client between windows without changing the
+    # session's count, so a real move read as no effect. That was not merely a
+    # conservative False. With ``last_fallback`` set — which is exactly how
+    # ``tui.launch.return_attached_client`` calls it — the failed verdict fired
+    # ``-l``, which dragged the client out to an unrelated session and produced
+    # the delta the correct move never could, so the call returned True and the
+    # caller cleared its return option. Measured on a live attended client:
+    # right move, undone, reported as success. Which is why the fallback in
+    # switch_client hangs on the rc and not on the verdict — see the comment
+    # there; a verdict-gated fallback keeps that drag alive for every rc-0
+    # switch the gate merely cannot vouch for.
 
     def _attached_clients(self, session: str) -> int | None:
         """Clients attached to ``session``, or None when psmux cannot say.
@@ -849,8 +869,35 @@ class PsmuxMultiplexer(BaseTmuxBackend):
         return self._client_left(["detach-client"])
 
     def switch_client(self, target: str, last_fallback: bool = False) -> bool:
-        if self._client_left(["switch-client", "-t", target]):
-            return True
+        # Two questions, deliberately separate: did the verb SUCCEED (rc), and
+        # was there a client here to succeed on (the gate count, read BEFORE the
+        # verb — a successful move can take the client off this session, so a
+        # read taken after would answer 0 for the very case it has to admit).
+        #
+        # The fallback hangs on the rc alone, never on the verdict. `-l` has no
+        # target form: it relocates whichever client the server last had, so
+        # firing it after a `-t` that already succeeded is the #659 drag itself —
+        # the correct move undone, and the delta the drag produces then read as
+        # success. An rc-0 switch we merely cannot VOUCH for (count unreadable,
+        # or zero clients here) is still a switch that happened or a no-op that
+        # moved nobody; either way there is nothing to fall back to. This is the
+        # `$LASTEXITCODE -ne 0` rule the pwsh trailer (_parked_trailer) has
+        # always used, and the same shape as the tmux leaf's switch_client.
+        session = self.current_session()
+        if not session:
+            # Not inside a pane (or the probe failed): there is no "this
+            # session" to measure against, and no client of ours to move.
+            return False
+        before = self._attached_clients(session)
+        try:
+            sent = self._run(["switch-client", "-t", target], check=False).returncode == 0
+        except (subprocess.SubprocessError, OSError):
+            sent = False
+        if sent:
+            # None is "cannot say", not "zero" — both refuse the claim, but only
+            # the second is evidence, so keep them spelled apart (as _client_left
+            # does) rather than collapsed into a truthiness test.
+            return before is not None and before > 0
         return last_fallback and self._client_left(["switch-client", "-l"])
 
     def pipe_pane(self, window_id: str, log_file: Path) -> None:

--- a/src/bmad_loop/adapters/psmux_backend.py
+++ b/src/bmad_loop/adapters/psmux_backend.py
@@ -891,7 +891,19 @@ class PsmuxMultiplexer(BaseTmuxBackend):
         before = self._attached_clients(session)
         try:
             sent = self._run(["switch-client", "-t", target], check=False).returncode == 0
+        except subprocess.TimeoutExpired:
+            # A timeout is not a failure — it is the absence of an answer. The
+            # server may well have moved the client before our wait ran out, so
+            # this is the one exit that must neither claim the move nor fall
+            # back: `-l` on a client that already went where it was asked is the
+            # #659 drag, and the drag manufactures the delta that would report it
+            # as a success. Answer False and leave the retry to the caller, which
+            # still holds its return option (return_attached_client clears that
+            # only on a True).
+            return False
         except (subprocess.SubprocessError, OSError):
+            # Spawn-level faults, by contrast, are proof the verb never ran:
+            # nothing moved, so the fallback is as available as after a nonzero rc.
             sent = False
         if sent:
             # None is "cannot say", not "zero" — both refuse the claim, but only

--- a/src/bmad_loop/adapters/psmux_backend.py
+++ b/src/bmad_loop/adapters/psmux_backend.py
@@ -31,13 +31,18 @@ sent, so neither seam boolean can be read off the exit code alone. The
 session's attached-client count supplies what the rc cannot — as a drop
 across ``detach-client`` and ``switch-client -l``, and as a gate on the
 targeted ``switch-client -t``, whose same-session move no drop can see
-(#659); see the ``client verbs: observed effect (#317)`` block. Residue of
-that split: a ``switch_client`` False is not proof the client stayed — the
-timed-out verb and the unvouched rc-0 (count unreadable) both answer False
-for a move the server may have completed; the return option survives a
-False, so the parked trailer's retry is the recovery. ``available()``
-additionally gates on the reported version — see ``_LAST_UNSUPPORTED``
-for what the floor buys and why it moves. ``has_session``
+(#659); see the ``client verbs: observed effect (#317)`` block. The seam's
+``False`` is the joint claim that no switch happened *and* a client is still
+here, so ``switch_client`` answers ``None`` wherever it cannot carry the
+second half — for two different reasons. A timed-out verb and an rc-0 whose
+gate count is unreadable are moves the server may have completed; a session
+with nothing attached is a move it cannot have made, but there is nobody here
+to keep prompting either. ``False`` is left to the exits that do carry the
+whole claim, both of which dispatch nothing: no session to measure, and a
+spawn fault with no fallback. ``available()`` additionally gates on the
+reported version —
+see ``_LAST_UNSUPPORTED`` for what the floor buys and why it moves.
+``has_session``
 is inherited unchanged, but one server per session gives it a residual the
 tmux path does not have: a ``-t`` read naming a session whose own server is
 gone can be answered by a different server, so a wrong ``True`` is reachable
@@ -783,13 +788,18 @@ class PsmuxMultiplexer(BaseTmuxBackend):
     # ------------------------------- client verbs: observed effect (#317)
     #
     # psmux's client verbs report *dispatch*, not effect, and the seam's contract
-    # is effect: an unobservable move must answer False, never a vacuous True.
+    # is effect: an unobservable move must never answer a vacuous True. WHAT it
+    # answers instead is per verb — False from detach_client, None from
+    # switch_client, whose False is the stronger joint claim that a client is
+    # still HERE (see TerminalMultiplexer.switch_client).
     # The exit code is trustworthy in ONE direction for every verb — a nonzero
     # one is a real failure (an unreachable session server, a target that would
     # not parse) — so the verdict source is per verb, and there are two of them.
     #
     # ``switch-client -t`` reads the exit code, gated on this session having had
-    # a client to move. The gate is what a bare rc cannot supply: the verb still
+    # a client to move; an rc-0 the gate cannot vouch for answers None, never
+    # False — the move may well have happened. The gate is what a bare rc
+    # cannot supply: the verb still
     # exits 0 with nothing attached (pinned by
     # test_premise_client_verbs_exit_zero_with_no_client_to_move), which is the
     # rc-0 no-op (#228) reached through Python. With a client present the rc is
@@ -852,27 +862,47 @@ class PsmuxMultiplexer(BaseTmuxBackend):
         text = proc.stdout.strip()
         return int(text) if text.isdigit() else None
 
-    def _client_left(self, verb: list[str]) -> bool:
-        """Run a client verb and answer whether a client left this session."""
+    def _client_left(self, verb: list[str]) -> bool | None:
+        """Run a client verb and answer whether a client left this session —
+        None both when that cannot be established and when it can but the
+        session had nobody on it to begin with. See
+        TerminalMultiplexer.switch_client for why those share an answer: the
+        seam's False is the joint claim that a client is still HERE, which an
+        empty session refutes rather than supports."""
         session = self.current_session()
         if not session:
             # Not inside a pane (or the probe failed): there is no "this
-            # session" to measure against, and no client of ours to move.
+            # session" to measure against, and no client of ours to move. No
+            # verb is dispatched, so nothing moved and whoever was here still
+            # is — the joint claim, hence a real False.
             return False
         before = self._attached_clients(session)
         try:
             self._run(verb, check=False)
+        except subprocess.TimeoutExpired:
+            # The verb may have landed after our wait ran out, and an `after`
+            # read now measures a session the client may still be leaving. No
+            # drop can be established in either direction.
+            return None
         except (subprocess.SubprocessError, OSError):
+            # A spawn-level fault is proof the verb never ran.
             return False
         after = self._attached_clients(session)
         if before is None or after is None:
-            return False
-        return before > 0 and after < before
+            return None
+        if before == 0:
+            # Nothing was attached, so nothing left — but there is nobody here
+            # to keep prompting at either, which is not what False claims.
+            return None
+        return after < before
 
     def detach_client(self) -> bool:
-        return self._client_left(["detach-client"])
+        # This leg stays a bool: return_attached_client already routes a failed
+        # detach to UNREACHABLE, so the state a None would add is one the
+        # caller has no separate answer for.
+        return self._client_left(["detach-client"]) is True
 
-    def switch_client(self, target: str, last_fallback: bool = False) -> bool:
+    def switch_client(self, target: str, last_fallback: bool = False) -> bool | None:
         # Two questions, deliberately separate: did the verb SUCCEED (rc), and
         # was there a client here to succeed on (the gate count, read BEFORE the
         # verb — a successful move can take the client off this session, so a
@@ -887,10 +917,23 @@ class PsmuxMultiplexer(BaseTmuxBackend):
         # moved nobody; either way there is nothing to fall back to. This is the
         # `$LASTEXITCODE -ne 0` rule the pwsh trailer (_parked_trailer) has
         # always used, and the same shape as the tmux leaf's switch_client.
+        #
+        # What the gate cannot VOUCH for answers None rather than False. The
+        # seam's False is the joint claim "no switch happened AND the client is
+        # still here", and every unvouched case below is one where the client
+        # may already be gone; collapsing them into False sends the return path
+        # back to prompting a window nobody is viewing, which a --repeat sweep
+        # then blocks on forever (the parked trailer's retry is no rescue — it
+        # sits behind that same blocking read).
         session = self.current_session()
         if not session:
             # Not inside a pane (or the probe failed): there is no "this
-            # session" to measure against, and no client of ours to move.
+            # session" to measure against, and no client of ours to move. No
+            # verb is dispatched, so nothing moved — and when it is the probe
+            # that failed rather than the pane that is absent, a wedged server
+            # is a frozen terminal someone may still be sitting at. The second
+            # half of the claim is a policy call here, not a measurement, and
+            # False is the half that keeps talking to them.
             return False
         before = self._attached_clients(session)
         try:
@@ -901,20 +944,23 @@ class PsmuxMultiplexer(BaseTmuxBackend):
             # this is the one exit that must neither claim the move nor fall
             # back: `-l` on a client that already went where it was asked is the
             # #659 drag, and the drag manufactures the delta that would report it
-            # as a success. Answer False and leave the retry to the caller, which
-            # still holds its return option (return_attached_client clears that
-            # only on a True).
-            return False
+            # as a success. None leaves the caller its return option (cleared
+            # only on a True) AND stops it prompting a window the client may
+            # have left.
+            return None
         except (subprocess.SubprocessError, OSError):
             # Spawn-level faults, by contrast, are proof the verb never ran:
             # nothing moved, so the fallback is as available as after a nonzero rc.
             sent = False
         if sent:
-            # None is "cannot say", not "zero" — both refuse the claim, but only
-            # the second is evidence, so keep them spelled apart (as _client_left
-            # does) rather than collapsed into a truthiness test.
-            return before is not None and before > 0
-        return last_fallback and self._client_left(["switch-client", "-l"])
+            # "Cannot say" and "nobody here" are different facts — an old build
+            # with no #{session_attached} versus a session the client has
+            # already left — and both refuse the True. They share a verdict
+            # only because neither can vouch that a human is still watching.
+            if before is None or before == 0:
+                return None
+            return True
+        return self._client_left(["switch-client", "-l"]) if last_fallback else False
 
     def pipe_pane(self, window_id: str, log_file: Path) -> None:
         # The base's POSIX `cat >>` sink assumes a POSIX host shell, so the sink

--- a/src/bmad_loop/adapters/psmux_backend.py
+++ b/src/bmad_loop/adapters/psmux_backend.py
@@ -31,7 +31,11 @@ sent, so neither seam boolean can be read off the exit code alone. The
 session's attached-client count supplies what the rc cannot — as a drop
 across ``detach-client`` and ``switch-client -l``, and as a gate on the
 targeted ``switch-client -t``, whose same-session move no drop can see
-(#659); see the ``client verbs: observed effect (#317)`` block. ``available()``
+(#659); see the ``client verbs: observed effect (#317)`` block. Residue of
+that split: a ``switch_client`` False is not proof the client stayed — the
+timed-out verb and the unvouched rc-0 (count unreadable) both answer False
+for a move the server may have completed; the return option survives a
+False, so the parked trailer's retry is the recovery. ``available()``
 additionally gates on the reported version — see ``_LAST_UNSUPPORTED``
 for what the floor buys and why it moves. ``has_session``
 is inherited unchanged, but one server per session gives it a residual the

--- a/src/bmad_loop/adapters/psmux_backend.py
+++ b/src/bmad_loop/adapters/psmux_backend.py
@@ -885,7 +885,14 @@ class PsmuxMultiplexer(BaseTmuxBackend):
             # drop can be established in either direction.
             return None
         except (subprocess.SubprocessError, OSError):
-            # A spawn-level fault is proof the verb never ran.
+            # A spawn-level fault is proof the verb never ran — but "nothing
+            # moved" is only the first half of the seam's False, and the count
+            # read before the verb still governs the second. An empty or
+            # unreadable session leaves it unvouched here exactly as it does
+            # past the verb, which is what this function's own docstring
+            # promises; probing again now would only measure a broken transport.
+            if before is None or before == 0:
+                return None
             return False
         after = self._attached_clients(session)
         if before is None or after is None:
@@ -960,7 +967,18 @@ class PsmuxMultiplexer(BaseTmuxBackend):
             if before is None or before == 0:
                 return None
             return True
-        return self._client_left(["switch-client", "-l"]) if last_fallback else False
+        if last_fallback:
+            return self._client_left(["switch-client", "-l"])
+        # The refusal carries the joint claim only if a client was measurably
+        # here to refuse on. Same gate as the rc-0 arm, for the same reason: an
+        # unreadable count and an empty session each leave the "still here" half
+        # unvouched, and which way the rc went does not touch that half. tmux
+        # reaches this by probing AFTER a failed verb; the pre-verb read is what
+        # lets this leaf answer it on the spawn-fault exit too, where a probe
+        # taken now would be measuring an already-broken transport.
+        if before is None or before == 0:
+            return None
+        return False
 
     def pipe_pane(self, window_id: str, log_file: Path) -> None:
         # The base's POSIX `cat >>` sink assumes a POSIX host shell, so the sink

--- a/src/bmad_loop/adapters/tmux_base.py
+++ b/src/bmad_loop/adapters/tmux_base.py
@@ -545,18 +545,48 @@ class BaseTmuxBackend(TerminalMultiplexer):
             return False
         return proc.returncode == 0
 
-    def switch_client(self, target: str, last_fallback: bool = False) -> bool:
-        # Returns True iff a switch happened; a transport failure didn't switch, so
-        # the documented False sentinel is the honest answer.
+    def _attached_here(self) -> int | None:
+        """Clients attached to this process's session, or None when tmux cannot
+        say. Only :meth:`switch_client`'s failure path needs it, so it is read
+        after the verb — nothing moved on that path, and the success path pays
+        no probe at all."""
+        text = self._display_message("#{session_attached}")
+        return int(text) if text is not None and text.isdigit() else None
+
+    def switch_client(self, target: str, last_fallback: bool = False) -> bool | None:
+        # rc 0 is a real move and needs no gate: tmux runs one server, and it
+        # refuses rather than no-ops when there is nobody to move.
+        #
+        # A nonzero rc is where the exit code stops being the whole answer. It
+        # is TWO facts wearing one code — a target this client cannot reach, and
+        # no client here at all — and only the first is the seam's False.
+        # Measured on tmux 3.7c from inside a pane whose server had no attached
+        # client: `-t <live session>`, `-t <other session>`, `-l` and `-t
+        # <nonexistent>` ALL exit 1 with "no current client". So a bare rc would
+        # answer False — "no switch, and the client is still here" — for the one
+        # state where there is no client here at all, which is #659's hazard on
+        # the default backend. The attached count is what separates them, the
+        # same gate the psmux leaf applies to its own rc.
+        #
+        # A TIMEOUT is neither: the server may have completed the switch before
+        # the wait expired, so False would report a human still watching a
+        # window the client has already left. A spawn-level fault IS the joint
+        # claim — proof the verb never ran, so nothing moved.
         try:
             proc = self._run(["switch-client", "-t", target], check=False)
             if proc.returncode == 0:
                 return True
-            if last_fallback:
-                fb = self._run(["switch-client", "-l"], check=False)
-                return fb.returncode == 0
+            if last_fallback and self._run(["switch-client", "-l"], check=False).returncode == 0:
+                return True
+        except subprocess.TimeoutExpired:
+            return None
         except (subprocess.SubprocessError, OSError):
             return False
+        attached = self._attached_here()
+        if attached is None or attached == 0:
+            # Unreadable and zero part company as facts and meet as verdicts:
+            # neither can vouch that a human is still in front of this window.
+            return None
         return False
 
     def available(self) -> bool:

--- a/src/bmad_loop/sweep.py
+++ b/src/bmad_loop/sweep.py
@@ -1236,15 +1236,20 @@ class SweepEngine(Engine):
 
         The trigger for that is "nobody can be relied on to answer here any
         more", NOT "the hand-back succeeded" — the two come apart on a failed
-        return, in opposite directions. A failed switch is evidence the client
-        is still in this window with a human in front of it (ATTENDED: keep
-        prompting, which is the whole point of #227). A failed detach reports
-        only that no hand-back was verified — nothing attached, an effect the
-        backend cannot observe, or no detach verb at all — and under that
+        return, in opposite directions. A *refused* switch is evidence the
+        client is still in this window with a human in front of it (ATTENDED:
+        keep prompting, which is the whole point of #227). Everything else
+        reports only that no hand-back was verified — a detach that found
+        nothing attached, an effect the backend cannot observe, no detach verb
+        at all, or a switch the backend cannot vouch for (a timed-out verb, an
+        unreadable client count, nothing attached to move) — and under that
         uncertainty going unattended is the outcome that does not strand a
         --repeat cycle on input(); the decisions it defers stay reachable via
-        `bmad-loop decisions`. Only a real return is announced: UNREACHABLE
-        prints nothing, since there may be no one to read it."""
+        `bmad-loop decisions`. The `sweep-return-no-client` record keeps its
+        name across that widening: it has always meant "no hand-back verified",
+        which is what an unvouched switch reports too. Only a real return is
+        announced: UNREACHABLE prints nothing, since there may be no one to
+        read it."""
         from .tui import launch  # import-light: launch.py has no textual imports
 
         outcome = launch.return_attached_client()

--- a/src/bmad_loop/tui/launch.py
+++ b/src/bmad_loop/tui/launch.py
@@ -535,26 +535,25 @@ class ReturnOutcome(StrEnum):
     unattended on the strength of it, whether a human can still answer here.
 
     A plain boolean cannot carry that: "the hand-back succeeded" and "there is
-    still someone at this terminal" are independent, and the two failures point
-    opposite ways. A failed *switch* leaves the client sitting in this very
-    window; a failed *detach* reports no verified hand-back, which is not the
-    same claim and does not license the same response."""
+    still someone at this terminal" are independent, and the ways of failing
+    point in different directions. A *refused* switch leaves the client sitting
+    in this very window; a switch the backend cannot vouch for may already have
+    moved it; a failed *detach* reports no verified hand-back. Three claims, and
+    they do not license the same response."""
 
     RETURNED = "returned"
     #: No hand-back, but a human may still be here: nothing was recorded to
     #: return to (a plain foreground sweep), the backend is unusable, or the
-    #: switch failed — usually with the client still in this window, though a
-    #: backend may also answer False for a switch it could not vouch for (a
-    #: timed-out verb, an unreadable client count) where the client may in fact
-    #: have left. The conservative answer either way — a caller must keep
-    #: talking to the terminal.
+    #: switch failed with the client still in this window. The conservative
+    #: answer — a caller must keep talking to the terminal.
     ATTENDED = "attended"
     #: A hand-back was attempted and did not verifiably happen: the detach found
-    #: nothing attached, the effect could not be observed, or the backend has no
-    #: detach verb at all (herdr). A caller must not rely on anyone answering a
-    #: prompt in this window — a policy for the uncertainty, not a proof that
-    #: the window is empty (see return_attached_client for why it is the safe
-    #: way to be wrong).
+    #: nothing attached, the switch could not be vouched for (a timed-out verb,
+    #: an unreadable client count, nothing attached to move), the effect could
+    #: not be observed, or the backend has no detach verb at all (herdr). A
+    #: caller must not rely on anyone answering a prompt in this window — a
+    #: policy for the uncertainty, not a proof that the window is empty (see
+    #: return_attached_client for why it is the safe way to be wrong).
     UNREACHABLE = "unreachable"
 
 
@@ -575,18 +574,24 @@ def return_attached_client() -> ReturnOutcome:
     only once a human dismisses the park prompt, never in the unattended case.
 
     The two failures are not interchangeable, which is why this answers a
-    ReturnOutcome and not a bool. A failed switch is normally evidence that the
+    ReturnOutcome and not a bool. A failed switch is positive evidence that the
     client is still in this window, so ATTENDED keeps the caller prompting —
-    though not proof: a backend may answer False for a switch it could not
-    vouch for (psmux's timed-out verb or unreadable client count), and the
-    return option surviving a False is what keeps the parked trailer's retry
-    available for exactly that case. A
+    but only because the seam reserves False for that joint claim. A backend
+    that merely cannot vouch for the move (psmux's timed-out verb, an
+    unreadable client count, nothing attached to move) answers None, and that
+    lands in UNREACHABLE instead. The routing is load-bearing, not tidiness:
+    an ATTENDED the client has already walked away from cannot be recovered by
+    the surviving return option, because a --repeat cycle prompting into the
+    empty window blocks on input() before anyone can reach the trailer. A
     failed detach carries no such evidence in general: on tmux it does
     (`detach-client` fails with "no current client"), but off tmux False also
     covers an effect the backend could not observe and a detach verb it does
-    not have at all — herdr, whose False rather than None is exactly what the
-    seam's widened return type buys. UNREACHABLE is the policy for all three,
-    because the two ways of being wrong are not equally bad: prompting into a
+    not have at all — herdr, whose False rather than None is exactly what
+    detach_client's own widening to a returned bool (#317) buys. That is a
+    different widening from switch_client's third state above; detach_client is
+    the verb that stays a bool. UNREACHABLE is the policy for all of them, the
+    unvouched switch included, because the two ways of being wrong are not
+    equally bad: prompting into a
     window no one is viewing blocks a --repeat sweep on input() forever, while
     going unattended in front of a human only defers this cycle's decisions to
     `bmad-loop decisions` or the next attended sweep."""
@@ -603,7 +608,10 @@ def return_attached_client() -> ReturnOutcome:
         outcome = ReturnOutcome.RETURNED if mux.detach_client() else ReturnOutcome.UNREACHABLE
     else:
         switched = mux.switch_client(ret, last_fallback=True)
-        outcome = ReturnOutcome.RETURNED if switched else ReturnOutcome.ATTENDED
+        if switched is None:
+            outcome = ReturnOutcome.UNREACHABLE
+        else:
+            outcome = ReturnOutcome.RETURNED if switched else ReturnOutcome.ATTENDED
     if outcome is ReturnOutcome.RETURNED:
         mux.unset_window_option(win, RETURN_OPTION)
     return outcome

--- a/src/bmad_loop/tui/launch.py
+++ b/src/bmad_loop/tui/launch.py
@@ -543,8 +543,11 @@ class ReturnOutcome(StrEnum):
     RETURNED = "returned"
     #: No hand-back, but a human may still be here: nothing was recorded to
     #: return to (a plain foreground sweep), the backend is unusable, or the
-    #: switch failed with the client still in this window. The conservative
-    #: answer — a caller must keep talking to the terminal.
+    #: switch failed — usually with the client still in this window, though a
+    #: backend may also answer False for a switch it could not vouch for (a
+    #: timed-out verb, an unreadable client count) where the client may in fact
+    #: have left. The conservative answer either way — a caller must keep
+    #: talking to the terminal.
     ATTENDED = "attended"
     #: A hand-back was attempted and did not verifiably happen: the detach found
     #: nothing attached, the effect could not be observed, or the backend has no
@@ -572,8 +575,12 @@ def return_attached_client() -> ReturnOutcome:
     only once a human dismisses the park prompt, never in the unattended case.
 
     The two failures are not interchangeable, which is why this answers a
-    ReturnOutcome and not a bool. A failed switch is positive evidence that the
-    client is still in this window, so ATTENDED keeps the caller prompting. A
+    ReturnOutcome and not a bool. A failed switch is normally evidence that the
+    client is still in this window, so ATTENDED keeps the caller prompting —
+    though not proof: a backend may answer False for a switch it could not
+    vouch for (psmux's timed-out verb or unreadable client count), and the
+    return option surviving a False is what keeps the parked trailer's retry
+    available for exactly that case. A
     failed detach carries no such evidence in general: on tmux it does
     (`detach-client` fails with "no current client"), but off tmux False also
     covers an effect the backend could not observe and a detach verb it does

--- a/tests/test_multiplexer.py
+++ b/tests/test_multiplexer.py
@@ -213,6 +213,7 @@ def boom_run(request, monkeypatch):
         raise request.param
 
     monkeypatch.setattr(tmux_base.subprocess, "run", boom)
+    return request.param
 
 
 def test_seam_methods_never_leak_raw_subprocess_error(boom_run, tmp_path):
@@ -242,8 +243,6 @@ def test_seam_methods_never_leak_raw_subprocess_error(boom_run, tmp_path):
     # (never a raise, never a mis-typed answer).
     assert mux.list_windows("s", ["window_id"]) == []
     assert mux.show_window_option("@1", "opt") == ""
-    assert mux.switch_client("s") is False
-    assert mux.switch_client("s", last_fallback=True) is False
     assert mux.detach_client() is False
     assert mux.kill_window("@1") is None
     assert mux.select_window("@1") is None
@@ -251,6 +250,16 @@ def test_seam_methods_never_leak_raw_subprocess_error(boom_run, tmp_path):
     assert mux.unset_window_option("@1", "opt") is None
     assert mux.pipe_pane("@1", tmp_path / "log") is None
     assert mux.window_pane_pids("@1") == []
+
+    # switch_client is the one sentinel that splits the two faults the rest
+    # collapse: a missing binary never ran the verb, so nobody moved and whoever
+    # was in front of this window still is — the joint claim False stands for.
+    # A timeout may have completed the switch server-side, and only None can say
+    # so; a False there tells the return path to keep prompting a window the
+    # client has already left (#659, one seam up).
+    unvouched = None if isinstance(boom_run, subprocess.TimeoutExpired) else False
+    assert mux.switch_client("s") is unvouched
+    assert mux.switch_client("s", last_fallback=True) is unvouched
 
     # Already-correct swallowers stay swallowing (lock-in).
     assert mux.kill_session("s") is None

--- a/tests/test_psmux_backend.py
+++ b/tests/test_psmux_backend.py
@@ -1694,14 +1694,19 @@ def test_psmux_switch_reports_a_cross_session_move(monkeypatch):
     assert calls.count(["psmux", "display-message", "-p", "-t", "ctl", "#{session_attached}"]) == 1
 
 
-def test_psmux_switch_with_nothing_attached_is_false(monkeypatch):
+def test_psmux_switch_with_nothing_attached_cannot_vouch(monkeypatch):
     """psmux's switch-client exits 0 with no client to move, so rc alone would be
     the vacuous True the seam forbids; the gate count refuses it. The verb is
     still dispatched — the refusal is a verdict, not a skip — but the `-l`
     fallback must NOT be: it has no target form, so with nobody attached here it
-    can only relocate a stranger's client."""
+    can only relocate a stranger's client.
+
+    None, not False: False is the joint claim that the client is still in this
+    window, and a session with nothing attached is the case that flatly refutes
+    its second half. Answering False routes the caller to ATTENDED and leaves a
+    --repeat sweep prompting a window nobody is viewing."""
     calls = _client_fake(monkeypatch, attached=["0"] * 4)
-    assert PsmuxMultiplexer().switch_client("ctl:%9", last_fallback=True) is False
+    assert PsmuxMultiplexer().switch_client("ctl:%9", last_fallback=True) is None
     assert ["psmux", "switch-client", "-t", "ctl:%9"] in calls
     assert not any(c[1:3] == ["switch-client", "-l"] for c in calls)
 
@@ -1711,9 +1716,13 @@ def test_psmux_switch_does_not_fall_back_after_a_switch_that_succeeded(monkeypat
     unreadable (any transient probe failure, not just an old build) while the
     verb exits 0 and, on a supported build, really moved the client. Hanging the
     fallback on the verdict rather than the rc fires `-l` here — undoing a
-    correct move and, worse, manufacturing the delta that reports it as success."""
+    correct move and, worse, manufacturing the delta that reports it as success.
+
+    And the verdict itself is None: on a supported build the client really did
+    move, so the one thing this exit must not tell the caller is that a human is
+    still sitting in front of this window."""
     calls = _client_fake(monkeypatch, attached=["#{session_attached}", "1", "0"])
-    assert PsmuxMultiplexer().switch_client("ctl:%9", last_fallback=True) is False
+    assert PsmuxMultiplexer().switch_client("ctl:%9", last_fallback=True) is None
     assert ["psmux", "switch-client", "-t", "ctl:%9"] in calls
     assert not any(c[1:3] == ["switch-client", "-l"] for c in calls)
 
@@ -1736,10 +1745,17 @@ def test_psmux_switch_is_false_when_both_legs_fail(monkeypatch):
 
 def test_psmux_switch_never_claims_an_unobservable_move(monkeypatch):
     """A build with no #{session_attached} to read cannot establish that a client
-    was here, so rc 0 stays False — but the verb is dispatched anyway, so the
-    degraded read costs the caller nothing but the claim."""
+    was here, so rc 0 never becomes True — but the verb is dispatched anyway, so
+    the degraded read costs the caller nothing but the claim.
+
+    It costs it the opposite claim too, which is why this is None and not False.
+    An unreadable count does not say WHICH world this is: on a pre-floor build
+    `-t` is inert (psmux/psmux#483) and the client certainly stayed, while a
+    transient probe failure on a supported build means it certainly moved — the
+    case its sibling test pins. One branch, two physical stories, and nothing
+    here can tell them apart. None is the only answer that does not pick one."""
     calls = _client_fake(monkeypatch, attached=["#{session_attached}"] * 3)
-    assert PsmuxMultiplexer().switch_client("ctl:%9") is False
+    assert PsmuxMultiplexer().switch_client("ctl:%9") is None
     assert ["psmux", "switch-client", "-t", "ctl:%9"] in calls
 
 
@@ -1766,11 +1782,14 @@ def test_psmux_switch_survives_a_transport_fault(monkeypatch):
 def test_psmux_switch_failed_rc_with_empty_session_still_dispatches_the_fallback(monkeypatch):
     """The one released `-l` with nobody attached here: a failed `-t` frees the
     fallback regardless of the gate, and `_client_left` then dispatches it and
-    answers on its own delta (0 -> 0 reads False). Pinned as the fallback leg's
-    pre-#659 shape — skipping `-l` on an empty session would be a behavior
-    change with its own review, not a side effect of the verdict split."""
+    answers on its own delta. Pinned as the fallback leg's pre-#659 shape —
+    skipping `-l` on an empty session would be a behavior change with its own
+    review, not a side effect of the verdict split.
+
+    0 -> 0 is no drop, but it is not the joint claim either: nobody was here to
+    stay, so the leg answers None and the sweep stops prompting."""
     calls = _client_fake(monkeypatch, attached=["0", "0", "0"], verb_rc=1)
-    assert PsmuxMultiplexer().switch_client("ctl:%9", last_fallback=True) is False
+    assert PsmuxMultiplexer().switch_client("ctl:%9", last_fallback=True) is None
     assert ["psmux", "switch-client", "-l"] in calls
 
 
@@ -1778,7 +1797,11 @@ def test_psmux_switch_timeout_does_not_fall_back(monkeypatch):
     """A timeout is the absence of an answer, not a failed switch: the server may
     have moved the client before the wait ran out. Treating it as proven failure
     fires `-l` at a client that already went where it was asked — the #659 drag,
-    which then manufactures the delta that reports it as a success."""
+    which then manufactures the delta that reports it as a success.
+
+    None is the same refusal one level up: a False would tell the return path
+    the client is still in this window, and the surviving return option is no
+    rescue when the caller answers that by blocking on input() here."""
     calls = _client_fake(monkeypatch, attached=["1", "1", "0"])
     probing = tmux_base.subprocess.run
 
@@ -1788,8 +1811,62 @@ def test_psmux_switch_timeout_does_not_fall_back(monkeypatch):
         return probing(argv, **kwargs)
 
     monkeypatch.setattr(tmux_base.subprocess, "run", stall)
-    assert PsmuxMultiplexer().switch_client("ctl:%9", last_fallback=True) is False
+    assert PsmuxMultiplexer().switch_client("ctl:%9", last_fallback=True) is None
     assert not any(c[1:3] == ["switch-client", "-l"] for c in calls)
+
+
+def test_psmux_switch_fallback_timeout_cannot_vouch(monkeypatch):
+    """The `-t` leg is not the only one that can relocate a client without
+    saying so. A `-l` whose answer never arrives may have moved the operator
+    anyway, so the delta legs owe the same None — otherwise the walked-away
+    client lands back in the ATTENDED bucket through the one path the #659 fix
+    left measuring.
+
+    The dispatch is recorded inside the stall, not read off `calls`: the raise
+    pre-empts the fixture, and without the record "the fallback timed out" and
+    "the fallback was never reached" would assert the same."""
+    _client_fake(monkeypatch, attached=["1", "1", "1"], verb_rc=1)
+    probing = tmux_base.subprocess.run
+    dispatched: list[list[str]] = []
+
+    def stall(argv, **kwargs):
+        if argv[1:3] == ["switch-client", "-l"]:
+            dispatched.append(list(argv))
+            raise subprocess.TimeoutExpired(argv, 30)
+        return probing(argv, **kwargs)
+
+    monkeypatch.setattr(tmux_base.subprocess, "run", stall)
+    assert PsmuxMultiplexer().switch_client("ctl:%9", last_fallback=True) is None
+    assert dispatched == [["psmux", "switch-client", "-l"]]
+
+
+def test_psmux_switch_fallback_with_an_unreadable_count_cannot_vouch(monkeypatch):
+    """`-l` dispatched, its drop unmeasurable: the verb may have relocated the
+    client, so the leg answers None rather than claiming one stayed. Only the
+    fallback's own pair degrades — the `-t` gate read is scripted readable, so a
+    blanket-unreadable fixture could not tell this from the rc-0 gate's None."""
+    calls = _client_fake(
+        monkeypatch, attached=["1", "#{session_attached}", "#{session_attached}"], verb_rc=1
+    )
+    assert PsmuxMultiplexer().switch_client("ctl:%9", last_fallback=True) is None
+    assert ["psmux", "switch-client", "-l"] in calls
+
+
+def test_psmux_detach_timeout_still_answers_false(monkeypatch):
+    """`_client_left` widened to a tri-state for the switch leg; the detach leg
+    must not widen with it. Its caller already routes a failed detach to
+    UNREACHABLE, so a None here would be a seam state with no consumer — and
+    `detach_client` is typed bool."""
+    _client_fake(monkeypatch, attached=["1", "0"])
+    probing = tmux_base.subprocess.run
+
+    def stall(argv, **kwargs):
+        if argv[1] == "detach-client":
+            raise subprocess.TimeoutExpired(argv, 30)
+        return probing(argv, **kwargs)
+
+    monkeypatch.setattr(tmux_base.subprocess, "run", stall)
+    assert PsmuxMultiplexer().detach_client() is False
 
 
 def test_psmux_switch_transport_fault_without_fallback_is_false(monkeypatch):

--- a/tests/test_psmux_backend.py
+++ b/tests/test_psmux_backend.py
@@ -1592,13 +1592,20 @@ def test_ctl_prune_scan_discriminates_projects_end_to_end(monkeypatch, tmp_path)
 # ---------------------------------------- client verbs: observed effect (#317)
 
 
-def _client_fake(monkeypatch, *, attached, session="ctl", verb_rc=0):
+def _client_fake(monkeypatch, *, attached, session="ctl", verb_rc=0, drains_on_switch=False):
     """Script the two probes the client verbs measure with.
 
     ``attached`` is the successive answers to ``#{session_attached}``, consumed
-    in call order — so a detach that worked is ["1", "0"] and psmux's rc-0 no-op
-    is ["1", "1"]. Every verb exits ``verb_rc`` (0 by default: on psmux the exit
-    code says nothing, which is the whole point).
+    in call order. The delta verbs (``-l``, ``detach-client``) take two each — a
+    detach that worked is ["1", "0"] and psmux's rc-0 no-op is ["1", "1"] — while
+    ``switch-client -t`` takes ONE, the gate count read before it. Every verb
+    exits ``verb_rc`` (0 by default), which only the ``-t`` leg reads.
+
+    ``drains_on_switch`` makes the count answer ``"0"`` from the moment a
+    ``switch-client`` has been seen, i.e. the session empties BECAUSE the verb
+    ran — the one input that tells a gate read taken before the verb apart from
+    one taken after it. Without it that ordering is unobservable here, since
+    either position consumes the same single scripted answer.
     """
     monkeypatch.setenv("TMUX", "/tmp/psmux-1000/default,123,0")  # inside a pane
     counts = list(attached)
@@ -1609,7 +1616,9 @@ def _client_fake(monkeypatch, *, attached, session="ctl", verb_rc=0):
         if argv[1] == "display-message" and argv[-1] == "#{session_name}":
             return subprocess.CompletedProcess(argv, 0, stdout=f"{session}\n", stderr="")
         if argv[1] == "display-message" and argv[-1] == "#{session_attached}":
-            return subprocess.CompletedProcess(argv, 0, stdout=f"{counts.pop(0)}\n", stderr="")
+            drained = drains_on_switch and any(c[1] == "switch-client" for c in calls[:-1])
+            answer = "0" if drained else counts.pop(0)
+            return subprocess.CompletedProcess(argv, 0, stdout=f"{answer}\n", stderr="")
         return subprocess.CompletedProcess(argv, verb_rc, stdout="", stderr="")
 
     monkeypatch.setattr(tmux_base.subprocess, "run", fake)
@@ -1652,38 +1661,134 @@ def test_psmux_detach_outside_a_pane_is_false(monkeypatch):
     assert not any(c[1] == "detach-client" for c in calls)
 
 
-def test_psmux_switch_reports_the_drop(monkeypatch):
-    # `last_fallback=True` is what gives the last assertion teeth: with the
-    # default False the `-l` leg is unreachable by construction, so "no fallback
-    # when -t moved it" would hold even with the early return gone. Counts for
-    # two probes for the same reason — a second one must reach the assertion
-    # rather than run the fixture dry.
-    calls = _client_fake(monkeypatch, attached=["1", "0", "1", "0"])
+def test_psmux_switch_reports_a_same_session_move(monkeypatch):
+    """The regression the delta could not see (#659): the target pane lives in
+    THIS session, so the client moves between windows and the attached count
+    never changes. rc plus "there was a client here" is what answers True — and
+    the `-l` leg must stay unreached, since on a live client it drags that human
+    out to whatever session psmux last had, and reports THAT as the success.
+
+    `last_fallback=True` is what gives the last assertion teeth: with the
+    default False the `-l` leg is unreachable by construction. The counts are
+    scripted well past what either leg can consume for the same reason — put
+    the verdict back on the delta and this must fail on its own assertions, not
+    on a fixture running dry.
+    """
+    calls = _client_fake(monkeypatch, attached=["1"] * 6)
     assert PsmuxMultiplexer().switch_client("ctl:%9", last_fallback=True) is True
     assert ["psmux", "switch-client", "-t", "ctl:%9"] in calls
-    # no fallback when -t moved it
+    assert not any(c[1:3] == ["switch-client", "-l"] for c in calls)
+
+
+def test_psmux_switch_reports_a_cross_session_move(monkeypatch):
+    """The move empties this session, and the gate still admits it: the count is
+    read BEFORE the verb. `drains_on_switch` is what makes that ordering an
+    observable input — take the read after the switch and the emptied session
+    answers 0, refusing the very hand-back that just succeeded."""
+    calls = _client_fake(monkeypatch, attached=["1"] * 4, drains_on_switch=True)
+    assert PsmuxMultiplexer().switch_client("ctl:%9", last_fallback=True) is True
+    assert ["psmux", "switch-client", "-t", "ctl:%9"] in calls
+    assert not any(c[1:3] == ["switch-client", "-l"] for c in calls)
+    # One gate read, routed at this session — the #315-safe shape the detach
+    # tests pin for the delta legs, and the arity a re-added `after` read breaks.
+    assert calls.count(["psmux", "display-message", "-p", "-t", "ctl", "#{session_attached}"]) == 1
+
+
+def test_psmux_switch_with_nothing_attached_is_false(monkeypatch):
+    """psmux's switch-client exits 0 with no client to move, so rc alone would be
+    the vacuous True the seam forbids; the gate count refuses it. The verb is
+    still dispatched — the refusal is a verdict, not a skip — but the `-l`
+    fallback must NOT be: it has no target form, so with nobody attached here it
+    can only relocate a stranger's client."""
+    calls = _client_fake(monkeypatch, attached=["0"] * 4)
+    assert PsmuxMultiplexer().switch_client("ctl:%9", last_fallback=True) is False
+    assert ["psmux", "switch-client", "-t", "ctl:%9"] in calls
+    assert not any(c[1:3] == ["switch-client", "-l"] for c in calls)
+
+
+def test_psmux_switch_does_not_fall_back_after_a_switch_that_succeeded(monkeypatch):
+    """The #659 drag, in the window the gate cannot vouch for: the count is
+    unreadable (any transient probe failure, not just an old build) while the
+    verb exits 0 and, on a supported build, really moved the client. Hanging the
+    fallback on the verdict rather than the rc fires `-l` here — undoing a
+    correct move and, worse, manufacturing the delta that reports it as success."""
+    calls = _client_fake(monkeypatch, attached=["#{session_attached}", "1", "0"])
+    assert PsmuxMultiplexer().switch_client("ctl:%9", last_fallback=True) is False
+    assert ["psmux", "switch-client", "-t", "ctl:%9"] in calls
     assert not any(c[1:3] == ["switch-client", "-l"] for c in calls)
 
 
 def test_psmux_switch_falls_back_then_reports_the_drop(monkeypatch):
-    calls = _client_fake(monkeypatch, attached=["1", "1", "1", "0"])
+    """A target that would not parse or no longer exists exits nonzero — the one
+    direction psmux's exit code was always honest in — so the `-l` leg runs and
+    answers on its own delta."""
+    calls = _client_fake(monkeypatch, attached=["1", "1", "0"], verb_rc=1)
     assert PsmuxMultiplexer().switch_client("ctl:%9", last_fallback=True) is True
     assert ["psmux", "switch-client", "-l"] in calls
 
 
-def test_psmux_switch_is_false_while_the_leg_is_inert(monkeypatch):
-    """psmux/psmux#483: the switch moves no client, and every arm still exits 0.
-    Both legs are attempted and both read as no effect, so the caller keeps
-    prompting instead of being told the human was handed their terminal back."""
-    calls = _client_fake(monkeypatch, attached=["1", "1", "1", "1"])
+def test_psmux_switch_is_false_when_both_legs_fail(monkeypatch):
+    calls = _client_fake(monkeypatch, attached=["1", "1", "1"], verb_rc=1)
     assert PsmuxMultiplexer().switch_client("ctl:%9", last_fallback=True) is False
     assert ["psmux", "switch-client", "-t", "ctl:%9"] in calls
     assert ["psmux", "switch-client", "-l"] in calls
 
 
+def test_psmux_switch_never_claims_an_unobservable_move(monkeypatch):
+    """A build with no #{session_attached} to read cannot establish that a client
+    was here, so rc 0 stays False — but the verb is dispatched anyway, so the
+    degraded read costs the caller nothing but the claim."""
+    calls = _client_fake(monkeypatch, attached=["#{session_attached}"] * 3)
+    assert PsmuxMultiplexer().switch_client("ctl:%9") is False
+    assert ["psmux", "switch-client", "-t", "ctl:%9"] in calls
+
+
+def test_psmux_switch_survives_a_transport_fault(monkeypatch):
+    """A `-t` that cannot be spawned at all moved nobody — the documented False
+    sentinel, never an escalation out of a seam whose callers treat the answer as
+    advisory. The fault is scoped to `-t` on purpose: faulting both legs could
+    not tell "the fallback ran and also faulted" from "it was never reached",
+    and reaching it is the claim here — a fault is a failed switch, so the
+    fallback is exactly as available as it is after a nonzero rc."""
+    calls = _client_fake(monkeypatch, attached=["1", "1", "0"])
+    probing = tmux_base.subprocess.run  # the fixture's scripted probes
+
+    def boom(argv, **kwargs):
+        if argv[1:3] == ["switch-client", "-t"]:
+            raise OSError("psmux vanished mid-call")
+        return probing(argv, **kwargs)
+
+    monkeypatch.setattr(tmux_base.subprocess, "run", boom)
+    assert PsmuxMultiplexer().switch_client("ctl:%9", last_fallback=True) is True
+    assert ["psmux", "switch-client", "-l"] in calls
+
+
+def test_psmux_switch_transport_fault_without_fallback_is_false(monkeypatch):
+    _client_fake(monkeypatch, attached=["1", "1", "1"])
+    probing = tmux_base.subprocess.run
+
+    def boom(argv, **kwargs):
+        if argv[1:3] == ["switch-client", "-t"]:
+            raise OSError("psmux vanished mid-call")
+        return probing(argv, **kwargs)
+
+    monkeypatch.setattr(tmux_base.subprocess, "run", boom)
+    assert PsmuxMultiplexer().switch_client("ctl:%9") is False
+
+
+def test_psmux_switch_outside_a_pane_is_false(monkeypatch):
+    """No TMUX, so current_session answers None: no session to gate against and
+    no client of ours to move. Answer False without issuing the switch."""
+    calls = _client_fake(monkeypatch, attached=["1", "1"])
+    monkeypatch.delenv("TMUX", raising=False)
+    assert PsmuxMultiplexer().switch_client("ctl:%9", last_fallback=True) is False
+    assert not any(c[1] == "switch-client" for c in calls)
+
+
 def test_psmux_switch_without_fallback_does_not_attempt_it(monkeypatch):
-    # Scripted for two probes though one is expected: dropping the `last_fallback`
-    # conjunct must fail this on its assertion, not on the counts running dry.
-    calls = _client_fake(monkeypatch, attached=["1", "1", "1", "1"])
+    # Scripted past the gate though the fallback is not expected: dropping the
+    # `last_fallback` conjunct must fail this on its assertion, not on the
+    # counts running dry.
+    calls = _client_fake(monkeypatch, attached=["1", "1", "1"], verb_rc=1)
     assert PsmuxMultiplexer().switch_client("ctl:%9") is False
     assert not any(c[1:3] == ["switch-client", "-l"] for c in calls)

--- a/tests/test_psmux_backend.py
+++ b/tests/test_psmux_backend.py
@@ -1901,11 +1901,20 @@ def test_psmux_switch_without_fallback_does_not_attempt_it(monkeypatch):
 
 
 def test_psmux_switch_failed_rc_on_an_empty_session_cannot_vouch(monkeypatch):
-    """The rc-nonzero twin of the gate above, and the row the tmux leaf was just
-    fixed for: `switch-client -t` refusing while nothing is attached here. The
-    refusal proves no switch happened — the first half of the seam's False — but
-    an empty session refutes the second half rather than supporting it, so the
-    joint claim is not available and the answer is None.
+    """The rc-nonzero twin of the gate above. Read what a nonzero rc means HERE
+    before reading across from tmux: the live gate bounds psmux's exit code from
+    both sides, and it does not divide the way tmux's does. A `-t` with nothing
+    to move exits ZERO on this backend (test_premise_client_verbs_exit_zero_...)
+    — psmux reports dispatch, not effect, which is the whole reason the count
+    gate exists — and rc goes nonzero for a target that cannot RESOLVE
+    (test_adopted_switch_client_rejects_an_unresolvable_target). So this state is
+    a stale target over an empty session, not tmux's "no current client", which
+    psmux never spends this code on.
+
+    That makes it an edge rather than the return path's common shape, and the
+    gate is still owed: the refusal proves no switch happened — the first half of
+    the seam's False — while a measured 0 refutes the second half rather than
+    supporting it, so the joint claim is not available and the answer is None.
 
     Scripted past the gate though no fallback is expected, so dropping the gate
     fails this on its assertion rather than on the counts running dry."""

--- a/tests/test_psmux_backend.py
+++ b/tests/test_psmux_backend.py
@@ -1763,6 +1763,24 @@ def test_psmux_switch_survives_a_transport_fault(monkeypatch):
     assert ["psmux", "switch-client", "-l"] in calls
 
 
+def test_psmux_switch_timeout_does_not_fall_back(monkeypatch):
+    """A timeout is the absence of an answer, not a failed switch: the server may
+    have moved the client before the wait ran out. Treating it as proven failure
+    fires `-l` at a client that already went where it was asked — the #659 drag,
+    which then manufactures the delta that reports it as a success."""
+    calls = _client_fake(monkeypatch, attached=["1", "1", "0"])
+    probing = tmux_base.subprocess.run
+
+    def stall(argv, **kwargs):
+        if argv[1:3] == ["switch-client", "-t"]:
+            raise subprocess.TimeoutExpired(argv, 30)
+        return probing(argv, **kwargs)
+
+    monkeypatch.setattr(tmux_base.subprocess, "run", stall)
+    assert PsmuxMultiplexer().switch_client("ctl:%9", last_fallback=True) is False
+    assert not any(c[1:3] == ["switch-client", "-l"] for c in calls)
+
+
 def test_psmux_switch_transport_fault_without_fallback_is_false(monkeypatch):
     _client_fake(monkeypatch, attached=["1", "1", "1"])
     probing = tmux_base.subprocess.run

--- a/tests/test_psmux_backend.py
+++ b/tests/test_psmux_backend.py
@@ -1898,3 +1898,69 @@ def test_psmux_switch_without_fallback_does_not_attempt_it(monkeypatch):
     calls = _client_fake(monkeypatch, attached=["1", "1", "1"], verb_rc=1)
     assert PsmuxMultiplexer().switch_client("ctl:%9") is False
     assert not any(c[1:3] == ["switch-client", "-l"] for c in calls)
+
+
+def test_psmux_switch_failed_rc_on_an_empty_session_cannot_vouch(monkeypatch):
+    """The rc-nonzero twin of the gate above, and the row the tmux leaf was just
+    fixed for: `switch-client -t` refusing while nothing is attached here. The
+    refusal proves no switch happened — the first half of the seam's False — but
+    an empty session refutes the second half rather than supporting it, so the
+    joint claim is not available and the answer is None.
+
+    Scripted past the gate though no fallback is expected, so dropping the gate
+    fails this on its assertion rather than on the counts running dry."""
+    calls = _client_fake(monkeypatch, attached=["0", "0", "0"], verb_rc=1)
+    assert PsmuxMultiplexer().switch_client("ctl:%9") is None
+    assert ["psmux", "switch-client", "-t", "ctl:%9"] in calls
+
+
+def test_psmux_switch_failed_rc_with_an_unreadable_count_cannot_vouch(monkeypatch):
+    """The gate's other half, pinned separately: a count that cannot be read at
+    all. `verb_rc=1` is what separates this from the rc-0 arm's None — the two
+    branches answer alike but are reached through opposite exit codes, so a
+    fixture that left the rc at 0 would grade the wrong gate."""
+    calls = _client_fake(monkeypatch, attached=["#{session_attached}"] * 3, verb_rc=1)
+    assert PsmuxMultiplexer().switch_client("ctl:%9") is None
+    assert ["psmux", "switch-client", "-t", "ctl:%9"] in calls
+
+
+def test_psmux_switch_transport_fault_on_an_empty_session_cannot_vouch(monkeypatch):
+    """A spawn-level fault proves the verb never ran, which is why its sibling
+    (a client measurably here) stays False. It says nothing about whether anyone
+    is at this terminal, and that half is already in hand: the gate count is read
+    BEFORE the verb, so this leaf can answer it on the fault exit too, where a
+    probe taken afterwards would only be measuring the broken transport."""
+    _client_fake(monkeypatch, attached=["0", "0", "0"])
+    probing = tmux_base.subprocess.run
+
+    def boom(argv, **kwargs):
+        if argv[1:3] == ["switch-client", "-t"]:
+            raise OSError("psmux vanished mid-call")
+        return probing(argv, **kwargs)
+
+    monkeypatch.setattr(tmux_base.subprocess, "run", boom)
+    assert PsmuxMultiplexer().switch_client("ctl:%9") is None
+
+
+def test_psmux_switch_fallback_transport_fault_on_an_empty_session_cannot_vouch(monkeypatch):
+    """The same rule one level down. `_client_left`'s fault exit answered False
+    without consulting the count it had already taken, which its own docstring
+    forbids — None when the session had nobody on it to begin with — and the
+    fallback leg is the path that carried it back to the seam.
+
+    The dispatch is recorded inside the fault, not read off `calls`: the raise
+    pre-empts the fixture, so "the fallback faulted" and "the fallback was never
+    reached" would otherwise assert the same."""
+    _client_fake(monkeypatch, attached=["0", "0", "0"], verb_rc=1)
+    probing = tmux_base.subprocess.run
+    dispatched: list[list[str]] = []
+
+    def boom(argv, **kwargs):
+        if argv[1:3] == ["switch-client", "-l"]:
+            dispatched.append(list(argv))
+            raise OSError("psmux vanished mid-call")
+        return probing(argv, **kwargs)
+
+    monkeypatch.setattr(tmux_base.subprocess, "run", boom)
+    assert PsmuxMultiplexer().switch_client("ctl:%9", last_fallback=True) is None
+    assert dispatched == [["psmux", "switch-client", "-l"]]

--- a/tests/test_psmux_backend.py
+++ b/tests/test_psmux_backend.py
@@ -1763,6 +1763,17 @@ def test_psmux_switch_survives_a_transport_fault(monkeypatch):
     assert ["psmux", "switch-client", "-l"] in calls
 
 
+def test_psmux_switch_failed_rc_with_empty_session_still_dispatches_the_fallback(monkeypatch):
+    """The one released `-l` with nobody attached here: a failed `-t` frees the
+    fallback regardless of the gate, and `_client_left` then dispatches it and
+    answers on its own delta (0 -> 0 reads False). Pinned as the fallback leg's
+    pre-#659 shape — skipping `-l` on an empty session would be a behavior
+    change with its own review, not a side effect of the verdict split."""
+    calls = _client_fake(monkeypatch, attached=["0", "0", "0"], verb_rc=1)
+    assert PsmuxMultiplexer().switch_client("ctl:%9", last_fallback=True) is False
+    assert ["psmux", "switch-client", "-l"] in calls
+
+
 def test_psmux_switch_timeout_does_not_fall_back(monkeypatch):
     """A timeout is the absence of an answer, not a failed switch: the server may
     have moved the client before the wait ran out. Treating it as proven failure

--- a/tests/test_psmux_live.py
+++ b/tests/test_psmux_live.py
@@ -343,8 +343,8 @@ def test_premise_client_verbs_exit_zero_with_no_client_to_move(probe):
     # when pytest itself runs inside psmux, so it is deliberately unobservable.
     proc = mux._run(["switch-client", "-t", windows[0]], check=False, env=clientless)
     assert proc.returncode == 0, (
-        "psmux now reports effect rather than dispatch for switch-client — the "
-        "#{session_attached} delta in _client_left can go back to trusting rc"
+        "psmux now reports effect rather than dispatch for switch-client -t — the "
+        "attached-count gate in switch_client is droppable and rc alone can answer"
     )
 
 
@@ -455,6 +455,33 @@ def test_adopted_select_window_focuses_a_qualified_window_id(probe):
     assert _active_window(mux, session) == windows[0], (
         "psmux no longer focuses `select-window -t session:@N` — the override "
         "dropped on the 3.3.8 floor (psmux/psmux#497) is needed again"
+    )
+
+
+def test_adopted_switch_client_rejects_an_unresolvable_target(probe):
+    mux, session, _ = probe
+    # The half of switch_client's verdict that needs no attached client: rc is
+    # honest in the FAILURE direction, which is what lets the `-t` leg read it at
+    # all — and what its `-l` fallback hangs on. Green with zero clients here and
+    # green in the premise probe above (rc 0 with nothing to move) are what bound
+    # rc between them — neither alone would justify trusting it (#659).
+    #
+    # Same scrub as that premise probe, and the same reason: pytest may itself be
+    # running inside psmux, and a raw client verb issued with an inherited $TMUX
+    # addresses the developer's server. Here it would also decide the rc — a
+    # target unresolvable on THAT server proves nothing about this one.
+    clientless = {
+        key: value for key, value in os.environ.items() if key not in ("TMUX", "TMUX_PANE")
+    }
+    # `=session:%N` is what current_return_target composes and switch_client is
+    # handed, so probe that grammar rather than the bare one (psmux strips the
+    # leading `=`, but the rc under test belongs to the argv production emits).
+    target = mux.target(session, "%9999")
+    proc = mux._run(["switch-client", "-t", target], check=False, env=clientless)
+    assert proc.returncode != 0, (
+        "psmux now exits 0 for a switch-client target that cannot resolve — rc no "
+        "longer separates a failed switch from a real one, so switch_client's "
+        "verdict and its `-l` fallback both lose their source"
     )
 
 

--- a/tests/test_tui_launch.py
+++ b/tests/test_tui_launch.py
@@ -1569,24 +1569,42 @@ def test_detach_client_argv(fake_run):
 
 
 def _return_fake(
-    monkeypatch, *, win="@5", option="=main:%9", switch_rc=0, fallback_rc=0, detach_rc=0
+    monkeypatch,
+    *,
+    win="@5",
+    option="=main:%9",
+    switch_rc=0,
+    fallback_rc=0,
+    detach_rc=0,
+    switch_exc=None,
+    attached="1",
 ):
     """Script tmux for return_attached_client: display-message -> window id,
     show-options -> the recorded RETURN_OPTION, switch-client -t -> switch_rc,
     switch-client -l -> fallback_rc, detach-client -> detach_rc.
     return_attached_client runs inside a ctl window, so TMUX is set (the
-    backend's current_window_id answers None otherwise)."""
+    backend's current_window_id answers None otherwise).
+
+    ``attached`` answers `#{session_attached}`, which switch_client's FAILURE
+    path reads to tell "that target is unreachable" from "there is no client
+    here at all" — tmux spends one nonzero rc on both. None makes the read
+    itself fail. It defaults to "1" because a client sitting in this window is
+    the premise of every case that expects ATTENDED."""
     monkeypatch.setenv("TMUX", "/tmp/tmux-1000/default,123,0")
     calls: list[list[str]] = []
 
     def fake(argv, **kwargs):
         calls.append(list(argv))
         verb = argv[1]
-        if verb == "display-message":
+        if verb == "display-message" and argv[-1] == "#{session_attached}":
+            out, rc = (f"{attached}\n", 0) if attached is not None else ("", 1)
+        elif verb == "display-message":
             out, rc = (f"{win}\n", 0) if win is not None else ("", 1)
         elif verb == "show-options":
             out, rc = (f"{option}\n" if option else "", 0)
         elif verb == "switch-client" and argv[2] == "-t":
+            if switch_exc is not None:
+                raise switch_exc
             out, rc = "", switch_rc
         elif verb == "switch-client" and argv[2] == "-l":
             out, rc = "", fallback_rc
@@ -1620,12 +1638,64 @@ def test_return_attached_client_switch_fallback(monkeypatch):
 
 
 def test_return_attached_client_switch_fails_stays_attended(monkeypatch):
-    """Stale target plus no last client: the client never left this window, so
-    the human is still in front of it — ATTENDED, and RETURN_OPTION stays set
-    or the post-exit trailer loses its retry."""
-    calls = _return_fake(monkeypatch, option="=main:%9", switch_rc=1, fallback_rc=1)
+    """Stale target plus no last client, with a client still attached here: the
+    refusal is a real one, the client never left this window, and the human is
+    in front of it — ATTENDED, and RETURN_OPTION stays set or the post-exit
+    trailer loses its retry.
+
+    The attached count is what earns that claim rather than assuming it; the two
+    tests below are the same rc with the count answering differently."""
+    calls = _return_fake(monkeypatch, option="=main:%9", switch_rc=1, fallback_rc=1, attached="1")
     assert launch.return_attached_client() is launch.ReturnOutcome.ATTENDED
     assert ["tmux", "switch-client", "-l"] in calls  # fallback was attempted
+    assert not any(c[1] == "set-option" for c in calls)  # option survives
+
+
+def test_return_attached_client_switch_fails_with_no_client_is_unreachable(monkeypatch):
+    """tmux spends ONE nonzero rc on two different facts. Measured on 3.7c from
+    inside a pane whose server had no attached client, `-t <live session>`,
+    `-t <other session>`, `-l` and `-t <nonexistent>` all exit 1 with "no current
+    client" — so a bare rc reads "nobody is here" as "the client is still here".
+    That is #659's hazard on the DEFAULT backend: the sweep keeps prompting a
+    window no one is viewing and a later --repeat cycle blocks on input().
+
+    Same rc as the test above; only the count differs, which is the whole point.
+    The option survives — nothing was handed back, so a real return is still
+    owed."""
+    calls = _return_fake(monkeypatch, option="=main:%9", switch_rc=1, fallback_rc=1, attached="0")
+    assert launch.return_attached_client() is launch.ReturnOutcome.UNREACHABLE
+    assert ["tmux", "switch-client", "-l"] in calls  # the fallback still ran
+    assert not any(c[1] == "set-option" for c in calls)
+
+
+def test_return_attached_client_switch_fails_with_an_unreadable_count_is_unreachable(monkeypatch):
+    """The count probe itself fails, so the rc stays two facts wide and neither
+    can be ruled out. Unreadable and zero are different facts that meet at the
+    same verdict: neither vouches that a human is still in front of this
+    window."""
+    calls = _return_fake(monkeypatch, option="=main:%9", switch_rc=1, fallback_rc=1, attached=None)
+    assert launch.return_attached_client() is launch.ReturnOutcome.UNREACHABLE
+    assert not any(c[1] == "set-option" for c in calls)
+
+
+def test_return_attached_client_unvouched_switch_is_unreachable(monkeypatch):
+    """A switch whose answer never arrived: the server may already have put the
+    client on the target, so this must not report that a human is still in front
+    of this window. UNREACHABLE stops the prompting a later --repeat cycle would
+    block on, and RETURN_OPTION survives so a real hand-back is still owed.
+
+    ATTENDED here is #659's hazard one seam up, and the surviving option is no
+    rescue for it: the parked trailer sits behind the same blocking read the
+    stuck cycle never reaches. The `-l` leg must stay unreached too — firing it
+    at a client that already went where it was asked is the drag itself."""
+    calls = _return_fake(
+        monkeypatch,
+        option="=main:%9",
+        switch_exc=subprocess.TimeoutExpired(["tmux"], 30),
+    )
+    assert launch.return_attached_client() is launch.ReturnOutcome.UNREACHABLE
+    assert ["tmux", "switch-client", "-t", "=main:%9"] in calls
+    assert ["tmux", "switch-client", "-l"] not in calls
     assert not any(c[1] == "set-option" for c in calls)  # option survives
 
 


### PR DESCRIPTION
`PsmuxMultiplexer.switch_client` decided whether a client moved from the session's attached-client count. A same-session move cannot change that count — and same-session is the common shape for the parked-window return path, whose target is recorded from inside the control session. So the switch landed the client correctly, the delta read no change, and the verdict was `False`.

With `last_fallback=True` — which is exactly how `tui.launch.return_attached_client` calls it — that wrong verdict then fired `switch-client -l`. `-l` has no target form: it relocated the operator into an unrelated session, and *that* produced the delta the correct move never could, so the call returned `True`, `return_attached_client` reported `RETURNED`, and it cleared the return option so the parked trailer would never retry.

Right move, undone, reported as success.

## What changed

`switch-client -t`'s **exit code** is the verdict, gated on a client having been attached to this session — the count read *before* the verb, since a successful move can take the client off the session. The `-l` fallback hangs on that rc alone: an rc-0 switch the gate merely cannot vouch for is still a switch that happened or a no-op that moved nobody, and firing `-l` there is the same drag in a narrower window. This is the `$LASTEXITCODE -ne 0` rule `_parked_trailer` has always used, and the shape the tmux leaf already has.

A `TimeoutExpired` is treated as neither: the server may have completed the switch before the wait expired, so it answers `False` without falling back and leaves the retry to the caller, which still holds its return option.

The attached-count **delta** remains the verdict for `switch-client -l` and `detach-client`, where rc proves dispatch and not effect.

## Measured

`psmux 3.3.8 (66cf613)`, Windows 11, real attached client, before → after:

| Scenario | before | after |
| --- | --- | --- |
| same-session switch, no last session | `False` (client had moved) | `True`, client stays put |
| same-session switch, last session in reach | `True` — client dragged into the other session | `True`, client stays put, other session untouched |
| `return_attached_client()` on the real path | `RETURNED`, client thrown to another session, option cleared | `RETURNED`, client on the armed target, option cleared |
| unresolvable target | — | rc nonzero, fallback relocates, delta reports it honestly |
| no client attached to this session | `-l` dispatched anyway | no `-l`; answers `ATTENDED` |

The measurements come from an attended-console rig: a real psmux client attached in a terminal, every verb issued from an in-pane executor, and the landing read back objectively from `#{session_attached}` plus the session's active window rather than from a human's report.

## Tests

- `tests/test_psmux_backend.py` — the client-verb cases re-cut against the new matrix: same-session move answers `True` with no `-l`; a gate the count cannot vouch for answers `False` with no `-l`; nothing attached answers `False` with no `-l`; a failed `-t` releases the fallback; a timeout does not. Both regression tests were ablated — reverting the code fails them on their own assertions, not on a fixture running dry.
- `_client_fake` gained `drains_on_switch`, so the session can empty *because* the verb ran. Without it the gate count's read order is not an observable input and the "read it before the verb" rule cannot be pinned.
- `tests/test_psmux_live.py` — new `test_adopted_switch_client_rejects_an_unresolvable_target` pins rc honesty in the failure direction (no attached client needed, so it runs in the same zero-token gate), in production's `=session:%N` target grammar and with the same client scrub its sibling premise probe documents.

`uv run pytest`, `uv run pyright`, `trunk check` clean; the live gate is 10/10 on the 3.3.8 box and still consumes zero tokens.

## Docs

The module docstring and `docs/adapter-authoring-guide.md` both still described the drop as the measure for *both* client verbs, and the guide cited psmux's deleted `Residue:` note as its worked example of a degradation ledger. Both rewritten; the guide now also says a fallback verb belongs to the same audit — hang it on the primary verb's failure, never on "the primary could not be vouched for".

Closes #659


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when returning to attached clients, including same-session and cross-session switches.
  - Prevented uncertain switch results from being reported as confirmed failures.
  - Improved handling of timeouts, unavailable client state, transport errors, missing clients, and invalid targets.
  - Prevented repeated prompts when a client disconnects during a sweep.
  - Refined fallback behavior to avoid unnecessary or conflicting switch attempts.

- **Documentation**
  - Clarified client-switching outcomes and transport behavior for adapter authors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->