### PR TITLE
chore(verify): remove the dead `same_commit` helper; record a measured ablation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,10 @@ breaking changes may land in a minor release.
 
 ### Removed
 
-- **Dropped `verify.same_commit`, which no longer had a caller.** Its last call site went with
-  #645's `_canonical_commit_oid`, which resolves both sides to a canonical full object id and
-  compares them exactly. The helper's prefix-tolerant equality — either argument a prefix of the
-  other once both reach 7 characters — would have handed that looseness back to whichever caller
-  reached for it next.
+- **`verify.same_commit` is gone — nothing called it.** #645's `_canonical_commit_oid` displaced
+  its last call site and compares canonical full object ids exactly. The helper's leftover
+  prefix-tolerant equality — either argument a prefix of the other once both reach 7 characters —
+  would have handed that looseness to whichever caller reached for it next.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ breaking changes may land in a minor release.
 
 ## [Unreleased]
 
+### Removed
+
+- **Dropped `verify.same_commit`, which no longer had a caller.** Its last call site went with
+  #645's `_canonical_commit_oid`, which resolves both sides to a canonical full object id and
+  compares them exactly. The helper's prefix-tolerant equality — either argument a prefix of the
+  other once both reach 7 characters — would have handed that looseness back to whichever caller
+  reached for it next.
+
 ### Fixed
 
 - **psmux: a hand-back that succeeded no longer reports as failed — or undoes itself (#659).**

--- a/src/bmad_loop/verify.py
+++ b/src/bmad_loop/verify.py
@@ -252,8 +252,8 @@ def git_bytes(
 
 def rev_parse_head(repo: Path) -> str:
     """The sha HEAD resolves to. Reads stdout alone (`_git_out`): git exits 0 while
-    still warning on stderr, and a warning-suffixed "sha" flows into `same_commit`
-    comparisons and into persisted run baselines (#442)."""
+    still warning on stderr, and a warning-suffixed "sha" flows into every commit
+    comparison and into persisted run baselines (#442)."""
     rc, out, detail = _git_out(repo, "rev-parse", "HEAD")
     if rc != 0:
         raise GitError(f"git rev-parse HEAD failed in {repo}: {detail}")
@@ -316,17 +316,6 @@ def worktree_clean(repo: Path) -> bool:
     return proc.stdout.strip() == ""
 
 
-def same_commit(a: str, b: str) -> bool:
-    """Hash equality tolerant of abbreviated forms (>= 7 chars); sessions
-    sometimes report `git rev-parse --short HEAD`. The 7 is git's *minimum* auto
-    abbreviation, not a fixed default: `core.abbrev` defaults to `auto`, which
-    scales the length with repository size and clamps upward to 7 only for small
-    repos, so there is no single "default --short length" to mirror."""
-    if len(a) < 7 or len(b) < 7:
-        return a == b
-    return a.startswith(b) or b.startswith(a)
-
-
 def is_ancestor(repo: Path, ancestor: str, descendant: str) -> bool:
     """True when `ancestor` is an ancestor of (or equal to) `descendant`.
 
@@ -346,7 +335,9 @@ def is_ancestor(repo: Path, ancestor: str, descendant: str) -> bool:
 # session stamped it. Hex spelling is necessary but insufficient: Git also permits
 # all-hex ref names. The stamp is `git rev-parse HEAD` output by contract, so requiring
 # a uniquely disambiguated direct commit costs a well-behaved session nothing. Length
-# floor mirrors `same_commit`'s 7; ceiling admits sha256.
+# floor is git's shortest auto abbreviation: with `core.abbrev` unset the length scales
+# with the repository's object count and clamps upward to 7 only for small repos, so
+# nothing git abbreviates on its own is shorter. Ceiling admits sha256.
 _OBJECT_ID = re.compile(r"\A[0-9a-fA-F]{7,64}\Z")
 
 

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -2001,8 +2001,8 @@ def test_verify_dev_bundle_single_char_ref_baseline_is_refused(project):
 def test_verify_dev_bundle_below_floor_abbreviation_is_refused(project):
     """Characterizes the deliberate 7-character floor on the bundle path: an
     abbreviation git itself resolves is still refused when it is shorter than
-    ``_OBJECT_ID``'s floor. That floor mirrors ``same_commit``'s 7; it is not a
-    length git derives (``core.abbrev`` defaults to ``auto``, which scales with
+    ``_OBJECT_ID``'s floor. That 7 is a constant the gate chooses, not a length
+    git derives (``core.abbrev`` defaults to ``auto``, which scales with
     repository size and clamps upward to 7 only for small repos, so there is no
     fixed default to mirror). The stamp is ``git rev-parse HEAD`` output by
     contract, so the floor costs a well-behaved session nothing, and
@@ -3682,7 +3682,7 @@ def test_worktree_clean_ignores_stderr_chatter_on_success(project, monkeypatch):
 
 
 def test_rev_parse_head_reads_stdout_alone_under_host_noise(project):
-    """A warning-suffixed "sha" is not a sha. It reaches `same_commit` comparisons
+    """A warning-suffixed "sha" is not a sha. It reaches every commit comparison
     and the baselines persisted in run state, so a resume grades a warning-carrying
     string against a clean one and reads "moved" — silent, with a plausible-looking
     value.

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -122,7 +122,17 @@ def test_attempt_dirty_tracked_change(project):
 
 
 def test_file_bytes_at_revision_distinguishes_blob_absence_tree_and_git_failure(project):
-    """The baseline oracle returns only proven blob bytes, never tree listings."""
+    """The baseline oracle returns only proven blob bytes, never tree listings.
+
+    Ablation: drop either side of ``entry is None or entry[1] != "blob"`` from
+    either oracle — four mutations, each reddening exactly one of the four ``is
+    None`` assertions. The absence side raises ``TypeError`` on the ``missing.bin``
+    case; the type side reddens the ``oracle`` case, and only there do the two
+    oracles differ. Plain ``cat-file blob`` is refused by git on a tree oid, so
+    that mutation still fails loudly; ``cat-file --filters`` instead renders the
+    tree's listing and hands it back as file content, which nothing but this
+    clause keeps out of a baseline comparison.
+    """
     repo = project.project
     nested = repo / "oracle" / "spec.bin"
     nested.parent.mkdir()

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -2011,10 +2011,10 @@ def test_verify_dev_bundle_single_char_ref_baseline_is_refused(project):
 def test_verify_dev_bundle_below_floor_abbreviation_is_refused(project):
     """Characterizes the deliberate 7-character floor on the bundle path: an
     abbreviation git itself resolves is still refused when it is shorter than
-    ``_OBJECT_ID``'s floor. That 7 is a constant the gate chooses, not a length
-    git derives (``core.abbrev`` defaults to ``auto``, which scales with
-    repository size and clamps upward to 7 only for small repos, so there is no
-    fixed default to mirror). The stamp is ``git rev-parse HEAD`` output by
+    ``_OBJECT_ID``'s floor. That 7 is the gate's own constant, set where git's
+    auto abbreviation bottoms out (``core.abbrev`` defaults to ``auto``, which
+    scales with repository size and clamps upward to 7 only for small repos, so
+    there is no fixed default to mirror). The stamp is ``git rev-parse HEAD`` output by
     contract, so the floor costs a well-behaved session nothing, and
     accepting shorter claims would re-admit prefix collisions the gate cannot
     distinguish from drift. The refusal is the floor's doing, not an


### PR DESCRIPTION
## What

Two housekeeping items carried out of the #647 review, both small and independent:

1. Remove `verify.same_commit` — dead production code — and restate the four prose references to it.
2. Record the measured ablation on `test_file_bytes_at_revision_distinguishes_blob_absence_tree_and_git_failure`, which asserted three refusals with no note of what a regression would look like.

## Why the helper goes

Its last call site went with #645's `_canonical_commit_oid`, which resolves both sides to a canonical full object id and compares them exactly. What was left is prefix-tolerant equality — either argument a prefix of the other once both reach 7 characters — with nothing calling it. That is precisely the looseness the gate spent #645 removing, sitting in the module as a ready-made shortcut for the next caller who needs to compare two shas.

**Proven dead, not grepped.** The repo's shell `grep` is `ugrep`, which exits silently on zero matches, so absence was established in Python instead: an AST scan over `src/` and `tests/` (161 files) walks every module for a `Name`, `Attribute`, or import alias binding `same_commit` and finds one def site and zero executable references. A textual sweep of every text file in the repo (244) then catches anything the AST cannot see — dynamic `getattr`, docs, config — and adds only four prose mentions, all restated here:

| Site (at `4650ca3f`) | What it said |
|---|---|
| `verify.py:255` | `rev_parse_head` — a warning-suffixed sha "flows into `same_commit` comparisons" |
| `verify.py:349` | the `_OBJECT_ID` length-floor comment — "Length floor mirrors `same_commit`'s 7" |
| `tests/test_verify.py:2004` | #647's floor-characterization docstring — "That floor mirrors `same_commit`'s 7" |
| `tests/test_verify.py:3685` | the rev-parse-under-noise docstring, same phrase as the first |

### The 7 survives the removal

#647 had just corrected this docstring (#674) rather than deleting it, and that correction is worth keeping: there is no fixed "default `--short` length" for the floor to mirror. `core.abbrev` defaults to `auto`, which scales the abbreviation with the repository's object count — 8 in this repo, 7 in the test sandbox — and clamps *upward* to 7 only for small repos. Both surviving statements of the floor now say the same thing — the 7 is the gate's own constant, set where git's auto abbreviation bottoms out — rather than one sourcing it from git and the other denying git derives it. Deleting the function removes the third copy of the claim rather than leaving a corrected docstring on an uncallable helper.

## The ablation, measured before it was written down

Per the repo's doctrine, a negative assertion is only trustworthy once the gate has been deleted and the test seen to fail. All four single-side mutations of `entry is None or entry[1] != "blob"` were run — both sides, both oracles, one at a time, each verified to change exactly one line. All four redden, and on four *disjoint* assertions, one per mutation:

| Mutation | Reddens | How |
|---|---|---|
| `file_bytes_at_revision`, absence side dropped | `missing.bin` | `TypeError: 'NoneType' object is not subscriptable` |
| `file_bytes_at_revision`, type side dropped | `oracle` | `GitError` — `cat-file blob <tree-oid>: bad file` |
| `worktree_file_bytes_at_revision`, absence side dropped | `missing.bin` | same `TypeError` |
| `worktree_file_bytes_at_revision`, type side dropped | `oracle` | **no exception** — returns tree-listing bytes |

The last row is the one the docstring now names, because the two oracles are not symmetric there. Plain `cat-file blob` is refused by git on a tree oid, so that leg fails loudly on its own. `cat-file --filters --path=` instead renders the tree's listing and hands it back as file content — `b'100644 spec.bin\x00<20 raw oid bytes>'` — which recovery would compare against a live file as if it were a baseline blob. That clause is the only thing standing between a caller and tree bytes, which is exactly the claim the test's summary line makes.

No mutation passed, so nothing here documents an uncaught guard side.

## Scope

No behavior change. One deleted function with no callers, four prose restatements, one test docstring. The `Removed` changelog entry covers the helper; the docstring work takes none.

## Testing

- `uv run pytest -q -n logical` → **6118 passed, 53 skipped**
- `uv run pyright` → **0 errors**
- `trunk check` → **no issues**
