### PR TITLE
fix(psmux): pin display-message self-probes to the calling pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,12 +27,13 @@ breaking changes may land in a minor release.
   the return option survives, but the sweep goes unattended instead of blocking a later `--repeat`
   cycle on `input()`. `False` now carries the joint claim its caller always read it as. Out-of-tree
   backends answering a plain bool still work; `detach_client` is unchanged.
-- psmux probes (`current_window_id`, `current_pane_id`, `current_session`,
-  `current_return_target`) now
-  pin `display-message` to the calling pane via `TMUX_PANE`; a target-less probe
-  answered for the server's _active_ window, so a caller in a non-active window could
-  prune its own window or record another window's return target (#669). With `TMUX`
-  set but `TMUX_PANE` unset the probe returns `None` instead of running unpinned.
+- **A psmux probe now answers for the calling pane, not the focused window (#669).** A target-less
+  `display-message -p` resolves the server's _active_ window, so `current_window_id`,
+  `current_pane_id`, `current_session` and `current_return_target` answered for a foreign window
+  whenever the caller's own window was not the focused one — the ctl prune could kill the window it
+  was running in, and the attach return could record a pane the human never came from. The probes
+  now pin to the calling pane via `TMUX_PANE`, and answer `None` without spawning when that value
+  is absent or not pane-shaped.
 
 ## [0.11.0] — 2026-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ breaking changes may land in a minor release.
 
 ## [Unreleased]
 
+### Fixed
+
+- psmux probes (`current_window_id`, `current_pane_id`, `current_session`,
+  `current_return_target`) now
+  pin `display-message` to the calling pane via `TMUX_PANE`; a target-less probe
+  answered for the server's _active_ window, so a caller in a non-active window could
+  prune its own window or record another window's return target (#669). With `TMUX`
+  set but `TMUX_PANE` unset the probe returns `None` instead of running unpinned.
+
 ## [0.11.0] — 2026-08-19
 
 ### Added

--- a/src/bmad_loop/adapters/psmux_backend.py
+++ b/src/bmad_loop/adapters/psmux_backend.py
@@ -723,6 +723,38 @@ class PsmuxMultiplexer(BaseTmuxBackend):
         except (subprocess.SubprocessError, OSError, TmuxError) as exc:
             print(f"warning: kill-window key cleanup failed on {session}: {exc}", file=sys.stderr)
 
+    def _display_message(self, fmt: str) -> str | None:
+        # The base's target-less probe resolves the server's *active* window on
+        # psmux, so every inherited probe (current_window_id / current_pane_id /
+        # current_session / current_return_target) answers for a foreign window
+        # whenever this process's window is not the focused one (gh-669): the
+        # ctl prune's own-window exclusion lands on the wrong window, and the
+        # attach return records a pane the human never came from. Pin the probe
+        # to the calling pane, exactly as _parked_trailer already does in pwsh:
+        # psmux sets TMUX_PANE in every pane, and a bare `%N` target resolves
+        # globally via DisplayMessageById. Still a probe rather than a
+        # short-circuit to the env value — the round trip also verifies the
+        # pane is live (a dead id exits nonzero, hence None). TMUX guard first,
+        # as in the base; with TMUX set but TMUX_PANE unset the probe is
+        # unpinnable, and an unpinnable probe must not answer for a foreign
+        # window — None without spawning.
+        if not os.environ.get("TMUX"):
+            return None
+        pane = os.environ.get("TMUX_PANE")
+        if not pane:
+            return None
+        # Measured on 3.3.8: an `@N`-shaped or live-session-name value in the
+        # target slot resolves rc=0 to the ACTIVE window — the foreign answer
+        # this override exists to eliminate — while plain garbage fails closed
+        # at rc!=0. Only a pane-shaped value may reach `-t`.
+        if not re.fullmatch(r"%\d+", pane):
+            return None
+        try:
+            proc = self._run(["display-message", "-p", "-t", pane, fmt], check=False)
+        except (subprocess.SubprocessError, OSError):
+            return None
+        return proc.stdout.strip() if proc.returncode == 0 else None
+
     # What _qualified_window_id composes: `<session>:@<n>`. The session part
     # excludes `:` because that is exactly when qualification degrades to a bare
     # id; requiring `@<digits>` keeps a `=session:window-name` token out — which

--- a/tests/test_psmux_backend.py
+++ b/tests/test_psmux_backend.py
@@ -357,6 +357,7 @@ def _probe_fake(monkeypatch, answers: dict[str, tuple[int, str]]):
         return subprocess.CompletedProcess(argv, rc, stdout=out, stderr="")
 
     monkeypatch.setenv("TMUX", "/tmp/psmux-1000/default,123,0")  # inside psmux
+    monkeypatch.setenv("TMUX_PANE", "%9")  # the pane the probes pin to (gh-669)
     monkeypatch.setattr(tmux_base.subprocess, "run", fake)
 
 
@@ -703,10 +704,11 @@ def test_current_window_id_resolves_session_and_id_in_one_probe(monkeypatch):
     # own window and kill it. One expansion yields both parts or neither.
     recorder = _RecordRun(stdout="ctl:@2\n")
     monkeypatch.setenv("TMUX", "/tmp/psmux-1000/default,123,0")
+    monkeypatch.setenv("TMUX_PANE", "%9")
     monkeypatch.setattr(tmux_base.subprocess, "run", recorder)
     assert PsmuxMultiplexer().current_window_id() == "ctl:@2"
     assert len(recorder.calls) == 1
-    assert recorder.argv[1:] == ["display-message", "-p", _CURRENT_FMT]
+    assert recorder.argv[1:] == ["display-message", "-p", "-t", "%9", _CURRENT_FMT]
 
 
 def test_current_window_id_none_outside_mux(monkeypatch):
@@ -716,6 +718,55 @@ def test_current_window_id_none_outside_mux(monkeypatch):
     rec = _RecordRun()
     monkeypatch.setattr(tmux_base.subprocess, "run", rec)
     assert PsmuxMultiplexer().current_window_id() is None
+    assert rec.calls == []
+
+
+def test_display_message_pins_probe_to_the_calling_pane(monkeypatch):
+    # A target-less display-message resolves the server's *active* window on
+    # psmux, answering for a foreign window whenever the caller's window is not
+    # focused (gh-669) — every probe must carry `-t $TMUX_PANE`.
+    recorder = _RecordRun(stdout="%4\n")
+    monkeypatch.setenv("TMUX", "/tmp/psmux-1000/default,123,0")
+    monkeypatch.setenv("TMUX_PANE", "%4")
+    monkeypatch.setattr(tmux_base.subprocess, "run", recorder)
+    assert PsmuxMultiplexer().current_pane_id() == "%4"
+    assert len(recorder.calls) == 1  # the pinned probe, and nothing unpinned
+    assert recorder.argv[1:] == ["display-message", "-p", "-t", "%4", "#{pane_id}"]
+
+
+def test_display_message_unpinnable_probe_is_refused(monkeypatch):
+    # TMUX set but TMUX_PANE unset: the probe cannot be pinned, and an
+    # unpinnable probe would answer for whichever window is active — None
+    # without spawning, never a target-less display-message (gh-669).
+    monkeypatch.setenv("TMUX", "/tmp/psmux-1000/default,123,0")
+    monkeypatch.delenv("TMUX_PANE", raising=False)
+    rec = _RecordRun()
+    monkeypatch.setattr(tmux_base.subprocess, "run", rec)
+    assert PsmuxMultiplexer().current_window_id() is None
+    assert rec.calls == []
+
+
+def test_display_message_non_pane_shaped_tmux_pane_is_refused(monkeypatch):
+    # Measured on 3.3.8: an `@N`-shaped (or live-session-name) target resolves
+    # rc=0 to the ACTIVE window — a foreign answer the rc cannot catch, unlike
+    # plain garbage, which fails closed at rc!=0 — so a TMUX_PANE that is not
+    # pane-shaped must never reach `-t` (gh-669).
+    monkeypatch.setenv("TMUX", "/tmp/psmux-1000/default,123,0")
+    monkeypatch.setenv("TMUX_PANE", "@3")
+    rec = _RecordRun()
+    monkeypatch.setattr(tmux_base.subprocess, "run", rec)
+    assert PsmuxMultiplexer().current_window_id() is None
+    assert rec.calls == []
+
+
+def test_display_message_none_outside_mux_even_with_pane_var(monkeypatch):
+    # The base's TMUX guard survives the override: a stale TMUX_PANE in the
+    # environment of a plain shell must not conjure an "inside psmux" answer.
+    monkeypatch.delenv("TMUX", raising=False)
+    monkeypatch.setenv("TMUX_PANE", "%4")
+    rec = _RecordRun()
+    monkeypatch.setattr(tmux_base.subprocess, "run", rec)
+    assert PsmuxMultiplexer().current_pane_id() is None
     assert rec.calls == []
 
 
@@ -1601,6 +1652,7 @@ def _client_fake(monkeypatch, *, attached, session="ctl", verb_rc=0):
     code says nothing, which is the whole point).
     """
     monkeypatch.setenv("TMUX", "/tmp/psmux-1000/default,123,0")  # inside a pane
+    monkeypatch.setenv("TMUX_PANE", "%9")  # the pane the probes pin to (gh-669)
     counts = list(attached)
     calls: list[list] = []
 

--- a/tests/test_psmux_live.py
+++ b/tests/test_psmux_live.py
@@ -396,6 +396,35 @@ def test_premise_option_values_survive_the_control_line(probe):
     )
 
 
+def test_premise_target_less_display_message_ignores_tmux_pane(probe):
+    mux, session, windows = probe
+    # The founding divergence of the _display_message pin (gh-669): psmux
+    # resolves a target-less display-message against the server's ACTIVE
+    # window, ignoring the caller's TMUX_PANE.
+    mux.select_window(windows[1])
+    assert (
+        _active_window(mux, session) == windows[1]
+    ), "probe setup: could not focus the probe's other window"
+    panes = mux._run(["list-panes", "-t", windows[0], "-F", "#{pane_id}"], check=False)
+    assert panes.returncode == 0, f"probe setup: list-panes failed: {panes.stderr.strip()!r}"
+    pane = panes.stdout.split()[0] if panes.stdout.split() else ""
+    assert re.fullmatch(r"%\d+", pane), f"probe setup: unexpected pane id {pane!r}"
+    env = _new_session_env()
+    for var in ("TMUX", "PSMUX_TARGET_SESSION", "PSMUX_TARGET_FULL"):
+        env.pop(var, None)
+    env["TMUX_PANE"] = pane  # a caller in a NON-active window, as psmux sets it
+    answered = mux._run(["display-message", "-p", "#{window_id}"], check=False, env=env)
+    assert (
+        answered.returncode == 0
+    ), f"probe setup: target-less display-message failed: {answered.stderr.strip()!r}"
+    active = windows[1].rsplit(":", 1)[1]
+    assert answered.stdout.strip() == active, (
+        "psmux now resolves a target-less display-message via the caller's "
+        "TMUX_PANE instead of the active window — the `-t $TMUX_PANE` pin in "
+        "psmux_backend._display_message (gh-669) has become droppable"
+    )
+
+
 # ------------------------------------------------- adopted-behavior probes
 #
 # The mirror image of the premise probes above. Those guarded workarounds and
@@ -486,4 +515,41 @@ def test_adopted_unresolvable_kill_target_exits_nonzero_and_spares_live_windows(
     assert after == before, (
         "an unresolvable kill-window target destroyed a live window again "
         f"(psmux/psmux#545): {sorted(before)} -> {sorted(after)}"
+    )
+
+
+def test_adopted_display_message_pane_target_resolves_globally(probe):
+    mux, session, windows = probe
+    # The premise the psmux _display_message override rests on (gh-669): a bare
+    # `%N` display-message target resolves globally across windows
+    # (DisplayMessageById, psmux/psmux#332), so a probe pinned to a pane of a
+    # NON-active window answers that window — while a target-less probe answers
+    # whichever window has focus. Focus the other window first, so a green here
+    # is genuine cross-window resolution, not the active window by accident.
+    mux.select_window(windows[1])
+    assert (
+        _active_window(mux, session) == windows[1]
+    ), "probe setup: could not focus the probe's other window"
+    panes = mux._run(["list-panes", "-t", windows[0], "-F", "#{pane_id}"], check=False)
+    assert panes.returncode == 0, f"probe setup: list-panes failed: {panes.stderr.strip()!r}"
+    pane = panes.stdout.split()[0] if panes.stdout.split() else ""
+    assert re.fullmatch(r"%\d+", pane), f"probe setup: unexpected pane id {pane!r}"
+    # Route by registry (the probe session is the isolated registry's only — and
+    # otherwise its most recent — session): a bare `%N` target carries no session,
+    # and this process's own $TMUX, when running inside a mux, would route the
+    # probe to the wrong server entirely.
+    env = _new_session_env()
+    for var in ("TMUX", "PSMUX_TARGET_SESSION", "PSMUX_TARGET_FULL"):
+        env.pop(var, None)
+    answered = mux._run(["display-message", "-p", "-t", pane, "#{window_id}"], check=False, env=env)
+    assert answered.returncode == 0, (
+        "psmux no longer answers a bare `%N` display-message target "
+        f"(psmux/psmux#332): {answered.stderr.strip()!r}"
+    )
+    expected = windows[0].rsplit(":", 1)[1]
+    assert answered.stdout.strip() == expected, (
+        "a pane-pinned display-message no longer resolves the pane's own window "
+        "across window focus (DisplayMessageById, psmux/psmux#332) — the "
+        "TMUX_PANE pin in psmux_backend._display_message answers for the "
+        f"active window again: expected {expected!r}, got {answered.stdout.strip()!r}"
     )


### PR DESCRIPTION
A target-less `display-message -p` on psmux resolves the **server's active window**, not the calling pane, so `current_window_id()`, `current_pane_id()`, `current_session()` and `current_return_target()` answered for a foreign window whenever the caller's window was not the focused one. The ctl prune's own-window exclusion could land on an unrelated window (a prune run from a non-active ctl window could kill the window it was running in), and the attach return could record and replay a pane the human never came from.

## Fix

- `PsmuxMultiplexer` now overrides `_display_message` to pin the probe with `-t $TMUX_PANE`, exactly as the pwsh parked trailer already did — one chokepoint, all four inherited probes fixed. The tmux base is untouched (its behavior for the target-less form is unmeasured).
- Fail closed instead of answering for a foreign window: `None` without spawning when `TMUX_PANE` is absent, and when it holds a non-`%N`-shaped value — measured on psmux 3.3.8: `@N`-shaped values and a live session name resolve rc=0 to the *active* window, while plain garbage already exits nonzero.

## Tests

- Unit: pinned argv asserted exactly (single spawn); three refusal paths (`TMUX` unset, `TMUX_PANE` unset, non-pane-shaped) each proven ablation-red — `None` with zero subprocess calls.
- Live gate (real psmux 3.3.8, zero tokens): a new `test_premise_*` probe observes the founding divergence itself — it goes red the day psmux starts honoring `TMUX_PANE` for target-less probes, signalling the pin is droppable — and a new `test_adopted_*` probe covers the global bare-`%N` resolution (`DisplayMessageById`) the pin rides on. 11/11 passing on a Windows host.
- Smoke-verified end to end with a real attached client: with the client focused on another window, the fixed probes answer the caller's own window/pane; the target-less form still answers the active window.

Closes #669

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved psmux probing to target the calling pane reliably.
  - Prevented unpinned queries when pane context is unavailable or invalid.
  - Avoided incorrect results caused by changes to the active window.

- **Tests**
  - Added coverage for pane-targeted queries, missing context, invalid pane identifiers, and execution failures.
  - Added live checks for behavior across window focus changes.

- **Documentation**
  - Documented the psmux probe targeting fix in the unreleased changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->