### PR TITLE
fix(release): hold the publish queue, pin check=False, fix a stale comment (#468)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # need all tags to detect whether vX.Y.Z already exists
+          persist-credentials: false # nothing here runs an authenticated git op
 
       - name: Install uv
         uses: astral-sh/setup-uv@v10.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,14 @@ concurrency:
   # leaves the tag unmade.
   group: release-publish
   cancel-in-progress: false
+  # `queue: max` because the default single-slot queue cancels an older *pending*
+  # publish when a newer run enters the group — an evicted publish is a silently
+  # unmade tag, the same failure the no-cancel rule above exists to prevent.
+  # The key shipped 2026-05-07; actionlint 1.7.12 (pinned, and upstream's latest,
+  # 2026-03-30) predates it and rejects it as unknown, so the check is suppressed
+  # here rather than repo-wide. Drop this once actionlint learns the key.
+  # trunk-ignore(actionlint/syntax-check)
+  queue: max
 
 permissions:
   contents: write # create tags + releases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,13 @@ breaking changes may land in a minor release.
 
 ### Fixed
 
+- **A queued release publish can no longer be evicted by a newer push (#468)** — the
+  repo-wide `release-publish` concurrency group now sets `queue: max`; the default
+  single-slot queue cancels an older _pending_ run when a newer one queues, so a
+  maintenance-branch publish could be silently discarded by an unrelated `main` push.
+  Also pins `cmd_publish`'s `check=False` with a regression test (the lost-race swallow
+  was one revert away from dead code with the suite still green) and corrects a comment
+  that still described the group as keying on `github.ref`.
 - TUI: story-gate and epic-boundary pauses open a pause-reason viewer naming the blocking
   entries and the remedy, instead of an empty spec pane (#515)
 - **Provisioning refuses an unparseable seeded hook config instead of silently replacing it

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -543,13 +543,14 @@ def cmd_publish(args: argparse.Namespace) -> int:
     if proc.returncode != 0:
         # The `tag_exists` probe above reads the *checkout's* refs, and nothing
         # fetches between it and this call — so it answers for tag state at
-        # checkout time, not for the remote now. Since release.yml fires on
-        # `main` and on `release/*`, and its concurrency group keys on
-        # `github.ref` (two branches ⇒ two groups), two runs carrying the same
-        # version can both pass the probe and both land here. Losing that race
-        # is not a failure: the winner created this exact tag from this exact
-        # CHANGELOG section, so the desired end state already holds. Anything
-        # else is a real error and still dies loudly.
+        # checkout time, not for the remote now. release.yml serializes its own
+        # runs (one repo-wide `release-publish` concurrency group), but that
+        # group covers only CI: a publisher outside it — a manual
+        # `release.py publish`, a hand-cut release — can create this tag after
+        # our checkout and before this call. Losing that race is not a failure:
+        # the winner created this exact tag from this exact CHANGELOG section,
+        # so the desired end state already holds. Anything else is a real error
+        # and still dies loudly.
         if _already_exists(proc.stderr):
             print(f"{tag} was created concurrently — nothing to publish")
             return 0

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -547,10 +547,13 @@ def cmd_publish(args: argparse.Namespace) -> int:
         # runs (one repo-wide `release-publish` concurrency group), but that
         # group covers only CI: a publisher outside it — a manual
         # `release.py publish`, a hand-cut release — can create this tag after
-        # our checkout and before this call. Losing that race is not a failure:
-        # the winner created this exact tag from this exact CHANGELOG section,
-        # so the desired end state already holds. Anything else is a real error
-        # and still dies loudly.
+        # our checkout and before this call. Losing that race is not a failure
+        # for the flow this script drives: every publisher running it derives
+        # both the tag and the notes from the checkout's canonical version, so
+        # the winner made the release we would have made. That is an argument
+        # from the flow, not a proof — nothing here re-reads the remote, so a
+        # release hand-cut under this tag from another commit passes unchecked
+        # (#704). Anything else is a real error and still dies loudly.
         if _already_exists(proc.stderr):
             print(f"{tag} was created concurrently — nothing to publish")
             return 0

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -314,7 +314,7 @@ def test_publish_dry_run_prints_notes(monkeypatch, capsys, tmp_path):
 # `tag_exists` reads the checkout's refs, so a run whose checkout predates another
 # runner's tag push reaches `gh release create` and loses. That is the only failure
 # the command may swallow; every other one still has to be loud.
-def _publish_with_gh(monkeypatch, tmp_path, *, returncode, stderr):
+def _publish_with_gh(monkeypatch, tmp_path, *, returncode, stderr, seen=None):
     cl = tmp_path / "CHANGELOG.md"
     cl.write_text(SAMPLE)
     monkeypatch.setattr(release, "CHANGELOG", cl)
@@ -322,11 +322,13 @@ def _publish_with_gh(monkeypatch, tmp_path, *, returncode, stderr):
     monkeypatch.setattr(release, "tag_exists", lambda tag: False)
     monkeypatch.setattr(release, "_git_out", lambda *a: "deadbeef" * 5)
     monkeypatch.setattr(release.shutil, "which", lambda name: f"/usr/bin/{name}")
-    monkeypatch.setattr(
-        release.subprocess,
-        "run",
-        lambda *a, **kw: SimpleNamespace(returncode=returncode, stdout="", stderr=stderr),
-    )
+
+    def fake_run(*a, **kw):
+        if seen is not None:
+            seen.update(kw)
+        return SimpleNamespace(returncode=returncode, stdout="", stderr=stderr)
+
+    monkeypatch.setattr(release.subprocess, "run", fake_run)
     return release.cmd_publish(SimpleNamespace(dry_run=False))
 
 
@@ -351,6 +353,12 @@ def test_publish_still_dies_on_a_genuine_gh_failure(monkeypatch, capsys, tmp_pat
         )
     assert "gh release create v0.5.0" in str(exc.value)
     assert "Bad credentials" in capsys.readouterr().err
+
+
+def test_publish_passes_check_false_so_the_swallow_inspects_the_rc(monkeypatch, tmp_path):
+    seen: dict[str, object] = {}
+    _publish_with_gh(monkeypatch, tmp_path, returncode=0, stderr="", seen=seen)
+    assert seen["check"] is False
 
 
 # --- prepare refuses an unpromoted changelog -------------------------------- #


### PR DESCRIPTION
Closes #468

Three residuals left behind by #431's publish-race closure (`9a1dfb8`, PR #430). Main-only — see "Scope" below.

## Residual 1 — the `check=False` half was untested

`cmd_publish` passes `check=False` to `gh release create` (`scripts/release.py:538`) so a nonzero rc reaches the `_already_exists` swallow instead of raising `CalledProcessError`. The two existing tests pinned the *swallow*; nothing pinned the `check=` kwarg, because `_publish_with_gh` stubbed `release.subprocess.run` with a `lambda *a, **kw:` that discarded every kwarg. Reverting to `check=True` — the literal pre-#431 bug — left the suite green.

**Fix:** the driver now records the call's kwargs into an optional keyword-only `seen` dict (the repo's existing spy idiom, `tests/test_verify.py:346-360`), plus one test:

```python
def test_publish_passes_check_false_so_the_swallow_inspects_the_rc(monkeypatch, tmp_path):
    seen: dict[str, object] = {}
    _publish_with_gh(monkeypatch, tmp_path, returncode=0, stderr="", seen=seen)
    assert seen["check"] is False
```

Both regression directions redden: `check=True` records `True`, and dropping the kwarg entirely raises `KeyError`. The two existing callers are untouched (`seen` is optional and keyword-only).

### Ablation record (the gate was deleted and the test confirmed red)

`scripts/release.py:538` `check=False` → `check=True`:

```
    def test_publish_passes_check_false_so_the_swallow_inspects_the_rc(monkeypatch, tmp_path):
        seen: dict[str, object] = {}
        _publish_with_gh(monkeypatch, tmp_path, returncode=0, stderr="", seen=seen)
>       assert seen["check"] is False
E       assert True is False

tests/test_release.py:361: AssertionError
FAILED tests/test_release.py::test_publish_passes_check_false_so_the_swallow_inspects_the_rc
1 failed, 58 deselected in 0.06s
```

Restored by editing the single token back — never `git checkout --`, which would also have reverted residual 3's comment rewrite. The ablation was re-run during the review gate after the comment was narrowed (below), confirming the fix had not made the test vacuous; the restore was proven exact by SHA-256 of `scripts/release.py` before and after (identical), and the test returns green.

## Residual 2 — pending-run eviction in the shared concurrency group

`cancel-in-progress: false` protects a *running* publish, not a *pending* one. Under the default `queue: single`, a newer run entering the group **cancels the older pending run** — so after #431 widened the group repo-wide, a queued `release/*` publish could be evicted by an unrelated `main` push. That is a silently unmade tag, not a red job: exactly the failure the no-cancel rule exists to prevent.

**Fix:** `queue: max` on the group.

Verified against current GitHub docs rather than memory:

- Syntax + semantics: <https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#concurrency> — "To allow more than one pending job or workflow run to wait in the same concurrency group, use the optional `queue` property." Default `single`: "any existing pending job or workflow run in the same group is canceled and replaced."
- Shipped 2026-05-07: <https://github.blog/changelog/2026-05-07-github-actions-concurrency-groups-now-allow-larger-queues/> — "Increased queuing can be enabled by adding `queue: max` to the concurrency block in YAML when `cancel-in-progress` is false or not set."
- Compatible with `cancel-in-progress: false`; pairing it with `true` is a **workflow validation error**, so the existing `false` is load-bearing for this key.

**Caveats, stated because they bound the fix rather than undermine it:**

- **Ordering is FIFO by wait-start but explicitly not guaranteed** — "Since the actual start time of a job or run may vary, ordering is not guaranteed." This fix buys *retention* of pending runs, not deterministic publish order. That is sufficient here: `release.py publish` is idempotent and whichever run reaches the tag first wins, so order does not affect the end state.
- **Capacity is 100 pending runs, and overflow is still canceled** — "When the queue is full, any additional jobs or workflow runs are canceled." 100 concurrent pending publishes is far outside this repo's shape, but the eviction mode is narrowed, not eliminated.

## Residual 3 — stale comment

`scripts/release.py:544-552` still described release.yml's concurrency group as keying on `github.ref` ("two branches ⇒ two groups"). `9a1dfb8` made the group ref-independent in the same commit that shipped the comment, so it was **stale on arrival**. The swallow's conclusion is still correct, but for a different reason, which the replacement now states: the group covers only CI, and a publisher *outside* it — a manual `release.py publish`, a hand-cut release — can create the tag between our checkout and the `gh` call. Code below the comment is untouched.

**Narrowed further during review.** CodeRabbit flagged the comment's surviving claim that "the winner created this exact tag from this exact CHANGELOG section, so the desired end state already holds" as asserting something the code never checks — correctly. `_already_exists` matches only the stderr phrase, and nothing re-reads the remote, so the swallow cannot distinguish a same-flow race from a tag hand-cut off another commit. That clause was itself pre-existing (verbatim on `main`; this PR had rewritten only the stale `github.ref` half), but since residual 3 *is* "this comment claims something untrue", it was fixed rather than shipped. The comment now states the flow argument as an argument and names the uncovered case.

The underlying **verification gap is real but out of scope here** and is tracked in **#704**: a remote probe added to the failure path alone would still exit 0 on the success path via the pre-existing local `tag_exists` pre-check (`:518-520`), so any genuine fix has to cover both call sites and change `cmd_publish`'s idempotence contract — a behavior change to the release path with a new failure mode, deserving its own tests and review.

## Two corrections to the issue

1. **The issue's line numbers (~430, ~441-443) are `release/0.9.x` numbering.** On `main` the anchors are `:538` and `:544-552`.
2. **The issue's "`scripts/release.py` is byte-identical on `release/0.9.x`" claim is false** — main gained the changelog-contract work (539 vs 667 lines). The *publish path itself* is identical on both branches, just shifted ~105 lines, so the issue's underlying reasoning holds even though the stated premise does not.

## Scope

`release/0.9.x` is **deliberately left alone** (user decision, 2026-08-23): the line is dormant, with 0.10.0 and 0.11.0 both shipped from `main`. This PR is main-only by choice, not by oversight.

## Deviations from plan, and linter notes

- **actionlint suppression (deviation).** The plan's fallback for a linter that predates `queue:` was "bump actionlint." That is not available: `1.7.12` is *both* the pinned version and upstream's latest (2026-03-30), predating the 2026-05-07 feature, and upstream's support PR (rhysd/actionlint#661) was closed unmerged. So the check is suppressed with a `# trunk-ignore(actionlint/syntax-check)` on that line only — not repo-wide — with a comment saying to drop it once actionlint learns the key.
- **Pre-existing zizmor finding — fixed, because CI forced it (deviation).** `zizmor/artipacked` ("does not set `persist-credentials: false`") fires on release.yml's checkout step. It is **pre-existing, not introduced here**, and the proof is mechanical: this PR's release.yml diff is a pure insertion into the `concurrency:` block, the checkout step is **byte-identical** to `origin/main` (only shifted 31 → 39), and `persist-credentials` is absent from **both** versions. Repo-wide, `trunk check --all --filter=zizmor` finds it in this file alone.

  The plan said to argue pre-existence and not patch it. That turned out to be unactionable: CI's trunk runs in pull-request mode and lints only **modified** files, so this finding lies dormant on `main` and wakes the moment anything in release.yml changes — it reddened the `lint (trunk)` leg on a diff that never touched the checkout step, and a red leg cannot be argued green. On a **user decision (2026-08-23)** overriding the plan's note, zizmor's own one-line remedy was applied instead of suppressing a genuine finding.

  It is **functionally inert** for this job, which is why it is safe to land here: the workflow's only `run:` step is `release.py publish`, whose reachable git calls are local ref reads (`rev-parse --verify refs/tags/<tag>`, `rev-parse HEAD`), and `gh release create` authenticates via `GH_TOKEN`, not git credentials. Nothing pushes or fetches, so no step needs the persisted credential. **One line added, nothing else in release.yml touched** — this is a CI-forced hardening of pre-existing code, not a scope expansion.
- **Test count.** The plan predicted "39 passed" for `tests/test_release.py`; the real figure is **59** (58 on `origin/main` + 1 new). The plan's absolute was stale; the +1 delta is as designed.

## Verification

- `uv run pytest tests/test_release.py -q` — 59 passed
- `uv run pytest -q -n logical` — 6522 passed, 47 skipped
- `uv run pyright` — 0 errors, 0 warnings
- `trunk fmt` — clean; `trunk check` — **clean, no issues**
- `uv run --no-project python scripts/release.py check` — passes (the command CI's `version-sync` job runs); CHANGELOG entry is under `## [Unreleased]` → `### Fixed`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release publishing reliability when multiple publishing processes run concurrently.
  * Added safer handling for concurrent tag creation, preventing duplicate-tag conflicts from interrupting otherwise successful releases.

* **Documentation**
  * Updated release documentation and changelog entries to clarify publishing concurrency protection and regression coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
