### PR TITLE
fix(policy,adapters,plugins): typed errors for every user-authored TOML read (#440, #473)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,43 @@ breaking changes may land in a minor release.
 
 ### Fixed
 
+- **A policy field of the wrong TOML type now raises `PolicyError` naming `section.key`
+  (#440).** `loads()` coerced with bare `int()`/`float()`/`bool()`/`str()` outside the
+  `PolicyError` funnel, so a wrong-typed value escaped as a raw `ValueError` or
+  `TypeError` — past every `except (PolicyError, OSError)` degrade handler in the
+  codebase. `_configure_mux` runs before dispatch on _every_ command, so one bad
+  character in `.bmad-loop/policy.toml` traced back at you instead of being reported;
+  the TUI died at construction rather than falling back to defaults; and `validate --json`
+  exited before printing the document its one-object contract promises, which is now
+  emitted with the fault as an ordinary `policy` finding. #587 had fixed `[limits]` this
+  way; this finishes the sweep across `[verify]`, `[sweep]`, `[scm]`, `[cleanup]`,
+  `[notify]`, `[review]`, `[gates]`, `[stories]`, `[dev]`, `[adapter]` and its stage
+  tables, `[tui]`, `[operator]`, `[mux]`, and `[plugins]`, and `[limits]`' own messages
+  are unchanged. Two of these never announced themselves at all: `notify.desktop = "false"`
+  is a truthy string, so it turned the feature **on** (the hazard #278 recorded), and
+  `verify.commands = "pytest"` iterated a bare string into six one-character commands
+  that read back as applied configuration — both now refuse. Fields with an allowlist
+  (`gates.mode`, `review.trigger`, `mux.backend`, …) keep it and blame the type first
+  rather than reporting a coerced value that was never written. Valid policies parse
+  identically; `usage_grace_s = 30` is still a legal float, and an unset `extra_args`
+  still means "inherit the profile's flags" where `[]` means "none".
+- **An undecodable or unreadable profile overlay or plugin manifest is a typed error
+  naming the file, not a traceback (#473).** `load_profiles` and the plugin loader read
+  each `*.toml` with `read_text(encoding="utf-8")` in the _argument expression_ of the
+  parse call — ahead of the conversion funnel that wraps parsing, so widening that funnel
+  could never have caught it. A non-UTF-8 file therefore escaped as a raw
+  `UnicodeDecodeError` past consumers that all key on the domain error: `validate --json`
+  printed a bare `error:` line and an empty stdout instead of an `adapter.profile`
+  finding, `get_profile` backs every adapter resolution so the same escape reached
+  run/sweep preflight, and a non-UTF-8 project `plugin.toml` walked through the settings
+  screen's `except (PolicyError, PluginError)` and took that surface down at
+  construction. Both loaders now raise `ProfileError`/`PluginError` naming the offending
+  path, and both arms are covered — a file that is present but unreadable (permissions,
+  a dead mount) was leaking a bare `OSError` on the same route, since the existing
+  `is_dir()`/`is_file()` checks rule out absence and nothing else. The packaged built-ins
+  read through the same guard: they are trusted, but a corrupt install is a packaging bug
+  and should say so.
+
 - **Merge-back failures are classified from the measured tree state, and the catch-all stopped
   inventing a conflict (#619).** A merge that died part-way through its checkout — all three
   strategies, `--ff-only` included — now raises `MergeHalfAppliedError` instead of "refused

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,40 +18,28 @@ breaking changes may land in a minor release.
 
 - **A policy field of the wrong TOML type now raises `PolicyError` naming `section.key`
   (#440).** `loads()` coerced with bare `int()`/`float()`/`bool()`/`str()` outside the
-  `PolicyError` funnel, so a wrong-typed value escaped as a raw `ValueError` or
-  `TypeError` — past every `except (PolicyError, OSError)` degrade handler in the
-  codebase. `_configure_mux` runs before dispatch on _every_ command, so one bad
-  character in `.bmad-loop/policy.toml` traced back at you instead of being reported;
-  the TUI died at construction rather than falling back to defaults; and `validate --json`
-  exited before printing the document its one-object contract promises, which is now
-  emitted with the fault as an ordinary `policy` finding. #587 had fixed `[limits]` this
-  way; this finishes the sweep across `[verify]`, `[sweep]`, `[scm]`, `[cleanup]`,
-  `[notify]`, `[review]`, `[gates]`, `[stories]`, `[dev]`, `[adapter]` and its stage
-  tables, `[tui]`, `[operator]`, `[mux]`, and `[plugins]`, and `[limits]`' own messages
-  are unchanged. Two of these never announced themselves at all: `notify.desktop = "false"`
-  is a truthy string, so it turned the feature **on** (the hazard #278 recorded), and
-  `verify.commands = "pytest"` iterated a bare string into six one-character commands
-  that read back as applied configuration — both now refuse. Fields with an allowlist
-  (`gates.mode`, `review.trigger`, `mux.backend`, …) keep it and blame the type first
-  rather than reporting a coerced value that was never written. Valid policies parse
-  identically; `usage_grace_s = 30` is still a legal float, and an unset `extra_args`
-  still means "inherit the profile's flags" where `[]` means "none".
-- **An undecodable or unreadable profile overlay or plugin manifest is a typed error
-  naming the file, not a traceback (#473).** `load_profiles` and the plugin loader read
-  each `*.toml` with `read_text(encoding="utf-8")` in the _argument expression_ of the
-  parse call — ahead of the conversion funnel that wraps parsing, so widening that funnel
-  could never have caught it. A non-UTF-8 file therefore escaped as a raw
-  `UnicodeDecodeError` past consumers that all key on the domain error: `validate --json`
-  printed a bare `error:` line and an empty stdout instead of an `adapter.profile`
-  finding, `get_profile` backs every adapter resolution so the same escape reached
-  run/sweep preflight, and a non-UTF-8 project `plugin.toml` walked through the settings
-  screen's `except (PolicyError, PluginError)` and took that surface down at
-  construction. Both loaders now raise `ProfileError`/`PluginError` naming the offending
-  path, and both arms are covered — a file that is present but unreadable (permissions,
-  a dead mount) was leaking a bare `OSError` on the same route, since the existing
-  `is_dir()`/`is_file()` checks rule out absence and nothing else. The packaged built-ins
-  read through the same guard: they are trusted, but a corrupt install is a packaging bug
-  and should say so.
+  `PolicyError` funnel, so a wrong-typed value escaped every handler written to degrade on
+  one: `_configure_mux` runs before dispatch on _every_ command, so one bad character in
+  `.bmad-loop/policy.toml` traced back at you; the TUI died at construction instead of
+  falling back to defaults; and `validate --json` exited before printing the document its
+  one-object contract promises, which now carries the fault as an ordinary `policy` finding.
+  Two of these never announced themselves at all: `notify.desktop = "false"` is a truthy
+  string, so it turned the feature **on** (the hazard #278 recorded), and
+  `verify.commands = "pytest"` exploded into six one-character commands that read back as
+  applied configuration. Extends #587's `[limits]` sweep to every remaining section, with
+  `[limits]`' own messages unchanged; allowlisted fields blame the type first. Valid policies
+  parse identically — an unset `extra_args` still means "inherit the profile's flags" where
+  `[]` means "none".
+- **An undecodable or unreadable profile overlay or plugin manifest is a typed error naming
+  the file, not a traceback (#473).** `load_profiles` and the plugin loader read each
+  `*.toml` outside the funnel that converts parse faults, so a non-UTF-8 file escaped as a
+  raw `UnicodeDecodeError` past consumers that all key on the domain error: `validate --json`
+  printed a bare `error:` line and empty stdout instead of an `adapter.profile` finding,
+  `get_profile` carried it into run/sweep preflight, and a bad project `plugin.toml` took the
+  settings screen down at construction. Both loaders now raise `ProfileError`/`PluginError`
+  naming the path, on both arms — a file present but unreadable (permissions, a dead mount)
+  was leaking a bare `OSError` on the same route. The packaged built-ins read through the
+  same guard: a corrupt install is a packaging bug and should say so.
 
 - **Merge-back failures are classified from the measured tree state, and the catch-all stopped
   inventing a conflict (#619).** A merge that died part-way through its checkout — all three

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ breaking changes may land in a minor release.
   parse identically — an unset `extra_args` still means "inherit the profile's flags" where
   `[]` means "none".
 - **An undecodable or unreadable profile overlay or plugin manifest is a typed error naming
-  the file, not a traceback (#473).** `load_profiles` and the plugin loader read each
+  the file, not a traceback (#473, #689).** `load_profiles` and the plugin loader read each
   `*.toml` outside the funnel that converts parse faults, so a non-UTF-8 file escaped as a
   raw `UnicodeDecodeError` past consumers that all key on the domain error: `validate --json`
   printed a bare `error:` line and empty stdout instead of an `adapter.profile` finding,

--- a/src/bmad_loop/adapters/profile.py
+++ b/src/bmad_loop/adapters/profile.py
@@ -36,6 +36,7 @@ import importlib.metadata
 import tomllib
 from dataclasses import dataclass, field, replace
 from importlib import resources
+from importlib.resources.abc import Traversable
 from pathlib import Path
 
 import regex
@@ -449,6 +450,36 @@ def _parse_profile(doc: dict, source: str) -> CLIProfile:
     return profile
 
 
+def _read_profile_text(entry: Traversable | Path, source: str) -> str:
+    """Read a profile TOML as text, converting a read fault into ProfileError.
+
+    Not part of `_load_toml`'s CONVERSION_FAULTS funnel and not reachable by
+    widening it: that funnel wraps `_parse_profile`, and the decode happens in
+    the *argument expression* at both of `load_profiles`' call sites, before
+    `_load_toml` is entered. So a non-UTF-8 overlay escaped as a raw
+    `UnicodeDecodeError` (a ValueError) while every consumer keys its fault
+    handling on ProfileError — `validate`'s role loop crashed before printing
+    its `--json` document instead of reporting an `adapter.profile` failure
+    naming the file, and `get_profile` backs every adapter resolution, so the
+    same escape reached run/sweep preflight (#473). Both-arms precedent:
+    `stories.py`'s manifest read; the decode-only twin is `policy.load`.
+
+    Takes the packaged built-ins too. They are trusted, but a corrupt package
+    is a packaging bug and should say so with a typed error rather than a
+    traceback. One helper covers both call shapes: an `importlib.resources`
+    Traversable and a `Path` each expose ``read_text(encoding=...)``.
+    """
+    try:
+        return entry.read_text(encoding="utf-8")
+    except UnicodeDecodeError as e:
+        raise ProfileError(f"profile {source}: not valid UTF-8: {e}") from e
+    except OSError as e:
+        # A profile that is present but cannot be read — permissions, an I/O
+        # error, a dead mount. The overlay's `is_dir()` + glob rule out ABSENCE
+        # and nothing else, so this escaped as a bare OSError.
+        raise ProfileError(f"profile {source}: unreadable: {e}") from e
+
+
 def _load_toml(text: str, source: str) -> CLIProfile:
     try:
         doc = tomllib.loads(text)
@@ -577,7 +608,7 @@ def load_profiles(project: Path | None = None) -> dict[str, CLIProfile]:
     packaged = resources.files("bmad_loop.data").joinpath("profiles")
     for entry in sorted(packaged.iterdir(), key=lambda e: e.name):
         if entry.name.endswith(".toml"):
-            profile = _load_toml(entry.read_text(encoding="utf-8"), entry.name)
+            profile = _load_toml(_read_profile_text(entry, entry.name), entry.name)
             # Stamped HERE and nowhere else: this loop is the only code that knows
             # a profile came out of the package rather than off a project's disk.
             profiles[profile.name] = replace(profile, packaged=True)
@@ -586,7 +617,7 @@ def load_profiles(project: Path | None = None) -> dict[str, CLIProfile]:
         user_dir = project / USER_PROFILES_REL
         if user_dir.is_dir():
             for path in sorted(user_dir.glob("*.toml")):
-                profile = _load_toml(path.read_text(encoding="utf-8"), str(path))
+                profile = _load_toml(_read_profile_text(path, str(path)), str(path))
                 profiles[profile.name] = profile
     return profiles
 

--- a/src/bmad_loop/plugins/loader.py
+++ b/src/bmad_loop/plugins/loader.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import warnings
 from collections.abc import Iterator
 from importlib import resources
+from importlib.resources.abc import Traversable
 from pathlib import Path
 
 from . import trust
@@ -35,6 +36,35 @@ USER_PLUGINS_REL = Path(".bmad-loop") / "plugins"
 ENTRY_POINT_GROUP = "bmad_loop.plugins"
 
 
+def _read_manifest_text(toml: Traversable | Path, source: str) -> str:
+    """Read a plugin manifest as text, converting a read fault into PluginError.
+
+    Not reachable by widening `load_manifest`'s CONVERSION_FAULTS funnel: that
+    funnel wraps the manifest *parse*, and the decode happens in the argument
+    expression at both discovery call sites, before `load_manifest` is entered.
+    So a non-UTF-8 `plugin.toml` escaped as a raw `UnicodeDecodeError` (a
+    ValueError) while every consumer keys its fault handling on PluginError —
+    `tui/settings.py`'s `except (PolicyError, PluginError)` degrade let it
+    through and took the settings surface down at construction. The sibling
+    guard is `adapters/profile.py`'s `_read_profile_text` (#473); both-arms
+    precedent is `stories.py`'s manifest read.
+
+    Takes the packaged built-ins too. They are trusted, but a corrupt package
+    is a packaging bug and should say so with a typed error rather than a
+    traceback. One helper covers both call shapes: an `importlib.resources`
+    Traversable and a `Path` each expose ``read_text(encoding=...)``.
+    """
+    try:
+        return toml.read_text(encoding="utf-8")
+    except UnicodeDecodeError as e:
+        raise PluginError(f"plugin {source}: not valid UTF-8: {e}") from e
+    except OSError as e:
+        # A manifest that is present but cannot be read — permissions, an I/O
+        # error, a dead mount. Discovery's `is_file()` rules out ABSENCE and
+        # nothing else, so this escaped as a bare OSError.
+        raise PluginError(f"plugin {source}: unreadable: {e}") from e
+
+
 def _discover_builtin() -> Iterator[PluginManifest]:
     packaged = resources.files("bmad_loop.data").joinpath("plugins")
     if not packaged.is_dir():
@@ -42,9 +72,10 @@ def _discover_builtin() -> Iterator[PluginManifest]:
     for entry in sorted(packaged.iterdir(), key=lambda e: e.name):
         toml = entry.joinpath(PLUGIN_FILE)
         if entry.is_dir() and toml.is_file():
+            source = f"{entry.name}/{PLUGIN_FILE}"
             yield load_manifest(
-                toml.read_text(encoding="utf-8"),
-                f"{entry.name}/{PLUGIN_FILE}",
+                _read_manifest_text(toml, source),
+                source,
                 str(entry),
                 origin="builtin",
             )
@@ -69,7 +100,7 @@ def _discover_project(project: Path) -> Iterator[PluginManifest]:
         toml = entry / PLUGIN_FILE
         if entry.is_dir() and toml.is_file():
             yield load_manifest(
-                toml.read_text(encoding="utf-8"), str(toml), str(entry), origin="project"
+                _read_manifest_text(toml, str(toml)), str(toml), str(entry), origin="project"
             )
 
 

--- a/src/bmad_loop/policy.py
+++ b/src/bmad_loop/policy.py
@@ -666,8 +666,8 @@ def _stage_adapter(adapter_d: dict[str, Any], key: str) -> StageAdapterPolicy:
     if not isinstance(raw, dict):
         raise PolicyError(f"[adapter.{key}] must be a table")
     return StageAdapterPolicy(
-        name=None if raw.get("name") is None else str(raw["name"]),
-        model=None if raw.get("model") is None else str(raw["model"]),
+        name=_opt_typed_str(raw, f"adapter.{key}", "name"),
+        model=_opt_typed_str(raw, f"adapter.{key}", "model"),
         extra_args=_typed_str_tuple(raw, f"adapter.{key}", "extra_args"),
         usage_grace_s=_opt_grace(raw, f"adapter.{key}"),
         stop_without_result_nudges=_opt_nudges(raw, f"adapter.{key}"),
@@ -734,6 +734,18 @@ def _typed_bool(d: dict[str, Any], where: str, key: str, default: bool) -> bool:
 
 def _typed_str(d: dict[str, Any], where: str, key: str, default: str) -> str:
     value = d.get(key, default)
+    if not isinstance(value, str):
+        raise PolicyError(f"{where}.{key} must be a string: got {value!r}")
+    return value
+
+
+def _opt_typed_str(d: dict[str, Any], where: str, key: str) -> str | None:
+    """The `_typed_str` shape for a key whose unset state is None rather than a
+    default — the per-stage `[adapter.<stage>]` overrides inherit from the parent
+    `[adapter]` table when absent, so they cannot express "unset" as a value."""
+    value = d.get(key)
+    if value is None:
+        return None
     if not isinstance(value, str):
         raise PolicyError(f"{where}.{key} must be a string: got {value!r}")
     return value
@@ -810,9 +822,9 @@ def loads(text: str, plugin_schemas: dict[str, Any] | None = None) -> Policy:
     mux_d = _section(doc, "mux")
 
     gates = GatesPolicy(
-        mode=str(gates_d.get("mode", GatesPolicy.mode)),
-        on_escalation=str(gates_d.get("on_escalation", GatesPolicy.on_escalation)),
-        retrospective=str(gates_d.get("retrospective", GatesPolicy.retrospective)),
+        mode=_typed_str(gates_d, "gates", "mode", GatesPolicy.mode),
+        on_escalation=_typed_str(gates_d, "gates", "on_escalation", GatesPolicy.on_escalation),
+        retrospective=_typed_str(gates_d, "gates", "retrospective", GatesPolicy.retrospective),
     )
     if gates.mode not in GATE_MODES:
         raise PolicyError(f"gates.mode must be one of {sorted(GATE_MODES)}: got {gates.mode!r}")
@@ -937,15 +949,15 @@ def loads(text: str, plugin_schemas: dict[str, Any] | None = None) -> Policy:
     if verify.stream_capture_kb < 0:
         raise PolicyError(f"verify.stream_capture_kb must be >= 0: got {verify.stream_capture_kb}")
     notify = NotifyPolicy(
-        desktop=bool(notify_d.get("desktop", NotifyPolicy.desktop)),
-        file=bool(notify_d.get("file", NotifyPolicy.file)),
+        desktop=_typed_bool(notify_d, "notify", "desktop", NotifyPolicy.desktop),
+        file=_typed_bool(notify_d, "notify", "file", NotifyPolicy.file),
     )
     review = ReviewPolicy(
-        enabled=bool(review_d.get("enabled", ReviewPolicy.enabled)),
-        trigger=str(review_d.get("trigger", ReviewPolicy.trigger)).strip(),
-        on_timeout=str(review_d.get("on_timeout", ReviewPolicy.on_timeout)).strip(),
-        on_status_contradiction=str(
-            review_d.get("on_status_contradiction", ReviewPolicy.on_status_contradiction)
+        enabled=_typed_bool(review_d, "review", "enabled", ReviewPolicy.enabled),
+        trigger=_typed_str(review_d, "review", "trigger", ReviewPolicy.trigger).strip(),
+        on_timeout=_typed_str(review_d, "review", "on_timeout", ReviewPolicy.on_timeout).strip(),
+        on_status_contradiction=_typed_str(
+            review_d, "review", "on_status_contradiction", ReviewPolicy.on_status_contradiction
         ).strip(),
     )
     if review.trigger not in REVIEW_TRIGGER_MODES:
@@ -964,8 +976,10 @@ def loads(text: str, plugin_schemas: dict[str, Any] | None = None) -> Policy:
             f" got {review.on_status_contradiction!r}"
         )
     stories = StoriesPolicy(
-        source=str(stories_d.get("source", StoriesPolicy.source)).strip(),
-        spec_folder=str(stories_d.get("spec_folder", StoriesPolicy.spec_folder)).strip(),
+        source=_typed_str(stories_d, "stories", "source", StoriesPolicy.source).strip(),
+        spec_folder=_typed_str(
+            stories_d, "stories", "spec_folder", StoriesPolicy.spec_folder
+        ).strip(),
     )
     if stories.source not in STORIES_SOURCES:
         raise PolicyError(
@@ -976,7 +990,7 @@ def loads(text: str, plugin_schemas: dict[str, Any] | None = None) -> Policy:
     # at run time — no error, so switching source back and forth keeps the path.
     if stories.source == "stories" and not stories.spec_folder:
         raise PolicyError('stories.source = "stories" requires stories.spec_folder to be set')
-    dev = DevPolicy(skill=str(dev_d.get("skill", DevPolicy.skill)))
+    dev = DevPolicy(skill=_typed_str(dev_d, "dev", "skill", DevPolicy.skill))
     if dev.skill not in DEV_SKILLS:
         raise PolicyError(
             f"dev.skill must be one of {sorted(DEV_SKILLS)}: got {dev.skill!r}. This is the "
@@ -991,11 +1005,14 @@ def loads(text: str, plugin_schemas: dict[str, Any] | None = None) -> Policy:
         if legacy in adapter_d:
             raise PolicyError(f"adapter.{legacy} was removed — use {replacement} instead")
     adapter = AdapterPolicy(
-        name=str(adapter_d.get("name", AdapterPolicy.name)),
-        model=str(adapter_d.get("model", AdapterPolicy.model)),
+        name=_typed_str(adapter_d, "adapter", "name", AdapterPolicy.name),
+        model=_typed_str(adapter_d, "adapter", "model", AdapterPolicy.model),
         extra_args=_typed_str_tuple(adapter_d, "adapter", "extra_args"),
-        cleanup_session_on_finish=bool(
-            adapter_d.get("cleanup_session_on_finish", AdapterPolicy.cleanup_session_on_finish)
+        cleanup_session_on_finish=_typed_bool(
+            adapter_d,
+            "adapter",
+            "cleanup_session_on_finish",
+            AdapterPolicy.cleanup_session_on_finish,
         ),
         usage_grace_s=_opt_grace(adapter_d, "adapter"),
         stop_without_result_nudges=_opt_nudges(adapter_d, "adapter"),
@@ -1004,7 +1021,7 @@ def loads(text: str, plugin_schemas: dict[str, Any] | None = None) -> Policy:
         triage=_stage_adapter(adapter_d, "triage"),
     )
     sweep = SweepPolicy(
-        auto=str(sweep_d.get("auto", SweepPolicy.auto)),
+        auto=_typed_str(sweep_d, "sweep", "auto", SweepPolicy.auto),
         max_bundles=_typed_int(sweep_d, "sweep", "max_bundles", SweepPolicy.max_bundles),
         max_triage_attempts=_typed_int(
             sweep_d, "sweep", "max_triage_attempts", SweepPolicy.max_triage_attempts
@@ -1012,7 +1029,7 @@ def loads(text: str, plugin_schemas: dict[str, Any] | None = None) -> Policy:
         max_migration_attempts=_typed_int(
             sweep_d, "sweep", "max_migration_attempts", SweepPolicy.max_migration_attempts
         ),
-        repeat=bool(sweep_d.get("repeat", SweepPolicy.repeat)),
+        repeat=_typed_bool(sweep_d, "sweep", "repeat", SweepPolicy.repeat),
         max_cycles=_typed_int(sweep_d, "sweep", "max_cycles", SweepPolicy.max_cycles),
     )
     if sweep.auto not in SWEEP_AUTO_MODES:
@@ -1053,27 +1070,29 @@ def loads(text: str, plugin_schemas: dict[str, Any] | None = None) -> Policy:
     if not all(isinstance(s, str) for s in raw_seed):
         raise PolicyError(f"scm.worktree_seed entries must be strings: got {list(raw_seed)!r}")
     scm = ScmPolicy(
-        isolation=str(scm_d.get("isolation", ScmPolicy.isolation)),
-        branch_per=str(scm_d.get("branch_per", ScmPolicy.branch_per)),
-        target_branch=str(scm_d.get("target_branch", ScmPolicy.target_branch)),
-        merge_strategy=str(scm_d.get("merge_strategy", ScmPolicy.merge_strategy)),
-        delete_branch=bool(scm_d.get("delete_branch", ScmPolicy.delete_branch)),
-        keep_failed=bool(scm_d.get("keep_failed", ScmPolicy.keep_failed)),
-        rollback_on_failure=bool(scm_d.get("rollback_on_failure", ScmPolicy.rollback_on_failure)),
+        isolation=_typed_str(scm_d, "scm", "isolation", ScmPolicy.isolation),
+        branch_per=_typed_str(scm_d, "scm", "branch_per", ScmPolicy.branch_per),
+        target_branch=_typed_str(scm_d, "scm", "target_branch", ScmPolicy.target_branch),
+        merge_strategy=_typed_str(scm_d, "scm", "merge_strategy", ScmPolicy.merge_strategy),
+        delete_branch=_typed_bool(scm_d, "scm", "delete_branch", ScmPolicy.delete_branch),
+        keep_failed=_typed_bool(scm_d, "scm", "keep_failed", ScmPolicy.keep_failed),
+        rollback_on_failure=_typed_bool(
+            scm_d, "scm", "rollback_on_failure", ScmPolicy.rollback_on_failure
+        ),
         preserve_keep=preserve_keep,
         failed_diff_max_mb=_typed_int(
             scm_d, "scm", "failed_diff_max_mb", ScmPolicy.failed_diff_max_mb
         ),
-        failed_diff_unlimited=bool(
-            scm_d.get("failed_diff_unlimited", ScmPolicy.failed_diff_unlimited)
+        failed_diff_unlimited=_typed_bool(
+            scm_d, "scm", "failed_diff_unlimited", ScmPolicy.failed_diff_unlimited
         ),
-        commit_message_template=str(
-            scm_d.get("commit_message_template", ScmPolicy.commit_message_template)
+        commit_message_template=_typed_str(
+            scm_d, "scm", "commit_message_template", ScmPolicy.commit_message_template
         ),
         # Phase 5 parallel fan-out is unbuilt: clamp to 1 so the knob is inert.
         max_parallel=min(requested_parallel, 1),
-        seed_adapter_defaults=bool(
-            scm_d.get("seed_adapter_defaults", ScmPolicy.seed_adapter_defaults)
+        seed_adapter_defaults=_typed_bool(
+            scm_d, "scm", "seed_adapter_defaults", ScmPolicy.seed_adapter_defaults
         ),
         worktree_seed=tuple(raw_seed),
     )
@@ -1133,12 +1152,14 @@ def loads(text: str, plugin_schemas: dict[str, Any] | None = None) -> Policy:
         retention_days=_typed_int(
             cleanup_d, "cleanup", "retention_days", CleanupPolicy.retention_days
         ),
-        trim_artifacts=bool(cleanup_d.get("trim_artifacts", CleanupPolicy.trim_artifacts)),
-        archive_old=bool(cleanup_d.get("archive_old", CleanupPolicy.archive_old)),
-        auto_clean_on_finish=bool(
-            cleanup_d.get("auto_clean_on_finish", CleanupPolicy.auto_clean_on_finish)
+        trim_artifacts=_typed_bool(
+            cleanup_d, "cleanup", "trim_artifacts", CleanupPolicy.trim_artifacts
         ),
-        clean_tmp=bool(cleanup_d.get("clean_tmp", CleanupPolicy.clean_tmp)),
+        archive_old=_typed_bool(cleanup_d, "cleanup", "archive_old", CleanupPolicy.archive_old),
+        auto_clean_on_finish=_typed_bool(
+            cleanup_d, "cleanup", "auto_clean_on_finish", CleanupPolicy.auto_clean_on_finish
+        ),
+        clean_tmp=_typed_bool(cleanup_d, "cleanup", "clean_tmp", CleanupPolicy.clean_tmp),
     )
     if cleanup.run_retention < 0:
         raise PolicyError(f"cleanup.run_retention must be >= 0: got {cleanup.run_retention}")
@@ -1147,7 +1168,11 @@ def loads(text: str, plugin_schemas: dict[str, Any] | None = None) -> Policy:
     raw_enabled = plugins_d.get("enabled", ())
     if isinstance(raw_enabled, str) or not isinstance(raw_enabled, (list, tuple)):
         raise PolicyError("plugins.enabled must be a list of plugin names")
-    enabled = [str(n) for n in raw_enabled]
+    enabled: list[str] = []
+    for n in raw_enabled:
+        if not isinstance(n, str):
+            raise PolicyError(f"plugins.enabled entries must be strings: got {n!r}")
+        enabled.append(n)
     # Every key under [plugins] other than `enabled` that is a table is a
     # per-plugin settings sub-table ([plugins.<name>]).
     plugin_settings = {
@@ -1163,14 +1188,16 @@ def loads(text: str, plugin_schemas: dict[str, Any] | None = None) -> Policy:
             _validate_plugin_settings(name, raw_settings, plugin_schemas.get(name))
     plugins = PluginsPolicy(enabled=tuple(enabled), settings=plugin_settings)
     tui = TuiPolicy(
-        low_frame_rate=bool(tui_d.get("low_frame_rate", TuiPolicy.low_frame_rate)),
+        low_frame_rate=_typed_bool(tui_d, "tui", "low_frame_rate", TuiPolicy.low_frame_rate),
         left_width=_tui_dim(tui_d, "left_width"),
         runs_height=_tui_dim(tui_d, "runs_height"),
         deferred_height=_tui_dim(tui_d, "deferred_height"),
         tasks_height=_tui_dim(tui_d, "tasks_height"),
     )
-    operator = OperatorPolicy(enabled=bool(operator_d.get("enabled", OperatorPolicy.enabled)))
-    mux = MuxPolicy(backend=str(mux_d.get("backend", MuxPolicy.backend)).strip())
+    operator = OperatorPolicy(
+        enabled=_typed_bool(operator_d, "operator", "enabled", OperatorPolicy.enabled)
+    )
+    mux = MuxPolicy(backend=_typed_str(mux_d, "mux", "backend", MuxPolicy.backend).strip())
     if mux.backend and not _MUX_NAME_RE.match(mux.backend):
         raise PolicyError(
             f"mux.backend must be a backend name (letters, digits, . _ -): got {mux.backend!r}"
@@ -1213,7 +1240,7 @@ def _fold_deprecated_engine(
         DeprecationWarning,
         stacklevel=3,
     )
-    name = str(engine_d.get("name", "")).strip()
+    name = _typed_str(engine_d, "engine", "name", "").strip()
     if not name:
         return
     if name not in enabled:

--- a/src/bmad_loop/policy.py
+++ b/src/bmad_loop/policy.py
@@ -428,6 +428,13 @@ def _snapshot_extra_args(raw: Any) -> tuple[str, ...] | None:
     # asdict() turns the extra_args tuple into a list and json keeps it a list;
     # rebuild the tuple so a reconstructed AdapterPolicy compares equal to a
     # freshly-parsed one (the #189 tuple-vs-list trap). None stays None.
+    #
+    # Deliberately keeps the lenient coercion `_typed_str_tuple` replaced in
+    # `loads()`: the input here is not user TOML but a json round-tripped
+    # `asdict(Policy)` whose extra_args was already validated on the way in, and
+    # the caller wraps this in `except Exception: return None` because it feeds
+    # status/TUI display surfaces that must never crash. Raising a PolicyError
+    # here would only be swallowed, at the cost of blanking the display.
     if raw is None:
         return None
     return tuple(str(a) for a in raw)

--- a/src/bmad_loop/policy.py
+++ b/src/bmad_loop/policy.py
@@ -615,9 +615,14 @@ def _section(doc: dict[str, Any], name: str) -> dict[str, Any]:
 
 
 def _opt_grace(d: dict[str, Any], where: str) -> float | None:
+    """An optional per-stage override; ``None`` means "inherit", which is why this
+    cannot take `_typed_float`'s default. The type guard is the same one, inline:
+    a TOML int is a legal number here (``usage_grace_s = 30``), a bool is not."""
     raw = d.get("usage_grace_s")
     if raw is None:
         return None
+    if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+        raise PolicyError(f"{where}.usage_grace_s must be a number: got {raw!r}")
     value = float(raw)
     if value < 0:
         raise PolicyError(f"{where}.usage_grace_s must be >= 0: got {value}")
@@ -625,9 +630,12 @@ def _opt_grace(d: dict[str, Any], where: str) -> float | None:
 
 
 def _opt_nudges(d: dict[str, Any], where: str) -> int | None:
+    """The `_opt_grace` shape for the integer knob; see there for why it is inline."""
     raw = d.get("stop_without_result_nudges")
     if raw is None:
         return None
+    if isinstance(raw, bool) or not isinstance(raw, int):
+        raise PolicyError(f"{where}.stop_without_result_nudges must be an integer: got {raw!r}")
     value = int(raw)
     if value < 0:
         raise PolicyError(f"{where}.stop_without_result_nudges must be >= 0: got {value}")
@@ -650,11 +658,10 @@ def _stage_adapter(adapter_d: dict[str, Any], key: str) -> StageAdapterPolicy:
     raw = adapter_d.get(key, {})
     if not isinstance(raw, dict):
         raise PolicyError(f"[adapter.{key}] must be a table")
-    raw_extra = raw.get("extra_args")
     return StageAdapterPolicy(
         name=None if raw.get("name") is None else str(raw["name"]),
         model=None if raw.get("model") is None else str(raw["model"]),
-        extra_args=None if raw_extra is None else tuple(str(a) for a in raw_extra),
+        extra_args=_typed_str_tuple(raw, f"adapter.{key}", "extra_args"),
         usage_grace_s=_opt_grace(raw, f"adapter.{key}"),
         stop_without_result_nudges=_opt_nudges(raw, f"adapter.{key}"),
     )
@@ -687,32 +694,60 @@ def _validate_plugin_settings(name: str, raw: dict[str, Any], specs: Any) -> Non
             )
 
 
-def _limit_int(raw: dict[str, Any], key: str, default: int) -> int:
-    value = raw.get(key, default)
+# The typed readers every user-TOML section coerces through. `where` is the
+# section label the message names ("limits", "scm", "adapter.dev", ...), so one
+# definition serves every section instead of a per-section family; a bare
+# `int()`/`bool()` in their place raises a raw ValueError/TypeError, which is
+# neither a PolicyError nor an OSError and so escapes every degrade handler in
+# the codebase (#440, and #278 for the [limits] leg these grew out of).
+
+
+def _typed_int(d: dict[str, Any], where: str, key: str, default: int) -> int:
+    value = d.get(key, default)
+    # bool is a subclass of int; a TOML `true` would read as 1 and silently
+    # rewrite the knob, so reject it before the isinstance check passes it.
     if isinstance(value, bool) or not isinstance(value, int):
-        raise PolicyError(f"limits.{key} must be an integer: got {value!r}")
+        raise PolicyError(f"{where}.{key} must be an integer: got {value!r}")
     return value
 
 
-def _limit_float(raw: dict[str, Any], key: str, default: float) -> float:
-    value = raw.get(key, default)
+def _typed_float(d: dict[str, Any], where: str, key: str, default: float) -> float:
+    value = d.get(key, default)
     if isinstance(value, bool) or not isinstance(value, (int, float)):
-        raise PolicyError(f"limits.{key} must be a number: got {value!r}")
+        raise PolicyError(f"{where}.{key} must be a number: got {value!r}")
     return float(value)
 
 
-def _limit_bool(raw: dict[str, Any], key: str, default: bool) -> bool:
-    value = raw.get(key, default)
+def _typed_bool(d: dict[str, Any], where: str, key: str, default: bool) -> bool:
+    value = d.get(key, default)
     if not isinstance(value, bool):
-        raise PolicyError(f"limits.{key} must be a boolean: got {value!r}")
+        raise PolicyError(f"{where}.{key} must be a boolean: got {value!r}")
     return value
 
 
-def _limit_str(raw: dict[str, Any], key: str, default: str) -> str:
-    value = raw.get(key, default)
+def _typed_str(d: dict[str, Any], where: str, key: str, default: str) -> str:
+    value = d.get(key, default)
     if not isinstance(value, str):
-        raise PolicyError(f"limits.{key} must be a string: got {value!r}")
+        raise PolicyError(f"{where}.{key} must be a string: got {value!r}")
     return value
+
+
+def _typed_str_tuple(d: dict[str, Any], where: str, key: str) -> tuple[str, ...] | None:
+    """An optional TOML array of strings, or None when the key is absent.
+
+    Shape before entries, for the reason `scm.worktree_seed` states below: a bare
+    string is iterable, so `tuple(str(a) for a in raw)` explodes it per character
+    into one-character entries that each look like a valid argument, and a scalar
+    raises a bare TypeError out of `loads` where every other malformed value here
+    raises PolicyError."""
+    raw = d.get(key)
+    if raw is None:
+        return None
+    if isinstance(raw, (str, bytes)) or not isinstance(raw, (list, tuple)):
+        raise PolicyError(f"{where}.{key} must be an array of strings: got {raw!r}")
+    if not all(isinstance(a, str) for a in raw):
+        raise PolicyError(f"{where}.{key} must be an array of strings: got {list(raw)!r}")
+    return tuple(raw)
 
 
 def load(path: Path | None) -> Policy:
@@ -780,44 +815,57 @@ def loads(text: str, plugin_schemas: dict[str, Any] | None = None) -> Policy:
         )
 
     limits = LimitsPolicy(
-        max_review_cycles=_limit_int(limits_d, "max_review_cycles", LimitsPolicy.max_review_cycles),
-        max_dev_attempts=_limit_int(limits_d, "max_dev_attempts", LimitsPolicy.max_dev_attempts),
-        max_followup_reviews=_limit_int(
-            limits_d, "max_followup_reviews", LimitsPolicy.max_followup_reviews
+        max_review_cycles=_typed_int(
+            limits_d, "limits", "max_review_cycles", LimitsPolicy.max_review_cycles
         ),
-        session_timeout_min=_limit_int(
-            limits_d, "session_timeout_min", LimitsPolicy.session_timeout_min
+        max_dev_attempts=_typed_int(
+            limits_d, "limits", "max_dev_attempts", LimitsPolicy.max_dev_attempts
         ),
-        git_timeout_s=_limit_int(limits_d, "git_timeout_s", LimitsPolicy.git_timeout_s),
-        teardown_grace_s=_limit_int(limits_d, "teardown_grace_s", LimitsPolicy.teardown_grace_s),
-        stop_without_result_nudges=_limit_int(
-            limits_d, "stop_without_result_nudges", LimitsPolicy.stop_without_result_nudges
+        max_followup_reviews=_typed_int(
+            limits_d, "limits", "max_followup_reviews", LimitsPolicy.max_followup_reviews
         ),
-        dev_stall_grace_s=_limit_int(limits_d, "dev_stall_grace_s", LimitsPolicy.dev_stall_grace_s),
-        dev_stall_nudges=_limit_int(limits_d, "dev_stall_nudges", LimitsPolicy.dev_stall_nudges),
-        dev_stall_nudges_cap=_limit_int(
-            limits_d, "dev_stall_nudges_cap", LimitsPolicy.dev_stall_nudges_cap
+        session_timeout_min=_typed_int(
+            limits_d, "limits", "session_timeout_min", LimitsPolicy.session_timeout_min
         ),
-        workflow_stall_nudges_cap=_limit_int(
-            limits_d, "workflow_stall_nudges_cap", LimitsPolicy.workflow_stall_nudges_cap
+        git_timeout_s=_typed_int(limits_d, "limits", "git_timeout_s", LimitsPolicy.git_timeout_s),
+        teardown_grace_s=_typed_int(
+            limits_d, "limits", "teardown_grace_s", LimitsPolicy.teardown_grace_s
         ),
-        dev_contract_nudge=_limit_bool(
-            limits_d, "dev_contract_nudge", LimitsPolicy.dev_contract_nudge
+        stop_without_result_nudges=_typed_int(
+            limits_d,
+            "limits",
+            "stop_without_result_nudges",
+            LimitsPolicy.stop_without_result_nudges,
         ),
-        max_tokens_per_story=_limit_int(
-            limits_d, "max_tokens_per_story", LimitsPolicy.max_tokens_per_story
+        dev_stall_grace_s=_typed_int(
+            limits_d, "limits", "dev_stall_grace_s", LimitsPolicy.dev_stall_grace_s
         ),
-        cache_read_weight=_limit_float(
-            limits_d, "cache_read_weight", LimitsPolicy.cache_read_weight
+        dev_stall_nudges=_typed_int(
+            limits_d, "limits", "dev_stall_nudges", LimitsPolicy.dev_stall_nudges
         ),
-        session_budget_mode=_limit_str(
-            limits_d, "session_budget_mode", LimitsPolicy.session_budget_mode
+        dev_stall_nudges_cap=_typed_int(
+            limits_d, "limits", "dev_stall_nudges_cap", LimitsPolicy.dev_stall_nudges_cap
         ),
-        max_tokens_per_session=_limit_int(
-            limits_d, "max_tokens_per_session", LimitsPolicy.max_tokens_per_session
+        workflow_stall_nudges_cap=_typed_int(
+            limits_d, "limits", "workflow_stall_nudges_cap", LimitsPolicy.workflow_stall_nudges_cap
         ),
-        session_budget_grace_s=_limit_int(
-            limits_d, "session_budget_grace_s", LimitsPolicy.session_budget_grace_s
+        dev_contract_nudge=_typed_bool(
+            limits_d, "limits", "dev_contract_nudge", LimitsPolicy.dev_contract_nudge
+        ),
+        max_tokens_per_story=_typed_int(
+            limits_d, "limits", "max_tokens_per_story", LimitsPolicy.max_tokens_per_story
+        ),
+        cache_read_weight=_typed_float(
+            limits_d, "limits", "cache_read_weight", LimitsPolicy.cache_read_weight
+        ),
+        session_budget_mode=_typed_str(
+            limits_d, "limits", "session_budget_mode", LimitsPolicy.session_budget_mode
+        ),
+        max_tokens_per_session=_typed_int(
+            limits_d, "limits", "max_tokens_per_session", LimitsPolicy.max_tokens_per_session
+        ),
+        session_budget_grace_s=_typed_int(
+            limits_d, "limits", "session_budget_grace_s", LimitsPolicy.session_budget_grace_s
         ),
     )
     if limits.max_review_cycles < 1 or limits.max_dev_attempts < 1:
@@ -874,8 +922,10 @@ def loads(text: str, plugin_schemas: dict[str, Any] | None = None) -> Policy:
         )
 
     verify = VerifyPolicy(
-        commands=tuple(str(c) for c in verify_d.get("commands", ())),
-        stream_capture_kb=int(verify_d.get("stream_capture_kb", VerifyPolicy.stream_capture_kb)),
+        commands=_typed_str_tuple(verify_d, "verify", "commands") or (),
+        stream_capture_kb=_typed_int(
+            verify_d, "verify", "stream_capture_kb", VerifyPolicy.stream_capture_kb
+        ),
     )
     if verify.stream_capture_kb < 0:
         raise PolicyError(f"verify.stream_capture_kb must be >= 0: got {verify.stream_capture_kb}")
@@ -933,11 +983,10 @@ def loads(text: str, plugin_schemas: dict[str, Any] | None = None) -> Policy:
     ):
         if legacy in adapter_d:
             raise PolicyError(f"adapter.{legacy} was removed — use {replacement} instead")
-    raw_extra = adapter_d.get("extra_args")
     adapter = AdapterPolicy(
         name=str(adapter_d.get("name", AdapterPolicy.name)),
         model=str(adapter_d.get("model", AdapterPolicy.model)),
-        extra_args=None if raw_extra is None else tuple(str(a) for a in raw_extra),
+        extra_args=_typed_str_tuple(adapter_d, "adapter", "extra_args"),
         cleanup_session_on_finish=bool(
             adapter_d.get("cleanup_session_on_finish", AdapterPolicy.cleanup_session_on_finish)
         ),
@@ -949,15 +998,15 @@ def loads(text: str, plugin_schemas: dict[str, Any] | None = None) -> Policy:
     )
     sweep = SweepPolicy(
         auto=str(sweep_d.get("auto", SweepPolicy.auto)),
-        max_bundles=int(sweep_d.get("max_bundles", SweepPolicy.max_bundles)),
-        max_triage_attempts=int(
-            sweep_d.get("max_triage_attempts", SweepPolicy.max_triage_attempts)
+        max_bundles=_typed_int(sweep_d, "sweep", "max_bundles", SweepPolicy.max_bundles),
+        max_triage_attempts=_typed_int(
+            sweep_d, "sweep", "max_triage_attempts", SweepPolicy.max_triage_attempts
         ),
-        max_migration_attempts=int(
-            sweep_d.get("max_migration_attempts", SweepPolicy.max_migration_attempts)
+        max_migration_attempts=_typed_int(
+            sweep_d, "sweep", "max_migration_attempts", SweepPolicy.max_migration_attempts
         ),
         repeat=bool(sweep_d.get("repeat", SweepPolicy.repeat)),
-        max_cycles=int(sweep_d.get("max_cycles", SweepPolicy.max_cycles)),
+        max_cycles=_typed_int(sweep_d, "sweep", "max_cycles", SweepPolicy.max_cycles),
     )
     if sweep.auto not in SWEEP_AUTO_MODES:
         raise PolicyError(
@@ -976,14 +1025,13 @@ def loads(text: str, plugin_schemas: dict[str, Any] | None = None) -> Policy:
             "sweep.max_bundles, sweep.max_triage_attempts, "
             "sweep.max_migration_attempts and sweep.max_cycles must be >= 1"
         )
-    requested_parallel = int(scm_d.get("max_parallel", ScmPolicy.max_parallel))
+    requested_parallel = _typed_int(scm_d, "scm", "max_parallel", ScmPolicy.max_parallel)
     if requested_parallel < 1:
         raise PolicyError(f"scm.max_parallel must be >= 1: got {requested_parallel}")
-    preserve_keep = scm_d.get("preserve_keep", ScmPolicy.preserve_keep)
-    # strict on purpose, unlike the sibling int knobs: a TOML `true` (int(True)=1)
-    # or `1.9` coercing through int() would silently shrink a safety-net budget
-    if isinstance(preserve_keep, bool) or not isinstance(preserve_keep, int):
-        raise PolicyError(f"scm.preserve_keep must be an integer: got {preserve_keep!r}")
+    # This one was strict before its sibling int knobs were (a TOML `true`, with
+    # int(True) == 1, or a `1.9` coercing through int() would silently shrink a
+    # safety-net budget); `_typed_int` is that same guard, message included.
+    preserve_keep = _typed_int(scm_d, "scm", "preserve_keep", ScmPolicy.preserve_keep)
     if preserve_keep < 0:
         raise PolicyError(f"scm.preserve_keep must be >= 0: got {preserve_keep}")
     # Shape before entries, because `tuple(str(s) for s in raw)` silently accepts
@@ -1006,7 +1054,9 @@ def loads(text: str, plugin_schemas: dict[str, Any] | None = None) -> Policy:
         keep_failed=bool(scm_d.get("keep_failed", ScmPolicy.keep_failed)),
         rollback_on_failure=bool(scm_d.get("rollback_on_failure", ScmPolicy.rollback_on_failure)),
         preserve_keep=preserve_keep,
-        failed_diff_max_mb=int(scm_d.get("failed_diff_max_mb", ScmPolicy.failed_diff_max_mb)),
+        failed_diff_max_mb=_typed_int(
+            scm_d, "scm", "failed_diff_max_mb", ScmPolicy.failed_diff_max_mb
+        ),
         failed_diff_unlimited=bool(
             scm_d.get("failed_diff_unlimited", ScmPolicy.failed_diff_unlimited)
         ),
@@ -1070,8 +1120,12 @@ def loads(text: str, plugin_schemas: dict[str, Any] | None = None) -> Policy:
                 f"scm.worktree_seed entries must be project-relative paths: got {seed!r}"
             )
     cleanup = CleanupPolicy(
-        run_retention=int(cleanup_d.get("run_retention", CleanupPolicy.run_retention)),
-        retention_days=int(cleanup_d.get("retention_days", CleanupPolicy.retention_days)),
+        run_retention=_typed_int(
+            cleanup_d, "cleanup", "run_retention", CleanupPolicy.run_retention
+        ),
+        retention_days=_typed_int(
+            cleanup_d, "cleanup", "retention_days", CleanupPolicy.retention_days
+        ),
         trim_artifacts=bool(cleanup_d.get("trim_artifacts", CleanupPolicy.trim_artifacts)),
         archive_old=bool(cleanup_d.get("archive_old", CleanupPolicy.archive_old)),
         auto_clean_on_finish=bool(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5400,6 +5400,26 @@ def test_validate_reports_an_undecodable_policy_instead_of_crashing(project, cap
     assert "not valid UTF-8" in finding["message"]
 
 
+def test_validate_reports_a_wrong_typed_policy_field_instead_of_crashing(project, capsys):
+    """The undecodable-file leg's twin one layer in (#440, carried by #474): the file
+    decodes and parses as TOML, but a *value* has the wrong type. `int()` on it raised
+    a raw ValueError — again not an OSError, again straight past every
+    `except (PolicyError, OSError)`, including `_configure_mux`'s, which runs before
+    argument dispatch on EVERY command. `_typed_int` converts it, so the offending
+    `section.key` is a named finding like any other bad policy.
+
+    Routed through `machine_json` for the same reason as the leg above: `main`'s bare
+    `except Exception` backstop also returns 1, so an rc-only assertion stays green
+    with the conversion reverted. What bites is the document — stderr carries the
+    backstop's line and stdout carries nothing to parse."""
+    _write_policy(project.project, CLAUDE_ONLY_POLICY + '[scm]\nmax_parallel = "x"\n')
+
+    doc = machine_json(["validate", "--project", str(project.project), "--json"], capsys, rc=1)
+    finding = next(f for f in doc["findings"] if f["check"] == "policy")
+    assert finding["severity"] == "problem"
+    assert "scm.max_parallel must be an integer" in finding["message"]
+
+
 def test_validate_reports_an_undecodable_bmad_config_instead_of_crashing(project, capsys):
     """The `config.yaml` half of the same conversion. Separate from the policy leg
     because they are separate loaders with separate typed errors, and the callers that

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5436,6 +5436,33 @@ def test_validate_reports_an_undecodable_bmad_config_instead_of_crashing(project
     assert "not valid UTF-8" in finding["message"]
 
 
+def test_validate_reports_an_undecodable_profile_overlay_instead_of_crashing(project, capsys):
+    """#473: the third loader, same conversion. `load_profiles` reads each overlay in
+    `.bmad-loop/profiles/` with `read_text(encoding="utf-8")`, so a non-UTF-8 file
+    raised `UnicodeDecodeError` — a ValueError, not a `ProfileError` — while the role
+    loop here catches only `ProfileError`. It is not the policy leg over again: these
+    are separate loaders with separate typed errors, and `get_profile` backs every
+    adapter resolution, so the raw escape also reached run/sweep preflight.
+
+    Routed through `machine_json` deliberately, for the reason the policy leg gives:
+    `main`'s bare `except Exception` backstop also returns 1, so an rc-only assertion
+    is green with the conversion reverted. What bites is the document — stderr carries
+    the backstop's line and stdout carries nothing to parse."""
+    _write_policy(project.project, '[adapter]\nname = "badcli"\nmodel = "opus"\n')
+    profiles = project.project / ".bmad-loop" / "profiles"
+    profiles.mkdir(parents=True, exist_ok=True)
+    overlay = profiles / "badcli.toml"
+    overlay.write_bytes(b'name = "b\xffad"\n')
+    with pytest.raises(UnicodeDecodeError):  # the fixture is genuinely undecodable
+        overlay.read_text(encoding="utf-8")
+
+    doc = machine_json(["validate", "--project", str(project.project), "--json"], capsys, rc=1)
+    finding = next(f for f in doc["findings"] if f["check"] == "adapter.profile")
+    assert finding["severity"] == "problem"
+    assert "not valid UTF-8" in finding["message"]
+    assert str(overlay) in finding["message"]  # the finding names the file at fault
+
+
 def test_validate_json_counts_and_ok_agree_with_findings(project, capsys):
     """`ok` mirrors the exit code exactly: problems clear it, warnings never do."""
     install_bmad_config(project)

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -12,6 +12,7 @@ from importlib import resources
 from pathlib import Path
 
 import pytest
+from conftest import fault_read_text
 
 from bmad_loop.plugins import (
     PluginError,
@@ -20,7 +21,7 @@ from bmad_loop.plugins import (
     get_plugin,
     load_plugins,
 )
-from bmad_loop.plugins.loader import USER_PLUGINS_REL
+from bmad_loop.plugins.loader import PLUGIN_FILE, USER_PLUGINS_REL
 from bmad_loop.plugins.manifest import load_manifest
 
 # --------------------------------------------------------------- helpers
@@ -228,6 +229,83 @@ def test_invalid_toml_rejected(tmp_path):
     write_plugin(tmp_path, "broken", "[plugin]\nname = \n")
     with pytest.raises(PluginError, match="invalid TOML"):
         load_plugins(tmp_path)
+
+
+# ------------------------------------------------------------ manifest reads
+
+
+def test_non_utf8_plugin_manifest_raises_plugin_error(tmp_path):
+    """The READ, not a value coercion. `load_manifest`'s CONVERSION_FAULTS funnel
+    cannot reach this one — it wraps the parse, and the decode happens in the
+    argument expression at the discovery call site, before `load_manifest` is
+    entered — so a non-UTF-8 `plugin.toml` escaped as a raw `UnicodeDecodeError`.
+    Asserting the TYPE is the point: `tui/settings.py` degrades on
+    `except (PolicyError, PluginError)`, and a `ValueError` escape walked through
+    it and took the settings surface down at construction. Sibling guard:
+    `adapters/profile.py`'s `_read_profile_text` (#473).
+
+    ABLATION: route the project read back through
+    `load_manifest(toml.read_text(encoding="utf-8"), ...)` and this raises
+    UnicodeDecodeError instead."""
+    pdir = write_plugin(tmp_path, "bad", MINIMAL.format(name="bad"))
+    manifest = pdir / PLUGIN_FILE
+    manifest.write_bytes(b'[plugin]\nname = "b\xffad"\napi_version = 1\n')
+    # Self-verify the fixture before trusting what it proves: a file that decoded
+    # fine would make the assertion below pass for the wrong reason.
+    with pytest.raises(UnicodeDecodeError):
+        manifest.read_text(encoding="utf-8")
+    with pytest.raises(PluginError, match="not valid UTF-8") as excinfo:
+        load_plugins(tmp_path)
+    assert str(manifest) in str(excinfo.value)  # the fault names the file at fault
+
+
+def test_unreadable_plugin_manifest_raises_plugin_error(tmp_path, monkeypatch):
+    """The OSError arm of the same guard: a manifest that is present but cannot be
+    read — permissions, an I/O error, a dead mount. Discovery's `is_file()` rules
+    out ABSENCE and nothing else, so this escaped as a bare OSError, which no
+    consumer of `load_plugins` catches.
+
+    `fault_read_text` rather than chmod for the reason its docstring gives, and
+    its targeting matters twice over: a blanket `Path.read_text` patch is answered
+    by the BUILTIN loop first, which would redden with this call site untouched.
+
+    ABLATION: route the project read back through `toml.read_text(...)` and this
+    raises PermissionError instead."""
+    pdir = write_plugin(tmp_path, "proj", MINIMAL.format(name="proj"))
+    manifest = pdir / PLUGIN_FILE
+    # Precondition: readable, this plugin loads — so the raise below is the fault
+    # being converted, not a manifest that was malformed all along.
+    assert load_plugins(tmp_path)["proj"].source == "project"
+    fault_read_text(monkeypatch, manifest)
+    with pytest.raises(PluginError, match="unreadable") as excinfo:
+        load_plugins(tmp_path)
+    assert str(manifest) in str(excinfo.value)
+
+
+def test_unreadable_builtin_plugin_manifest_raises_plugin_error(monkeypatch):
+    """The packaged built-ins are read through the same guard. They are trusted
+    content, so this is not the user-authored fault class the two tests above
+    cover — but a corrupt or unreadable install is a PACKAGING bug, and the loader
+    owes its callers the typed error that says so rather than a traceback:
+    `PluginRegistry.build` and the TUI settings screen both key on PluginError and
+    neither catches OSError.
+
+    Here because the two read sites are separate wiring axes, not one — the same
+    measurement `adapters/profile.py`'s packaged site forced. Reverting the
+    BUILTIN read to `toml.read_text(...)` leaves both project tests green; this is
+    the only test that reddens for it, and the project ablation leaves this one
+    green. Disjoint, which is the proof that neither site stands in for the
+    other."""
+    packaged = resources.files("bmad_loop.data").joinpath("plugins")
+    names = sorted(e.name for e in packaged.iterdir() if e.is_dir())
+    # Real path, not a zip member: `fault_read_text` targets `Path.read_text`, so a
+    # zipimported install would leave the fault unarmed. Asserted, not assumed.
+    victim = Path(str(packaged.joinpath(names[0], PLUGIN_FILE)))
+    assert victim.is_file()
+    fault_read_text(monkeypatch, victim)
+    with pytest.raises(PluginError, match="unreadable") as excinfo:
+        load_plugins()
+    assert f"{names[0]}/{PLUGIN_FILE}" in str(excinfo.value)
 
 
 # ----------------------------------------------------- discovery / overlay

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -628,6 +628,127 @@ def test_array_policy_fields_keep_unset_distinct_from_empty():
     assert policy.loads('[verify]\ncommands = ["pytest -q"]\n').verify.commands == ("pytest -q",)
 
 
+# The two silent-coercion grids below share their field lists with their positive
+# twin, so the "still parses" claim is made about the same keys the rejection grid
+# names rather than a hand-picked subset of them.
+_BOOLEAN_POLICY_FIELDS = [
+    ("notify", "desktop"),
+    ("notify", "file"),
+    ("review", "enabled"),
+    ("adapter", "cleanup_session_on_finish"),
+    ("sweep", "repeat"),
+    ("scm", "delete_branch"),
+    ("scm", "keep_failed"),
+    ("scm", "rollback_on_failure"),
+    ("scm", "failed_diff_unlimited"),
+    ("scm", "seed_adapter_defaults"),
+    ("cleanup", "trim_artifacts"),
+    ("cleanup", "archive_old"),
+    ("cleanup", "auto_clean_on_finish"),
+    ("cleanup", "clean_tmp"),
+    ("tui", "low_frame_rate"),
+    ("operator", "enabled"),
+]
+
+
+@pytest.mark.parametrize("bad", ['"false"', "1", "[true]"])
+@pytest.mark.parametrize(("section", "key"), _BOOLEAN_POLICY_FIELDS)
+def test_boolean_policy_fields_reject_non_boolean(section, key, bad):
+    """The silent half of #440: unlike the raw `int()` fields, a bare `bool()` never
+    raised at all — it accepted every one of these and rewrote the knob. `"false"` is
+    the hazard #278 was filed for, because a non-empty string is truthy, so the one
+    spelling a user reaches for to turn a feature OFF turned it ON; `1` and `[true]`
+    are the other two truthy shapes TOML can produce here. No degrade handler ever
+    saw a fault, because there was no fault to see — the run just behaved differently
+    from its configuration.
+
+    Ablation: delete `_typed_bool`'s conditional and raise, retaining `return value`;
+    every row fails because each bad value is returned unchanged and truthy."""
+    with pytest.raises(policy.PolicyError, match=rf"{section}\.{key} must be a boolean"):
+        policy.loads(f"[{section}]\n{key} = {bad}\n")
+
+
+@pytest.mark.parametrize(("section", "key"), _BOOLEAN_POLICY_FIELDS)
+def test_boolean_policy_fields_accept_a_real_toml_false(section, key):
+    """The guard rejects wrong TYPES, not falsy values — a real TOML `false` is how
+    every one of these knobs is legitimately turned off, and it must still parse to
+    `False` rather than tripping the new check."""
+    pol = policy.loads(f"[{section}]\n{key} = false\n")
+    assert getattr(getattr(pol, section), key) is False
+
+
+@pytest.mark.parametrize("bad", ["5", "true"])
+@pytest.mark.parametrize(
+    ("section", "key"),
+    [
+        ("gates", "mode"),
+        ("gates", "on_escalation"),
+        ("gates", "retrospective"),
+        ("review", "trigger"),
+        ("review", "on_timeout"),
+        ("review", "on_status_contradiction"),
+        ("stories", "source"),
+        ("stories", "spec_folder"),
+        ("dev", "skill"),
+        ("adapter", "name"),
+        ("adapter", "model"),
+        ("adapter.dev", "name"),
+        ("adapter.dev", "model"),
+        ("adapter.review", "name"),
+        ("adapter.review", "model"),
+        ("sweep", "auto"),
+        ("scm", "isolation"),
+        ("scm", "branch_per"),
+        ("scm", "target_branch"),
+        ("scm", "merge_strategy"),
+        ("scm", "commit_message_template"),
+        ("mux", "backend"),
+    ],
+)
+def test_string_policy_fields_reject_non_string(section, key, bad):
+    """`str()` never raises either, so a wrong-typed value became its `repr` and was
+    then judged as a string. Two outcomes, both wrong: the fields with a downstream
+    allowlist blamed the VALUE for a TYPE fault ("gates.mode must be one of [...]: got
+    '5'", naming a quoted 5 the file does not contain), and the free-form ones
+    (`scm.target_branch`, `scm.commit_message_template`, `adapter.model`) took the
+    stringified value silently. The allowlist and regex checks still run — they just
+    run second now.
+
+    Ablation: two disjoint conditionals. Delete `_typed_str`'s and raise, retaining
+    `return value`; every row fails except the four `adapter.dev`/`adapter.review`
+    ones, which are the per-stage overrides and go through `_opt_typed_str` — delete
+    that one instead and exactly those four fail."""
+    with pytest.raises(policy.PolicyError, match=rf"{re.escape(section)}\.{key} must be a string"):
+        policy.loads(f"[{section}]\n{key} = {bad}\n")
+
+
+@pytest.mark.parametrize("bad", ["5", "true", "[]"])
+def test_plugins_enabled_entries_reject_non_strings(bad):
+    """The list SHAPE was already typed; its entries were not, so `[str(n) for n in
+    raw_enabled]` turned any scalar into a plugin name that no loader can resolve —
+    `enabled = [5]` asked for a plugin literally named "5". The sibling entry guard on
+    `scm.worktree_seed` is the precedent this matches.
+
+    Ablation: delete the isinstance conditional and its raise, retaining the append;
+    all rows fail because every entry is collected whatever its type."""
+    with pytest.raises(policy.PolicyError, match=r"plugins\.enabled entries must be strings"):
+        policy.loads(f"[plugins]\nenabled = [{bad}]\n")
+
+
+@pytest.mark.parametrize("bad", ["5", "true"])
+def test_deprecated_engine_name_rejects_non_string(bad):
+    """The deprecated `[engine]` fold reads `name` to decide which plugin to enable,
+    so a wrong-typed one stringified into a bogus plugin name on the way out of a
+    block that is already warning the user it is going away. The DeprecationWarning
+    still fires: the type check runs after it, not instead of it.
+
+    Ablation: delete `_typed_str`'s conditional and raise; both rows fail because the
+    name is stringified and enables a plugin named "5"/"True"."""
+    with pytest.warns(DeprecationWarning):
+        with pytest.raises(policy.PolicyError, match=r"engine\.name must be a string"):
+            policy.loads(f"[engine]\nname = {bad}\n")
+
+
 @pytest.mark.parametrize("bad", ["true", '"0.5"'])
 def test_cache_read_weight_rejects_non_number(bad):
     """Ablation: delete `_typed_float`'s conditional and raise; both rows fail

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -1,4 +1,5 @@
 import json
+import re
 import sys
 
 import pytest
@@ -493,7 +494,7 @@ def test_dev_contract_nudge_default_parse_and_template():
 
 
 def test_dev_contract_nudge_rejects_non_boolean():
-    """Ablation: delete `_limit_bool`'s conditional and raise, retaining
+    """Ablation: delete `_typed_bool`'s conditional and raise, retaining
     `return value`; this test fails because the string is returned unchanged."""
     with pytest.raises(policy.PolicyError, match=r"limits\.dev_contract_nudge must be a boolean"):
         policy.loads('[limits]\ndev_contract_nudge = "false"\n')
@@ -520,16 +521,116 @@ def test_dev_contract_nudge_rejects_non_boolean():
     ],
 )
 def test_limits_integer_fields_reject_non_integer(key, bad):
-    """Ablation: delete `_limit_int`'s conditional and raise, retaining
+    """Ablation: delete `_typed_int`'s conditional and raise, retaining
     `return value`; all rows fail because bad scalars are accepted or reach
     downstream validation without the required integer `PolicyError`."""
     with pytest.raises(policy.PolicyError, match=rf"limits\.{key} must be an integer"):
         policy.loads(f"[limits]\n{key} = {bad}\n")
 
 
+@pytest.mark.parametrize("bad", ["true", "1.5", '"1"'])
+@pytest.mark.parametrize(
+    ("section", "key"),
+    [
+        ("verify", "stream_capture_kb"),
+        ("sweep", "max_bundles"),
+        ("sweep", "max_triage_attempts"),
+        ("sweep", "max_migration_attempts"),
+        ("sweep", "max_cycles"),
+        ("scm", "max_parallel"),
+        ("scm", "failed_diff_max_mb"),
+        ("cleanup", "run_retention"),
+        ("cleanup", "retention_days"),
+    ],
+)
+def test_numeric_policy_fields_reject_non_integer(section, key, bad):
+    """The [limits] grid above, for the sections #587 did not reach. Every one of
+    these was a bare `int()`: `"1"` and `1.5` came back as a raw ValueError and
+    `true` came back as 1, none of them a PolicyError, so all three walked past the
+    `except (PolicyError, OSError)` handlers that exist to degrade to defaults.
+
+    Ablation: delete `_typed_int`'s conditional and raise, retaining `return value`;
+    every row fails — the quoted and float rows raise ValueError instead of
+    PolicyError, and `true` is accepted outright."""
+    with pytest.raises(policy.PolicyError, match=rf"{section}\.{key} must be an integer"):
+        policy.loads(f"[{section}]\n{key} = {bad}\n")
+
+
+@pytest.mark.parametrize("table", ["adapter", "adapter.review"])
+@pytest.mark.parametrize(
+    ("key", "kind", "bad"),
+    [
+        ("usage_grace_s", "a number", "true"),
+        ("usage_grace_s", "a number", '"3"'),
+        ("stop_without_result_nudges", "an integer", "true"),
+        ("stop_without_result_nudges", "an integer", "2.5"),
+        ("stop_without_result_nudges", "an integer", '"1"'),
+    ],
+)
+def test_adapter_timing_knobs_reject_non_numeric(table, key, kind, bad):
+    """`_opt_grace`/`_opt_nudges` return None for "inherit from the profile", so they
+    cannot take `_typed_*`'s default — they carry the same guard inline. Before it,
+    `usage_grace_s = true` resolved to a 1.0-second grace and the quoted rows raised
+    a raw ValueError past every degrade handler.
+
+    Ablation: delete the isinstance conditional in the named helper (singly),
+    retaining the coercion below it; that helper's rows fail on both tables."""
+    with pytest.raises(policy.PolicyError, match=rf"{re.escape(table)}\.{key} must be {kind}"):
+        policy.loads(f"[{table}]\n{key} = {bad}\n")
+
+
+@pytest.mark.parametrize("table", ["adapter", "adapter.review"])
+def test_usage_grace_s_accepts_a_toml_integer(table):
+    """A grace in whole seconds is the natural spelling and stays legal — the guard
+    rejects wrong TYPES, not int-shaped numbers (`limits.cache_read_weight` above
+    makes the same promise)."""
+    pol = policy.loads(f"[{table}]\nusage_grace_s = 30\n")
+    stage = pol.adapter if table == "adapter" else pol.adapter.review
+    assert stage.usage_grace_s == 30.0
+    assert isinstance(stage.usage_grace_s, float)
+
+
+@pytest.mark.parametrize("bad", ['"pytest"', "5", "[1]"])
+@pytest.mark.parametrize(
+    ("table", "key"),
+    [
+        ("verify", "commands"),
+        ("adapter", "extra_args"),
+        ("adapter.dev", "extra_args"),
+    ],
+)
+def test_array_policy_fields_reject_scalars(table, key, bad):
+    """The `scm.worktree_seed` trap, in the three argv-shaped fields that still had
+    it. `tuple(str(a) for a in raw)` accepts anything iterable, so a bare TOML string
+    exploded CHARACTER-WISE — `commands = "pytest"` became six one-character commands
+    while reading as applied configuration — and a scalar int raised a bare TypeError
+    out of `loads`, untyped, where every other malformed value here raises
+    PolicyError. `[1]` is the third shape: right container, wrong entries, silently
+    stringified.
+
+    Ablation: delete `_typed_str_tuple`'s two conditionals (singly); the shape check
+    fails the string and int rows, the entry check fails the `[1]` rows."""
+    with pytest.raises(
+        policy.PolicyError, match=rf"{re.escape(table)}\.{key} must be an array of strings"
+    ):
+        policy.loads(f"[{table}]\n{key} = {bad}\n")
+
+
+def test_array_policy_fields_keep_unset_distinct_from_empty():
+    """`extra_args` is a tri-state: unset (None) inherits the profile's arguments,
+    `[]` is an explicit "no arguments". The shape guard must not fold one into the
+    other — `verify.commands` is not optional and normalizes both to ()."""
+    assert policy.loads("").adapter.extra_args is None
+    assert policy.loads("").adapter.dev.extra_args is None
+    assert policy.loads("[adapter]\nextra_args = []\n").adapter.extra_args == ()
+    assert policy.loads('[adapter]\nextra_args = ["-p"]\n').adapter.extra_args == ("-p",)
+    assert policy.loads("").verify.commands == ()
+    assert policy.loads('[verify]\ncommands = ["pytest -q"]\n').verify.commands == ("pytest -q",)
+
+
 @pytest.mark.parametrize("bad", ["true", '"0.5"'])
 def test_cache_read_weight_rejects_non_number(bad):
-    """Ablation: delete `_limit_float`'s conditional and raise; both rows fail
+    """Ablation: delete `_typed_float`'s conditional and raise; both rows fail
     because `float` accepts the boolean and quoted-number values."""
     with pytest.raises(policy.PolicyError, match=r"limits\.cache_read_weight must be a number"):
         policy.loads(f"[limits]\ncache_read_weight = {bad}\n")
@@ -559,7 +660,7 @@ def test_invalid_session_budget_mode():
 
 
 def test_session_budget_mode_rejects_non_string():
-    """Ablation: delete `_limit_str`'s conditional and raise; this test fails
+    """Ablation: delete `_typed_str`'s conditional and raise; this test fails
     because the downstream options check raises a different `PolicyError`."""
     with pytest.raises(policy.PolicyError, match=r"limits\.session_budget_mode must be a string"):
         policy.loads("[limits]\nsession_budget_mode = 1\n")

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -1,4 +1,8 @@
+from importlib import resources
+from pathlib import Path
+
 import pytest
+from conftest import fault_read_text
 
 from bmad_loop.adapters import profile as profile_mod
 from bmad_loop.adapters.profile import (
@@ -538,6 +542,79 @@ def test_every_toml_value_type_parses_or_raises_profile_error(tmp_path, key, val
         load_profiles(tmp_path)
     except ProfileError:
         pass
+
+
+def test_non_utf8_overlay_raises_profile_error(tmp_path):
+    """#473: the READ, not a value coercion. `CONVERSION_FAULTS` cannot reach this
+    one — the funnel wraps `_parse_profile`, and the decode happens in `_load_toml`'s
+    argument expression, before the funnel is entered — so a non-UTF-8 overlay
+    escaped as a raw `UnicodeDecodeError`. Asserting the TYPE is the point: every
+    consumer keys its fault handling on ProfileError, and a `ValueError` escape took
+    `validate` down before it printed any document.
+
+    ABLATION: route the overlay read back through
+    `_load_toml(path.read_text(encoding="utf-8"), str(path))` and this raises
+    UnicodeDecodeError instead."""
+    profiles_dir = tmp_path / ".bmad-loop" / "profiles"
+    profiles_dir.mkdir(parents=True)
+    bad = profiles_dir / "bad.toml"
+    bad.write_bytes(b'name = "b\xffad"\n')
+    # Self-verify the fixture before trusting what it proves: a file that decoded
+    # fine would make the assertion below pass for the wrong reason.
+    with pytest.raises(UnicodeDecodeError):
+        bad.read_text(encoding="utf-8")
+    with pytest.raises(ProfileError, match="not valid UTF-8") as excinfo:
+        load_profiles(tmp_path)
+    assert str(bad) in str(excinfo.value)  # the fault names the file at fault
+
+
+def test_unreadable_overlay_raises_profile_error(tmp_path, monkeypatch):
+    """The OSError arm of the same guard: a profile that is present but cannot be
+    read — permissions, an I/O error, a dead mount. `user_dir.is_dir()` and the glob
+    rule out ABSENCE and nothing else, so this escaped as a bare OSError.
+
+    `fault_read_text` rather than chmod for the reason its docstring gives, and its
+    targeting matters twice over here: a blanket `Path.read_text` patch is answered
+    by the PACKAGED loop first, which would redden with this call site untouched.
+
+    ABLATION: route the overlay read back through `path.read_text(...)` and this
+    raises PermissionError instead."""
+    profiles_dir = tmp_path / ".bmad-loop" / "profiles"
+    profiles_dir.mkdir(parents=True)
+    bad = profiles_dir / "bad.toml"
+    bad.write_text(MINIMAL_PROFILE)
+    # Precondition: readable, this overlay loads — so the raise below is the fault
+    # being converted, not a profile that was malformed all along.
+    assert load_profiles(tmp_path)["mycli"].binary == "mycli"
+    fault_read_text(monkeypatch, bad)
+    with pytest.raises(ProfileError, match="unreadable") as excinfo:
+        load_profiles(tmp_path)
+    assert str(bad) in str(excinfo.value)
+
+
+def test_unreadable_packaged_profile_raises_profile_error(monkeypatch):
+    """The packaged built-ins are read through the same guard. They are trusted
+    content, so this is not #473's user-authored fault class — but a corrupt or
+    unreadable install is a PACKAGING bug, and the loader owes its callers the typed
+    error that says so instead of a traceback: `validate`, `install` and
+    `_require_base_skills` all key on ProfileError and none of them catches OSError.
+
+    Here because the two read sites are separate wiring axes, not one. Measured:
+    reverting the PACKAGED read to `entry.read_text(...)` leaves all three overlay
+    tests green — that site had no oracle at all, and this is the only test that
+    reddens for it. (Reverting the OVERLAY read reddens the other three and leaves
+    this one green: disjoint, which is the proof that neither stands in for the
+    other.)"""
+    packaged = resources.files("bmad_loop.data").joinpath("profiles")
+    names = sorted(e.name for e in packaged.iterdir() if e.name.endswith(".toml"))
+    # Real path, not a zip member: `fault_read_text` targets `Path.read_text`, so a
+    # zipimported install would leave the fault unarmed. Asserted, not assumed.
+    victim = Path(str(packaged.joinpath(names[0])))
+    assert victim.is_file()
+    fault_read_text(monkeypatch, victim)
+    with pytest.raises(ProfileError, match="unreadable") as excinfo:
+        load_profiles()
+    assert victim.name in str(excinfo.value)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -4325,6 +4325,38 @@ async def test_dashboard_survives_undecodable_policy_bytes(project):
         assert not screen._left_frozen and not screen._detail_frozen
 
 
+async def test_dashboard_survives_a_wrong_typed_policy_value(project):
+    """The same `except (PolicyError, OSError)` handler, reached by a policy file that
+    is perfectly readable — valid UTF-8, valid TOML — and wrong only in a VALUE.
+
+    The two siblings above fault at the FILE level (a monkeypatched OSError raiser,
+    then undecodable bytes). This is the first one to fault at a KEY. `max_parallel`
+    was a bare `int()` until #440, so `"x"` left `policy.load` as a raw ValueError,
+    and a ValueError is neither a PolicyError nor an OSError — it walked past this
+    handler exactly as the undecodable bytes did, crashing at app CONSTRUCTION before
+    run_test could mount a screen. Note the fault sits in [scm], a section the
+    dashboard never reads: `load` parses the whole document, so a wrong-typed key
+    anywhere in the file took the TUI down."""
+    text = '[tui]\nleft_width = 50\n[scm]\nmax_parallel = "x"\n'
+    # Precondition: decodable AND well-formed TOML — that is what makes this a value
+    # test rather than a second copy of the two above.
+    assert tomllib.loads(text)["scm"]["max_parallel"] == "x"
+    # Precondition: the [tui] half alone would seed a 50-column sidebar, so asserting
+    # the CSS default below shows the file was REFUSED, not that it was inert.
+    assert policy_mod.loads("[tui]\nleft_width = 50\n").tui.left_width == 50
+    with pytest.raises(policy_mod.PolicyError):  # and the whole document is refused
+        policy_mod.loads(text)
+    bmad = project.project / ".bmad-loop"
+    bmad.mkdir(parents=True, exist_ok=True)
+    (bmad / "policy.toml").write_text(text, encoding="utf-8")
+    app = BmadLoopApp(project.project)
+    async with app.run_test(size=(120, 40)) as pilot:
+        screen = await _seeded(pilot, app)
+        assert screen._tui_policy == policy_mod.TuiPolicy()
+        assert screen.query_one("#left").size.width == 34  # CSS default, not the file's 50
+        assert not screen._left_frozen and not screen._detail_frozen
+
+
 async def test_first_geometry_save_writes_only_tui_keys(project):
     """A geometry save on a project without policy.toml must create a minimal
     [tui]-only file — not materialise POLICY_TEMPLATE, which would freeze every

--- a/tests/test_tui_settings.py
+++ b/tests/test_tui_settings.py
@@ -16,6 +16,7 @@ from textual.widgets import Collapsible, Input, Select, Switch
 
 from bmad_loop import policy as policy_mod
 from bmad_loop.plugins import load_plugins
+from bmad_loop.plugins.loader import PLUGIN_FILE, USER_PLUGINS_REL
 from bmad_loop.policy import POLICY_FILE, POLICY_TEMPLATE
 from bmad_loop.tui import settings as settings_mod
 from bmad_loop.tui.app import BmadLoopApp
@@ -196,6 +197,39 @@ def test_validate_with_project_accepts_valid_coupling(tmp_path):
     doc.set("plugins.unity", "editor_mode", "per_worktree")
     doc.set("scm", "isolation", "worktree")  # valid per_worktree combo
     assert doc.validate(schemas, project=tmp_path) is None
+
+
+def test_validate_survives_an_undecodable_plugin_manifest(tmp_path):
+    """The consumer half of `plugins/loader.py`'s read guard, and the reason that
+    guard is not loader hygiene. `validate(project=...)` degrades on
+    `except (PolicyError, PluginError)` and hands the message to the settings
+    screen to render, but a non-UTF-8 project `plugin.toml` reached it as a raw
+    `UnicodeDecodeError` — a ValueError, outside that tuple — so the settings
+    surface died at construction instead of naming the file to fix.
+
+    Not the coupling tests over again: those raise PluginError out of a plugin's
+    own `validate()`, the *second* half of this try block. This one raises it out
+    of `PluginRegistry.build`'s `load_plugins`, the half nothing graded. And
+    `build` loads EVERY discovered plugin, not just the enabled ones, so the drop
+    alone arms it — `plugins.enabled` is deliberately left untouched.
+
+    ABLATION: revert the project read in `_discover_project` to
+    `load_manifest(toml.read_text(encoding="utf-8"), ...)` and `validate` raises
+    UnicodeDecodeError instead of returning a string."""
+    pdir = tmp_path / USER_PLUGINS_REL / "bad"
+    pdir.mkdir(parents=True)
+    manifest = pdir / PLUGIN_FILE
+    manifest.write_bytes(b'[plugin]\nname = "b\xffad"\napi_version = 1\n')
+    # Self-verify the fixture before trusting what it proves: a file that decoded
+    # fine would make the assertion below pass for the wrong reason.
+    with pytest.raises(UnicodeDecodeError):
+        manifest.read_text(encoding="utf-8")
+
+    doc = PolicyDoc.load(tmp_path / "missing.toml")  # template-backed, valid
+    assert doc.validate() is None  # the POLICY is fine; only the plugin read is not
+    error = doc.validate(project=tmp_path)
+    assert error is not None and "not valid UTF-8" in error
+    assert str(manifest) in error  # the operator is told which file to fix
 
 
 def test_validate_with_project_skips_disabled_plugin_coupling(tmp_path):


### PR DESCRIPTION
## The problem

Three separate parsers read user-authored TOML — `policy.loads`, `adapters/profile.load_profiles`,
and `plugins/loader` — and each has a typed domain error (`PolicyError`, `ProfileError`,
`PluginError`) that every consumer keys its fault handling on. But a file whose *content* was
wrong escaped as a **raw** `ValueError` / `TypeError` / `UnicodeDecodeError` instead, walking
straight past the handlers written to survive exactly that:

- `cli.py`'s `_configure_mux` — `except (PolicyError, OSError)`, and it runs before dispatch on
  **every** subcommand, so one bad character traced back at you from an unrelated command.
- `tui/app.py` and `tui/screens/dashboard.py` — the TUI died at construction rather than falling
  back to defaults and letting the operator open the settings editor to fix the file.
- `tui/settings.py` — `except (PolicyError, PluginError)`, the degrade that renders the message
  into the settings screen's error line.
- `cmd_validate`'s role loop — the raw escape hit `main`'s bare-except backstop, which prints one
  `error:` line and **no document**, breaking `machine.py`'s one-object `--json` contract.

Two of the policy faults never announced themselves at all: `notify.desktop = "false"` is a truthy
string, so `bool()` turned the feature **on**; `verify.commands = "pytest"` iterated a bare string
into six one-character commands that read back as applied configuration.

## What changed, phase by phase

| # | Commit | Change |
|---|--------|--------|
| 1 | `d2e728c6`, `025d57ca` | **policy crash-class.** The four `[limits]`-only helpers generalized to section-aware `_typed_int` / `_typed_float` / `_typed_bool` / `_typed_str(d, where, key, default)` (+ `_typed_str_tuple`); every remaining raw `int()`/`float()` in `loads()` routed through them; `_opt_grace`/`_opt_nudges` given inline type guards; array shape guards on `verify.commands` and both `extra_args`. |
| 2 | `cda395d2` | **policy silent-class.** Every remaining bare `bool()`/`str()` routed through the typed helpers — 16 boolean fields, 22 string fields, the `plugins.enabled` entries, and the deprecated-`[engine]` fold. Allowlist fields keep their allowlist and blame the *type* first. |
| 3 | `bcddfed9` | **profile read guard.** `_read_profile_text(entry, source)` at both `load_profiles` read sites (packaged + overlay), converting `UnicodeDecodeError`/`OSError` into `ProfileError` naming the file. |
| 4 | `66d6e2e8` | **plugin loader read guard + ship (#689).** The same `_read_manifest_text(toml, source)` at both `plugins/loader` read sites (builtin + project); CHANGELOG. |

`[limits]` messages are byte-identical throughout — all call sites pass `where="limits"`. Valid
policies parse to identical `Policy` objects: this changes only what happens to *invalid* values.
`usage_grace_s = 30` is still a legal float, and an unset `extra_args` still means "inherit the
profile's flags" where `[]` means "none". The lenient snapshot readers (`_snapshot_extra_args`,
`adapter_policy_from_snapshot`) are deliberately untouched — they parse the json-round-tripped
`RunState.policy_snapshot` and must never crash; `025d57ca` documents why.

`plugins/manifest.py` needed no work: its value-coercion funnel already exists and its messages
are pinned by tests. The live plugin gap was the unguarded read, not the parse.

## Repros, re-measured on this branch

| Repro | Before | After |
|-------|--------|-------|
| `[scm] max_parallel = "x"` | raw `ValueError` | `PolicyError: scm.max_parallel must be an integer: got 'x'` |
| `[cleanup] run_retention = "x"` | raw `ValueError` | `PolicyError: cleanup.run_retention must be an integer: got 'x'` |
| `[limits] dev_contract_nudge = "false"` | typed already | unchanged, byte-identical (unregressed) |
| `[notify] desktop = "false"` | silently ON | `PolicyError: notify.desktop must be a boolean: got 'false'` |
| non-UTF-8 profile overlay, `validate --project proj --json` | bare `error:` line, **empty stdout**, rc 1 | **one** JSON document at rc 1 with an `adapter.profile` finding naming the file; stderr empty |
| non-UTF-8 project `plugin.toml` | raw `UnicodeDecodeError` through the TUI settings degrade | `PluginError: plugin <path>: not valid UTF-8: …`, settings surface degrades |

## Verification

- `uv run pytest -q -n logical` — **6397 passed, 53 skipped** (6225 before phase 1; +172 cases).
- `uv run pyright` — 0 errors. `trunk fmt` + `trunk check --all` (258 files) — clean.
- Every new gate was ablated **singly** and confirmed to redden, restored from a `cp` backup with
  an md5 check rather than `git checkout`. Where a fix had two axes, both were measured and the
  redden-sets are **disjoint** — which is what proves neither half stands in for the other:
  - *call-site axis* (phase 4): reverting the project read reddens 2 tests, the builtin read 1.
  - *arm axis* (phase 4): dropping the `UnicodeDecodeError` arm reddens 1, the `OSError` arm 2.
  - phase 2's wiring axis: reverting one call site (`scm.keep_failed`) to a bare `bool()` with
    both helpers intact reddens exactly 3 rows while 62 sibling rows stay green.
- The validate tests assert on the parsed `machine_json` document, never on rc alone: `main`'s
  bare-except backstop also returns 1, so an rc-only assertion is green with the fix reverted.

Closes #440. Closes #473. Closes #689.

#689 was filed for the plugin-manifest leg after review: #473's repro and contract are both
the `validate` command, which never reaches the plugin loader, so that leg had no issue of its
own even though it is the same fault at the third and last parser reading user-authored TOML.
Filed rather than split out — the guard is 37 lines in `loader.py` mirroring the profile guard,
and shipping two of three parsers fixed would leave a known crash on `main`.

Context, no status change intended: #587 (the earlier `[limits]` leg this extends), #474
(a duplicate of #440, contributing the validate-document carry test), #278 (where the
truthy-string hazard was recorded).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Policy validation now rejects incorrectly typed TOML values with clear, field-specific errors instead of coercing them.
  - Unreadable or invalid-encoding profile files and plugin manifests now produce structured, file-specific diagnostics.
  - Dashboard startup gracefully falls back to default settings when unrelated policy values are invalid.
- **Validation**
  - Expanded coverage for policy fields, profiles, and plugin manifests.
  - JSON validation output now includes actionable findings and an appropriate failure status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
