### PR TITLE
fix(tui): show the pause reason for spec-less gate pauses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@ breaking changes may land in a minor release.
 
 ### Fixed
 
+- TUI: story-gate and epic-boundary pauses open a pause-reason viewer naming the blocking
+  entries and the remedy, instead of an empty spec pane (#515)
 - **Provisioning refuses an unparseable seeded hook config instead of silently replacing it
   (#592).** An isolated worktree's seeded `.claude/settings.json` that failed to parse was read
   as an empty document, so the relay merge always ran against a blank baseline and published a

--- a/docs/tui-guide.md
+++ b/docs/tui-guide.md
@@ -486,11 +486,13 @@ artifacts the engine already wrote.
   interactive agent as `R`; **Re-arm & resume** (offered once the resolve agent has
   recorded a resolution) re-arms and resumes — deleting a sentinel with a preserved
   copy for a clean re-dispatch. Both refuse a still-live engine.
-- **Spec-approval / epic / story gate** — reuses the spec viewer (view the finalized
-  spec, then **Approve & resume**), so the pre-existing sprint-mode gates inherit the
-  same richer surface. A story gate fires before the story is recorded, so it has no
-  spec to show; read its reason — which names the blocking entries and the remedy — in
-  the run-header banner or the resume confirmation.
+- **Spec-approval / epic / story gate** — a spec-approval gate reuses the spec viewer
+  (view the finalized spec, then **Approve & resume**), so the pre-existing sprint-mode
+  gate inherits the same richer surface. Story-gate and epic-boundary pauses have no
+  spec to show — a story gate fires before the story is recorded, an epic boundary has
+  no story at all — so they open a compact pause-reason viewer instead: the reason names
+  the blocking entries and the remedy, and **Resume** re-picks the story and re-asks the
+  ledger, so a gate that is still open legitimately re-pauses.
 
 `p` and `R` overlap for an escalation (both reach Resolve); `p` also exposes
 Re-arm & resume inline once a resolution exists. Pause badges in the run list and

--- a/src/bmad_loop/tui/app.py
+++ b/src/bmad_loop/tui/app.py
@@ -46,6 +46,7 @@ from .screens.modals import (
     ConfirmResumeModal,
     DecisionModal,
     EscalationModal,
+    PauseReasonModal,
     SpecReviewModal,
     StartRunModal,
     StartSweepModal,
@@ -623,21 +624,39 @@ class BmadLoopApp(App[None]):
         self.push_screen(modal, done)
 
     def _review_gate(self, run_id: str, run_dir: Path, state: RunState) -> None:
-        labels = {
-            PAUSE_SPEC_APPROVAL: "spec-approval gate",
-            PAUSE_EPIC_BOUNDARY: "epic gate",
-            PAUSE_STORY_GATE: "story gate",
-        }
+        label = widgets.pause_label(state.paused_stage or "")[0] or "gate"
         spec_path, spec_text = self._paused_spec(state)
+
+        def done(verb: str | None) -> None:
+            if verb == "resume":
+                self._do_resume(run_id)
+
+        if spec_path is None:
+            # Spec-less gates: story-gate fires before the story is registered in
+            # state.tasks (deliberate, so a resume re-picks and re-asks the ledger)
+            # and epic-boundary has no story key. The pause reason is the payload.
+            subtitle = (
+                self._story_subtitle(state)
+                if state.paused_story_key
+                else Text(f"run {run_id}", style="bold")
+            )
+            self.push_screen(
+                PauseReasonModal(
+                    title=f"{label} — pause reason",
+                    subtitle=subtitle,
+                    reason=state.paused_reason or "",
+                ),
+                done,
+            )
+            return
         modal = SpecReviewModal(
-            # paused_stage may be None; dict.get tolerates a None key (returns the default).
-            title=f"{labels.get(state.paused_stage, 'gate')} — review the finalized spec",  # pyright: ignore[reportArgumentType, reportCallIssue]
+            title=f"{label} — review the finalized spec",
             subtitle=self._story_subtitle(state),
             spec_path=spec_path,
             spec_text=spec_text,
             actions=[("resume", "Approve & resume", "primary")],
         )
-        self.push_screen(modal, lambda verb: self._do_resume(run_id) if verb == "resume" else None)
+        self.push_screen(modal, done)
 
     @staticmethod
     def _checkpoint_gate_line(review_cycle: int) -> str:

--- a/src/bmad_loop/tui/screens/modals.py
+++ b/src/bmad_loop/tui/screens/modals.py
@@ -505,7 +505,7 @@ class SpecReviewModal(BaseDialog):
     """Read-only story-spec viewer with a configurable action row.
 
     Shared by the plan-checkpoint viewer (Approve & resume / Request replan) and
-    the spec-approval / epic gate viewer (Approve & resume). Dismisses with the
+    the spec-approval gate viewer (Approve & resume). Dismisses with the
     chosen action verb, or None on close/escape. The spec path is shown
     prominently with a copy-path action; the spec body is LLM-written markdown so
     it renders as plain Text, never markup. The modal owns no logic — the caller
@@ -573,6 +573,44 @@ class SpecReviewModal(BaseDialog):
             self.dismiss(bid[len("act-") :])
             return
         self.dismiss(None)
+
+
+class PauseReasonModal(BaseDialog):
+    """Spec-less gate viewer: a story gate fires before its story is registered
+    and an epic boundary has no story at all, so the pause reason IS the payload
+    — it names the blocking entries and the remedy. Dismisses with 'resume', or
+    None on close/escape. Reasons are arbitrary engine text → plain Text, never
+    markup. The modal owns no logic — the caller maps the verb to _do_resume."""
+
+    DEFAULT_CSS = """
+    PauseReasonModal #reason {
+        height: auto;
+        max-height: 60%;
+    }
+    """
+
+    def __init__(self, *, title: str, subtitle: str | Text, reason: str):
+        super().__init__()
+        self._title = title
+        self._subtitle = subtitle if isinstance(subtitle, Text) else Text(subtitle)
+        self._reason = reason
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="dialog"):
+            yield Label(self._title, classes="title")
+            yield Static(self._subtitle, id="subtitle")
+            with VerticalScroll(id="reason"):
+                body = self._reason.strip()
+                yield Static(
+                    Text(body) if body else Text("(no pause reason recorded)", style="dim")
+                )
+            with Horizontal(classes="buttons"):
+                yield Button("Resume", variant="primary", id="act-resume")
+                yield Button("close", id="cancel")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        bid = event.button.id or ""
+        self.dismiss(bid[len("act-") :] if bid.startswith("act-") else None)
 
 
 class StoryCheckpointModal(BaseDialog):

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -60,6 +60,7 @@ from bmad_loop.tui.screens.modals import (
     DecisionModal,
     DeferredEntryModal,
     EscalationModal,
+    PauseReasonModal,
     SpecReviewModal,
     StartRunModal,
     StartSweepModal,
@@ -1839,6 +1840,7 @@ _MIN_SIZE_CASES = (
     "deferred-entry",
     "story-checkpoint",
     "escalation",
+    "pause-reason",
     "text-output",
 )
 
@@ -1899,6 +1901,12 @@ def _minimum_size_case(name: str, project):
             ),
             ("#act-resolve", "#act-rearm", "#cancel", "#hint"),
             "#body",
+        )
+    if name == "pause-reason":
+        return (
+            PauseReasonModal(title="t", subtitle="s", reason="line\n" * 80),
+            ("#act-resume", "#cancel"),
+            "#reason",
         )
     assert name == "text-output", name
     return TextOutputModal("validate", 0, "out\n" * 40), ("#ok",), "#output"
@@ -3179,9 +3187,16 @@ def test_pause_tag_and_label_render():
     assert pause_tag("plan-checkpoint").plain == "plan"
     assert pause_tag("story-checkpoint").plain == "story"
     assert pause_tag("escalation").plain == "esc"
+    assert pause_tag("story-gate").plain == "gate"
+    assert pause_tag("epic-boundary").plain == "epic"
     assert pause_tag("").plain == ""  # not paused → no tag
     label, style = pause_label("escalation")
     assert label == "escalation" and "red" in style
+    # the gate viewers title themselves from pause_label, so these three strings
+    # are load-bearing UI, not just badge text (#515)
+    assert pause_label("story-gate") == ("story gate", "yellow")
+    assert pause_label("epic-boundary")[0] == "epic gate"
+    assert pause_label("spec-approval")[0] == "spec-approval gate"
 
 
 def test_stopping_tag_renders():
@@ -4012,6 +4027,118 @@ async def test_gate_pause_resume(project, monkeypatch):
         await _open_review(app, pilot, SpecReviewModal)
         await pilot.click(await ready(pilot, "#act-resume"))
         await until(pilot, lambda: calls == ["20260611-100000-aaaa"])
+
+
+# ------------------------------- #515: spec-less gate pauses show the reason
+#
+# A story gate fires BEFORE the story is registered in state.tasks (deliberate —
+# a resume re-picks the story and re-asks the ledger) and an epic boundary has no
+# story key at all, so _paused_spec returns (None, "") and the spec viewer had
+# nothing to show. These pin that the pause reason — which names the blocking
+# entries and the remedy — is what the operator gets instead.
+
+_GATE_REASON = (
+    "1-1 is gated by unlanded deferred work: DW-1 (gate: 1-1) — close the entry in "
+    "deferred-work.md, or clear its gate, then resume."
+)
+
+
+@pytest.mark.parametrize(
+    ("story_key", "tasks"),
+    [
+        # the engine gate: the story is not in state.tasks yet at all
+        ("1-1", {}),
+        # sweep's ledger-migration gate (sweep.py): the task IS registered, it just
+        # has no spec_file — the other arm of _paused_spec's (None, "") return
+        ("sweep-migrate", {"sweep-migrate": StoryTask(story_key="sweep-migrate", epic=0)}),
+    ],
+    ids=["task-unregistered", "task-without-spec-file"],
+)
+async def test_story_gate_pause_shows_reason_and_resumes(project, monkeypatch, story_key, tasks):
+    calls: list[str] = []
+    monkeypatch.setattr(launch, "mux_available", lambda: True)
+    monkeypatch.setattr(launch, "resume_detached", lambda proj, rid: calls.append(rid))
+    monkeypatch.setattr(data, "liveness", lambda run_dir: "dead")
+    make_run(
+        project.project,
+        "20260611-100000-aaaa",
+        paused_stage="story-gate",
+        paused_reason=_GATE_REASON,
+        paused_story_key=story_key,
+        tasks=tasks,
+    )
+    app = BmadLoopApp(project.project)
+    async with app.run_test() as pilot:
+        await _open_review(app, pilot, PauseReasonModal)  # routed away from the spec viewer
+        await ready(pilot, "#reason Static")
+        body = render(app.screen.query_one("#reason Static", Static).content)
+        assert "gated by unlanded deferred work" in body
+        assert "DW-1" in body, "the reason names the blocking entry, not a blank pane"
+        await pilot.click(await ready(pilot, "#act-resume"))
+        await until(pilot, lambda: calls == ["20260611-100000-aaaa"])
+
+
+async def test_epic_boundary_pause_shows_reason_and_run_id_subtitle(project, monkeypatch):
+    """An epic boundary raises with no story key, so the old viewer subtitled it
+    "?". The run id is the only identity there is — assert it positively, so a
+    regression back to _story_subtitle's placeholder reddens this."""
+    monkeypatch.setattr(data, "liveness", lambda run_dir: "dead")
+    make_run(
+        project.project,
+        "20260611-100000-aaaa",
+        paused_stage="epic-boundary",
+        paused_reason="epic 1 boundary — `bmad-loop resume <id>` to continue with epic 2",
+        paused_story_key=None,
+        tasks={},
+    )
+    app = BmadLoopApp(project.project)
+    async with app.run_test() as pilot:
+        await _open_review(app, pilot, PauseReasonModal)
+        await ready(pilot, "#reason Static")
+        assert "epic 1 boundary" in render(app.screen.query_one("#reason Static", Static).content)
+        subtitle = render(app.screen.query_one("#subtitle", Static).content)
+        assert "run 20260611-100000-aaaa" in subtitle
+
+
+async def test_spec_approval_unreadable_spec_still_uses_spec_viewer(project, monkeypatch):
+    """An unreadable spec file returns (path, "") from _paused_spec — a spec that
+    exists in the task and cannot be read, not a spec-less gate. It keeps the spec
+    viewer (path line + "(empty spec)"), which pins the branch as `spec_path is
+    None` rather than `not spec_text`."""
+    monkeypatch.setattr(data, "liveness", lambda run_dir: "dead")
+    task = StoryTask(story_key="1-1-a", epic=1, phase=Phase.DEV_VERIFY)
+    task.spec_file = str(project.project / "gone" / "spec-1-1-a.md")
+    make_run(
+        project.project,
+        "20260611-100000-aaaa",
+        paused_stage="spec-approval",
+        paused_reason="awaiting spec approval",
+        paused_story_key="1-1-a",
+        tasks={"1-1-a": task},
+    )
+    app = BmadLoopApp(project.project)
+    async with app.run_test() as pilot:
+        await _open_review(app, pilot, SpecReviewModal)
+
+
+async def test_story_gate_empty_reason_renders_fallback(project, monkeypatch):
+    """RunState.paused is `paused_reason is not None`, so an empty reason is a
+    reachable pause — the viewer says so rather than showing an empty pane."""
+    monkeypatch.setattr(data, "liveness", lambda run_dir: "dead")
+    make_run(
+        project.project,
+        "20260611-100000-aaaa",
+        paused_stage="story-gate",
+        paused_reason="",
+        paused_story_key="1-1",
+        tasks={},
+    )
+    app = BmadLoopApp(project.project)
+    async with app.run_test() as pilot:
+        await _open_review(app, pilot, PauseReasonModal)
+        await ready(pilot, "#reason Static")
+        body = render(app.screen.query_one("#reason Static", Static).content)
+        assert "(no pause reason recorded)" in body
 
 
 async def test_start_run_modal_stories_source_launches(project, monkeypatch):


### PR DESCRIPTION
## What

The TUI's `p` viewer routed `PAUSE_STORY_GATE` and `PAUSE_EPIC_BOUNDARY` into `SpecReviewModal`, which promised a spec neither pause has. `_review_gate` now branches on whether a spec resolved at all:

- **Spec-carrying gates** (spec-approval, and every plan-checkpoint viewer that shares the modal) are untouched — same title, same actions, byte-identical.
- **Spec-less gates** open a new compact `PauseReasonModal`: the pause reason, which names the blocking deferred-work entries and the remedy, with **Resume** and **close**. An epic boundary — which has no story key at all — is subtitled with the run id instead of the old `?`.

## Why

A story gate fires *before* the story is registered in `state.tasks`, deliberately, so a resume re-picks the story and re-asks the ledger (`engine.py`). So `_paused_spec` returns `(None, "")` and the operator got `(no spec file resolved)` / `(empty spec)` under a title promising a spec, with `Approve & resume` as the only action. The actionable payload — `state.paused_reason` — was rendered in the run-header banner and the resume confirmation, but never in the viewer the badge points you at. The path went live when #502 merged.

The branch condition is `spec_path is None`, not `not spec_text`: an *unreadable* spec file returns `(path, "")` and must stay on the spec viewer, which shows the path plus `(empty spec)`. That distinction has its own test.

Two shapes reach the reason viewer and both are covered: the engine gate (no task registered) and sweep's ledger-migration gate (task registered, no `spec_file`).

Reason text is arbitrary engine text, so it renders as rich `Text`, never markup. The modal uses `ConfirmModal`'s bounded `height: auto; max-height: 60%` tier, and joins the existing 39x9 minimum-size matrix.

## Tests

Six new/extended cases in `tests/test_tui_app.py`, next to the existing `test_gate_pause_resume` regression guard (untouched):

- `test_story_gate_pause_shows_reason_and_resumes` — both spec-less shapes, asserts the routing, the reason text, and that **Resume** reaches `resume_detached`
- `test_epic_boundary_pause_shows_reason_and_run_id_subtitle` — positive assert on the run-id subtitle
- `test_spec_approval_unreadable_spec_still_uses_spec_viewer` — pins the branch condition
- `test_story_gate_empty_reason_renders_fallback` — `paused_reason == ""` is reachable
- a `pause-reason` arm in the 39x9 minimum-size matrix
- `test_pause_tag_and_label_render` extended — the gate titles now come from `pause_label`, so those strings are load-bearing

Each was ablated against the whole file. Reverting the spec-less branch reddens the four routing tests; flipping the condition to `not spec_text` reddens only the unreadable-spec test; restoring the `?` subtitle reddens only the epic-boundary subtitle assert; opting the modal out of `BaseDialog`'s `max-width` clamp reddens only the new matrix case.

Full suite, `pyright` and `trunk check` clean.

Closes #515


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Story-gate and epic-boundary pauses now display a clear pause-reason viewer instead of an empty specification panel.
  - Pause details identify the blocked story or run and explain the required remedy.
  - Resuming correctly reselects the story and re-asks the ledger.

- **Documentation**
  - Updated paused-run guidance to distinguish specification, story-gate, and epic-boundary viewers.
  - Added an unreleased changelog entry describing the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->