### PR TITLE
fix(verify): run the review gates in the right tree and spare an empty park (#695, #676)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,20 @@ breaking changes may land in a minor release.
 
 ### Fixed
 
+- **Review-side `[verify] commands` run in the same tree the dev gate uses** (#695). All three
+  `verify_review*` gates ran them in `paths.project`, while the dev gate runs them in the
+  workspace root — `paths.repo_root` under `isolation = "none"`. With a `repo_root` override the
+  two gates built different trees on the same commit, so a command that passed for dev could
+  fail (or vacuously pass) for review. The artifacts each gate reads stay project-rooted; only
+  the operator's shell commands move, and the three gates now share one helper so the split
+  cannot drift.
+- **A park that legitimately produced no code passes the front gate** (#676). The parked leg
+  ran proof-of-work with the spec and the board excluded by name — the only two files a
+  first-pass park writes — so a correct park read as "no changes", retried until the attempt
+  budget ran out, and was then rolled back. That leg now skips the gate outright, the same
+  idiom the plan-halt leg already uses. Park is not thereby a free pass: the gate refusing a
+  park that declares no usable `operator_actions` runs ahead of it, and the spec/board pair
+  still has to match.
 - **The git-add shield refuses to enable `extensions.worktreeConfig` over an operator's
   explicit disable** (#396), instead of enabling it and deleting the line on rollback. The
   probe read the flag `--type=bool`, so a `false`/`off`/`no`/`0` in the shared config read

--- a/src/bmad_loop/verify.py
+++ b/src/bmad_loop/verify.py
@@ -3468,7 +3468,19 @@ def verify_dev(
         expected_status=(
             AWAITING_OPERATOR if parked else ("in-review" if review_enabled else "done")
         ),
-        extra_exclude=engine_written,
+        # A park may legitimately produce no code: the story's remaining work is a
+        # human's, and a session that correctly recognized that on its first pass
+        # wrote only the spec and the board — both of which the proof-of-work
+        # exclude already removes, so the gate reads the park as "no changes" and
+        # retries it to budget exhaustion, then rolls the park back (#676). Skip
+        # the gate on this leg (`extra_exclude=None`), the same idiom the
+        # plan-halt leg uses in `verify_dev_stories` for the same reason. Park is
+        # not thereby a free pass: `_operator_actions_gate` above already refused
+        # a park declaring no usable `operator_actions`, and the (spec, board)
+        # pair still has to match. The cost is that a park which *did* produce
+        # code no longer clears proof-of-work either — harmless, because skipping
+        # a gate never fails work that passed it.
+        extra_exclude=None if parked else engine_written,
         fm=fm,
     )
     if gate is not None:
@@ -3979,6 +3991,27 @@ def verify_commands_outcome(policy: Policy, cwd: Path) -> VerifyOutcome:
     return verify_command_results_outcome(run_verify_commands(policy, cwd), cwd)
 
 
+def _verify_review_commands(policy: Policy, paths: ProjectPaths) -> VerifyOutcome:
+    """Run the review-side verify commands in the tree the dev side already uses.
+
+    `paths.repo_root`, not `paths.project`: the dev gate runs them in
+    `Engine.workspace.root` (`_verify_commands_with_results`), which is
+    `paths.repo_root` for `isolation = "none"` and the worktree dir under
+    worktree isolation. With a `repo_root` override the two gates otherwise
+    disagree — dev builds the code tree, review builds the artifact tree — and a
+    `[verify] commands` entry that passes for dev fails (or vacuously passes) for
+    review on the same commit (#695).
+
+    This deliberately splits the two roots the review gates use: the *artifacts*
+    each gate reads (`paths.sprint_status`, `paths.deferred_work`, the claimed
+    spec) stay project-rooted, because that is where BMAD writes them; only the
+    operator's shell commands move, because those are about the code. The three
+    `verify_review*` gates share this one function so the split cannot drift
+    between them.
+    """
+    return verify_commands_outcome(policy, paths.repo_root)
+
+
 def verify_review(
     task: StoryTask,
     paths: ProjectPaths,
@@ -4051,7 +4084,7 @@ def verify_review(
             f"sprint-status for {task.story_key} is {sprint!r}, expected {expected!r}"
         )
 
-    return verify_commands_outcome(policy, paths.project)
+    return _verify_review_commands(policy, paths)
 
 
 def _is_signoff_regression(sprint: str | None, sprint_reached_done: bool, policy: Policy) -> bool:
@@ -4083,7 +4116,7 @@ def verify_review_stories(task: StoryTask, paths: ProjectPaths, policy: Policy) 
     status = status_of(fm)
     if status != "done":
         return VerifyOutcome.retry(f"spec status is {status!r}, expected 'done'")
-    return verify_commands_outcome(policy, paths.project)
+    return _verify_review_commands(policy, paths)
 
 
 def verify_review_bundle(task: StoryTask, paths: ProjectPaths, policy: Policy) -> VerifyOutcome:
@@ -4123,7 +4156,7 @@ def verify_review_bundle(task: StoryTask, paths: ProjectPaths, policy: Policy) -
             fixable=True,
         )
 
-    return verify_commands_outcome(policy, paths.project)
+    return _verify_review_commands(policy, paths)
 
 
 def commit_story(repo: Path, message: str) -> str:

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -13,6 +13,7 @@ from conftest import (
     _OK,
     MISSING_TOOL_CMD,
     UNRESOLVABLE,
+    _file_exists_cmd,
     fault_read_text,
     git,
     make_git_noisy,
@@ -704,13 +705,19 @@ def test_verify_dev_review_disabled_expects_done(project):
 # ------------------------------------------- awaiting-operator pair (#335)
 
 
-def _park(project, *, sprint="awaiting-operator", actions=("publish the TXT record",)):
-    """A dev session that finished its agent-doable work and parked the rest."""
+def _park(project, *, sprint="awaiting-operator", actions=("publish the TXT record",), code=True):
+    """A dev session that finished its agent-doable work and parked the rest.
+
+    `code=False` is the park that got it right on the first pass: its only residue
+    is the spec and the board, both of which the proof-of-work exclude already
+    removes. Every other row here keeps the default `src.txt` write, which is why
+    none of them can see #676."""
     write_sprint(project, {"1-1-a": sprint})
     task = make_task(project)
     sp = spec_path(project, "1-1-a")
     write_spec(sp, "awaiting-operator", task.baseline_commit, operator_actions=list(actions))
-    (project.project / "src.txt").write_text("changed\n")
+    if code:
+        (project.project / "src.txt").write_text("changed\n")
     return task, sp
 
 
@@ -725,6 +732,35 @@ def test_verify_dev_accepts_the_park_pair(project):
 
     assert out.ok
     assert task.spec_file == str(sp)
+
+
+def test_verify_dev_park_with_no_code_residue_passes(project):
+    """#676: the parked leg skips proof-of-work outright, the same idiom the
+    plan-halt leg uses in `verify_dev_stories`.
+
+    A park is *defined* by owing the remainder to a human, so a session that
+    recognized that on its first pass legitimately wrote nothing but the spec and
+    the board — and `verify_dev_exclude_relpaths` excludes exactly those two by
+    name. The gate therefore read a correct park as "no changes", retried it until
+    the attempt budget ran out, and rolled the park back.
+
+    The second half is the control, and it is what stops this row passing for the
+    wrong reason: the SAME empty tree under the SAME flags, differing only in the
+    observed spec status, must still fail proof-of-work. If the tree were not
+    actually empty the control would go green and the first assertion would prove
+    nothing."""
+    task, sp = _park(project, code=False)
+
+    out = verify.verify_dev(task, project, dev_result(sp), review_enabled=False, operator_park=True)
+
+    assert out.ok
+    assert task.spec_file == str(sp)
+
+    # scoped to the parked leg, not a blanket disable of proof-of-work
+    write_sprint(project, {"1-1-a": "review"})
+    write_spec(sp, "in-review", task.baseline_commit)
+    ordinary = verify.verify_dev(task, project, dev_result(sp), operator_park=True)
+    assert not ordinary.ok and ordinary.reason == "no changes in worktree since baseline commit"
 
 
 def test_verify_dev_park_needs_the_matching_board(project):
@@ -2449,6 +2485,57 @@ def test_verify_review_bundle_missing_entry_fails(project):
     bundle_ledger(project, {"DW-1": "done 2026-06-11"})  # DW-2 absent entirely
     out = verify.verify_review_bundle(task, project, Policy())
     assert not out.ok and out.fixable and "DW-2" in out.reason
+
+
+@pytest.mark.parametrize("gate", ["review", "stories", "bundle"])
+def test_verify_review_commands_run_in_repo_root(project, tmp_path, gate):
+    """#695: the review-side `[verify] commands` run in `paths.repo_root` — the same
+    tree the dev gate uses (`Engine._verify_commands_with_results` runs them in
+    `Engine.workspace.root`, which `Workspace.default` sets to `paths.repo_root`).
+
+    Under `isolation = "none"` with a `repo_root` override the two gates otherwise
+    build different trees on the same commit: dev the code repo, review the
+    artifact project. The `project` fixture leaves `repo_root == project`, so no
+    existing row can tell the two apart.
+
+    Pinned from both sides, because one direction alone is satisfiable by a cwd
+    that is neither: a marker only `repo_root` holds must pass, and a marker only
+    `project` holds must fail. All three `verify_review*` gates are covered — they
+    share one helper precisely so the split cannot drift between them."""
+    code_root = tmp_path / "code-repo"
+    code_root.mkdir()
+    (code_root / "in-repo-root.txt").write_text("x", encoding="utf-8")
+    (project.project / "in-project.txt").write_text("x", encoding="utf-8")
+    paths = dataclasses.replace(project, repo_root=code_root)
+
+    if gate == "review":
+        write_sprint(paths, {"1-1-a": "done"})
+        task = make_task(paths)
+        sp = spec_path(paths, "1-1-a")
+        write_spec(sp, "done", task.baseline_commit)
+        run_gate = verify.verify_review
+    elif gate == "stories":
+        task = make_stories_task(paths, "1")
+        sp = write_story(
+            paths.planning_artifacts / "epic-a", "1", "x", "done", task.baseline_commit
+        )
+        run_gate = verify.verify_review_stories
+    else:
+        task = make_bundle_task(paths)
+        sp = paths.implementation_artifacts / "spec-dw-test-bundle.md"
+        write_spec(sp, "done", task.baseline_commit)
+        bundle_ledger(paths, {"DW-1": "done 2026-06-11", "DW-2": "done 2026-06-11"})
+        run_gate = verify.verify_review_bundle
+    task.spec_file = str(sp)
+
+    def gate_with(marker: str):
+        return run_gate(
+            task, paths, Policy(verify=VerifyPolicy(commands=(_file_exists_cmd(marker),)))
+        )
+
+    assert gate_with("in-repo-root.txt").ok
+    out = gate_with("in-project.txt")
+    assert not out.ok and "verify command failed" in out.reason
 
 
 def test_verify_shared_gates_oserror_degrades_to_retry(project, monkeypatch):


### PR DESCRIPTION
Closes #695
Closes #676

Two confirmed work-loss fixes at the front gates, both scoped narrowly and both covered by ablated tests.

## #695 — the review gates ran the verify commands in the wrong tree

All three `verify_review*` gates ended in `verify_commands_outcome(policy, paths.project)`, while the dev gate runs the same commands in `Engine.workspace.root` — which `Workspace.default` sets to `paths.repo_root`. Under `isolation = "none"` with a `repo_root` override the two gates therefore build **different trees on the same commit**: dev the code repo, review the artifact project. A `[verify] commands` entry that passes for dev can fail, or vacuously pass, for review.

The three sites now share one helper, `_verify_review_commands`. That is deliberate rather than three edited lines: the change splits the two roots the review gates use — the *artifacts* each gate reads (`paths.sprint_status`, `paths.deferred_work`, the claimed spec) stay project-rooted because that is where BMAD writes them, and only the operator's shell commands move because those are about the code. One helper states that split once and keeps it from drifting between the three gates.

Worth noting that the review gates were the only outlier, not one of two competing conventions: the dev gate runs them in `Engine.workspace.root`, and `cli._reverify` — the `confirm --reverify` path — is called with `paths.repo_root` at both of its call sites. `repo_root` was already the answer everywhere else.

Reporter's scope, confirmed and narrowed: reachable only under `isolation = "none"` plus a `repo_root` override.

## #676 — a park that produced no code was judged as having produced nothing

The parked leg of `verify_dev` passed `extra_exclude=engine_written` unconditionally, so proof-of-work ran on a park. But `verify_dev_exclude_relpaths` excludes `paths.sprint_status` and the session's own spec by name — and those are exactly the only two files a park that got it right on its first pass writes. The gate read a correct park as "no changes", retried it until the attempt budget ran out, then rolled the park commit back and deferred.

The fix is the reporter's: `extra_exclude=None if parked else engine_written`, which is structurally the same idiom the plan-halt leg in `verify_dev_stories` already uses, for the same reason.

The `needs-design` question on that issue — "does park become a free pass?" — is answered by the surrounding code rather than by new design. `extra_exclude=None` skips exactly one block inside `_verify_shared_gates`, the `has_changes_since` proof-of-work check; everything above it still runs on the parked leg, including the workflow-tag gate, the expected-status gate and the baseline-match gate. And `_operator_actions_gate` runs *before* the shared gates on that leg, already refusing a park that declares no usable `operator_actions`, while the (spec status, board status) pair still has to match. What this does give up is that a park which *did* produce code no longer clears proof-of-work either. That is a small policy widening rather than a pure bug fix, and it is harmless in the only direction that matters: skipping a gate never fails work that would have passed it.

## Tests

Two new rows in `tests/test_verify.py`, both ablated — the gating code deleted and the row confirmed to go red.

**The empty-proof park.** No existing row could see this bug: the shared `_park` helper writes `src.txt`, so every current park row has a non-empty proof diff. The helper takes `code=False` now. The row carries its own control in the same test — the *same* empty tree under the *same* flags, differing only in the observed spec status, must still fail proof-of-work. Without that control the row would pass whenever the tree simply was not empty, which is the way this shape fails silently. Ablation: reverting `None if parked` reddens it with `no changes in worktree since baseline commit`, and the eleven pre-existing park rows all stay green.

**A `repo_root != project` review-gate row**, parametrized across all three gates. The `project` fixture sets no `repo_root`, so `repo_root == project` and no existing row can distinguish the two. This one splits them with `dataclasses.replace` and pins the command's cwd from both sides: a marker only `repo_root` holds must pass, and a marker only `project` holds must fail — one direction alone is satisfiable by a cwd that is neither. Ablation: reverting to `paths.project` reddens all three parameters.

## Gate

`uv run pytest -q -n logical` 7010 passed / 49 skipped · `uv run pyright` 0 errors · `trunk fmt` · `trunk check` · `trunk check --all` 258 files, no issues.

Related to #443, which names this `[verify] commands` split among the inconsistencies to settle; that bullet is now stale and comes out once this lands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Review verification commands now run against the same code workspace as development verification, preventing inconsistent results when a repository root is configured.
  * Sessions that are intentionally parked without producing code now pass verification correctly.
  * Parks without valid operator actions continue to be rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->