### PR TITLE
test(sweep): read feedback and manifest files as UTF-8 (#624)

### DIFF
--- a/tests/test_sweep.py
+++ b/tests/test_sweep.py
@@ -1614,7 +1614,7 @@ def test_sweep_happy_path(project):
     dev_spec = adapter.sessions[1]
     assert "Implement the deferred-work bundle" in dev_spec.prompt
     intent_path = re.findall(r"`([^`]*)`", dev_spec.prompt)[0]
-    intent = open(intent_path).read()
+    intent = Path(intent_path).read_text(encoding="utf-8")
     assert "fix both" in intent and "DW-2" in intent and "### DW-3" in intent
 
 
@@ -2409,7 +2409,7 @@ def test_triage_validation_failure_retries_with_feedback_then_escalates(project)
     assert len(prompts) == 2
     assert "--feedback" not in prompts[0] and "--feedback" in prompts[1]
     feedback_path = prompts[1].split("--feedback ", 1)[1]
-    assert "not triaged: DW-1" in open(feedback_path).read()
+    assert "not triaged: DW-1" in Path(feedback_path).read_text(encoding="utf-8")
 
 
 def test_overlong_bundle_name_is_normalized_without_triage_retry(project):
@@ -4031,7 +4031,7 @@ def test_sweep_migrates_legacy_then_triages_and_runs_bundle(project):
     # the migration session was prompted with the manifest path
     assert "--migrate" in adapter.sessions[0].prompt
     manifest_path = adapter.sessions[0].prompt.split("--migrate ", 1)[1].split()[0]
-    written = json.loads(open(manifest_path).read())
+    written = json.loads(Path(manifest_path).read_text(encoding="utf-8"))
     assert [m["key"] for m in written] == [m["key"] for m in manifest]
     # triage ran against the post-migration open set, strict check intact
     assert "--migrate" not in adapter.sessions[1].prompt
@@ -4060,7 +4060,7 @@ def test_migration_validation_failure_restores_ledger_then_escalates(project):
     prompts = [s.prompt for s in adapter.sessions]
     assert len(prompts) == 2
     assert "--feedback" not in prompts[0] and "--feedback" in prompts[1]
-    feedback = open(prompts[1].split("--feedback ", 1)[1]).read()
+    feedback = Path(prompts[1].split("--feedback ", 1)[1]).read_text(encoding="utf-8")
     assert "still parse as legacy" in feedback and "not mapped" in feedback
 
 


### PR DESCRIPTION
## What

Four bare `open(...).read()` calls in `tests/test_sweep.py` now read UTF-8 explicitly through `Path.read_text`, matching the sibling at `:4458` that #616 already fixed.

## Why

They use the platform default encoding and leak the handle. The default is not UTF-8 on Windows and CI runs `windows py3.11` / `py3.14`, so a non-ASCII byte in one of these files would raise `UnicodeDecodeError` there and nowhere else.

Fixes #624.

## How

- `:4063` — the instance the issue names, using the one-liner it proposes.
- `:1617`, `:2412`, `:4034` — the same defect in the same file, found by the same search. Happy to drop these three if you would rather keep the PR to the filed line.

## Testing

`uv run pytest -q tests/test_sweep.py` — 198 passed. `trunk check` clean. These tests pass before and after: the fault is latent and only reachable under a non-UTF-8 default encoding, so this is a non-regression check rather than a proof.

## Changelog

n/a — test-only, nothing user-visible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Standardized test file reading to explicitly use UTF-8 encoding.
  - Updated coverage for intent, triage feedback, migration manifest, and migration feedback files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->